### PR TITLE
Add ZTSI reported objects 

### DIFF
--- a/src/agents/pnp/daemon/osconfig.json
+++ b/src/agents/pnp/daemon/osconfig.json
@@ -1,5 +1,5 @@
 {
-  "ModelVersion": 5,  
+  "ModelVersion": 5,
   "FullLogging": 0,
   "Reported": [
     {
@@ -37,6 +37,14 @@
     {
       "ComponentName": "Tpm",
       "ObjectName": "TpmManufacturer"
+    },
+    {
+      "ComponentName": "Ztsi",
+      "ObjectName": "Enabled"
+    },
+    {
+      "ComponentName": "Ztsi",
+      "ObjectName": "ServiceUrl"
     }
   ],
   "ReportingIntervalSeconds": 30,


### PR DESCRIPTION
## Description

Adds reported objects (`Enabled` and `ServiceUrl`) to `/etc/osconfig/osconfig.json` so that objects are reported by default.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.