### PR TITLE
Update module logging on calls to MmiSet

### DIFF
--- a/src/modules/commandrunner/src/so/CommandRunnerModule.cpp
+++ b/src/modules/commandrunner/src/so/CommandRunnerModule.cpp
@@ -520,10 +520,6 @@ int MmiSetInternal(
             {
                 OsConfigLogInfo(CommandRunnerLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
-            else
-            {
-                OsConfigLogInfo(CommandRunnerLog::Get(), "MmiSet(%p, %s, %s, -, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, status);
-            }
         }
         else
         {

--- a/src/modules/hostname/src/so/HostNameModule.cpp
+++ b/src/modules/hostname/src/so/HostNameModule.cpp
@@ -214,11 +214,7 @@ int MmiSet(MMI_HANDLE clientSession, const char* componentName, const char* obje
             }
             else
             {
-                if (MMI_OK == status)
-                {
-                    OsConfigLogInfo(HostNameLog::Get(), "MmiSet(%p, %s, %s, -, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, status);
-                }
-                else
+                if (MMI_OK != status)
                 {
                     OsConfigLogError(HostNameLog::Get(), "MmiSet(%p, %s, %s, -, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, status);
                 }

--- a/src/modules/ztsi/src/so/ZtsiModule.cpp
+++ b/src/modules/ztsi/src/so/ZtsiModule.cpp
@@ -213,10 +213,6 @@ int MmiSet(
             {
                 OsConfigLogInfo(ZtsiLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
-            else
-            {
-                OsConfigLogInfo(ZtsiLog::Get(), "MmiSet(%p, %s, %s, -, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, status);
-            }
         }
         else
         {


### PR DESCRIPTION
## Description

Remove `OsConfigLogInfo(...)` from modules on calls to `MmiSet` when full logging is not enabled.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.