### PR TITLE
Fix HostName logging for invalid object names during MmiSet

### DIFF
--- a/src/modules/hostname/src/lib/HostNameBase.cpp
+++ b/src/modules/hostname/src/lib/HostNameBase.cpp
@@ -87,7 +87,7 @@ int HostNameBase::Set(
 
     if (!IsValidObjectName(objectName, true))
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Set", !objectName ? "-" : objectName, g_propertyDesiredName, g_propertyDesiredHosts);
+        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Set", objectName ? objectName : "-", g_propertyDesiredName, g_propertyDesiredHosts);
         return EINVAL;
     }
 
@@ -145,7 +145,7 @@ int HostNameBase::Get(
     {
         if (IsFullLoggingEnabled())
         {
-            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Get", !objectName ? "-" : objectName, g_propertyName, g_propertyHosts);
+            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Get", objectName ? objectName : "-", g_propertyName, g_propertyHosts);
         }
         return EINVAL;
     }

--- a/src/modules/hostname/src/lib/HostNameBase.cpp
+++ b/src/modules/hostname/src/lib/HostNameBase.cpp
@@ -87,7 +87,7 @@ int HostNameBase::Set(
 
     if (!IsValidObjectName(objectName, true))
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Set", !objectName ? "-" : objectName, g_propertyName, g_propertyHosts);
+        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Set", !objectName ? "-" : objectName, g_propertyDesiredName, g_propertyDesiredHosts);
         return EINVAL;
     }
 


### PR DESCRIPTION
## Description

Fixing one of the logging outputs of the `HostName` module. If `MmiSet` is called with an invalid object name, the logging output can be misleading.

Actual:
`[2022-01-05 16:52:03] [HostNameBase.cpp:90] [ERROR] Set called with an invalid object name: 'INVALID_OBJECT_NAME' (expected 'Name' or 'Hosts')`

Expected:
`[2022-01-05 16:52:03] [HostNameBase.cpp:90] [ERROR] Set called with an invalid object name: 'INVALID_OBJECT_NAME' (expected 'DesiredName' or 'DesiredHosts')`

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.