### PR TITLE
Making commonutils!ExecuteCommand capture as text output both stdout and stderr

### DIFF
--- a/src/common/commonutils/CommonUtils.c
+++ b/src/common/commonutils/CommonUtils.c
@@ -26,6 +26,7 @@
 
 static const char g_commandTextResultFileTemplate[] = "/tmp/~OSConfig.TextResult%u";
 static const char g_commandSeparator[] = " > ";
+static const char g_commandTerminator[] = " 2>&1";
 
 char* LoadStringFromFile(const char* fileName, bool stopAtEol)
 {
@@ -342,7 +343,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
         // Append a random number to the results file to prevent parallel commands overwriting each other results
         snprintf(commandTextResultFile, sizeof(commandTextResultFile), g_commandTextResultFileTemplate, rand());
 
-        commandLineLength += strlen(g_commandSeparator) + strlen(commandTextResultFile);
+        commandLineLength += strlen(g_commandSeparator) + strlen(commandTextResultFile) + strlen(g_commandTerminator) ;
     }
 
     maximumCommandLine = (size_t)sysconf(_SC_ARG_MAX);
@@ -372,7 +373,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
     }
     else
     {
-        snprintf(commandLine, commandLineLength, "%s%s%s", command, g_commandSeparator, commandTextResultFile);
+        snprintf(commandLine, commandLineLength, "%s%s%s%s", command, g_commandSeparator, commandTextResultFile, g_commandTerminator);
     }
 
     // Execute the command with the requested timeout: error ETIME (62) means the command timed out

--- a/src/modules/settings/tests/CommonUtilsUT.cpp
+++ b/src/modules/settings/tests/CommonUtilsUT.cpp
@@ -244,6 +244,27 @@ TEST_F(CommonUtilsTest, ExecuteCommandWithNullArgument)
     EXPECT_EQ(-1, ExecuteCommand(nullptr, nullptr, false, false, 0, 0, nullptr, nullptr, nullptr));
 }
 
+TEST_F(CommonUtilsTest, ExecuteCommandWithStdErrOutput)
+{
+    char* textResult = nullptr;
+
+    EXPECT_EQ(127, ExecuteCommand(nullptr, "hh", false, true, 100, 0, &textResult, nullptr, nullptr));
+    EXPECT_STREQ("sh: 1: hh: not found\n", textResult);
+
+    if (nullptr != textResult)
+    {
+        free(textResult);
+    }
+
+    EXPECT_EQ(127, ExecuteCommand(nullptr, "blah", true, true, 100, 0, &textResult, nullptr, nullptr));
+    EXPECT_STREQ("sh: 1: blah: not found ", textResult);
+
+    if (nullptr != textResult)
+    {
+        free(textResult);
+    }
+}
+
 TEST_F(CommonUtilsTest, ExecuteCommandThatTimesOut)
 {
     char* textResult = nullptr;


### PR DESCRIPTION
Making commonutils!ExecuteCommand capture as text output both stdout and stderr

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.