### PR TITLE
Fix JSON strings in MpiGetReported

### DIFF
--- a/src/platform/modulesmanager/inc/ModulesManager.h
+++ b/src/platform/modulesmanager/inc/ModulesManager.h
@@ -99,7 +99,7 @@ private:
     int SetReportedObjects(const std::string& configJson);
 
     int MpiSetDesiredInternal(rapidjson::Document& document);
-    int MpiGetReportedInternal(char** payload, int* payloadSizeBytes);
+    int MpiGetReportedInternal(MPI_JSON_STRING* payload, int* payloadSizeBytes);
 
     void ScheduleUnloadModule(ModuleMetadata& mm);
 };

--- a/src/platform/modulesmanager/src/ModulesManager.cpp
+++ b/src/platform/modulesmanager/src/ModulesManager.cpp
@@ -758,7 +758,7 @@ int ModulesManager::MpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeByt
     return status;
 }
 
-int ModulesManager::MpiGetReportedInternal(char** payload, int* payloadSizeBytes)
+int ModulesManager::MpiGetReportedInternal(MPI_JSON_STRING* payload, int* payloadSizeBytes)
 {
     int status = MPI_OK;
     rapidjson::Document document;
@@ -826,9 +826,9 @@ int ModulesManager::MpiGetReportedInternal(char** payload, int* payloadSizeBytes
         }
         else
         {
-            std::fill(*payload, *payload + buffer.GetSize() + 1, 0);
-            std::memcpy(*payload, buffer.GetString(), buffer.GetSize() + 1);
-            *payloadSizeBytes = buffer.GetSize() + 1;
+            std::fill(*payload, *payload + buffer.GetSize(), 0);
+            std::memcpy(*payload, buffer.GetString(), buffer.GetSize());
+            *payloadSizeBytes = buffer.GetSize();
         }
     }
     catch (const std::exception& e)

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/src/ModulesManagerTests.cpp
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/src/ModulesManagerTests.cpp
@@ -241,7 +241,9 @@ namespace Tests
         EXPECT_CALL(*mockModule, CallMmiGet(StrEq(componentName), StrEq(objectName), _, _)).Times(1).WillOnce(DoAll(SetArgPointee<2>(value), SetArgPointee<3>(strlen(value)), Return(MMI_OK)));
 
         EXPECT_EQ(MPI_OK, moduleManager->MpiGetReported(&payload, &payloadSizeBytes));
-        EXPECT_TRUE(JSON_EQ(expected, payload));
+
+        std::string actual(payload, payloadSizeBytes);
+        EXPECT_TRUE(JSON_EQ(expected, actual));
     }
 
     TEST_F(ModuleManagerTests, MpiGetReported_MultipleComponents)
@@ -274,7 +276,9 @@ namespace Tests
         EXPECT_CALL(*mockModule_2, CallMmiGet(StrEq(componentName_2), StrEq(objectName_2), _, _)).Times(1).WillOnce(DoAll(SetArgPointee<2>(value_2), SetArgPointee<3>(strlen(value_2)), Return(MMI_OK)));
 
         EXPECT_EQ(MPI_OK, moduleManager->MpiGetReported(&payload, &payloadSizeBytes));
-        EXPECT_TRUE(JSON_EQ(expected, payload));
+
+        std::string actual(payload, payloadSizeBytes);
+        EXPECT_TRUE(JSON_EQ(expected, actual));
     }
 
     TEST_F(ModuleManagerTests, MpiGetReported_MultipleObjects)
@@ -303,7 +307,9 @@ namespace Tests
         EXPECT_CALL(*mockModule, CallMmiGet(StrEq(componentName), StrEq(objectName_2), _, _)).Times(1).WillOnce(DoAll(SetArgPointee<2>(value_2), SetArgPointee<3>(strlen(value_2)), Return(MMI_OK)));
 
         EXPECT_EQ(MPI_OK, moduleManager->MpiGetReported(&payload, &payloadSizeBytes));
-        EXPECT_TRUE(JSON_EQ(expected, payload));
+
+        std::string actual(payload, payloadSizeBytes);
+        EXPECT_TRUE(JSON_EQ(expected, actual));
     }
 
     TEST_F(ModuleManagerTests, MpiGetReported_InvalidPayload)
@@ -340,7 +346,9 @@ namespace Tests
         ASSERT_EQ(MPI_OK, moduleManager->LoadModules(g_moduleDir, g_configJsonMultipleReported));
         EXPECT_EQ(MPI_OK, moduleManager->MpiSetDesired((MPI_JSON_STRING)g_localPayload, strlen(g_localPayload)));
         EXPECT_EQ(MPI_OK, moduleManager->MpiGetReported(&payload, &payloadSizeBytes));
-        EXPECT_TRUE(JSON_EQ(payload, g_localPayload));
+
+        std::string actual(payload, payloadSizeBytes);
+        EXPECT_TRUE(JSON_EQ(g_localPayload, actual));
     }
 
     TEST_F(ModuleManagerTests, LoadModules_InvalidDirectory)


### PR DESCRIPTION
## Description

Fix JSON strings in MpiGetReported and is ModulesManagerTests to use correct payload size bytes.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.