### PR TITLE
Update build revision number format

### DIFF
--- a/devops/pipeline/binary_package.yaml
+++ b/devops/pipeline/binary_package.yaml
@@ -3,7 +3,7 @@
 #  - Ubuntu 18.04
 #  - Ubuntu 20.04
 
-name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:.r)
+name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
 resources:
   containers:

--- a/devops/pipeline/binary_package_arm.yaml
+++ b/devops/pipeline/binary_package_arm.yaml
@@ -3,7 +3,7 @@
 #  - Ubuntu 18.04
 #  - Ubuntu 20.04
 
-name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:.r)
+name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
 variables:
   SERVICE_CONNECTION: OSConfig-ACR

--- a/devops/pipeline/binary_package_consolidated.yaml
+++ b/devops/pipeline/binary_package_consolidated.yaml
@@ -3,7 +3,7 @@
 #  - Ubuntu 18.04
 #  - Ubuntu 20.04
 
-name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:.r)
+name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
 variables:
   SERVICE_CONNECTION: OSConfig-ACR

--- a/devops/pipeline/e2etest.yaml
+++ b/devops/pipeline/e2etest.yaml
@@ -2,7 +2,7 @@
 #  - Ubuntu 18.04
 #  - Ubuntu 20.04
 
-name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:.r)
+name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
 resources:
   containers:

--- a/devops/pipeline/source_packaging.yaml
+++ b/devops/pipeline/source_packaging.yaml
@@ -1,6 +1,6 @@
 # Continuous Integration Pipeline
 
-name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:.r)
+name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
 resources:
   containers:


### PR DESCRIPTION
## Description

Fixes `$(Build.BuildNumber)` to use correct revision number format so that debian package versions are not broken when build artifacts are published.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.