### PR TITLE
Initialized submodule from dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 	"workspaceFolder": "/AzOsConfig",
 	"mounts": ["source=${localWorkspaceFolder},target=/AzOsConfig,type=bind,consistency=cached"],
 	"overrideCommand": true,
+	"postCreateCommand": "git submodule update --init --recursive",
 
 	"extensions": [
 		"eamodio.gitlens",


### PR DESCRIPTION
## Description

 * Added support for building C++ in dev containers without first cloning submodules which enables building the agent in Codespaces.

## Checklist

- [ x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ x] I have merged the latest `main` branch prior to this PR submission.
- [ x] I submitted this PR against the `main` branch.