### PR TITLE
Fix MPI desired configuration validation

### DIFF
--- a/src/platform/modulesmanager/src/ModulesManager.cpp
+++ b/src/platform/modulesmanager/src/ModulesManager.cpp
@@ -672,10 +672,6 @@ int ModulesManager::MpiSetDesired(const char* clientName, const char* payload, i
             {
                 OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload: %.*s", payloadSizeBytes, payload);
             }
-            else
-            {
-                OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload");
-            }
 
             status = EINVAL;
         }
@@ -684,10 +680,6 @@ int ModulesManager::MpiSetDesired(const char* clientName, const char* payload, i
             if (IsFullLoggingEnabled())
             {
                 OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload: %.*s", payloadSizeBytes, payload);
-            }
-            else
-            {
-                OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload");
             }
 
             status = EINVAL;

--- a/src/platform/modulesmanager/src/ModulesManager.cpp
+++ b/src/platform/modulesmanager/src/ModulesManager.cpp
@@ -663,18 +663,33 @@ int ModulesManager::MpiSetDesired(const char* clientName, const char* payload, i
     }
     else
     {
-        std::string payloadString(payload, payloadSizeBytes);
         rapidjson::Document document;
-        document.Parse(payloadString.c_str());
+        document.Parse(payload, payloadSizeBytes);
 
         if (document.HasParseError())
         {
-            OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload: %s", payloadString.c_str());
+            if (IsFullLoggingEnabled())
+            {
+                OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload: %.*s", payloadSizeBytes, payload);
+            }
+            else
+            {
+                OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload");
+            }
+
             status = EINVAL;
         }
-        else if (!document.IsArray())
+        else if (!document.IsObject())
         {
-            OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload: %s", payloadString.c_str());
+            if (IsFullLoggingEnabled())
+            {
+                OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload: %.*s", payloadSizeBytes, payload);
+            }
+            else
+            {
+                OsConfigLogError(ModulesManagerLog::Get(), "MpiSetDesired invalid payload");
+            }
+
             status = EINVAL;
         }
         else
@@ -690,54 +705,40 @@ int ModulesManager::MpiSetDesiredInternal(rapidjson::Document& document)
 {
     int status = MPI_OK;
 
-    for (auto& desired : document.GetArray())
+    for (auto& component : document.GetObject())
     {
-        if (desired.IsObject())
+        if (component.value.IsObject())
         {
-            for (auto& component : desired.GetObject())
+            std::string componentName = component.name.GetString();
+            if (modMap.end() != modMap.find(componentName))
             {
-                if (component.value.IsObject())
+                ModulesManager::ModuleMetadata& moduleMetadata = modMap[componentName];
+                for (auto& object : component.value.GetObject())
                 {
-                    std::string componentName = component.name.GetString();
-                    if (modMap.end() != modMap.find(componentName))
+                    int moduleStatus = MMI_OK;
+                    std::string objectName = object.name.GetString();
+
+                    rapidjson::StringBuffer buffer;
+                    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                    object.value.Accept(writer);
+
+                    moduleMetadata.operationInProgress = true;
+                    moduleMetadata.lastOperation = std::chrono::system_clock::now();
+                    moduleStatus = moduleMetadata.module->MmiSet(componentName.c_str(), objectName.c_str(), (MMI_JSON_STRING)buffer.GetString(), buffer.GetSize());
+                    moduleMetadata.operationInProgress = false;
+
+                    if ((moduleStatus != MMI_OK) && IsFullLoggingEnabled())
                     {
-                        ModulesManager::ModuleMetadata& moduleMetadata = modMap[componentName];
-                        for (auto& object : component.value.GetObject())
-                        {
-                            int moduleStatus = MMI_OK;
-                            std::string objectName = object.name.GetString();
-
-                            rapidjson::StringBuffer buffer;
-                            rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-                            object.value.Accept(writer);
-
-                            moduleMetadata.operationInProgress = true;
-                            moduleMetadata.lastOperation = std::chrono::system_clock::now();
-                            moduleStatus = moduleMetadata.module->MmiSet(componentName.c_str(), objectName.c_str(), (MMI_JSON_STRING)buffer.GetString(), buffer.GetSize());
-                            moduleMetadata.operationInProgress = false;
-
-                            if ((moduleStatus != MMI_OK) && IsFullLoggingEnabled())
-                            {
-                                OsConfigLogError(ModulesManagerLog::Get(), "MmiSet(%s, %s, %s, %d) to %s returned %d", componentName.c_str(), objectName.c_str(), buffer.GetString(), static_cast<int>(buffer.GetSize()), moduleMetadata.module.get()->GetName().c_str(), moduleStatus);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        status = EINVAL;
-                        if (IsFullLoggingEnabled())
-                        {
-                            OsConfigLogError(ModulesManagerLog::Get(), "Unable to find component %s in module map", componentName.c_str());
-                        }
+                        OsConfigLogError(ModulesManagerLog::Get(), "MmiSet(%s, %s, %s, %d) to %s returned %d", componentName.c_str(), objectName.c_str(), buffer.GetString(), static_cast<int>(buffer.GetSize()), moduleMetadata.module.get()->GetName().c_str(), moduleStatus);
                     }
                 }
-                else
+            }
+            else
+            {
+                status = EINVAL;
+                if (IsFullLoggingEnabled())
                 {
-                    status = EINVAL;
-                    if (IsFullLoggingEnabled())
-                    {
-                        OsConfigLogError(ModulesManagerLog::Get(), "Component value is not an object");
-                    }
+                    OsConfigLogError(ModulesManagerLog::Get(), "Unable to find component %s in module map", componentName.c_str());
                 }
             }
         }
@@ -746,7 +747,7 @@ int ModulesManager::MpiSetDesiredInternal(rapidjson::Document& document)
             status = EINVAL;
             if (IsFullLoggingEnabled())
             {
-                OsConfigLogError(ModulesManagerLog::Get(), "Desired configuration array element is not an object");
+                OsConfigLogError(ModulesManagerLog::Get(), "Component value is not an object");
             }
         }
     }

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/src/MpiTests.cpp
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/src/MpiTests.cpp
@@ -113,15 +113,61 @@ namespace Tests
     TEST_F(MpiTests, MpiSetDesired)
     {
         std::string clientName = "MpiTests.MpiSetDesired";
-        char payload[] = R""""(
+        char payload1[] = R""""(
             {
                 "TestComponent1": {
-                    "testParameter": "testValue"
+                    "TestObject": "testValue"
+                },
+                "TestComponent2": {
+                    "TestObject": 1
+                },
+                "TestComponent3": {
+                    "TestObject": true
+                }
+            })"""";
+        char payload2[] = R""""(
+            {
+                "TestComponent1": {
+                    "TestObject": {
+                        "string": "value",
+                        "integer": 1,
+                        "boolean": true,
+                        "integerEnum": 1,
+                        "stringArray": ["value1", "value2"],
+                        "integerArray": [1, 2],
+                        "stringMap": {"key1": "value1", "key2": "value2"},
+                        "integerMap": {"key1": 1, "key2": 2}
+                    }
+                },
+                "TestComponent2": {
+                    "TestObject": [
+                        {
+                            "string": "value",
+                            "integer": 1,
+                            "boolean": true,
+                            "integerEnum": 1,
+                            "stringArray": ["value1", "value2"],
+                            "integerArray": [1, 2],
+                            "stringMap": {"key1": "value1", "key2": "value2"},
+                            "integerMap": {"key1": 1, "key2": 2}
+                        },
+                        {
+                            "string": "value",
+                            "integer": 1,
+                            "boolean": true,
+                            "integerEnum": 1,
+                            "stringArray": ["value1", "value2"],
+                            "integerArray": [1, 2],
+                            "stringMap": {"key1": "value1", "key2": "value2"},
+                            "integerMap": {"key1": 1, "key2": 2}
+                        }
+                    ]
                 }
             })"""";
 
         SetUp(clientName);
-        ASSERT_EQ(MPI_OK, MpiSetDesired(clientName.c_str(), payload, ARRAY_SIZE(payload)));
+        ASSERT_EQ(MPI_OK, MpiSetDesired(clientName.c_str(), payload1, ARRAY_SIZE(payload1)));
+        ASSERT_EQ(MPI_OK, MpiSetDesired(clientName.c_str(), payload2, ARRAY_SIZE(payload2)));
     }
 
     TEST_F(MpiTests, MpiGetReported)

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/src/MpiTests.cpp
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/src/MpiTests.cpp
@@ -114,13 +114,11 @@ namespace Tests
     {
         std::string clientName = "MpiTests.MpiSetDesired";
         char payload[] = R""""(
-            [
-                {
-                    "TestComponent1": {
-                        "testParameter": "testValue"
-                    }
+            {
+                "TestComponent1": {
+                    "testParameter": "testValue"
                 }
-            ])"""";
+            })"""";
 
         SetUp(clientName);
         ASSERT_EQ(MPI_OK, MpiSetDesired(clientName.c_str(), payload, ARRAY_SIZE(payload)));


### PR DESCRIPTION
## Description

Fixes validation on desired configuration to align with [modules.md 3.2.3](https://github.com/Azure/azure-osconfig/blob/main/docs/modules.md#323-serialized-mim-payload-at-run-time). 

Fixes logging of JSON payloads without `IsFullLoggingEnabled()`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.