### PR TITLE
Fix module loading in MPI tests

### DIFF
--- a/src/platform/modulesmanager/tests/ModuleManagerTests/src/MpiTests.cpp
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/src/MpiTests.cpp
@@ -31,7 +31,9 @@ namespace Tests
             const char* clientName = testCaseName.c_str();
             h = MpiOpen(clientName, maxPayloadsize);
             ASSERT_TRUE(0 != h);
-            // By default uses /usr/lib/osconfig -- must override to test module path
+
+            // By default MpiOpen uses /usr/lib/osconfig to load modules. Unload default modules and load test modules.
+            static_cast<ModulesManager*>(h)->UnloadAllModules();
             static_cast<ModulesManager*>(h)->LoadModules(MODULE_TEST_PATH, OSCONFIG_JSON_SINGLE_REPORTED);
         }
 


### PR DESCRIPTION
## Description

Fixes MpiTests to only load modules from `MODULE_TEST_PATH` and read from the proper `osconfig.json`. 
## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `main` branch prior to this PR submission.
- [ ] I submitted this PR against the `main` branch.