### PR TITLE
The log files may lose root access-only protection after being trimmed and manually deleted before osconfig starts

### DIFF
--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -54,8 +54,8 @@ OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName)
 
     if (NULL != newLog->logFileName)
     {
-        RestrictAccessToRootOnly(newLog->logFileName);
         newLog->log = fopen(newLog->logFileName, "a");
+        RestrictAccessToRootOnly(newLog->logFileName);
     }
 
     if (NULL != newLog->backLogFileName)
@@ -138,6 +138,10 @@ void TrimLog(OSCONFIG_LOG_HANDLE log)
 
             // Reopen the log in append mode:
             whatLog->log = fopen(whatLog->logFileName, "a");
+            
+            // Reapply restrictions once the file is recreated (also for backup, if any):
+            RestrictAccessToRootOnly(whatLog->logFileName);
+            RestrictAccessToRootOnly(whatLog->backLogFileName);
         }
     }
 }


### PR DESCRIPTION
The log files may lose root access-only protection after being trimmed and manually deleted before osconfig starts
This commit fixes both these situations

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.