### PR TITLE
Update link to CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Checklist
 
-- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md).
-- [ ] I added unit-tests to validate my changes. All unit tests are passing. 
+- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
+- [ ] I added unit-tests to validate my changes. All unit tests are passing.
 - [ ] I have merged the latest `main` branch prior to this PR submission.
-- [ ] I submitted this PR against the `main` branch. 
+- [ ] I submitted this PR against the `main` branch.


### PR DESCRIPTION
## Description

Fix link to `CONTRIBUTING.md` in PR template.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.