### PR TITLE
Fix log file trimming to rely on stat primarily instead of ftell to get log file size

### DIFF
--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -111,6 +111,8 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
     }
 
     OSCONFIG_LOG* whatLog = (OSCONFIG_LOG*)log;
+    struct stat fileState = {0};
+    int fileSize = 0;
 
     whatLog->trimLogCount += (whatLog->trimLogCount >= MAX_LOG_SIZE) ? 0 : 1;
 
@@ -118,7 +120,9 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
     if ((NULL != whatLog->log) && (whatLog->trimLogCount > 0) && (0 == (whatLog->trimLogCount % 10)))
     {
         // In append mode the file pointer will always be at end of file:
-        if (ftell(whatLog->log) > MAX_LOG_SIZE)
+        fileSize = (-1 == stat(whatLog->logFileName, &fileState)) ? ftell(whatLog->log) : fileState.st_size;
+        
+        if ((fileSize >= MAX_LOG_SIZE) || (-1 == fileSize))
         {
             fclose(whatLog->log);
 


### PR DESCRIPTION
Small hardening fix in the logging library to primarily rely on stat for getting log file size instead of ftell.  

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.