### PR TITLE
Removed device identity details from E2E Cloud Tests pipeline logs 

### DIFF
--- a/devops/pipeline/e2etest.yaml
+++ b/devops/pipeline/e2etest.yaml
@@ -178,7 +178,7 @@ stages:
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "$(TENANT_ID)"
-            az iot hub device-identity create --device-id "$(device_id)" --hub-name $(IOTHUB_NAME)
+            az iot hub device-identity create --device-id "$(device_id)" --hub-name $(IOTHUB_NAME) --output none
             DEVICE_CONN_STR=`az iot hub device-identity connection-string show --hub-name $(IOTHUB_NAME) --device-id $(device_id) --output tsv`
             echo "##vso[task.setvariable variable=DEVICE_CONN_STR;issecret=true]$DEVICE_CONN_STR"
 


### PR DESCRIPTION
## Description

Added the azcli output suppression flag to the 'az iot hub device-identity create' command to suppress device identity details in E2E Cloud Tests pipeline logs. Verified the fix by running the pipeline with the updated yaml and confirmed device identity details were removed from logs and all pipeline tasks succeeded.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.