### PR TITLE
Cache enabled state

### DIFF
--- a/src/modules/ztsi/src/lib/Ztsi.h
+++ b/src/modules/ztsi/src/lib/Ztsi.h
@@ -75,4 +75,5 @@ private:
     std::string m_agentConfigurationFile;
     unsigned int m_maxPayloadSizeBytes;
     AgentConfiguration m_lastAvailableConfiguration;
+    bool m_lastEnabledState;
 };

--- a/src/modules/ztsi/tests/ZtsiTests.cpp
+++ b/src/modules/ztsi/tests/ZtsiTests.cpp
@@ -307,6 +307,44 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ(g_defaultServiceUrl.c_str(), ZtsiTests::ztsi->GetServiceUrl().c_str());
     }
 
+    TEST_F(ZtsiTests, CachedEnabledBeforeSetServiceUrl)
+    {
+        std::string serviceUrl = "https://www.example.com/";
+
+        // Should cache enabled state
+        ASSERT_EQ(EINVAL, ZtsiTests::ztsi->SetEnabled(true));
+        ASSERT_EQ(g_defaultEnabledState, ZtsiTests::ztsi->GetEnabledState());
+        ASSERT_STREQ(g_defaultServiceUrl.c_str(), ZtsiTests::ztsi->GetServiceUrl().c_str());
+        ASSERT_FALSE(ZtsiTests::FileExists());
+
+        // Should return serviceUrl and cached enabled state
+        ASSERT_EQ(0, ZtsiTests::ztsi->SetServiceUrl(serviceUrl));
+        ASSERT_EQ(Ztsi::EnabledState::Enabled, ZtsiTests::ztsi->GetEnabledState());
+        ASSERT_STREQ(serviceUrl.c_str(), ZtsiTests::ztsi->GetServiceUrl().c_str());
+        ASSERT_TRUE(ZtsiTests::FileExists());
+
+        // Modify JSON contents with default JSON values
+        std::string defaultJson = ZtsiTests::BuildFileContents(false, g_defaultServiceUrl);
+        std::ofstream file(ZtsiTests::filename);
+        file << defaultJson;
+        file.close();
+        ASSERT_STREQ(defaultJson.c_str(), ZtsiTests::ReadFileContents().c_str());
+
+        // Get should return the JSON contents
+        ASSERT_EQ(Ztsi::EnabledState::Disabled, ZtsiTests::ztsi->GetEnabledState());
+        ASSERT_STREQ(g_defaultServiceUrl.c_str(), ZtsiTests::ztsi->GetServiceUrl().c_str());
+
+        // Should cache enabled state
+        ASSERT_EQ(EINVAL, ZtsiTests::ztsi->SetEnabled(true));
+        ASSERT_EQ(Ztsi::EnabledState::Disabled, ZtsiTests::ztsi->GetEnabledState());
+        ASSERT_STREQ(g_defaultServiceUrl.c_str(), ZtsiTests::ztsi->GetServiceUrl().c_str());
+
+        // Should return serviceUrl and cached enabled state
+        ASSERT_EQ(0, ZtsiTests::ztsi->SetServiceUrl(serviceUrl));
+        ASSERT_EQ(Ztsi::EnabledState::Enabled, ZtsiTests::ztsi->GetEnabledState());
+        ASSERT_STREQ(serviceUrl.c_str(), ZtsiTests::ztsi->GetServiceUrl().c_str());
+    }
+
     TEST_F(ZtsiTests, ValidClientName)
     {
         std::list<std::string> validClientNames = {


### PR DESCRIPTION
## Description

Cache enabled state on every `SetEnabled()` call to allow enabling prior to setting of the service URL. This allows the module to handle `SetEnabled()` and `SetServiceUrl()` in any order they may arrive, alone or together.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.