### PR TITLE
Further optimization for logging

### DIFF
--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -120,7 +120,7 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
     if ((NULL != whatLog->log) && (0 == (whatLog->trimLogCount % 10)))
     {
         // In append mode the file pointer will always be at end of file:
-        fileSize = (-1 == stat(whatLog->logFileName, &fileState)) ? ftell(whatLog->log) : fileState.st_size;
+        fileSize = ftell(whatLog->log);
         
         if ((fileSize >= MAX_LOG_SIZE) || (-1 == fileSize))
         {

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -12,6 +12,8 @@
 #include <unistd.h>
 #include "Logging.h"
 
+#define MAX_LOG_TRIM 1000
+
 static bool g_fullLoggingEnabled = false;
 
 typedef struct OSCONFIG_LOG
@@ -105,19 +107,23 @@ char* GetFormattedTime()
 // Checks and rolls the log over if larger than MAX_LOG_SIZE
 void TrimLog(OSCONFIG_LOG_HANDLE log)
 {
-    if (!log)
+    OSCONFIG_LOG* whatLog = NULL;
+    int fileSize = 0;
+
+    if (NULL == log)
     {
         return;
     }
 
-    OSCONFIG_LOG* whatLog = (OSCONFIG_LOG*)log;
-    struct stat fileState = {0};
-    int fileSize = 0;
+    if (NULL == (whatLog = (OSCONFIG_LOG*)log))
+    {
+        return;
+    }
 
-    whatLog->trimLogCount += 1;
+    whatLog->trimLogCount = (whatLog->trimLogCount < MAX_LOG_TRIM) ? (whatLog->trimLogCount + 1) : 1;
 
-    // Check every 10 traces:
-    if ((NULL != whatLog->log) && (0 == (whatLog->trimLogCount % 10)))
+    // Check every 10 calls:
+    if (0 == (whatLog->trimLogCount % 10))
     {
         // In append mode the file pointer will always be at end of file:
         fileSize = ftell(whatLog->log);
@@ -136,8 +142,6 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
 
             // Reopen the log in append mode:
             whatLog->log = fopen(whatLog->logFileName, "a");
-            
-            whatLog->trimLogCount = 0;
         }
     }
 }

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -111,6 +111,8 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
     }
 
     OSCONFIG_LOG* whatLog = (OSCONFIG_LOG*)log;
+    struct stat fileState = {0};
+    int fileSize = 0;
 
     whatLog->trimLogCount += (whatLog->trimLogCount >= MAX_LOG_SIZE) ? 0 : 1;
 
@@ -118,7 +120,9 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
     if ((NULL != whatLog->log) && (whatLog->trimLogCount > 0) && (0 == (whatLog->trimLogCount % 10)))
     {
         // In append mode the file pointer will always be at end of file:
-        if (ftell(whatLog->log) > MAX_LOG_SIZE)
+        fileSize = (-1 == stat(whatLog->logFileName, &fileState)) ? ftell(whatLog->log) : fileState.st_size;
+        
+        if ((fileSize >= MAX_LOG_SIZE) || (-1 == fileSize))
         {
             fclose(whatLog->log);
 

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -114,10 +114,10 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
     struct stat fileState = {0};
     int fileSize = 0;
 
-    whatLog->trimLogCount += (whatLog->trimLogCount >= MAX_LOG_SIZE) ? 0 : 1;
+    whatLog->trimLogCount += 1;
 
     // Check every 10 traces:
-    if ((NULL != whatLog->log) && (whatLog->trimLogCount > 0) && (0 == (whatLog->trimLogCount % 10)))
+    if ((NULL != whatLog->log) && (0 == (whatLog->trimLogCount % 10)))
     {
         // In append mode the file pointer will always be at end of file:
         fileSize = (-1 == stat(whatLog->logFileName, &fileState)) ? ftell(whatLog->log) : fileState.st_size;

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -136,6 +136,8 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
 
             // Reopen the log in append mode:
             whatLog->log = fopen(whatLog->logFileName, "a");
+            
+            whatLog->trimLogCount = 0;
         }
     }
 }


### PR DESCRIPTION
Additional optimization for logging

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.