### PR TITLE
Commands without specified timeout default to be terminated in 60 seconds and can be canceled during execution

### DIFF
--- a/src/common/commonutils/CommonUtils.c
+++ b/src/common/commonutils/CommonUtils.c
@@ -150,7 +150,7 @@ static int SystemCommand(void* context, const char* command, int timeoutSeconds,
     {
         if (IsFullLoggingEnabled())
         {
-            OsConfigLogInfo(log, "SystemCommand: executing command '%s' with timeout of %d seconds and%cancelation", 
+            OsConfigLogInfo(log, "SystemCommand: executing command '%s' with timeout of %d seconds and%scancelation", 
                 command, (timeout > 0) ? timeout : DEFAULT_COMMAND_TIMEOUT, (NULL == callback) ? " no " : " ");
         }
 

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -19,8 +19,15 @@ using ::testing::Invoke;
 
 namespace OSConfig::Platform::Tests
 {
+    static void SignalDoWork(int signal)
+    {
+        UNUSED(signal);
+    }
+
     TEST(CommandRunnerTests, Execute)
     {
+        signal(SIGUSR1, SignalDoWork);
+
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::Execute", nullptr);
         cmdRunner.AddCommandStatus(cmdArgs.commandId, true);
@@ -34,6 +41,8 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, CommandStatusUpdated)
     {
+        signal(SIGUSR1, SignalDoWork);
+        
         CommandRunner cmdRunner("CommandRunnerTests::CommandStatusUpdated", nullptr);
 
         // Run 1st command
@@ -61,6 +70,8 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, ExecuteCommandLimitedPayload)
     {
+        signal(SIGUSR1, SignalDoWork);
+
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::ExecuteCommandLimitedPayload", nullptr, LIMITED_PAYLOAD_SIZE);
         cmdRunner.AddCommandStatus(cmdArgs.commandId, true);
@@ -74,6 +85,8 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, CachedCommandStatus)
     {
+        signal(SIGUSR1, SignalDoWork);
+
         CommandRunner::CommandArguments cmdArgs{ "1", "echo 1", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::CachedCommandStatus", nullptr, LIMITED_PAYLOAD_SIZE);
         cmdRunner.AddCommandStatus(cmdArgs.commandId, true);
@@ -88,6 +101,8 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, OverwriteBufferCommandStatus)
     {
+        signal(SIGUSR1, SignalDoWork);
+
         constexpr int CommandArgumentsListSize = COMMANDSTATUS_CACHE_MAX + 1;
         std::array<CommandRunner::CommandArguments, CommandArgumentsListSize> commandArgumentList;
         CommandRunner cmdRunner("CommandRunnerTests::OverwriteBufferCommandStatus", nullptr);

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -28,17 +28,11 @@ namespace OSConfig::Platform::Tests
     {
     public:
         void SetUp() override;
-        void TearDown() override;
     };
 
     void CommandRunnerTests::SetUp()
     {
         signal(SIGUSR1, SignalDoWork);
-    }
-
-    void CommandRunnerTests::TearDown() 
-    {
-        // Do nothing
     }
 
     TEST_F(CommandRunnerTests, Execute)

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -24,10 +24,19 @@ namespace OSConfig::Platform::Tests
         UNUSED(signal);
     }
 
-    TEST(CommandRunnerTests, Execute)
+    class CommandRunnerTests : public ::testing::Test
+    {
+    public:
+        void SetUp() override;
+    };
+
+    void CommandRunnerTests::SetUp()
     {
         signal(SIGUSR1, SignalDoWork);
+    }
 
+    TEST(CommandRunnerTests, Execute)
+    {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::Execute", nullptr);
         cmdRunner.AddCommandStatus(cmdArgs.commandId, true);
@@ -41,8 +50,6 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, CommandStatusUpdated)
     {
-        signal(SIGUSR1, SignalDoWork);
-        
         CommandRunner cmdRunner("CommandRunnerTests::CommandStatusUpdated", nullptr);
 
         // Run 1st command
@@ -70,8 +77,6 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, ExecuteCommandLimitedPayload)
     {
-        signal(SIGUSR1, SignalDoWork);
-
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::ExecuteCommandLimitedPayload", nullptr, LIMITED_PAYLOAD_SIZE);
         cmdRunner.AddCommandStatus(cmdArgs.commandId, true);
@@ -85,8 +90,6 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, CachedCommandStatus)
     {
-        signal(SIGUSR1, SignalDoWork);
-
         CommandRunner::CommandArguments cmdArgs{ "1", "echo 1", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::CachedCommandStatus", nullptr, LIMITED_PAYLOAD_SIZE);
         cmdRunner.AddCommandStatus(cmdArgs.commandId, true);
@@ -101,8 +104,6 @@ namespace OSConfig::Platform::Tests
 
     TEST(CommandRunnerTests, OverwriteBufferCommandStatus)
     {
-        signal(SIGUSR1, SignalDoWork);
-
         constexpr int CommandArgumentsListSize = COMMANDSTATUS_CACHE_MAX + 1;
         std::array<CommandRunner::CommandArguments, CommandArgumentsListSize> commandArgumentList;
         CommandRunner cmdRunner("CommandRunnerTests::OverwriteBufferCommandStatus", nullptr);

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -34,7 +34,6 @@ namespace OSConfig::Platform::Tests
     void CommandRunnerTests::SetUp()
     {
         signal(SIGUSR1, SignalDoWork);
-        ASSERT_NE(1, 2);
     }
 
     void CommandRunnerTests::TearDown() 

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -28,14 +28,21 @@ namespace OSConfig::Platform::Tests
     {
     public:
         void SetUp() override;
+        void TearDown() override;
     };
 
     void CommandRunnerTests::SetUp()
     {
         signal(SIGUSR1, SignalDoWork);
+        ASSERT_NE(1, 2);
     }
 
-    TEST(CommandRunnerTests, Execute)
+    void CommandRunnerTests::TearDown() 
+    {
+        // Do nothing
+    }
+
+    TEST_F(CommandRunnerTests, Execute)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::Execute", nullptr);
@@ -48,7 +55,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Succeeded, cmdStatus->commandState);
     }
 
-    TEST(CommandRunnerTests, CommandStatusUpdated)
+    TEST_F(CommandRunnerTests, CommandStatusUpdated)
     {
         CommandRunner cmdRunner("CommandRunnerTests::CommandStatusUpdated", nullptr);
 
@@ -75,7 +82,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ(cmdArgs2.commandId.c_str(), cmdRunner.GetCommandIdToRefresh().c_str());
     }
 
-    TEST(CommandRunnerTests, ExecuteCommandLimitedPayload)
+    TEST_F(CommandRunnerTests, ExecuteCommandLimitedPayload)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::ExecuteCommandLimitedPayload", nullptr, LIMITED_PAYLOAD_SIZE);
@@ -88,7 +95,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Succeeded, cmdStatus->commandState);
     }
 
-    TEST(CommandRunnerTests, CachedCommandStatus)
+    TEST_F(CommandRunnerTests, CachedCommandStatus)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo 1", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::CachedCommandStatus", nullptr, LIMITED_PAYLOAD_SIZE);
@@ -102,7 +109,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Succeeded, status.commandState);
     }
 
-    TEST(CommandRunnerTests, OverwriteBufferCommandStatus)
+    TEST_F(CommandRunnerTests, OverwriteBufferCommandStatus)
     {
         constexpr int CommandArgumentsListSize = COMMANDSTATUS_CACHE_MAX + 1;
         std::array<CommandRunner::CommandArguments, CommandArgumentsListSize> commandArgumentList;
@@ -126,7 +133,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_NE(nullptr, cmd2);
     }
 
-    TEST(CommandRunnerTests, WorkerThreadExecution)
+    TEST_F(CommandRunnerTests, WorkerThreadExecution)
     {
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 1s && echo 1", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner::CommandArguments cmdArgs2{ "2", "sleep 1s && echo 2", CommandRunner::Action::RunCommand, 0, true };
@@ -158,7 +165,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ("2 ", cmdStatus2->textResult.c_str());
     }
 
-    TEST(CommandRunnerTests, CommandTimeoutSeconds)
+    TEST_F(CommandRunnerTests, CommandTimeoutSeconds)
     {
         // Sleep for 10s, timeout in 1s
         // Actual timeout in 5s due to COMMAND_CALLBACK_INTERVAL = 5
@@ -174,7 +181,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::TimedOut, cmdStatus->commandState);
     }
 
-    TEST(CommandRunnerTests, CancelRunningCommand)
+    TEST_F(CommandRunnerTests, CancelRunningCommand)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "sleep 10s", CommandRunner::Action::RunCommand, 15, true };
         CommandRunner cmdRunner("CommandRunnerTests::CancelRunningCommand", nullptr);
@@ -194,7 +201,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Canceled, cmdStatus->commandState);
     }
 
-    TEST(CommandRunnerTests, CancelQueuedCommand)
+    TEST_F(CommandRunnerTests, CancelQueuedCommand)
     {
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 10s", CommandRunner::Action::RunCommand, 20, true };
         CommandRunner::CommandArguments cmdArgs2{ "2", "sleep 10s", CommandRunner::Action::RunCommand, 20, true };
@@ -229,7 +236,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Canceled, cmdStatus1->commandState);
     }
 
-    TEST(CommandRunnerTests, SingleLineTextResult)
+    TEST_F(CommandRunnerTests, SingleLineTextResult)
     {
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 1s && echo 'single\\nline'", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner::CommandArguments cmdArgs2{ "2", "sleep 1s && echo 'multiple\\nlines'", CommandRunner::Action::RunCommand, 0, false };
@@ -252,7 +259,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ("multiple\nlines\n", cmdStatus2->textResult.c_str());
     }
 
-    TEST(CommandRunnerTests, PersistedCommandStatus)
+    TEST_F(CommandRunnerTests, PersistedCommandStatus)
     {
         CommandRunner cmdRunner("CommandRunnerTests::PersistedCommandStatus", nullptr);
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 10s", CommandRunner::Action::RunCommand, 10, true };


### PR DESCRIPTION
Commands without specified timeout default to be terminated in 60 seconds and can be canceled during execution

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] There are already added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.