### PR TITLE
Remove payload logging from CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,12 +15,6 @@ option(BUILD_PLATFORM "Build OSConfig Platform" ON)
 option(BUILD_TESTS "Build test collateral" ON)
 option(COVERAGE "Enable code coverage" OFF)
 
-option(ENABLE_PAYLOAD_LOGGING "Enables value payloads logging." OFF)
-if (ENABLE_PAYLOAD_LOGGING)
-    message(WARNING "WARNING: value payloads logging enabled, this can expose confidential data!")
-    add_definitions(-DLOG_VALUE_PAYLOAD)
-endif()
-
 option(COMPILE_WITH_STRICTNESS "Builds with additional strict compiler options." ON)
 if (COMPILE_WITH_STRICTNESS)
     message(STATUS "Compiling with additional strictness")


### PR DESCRIPTION
## Description

Remove `ENABLE_PAYLOAD_LOGGING` from CMakeLists. This was replaced by run time configuration.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.