### PR TITLE
Fix ZTSI tests for invalid client name

### DIFF
--- a/src/modules/ztsi/tests/ZtsiTests.cpp
+++ b/src/modules/ztsi/tests/ZtsiTests.cpp
@@ -312,12 +312,12 @@ namespace OSConfig::Platform::Tests
         char dateNow[DATE_FORMAT_LENGTH] = {0};
         strftime(dateNow, DATE_FORMAT_LENGTH, STRFTIME_DATE_FORMAT, localtime(&t));
 
-        int monthNow, dayNow, yearNow;
-        sscanf(dateNow, SSCANF_DATE_FORMAT, &monthNow, &dayNow, &yearNow);
+        int yearNow, monthNow, dayNow;
+        sscanf(dateNow, SSCANF_DATE_FORMAT, &yearNow, &monthNow, &dayNow);
 
-        std::string clientNameWithMonthAfterCurrentDate = "Azure OSConfig 5;0.0.0." + std::to_string(monthNow + 1) + std::to_string(dayNow) + std::to_string(yearNow);
-        std::string clientNameWithDayAfterCurrentDate = "Azure OSConfig 5;0.0.0." + std::to_string(monthNow) + std::to_string(dayNow + 1) + std::to_string(yearNow);
-        std::string clientNameWithYearAfterCurrentDate = "Azure OSConfig 5;0.0.0." + std::to_string(monthNow) + std::to_string(dayNow) + std::to_string(yearNow + 1);
+        std::string clientNameWithYearAfterCurrentDate = "Azure OSConfig 5;0.0.0." + std::to_string(yearNow + 1) + std::to_string(monthNow) + std::to_string(dayNow);
+        std::string clientNameWithMonthAfterCurrentDate = "Azure OSConfig 5;0.0.0." + std::to_string(yearNow) + std::to_string(monthNow + 1) + std::to_string(dayNow);
+        std::string clientNameWithDayAfterCurrentDate = "Azure OSConfig 5;0.0.0." + std::to_string(yearNow) + std::to_string(monthNow) + std::to_string(dayNow + 1);
 
         ASSERT_FALSE(IsValidClientName(clientNameWithMonthAfterCurrentDate));
         ASSERT_FALSE(IsValidClientName(clientNameWithDayAfterCurrentDate));


### PR DESCRIPTION
## Description

Fix tests for invalid client name to check for the correct date strings.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.