### PR TITLE
Restricting system commands with timeout or cancelation executed from main process thread

### DIFF
--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -216,12 +216,6 @@ static void SignalReloadConfiguration(int signal)
     g_refreshSignal = signal;
 }
 
-static void SignalDoWork(int signal)
-{
-    UNUSED(signal);
-    IoTHubDeviceClient_LL_DoWork(g_moduleHandle);
-}
-
 static void RefreshConnection()
 {
     char* connectionString = NULL;
@@ -709,7 +703,6 @@ int main(int argc, char *argv[])
         signal(g_stopSignals[i], SignalInterrupt);
     }
     signal(SIGHUP, SignalReloadConfiguration);
-    signal(SIGUSR1, SignalDoWork);
 
     if (0 != InitializeAgent(connectionString))
     {

--- a/src/common/commonutils/CommonUtils.c
+++ b/src/common/commonutils/CommonUtils.c
@@ -146,7 +146,8 @@ static int SystemCommand(void* context, const char* command, int timeoutSeconds,
     {
         if (IsFullLoggingEnabled())
         {
-            OsConfigLogInfo(log, "SystemCommand: executing command '%s' with timeout of %d seconds and%scancelation", command, timeout, (NULL == callback) ? " no " : " ");
+            OsConfigLogInfo(log, "SystemCommand: executing command '%s' with timeout of %d seconds and%scancelation", 
+                command, timeout, (NULL == callback) ? " no " : " ");
         }
 
         // Fork an intermediate process to act as the parent for two more forked processes:

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -33,6 +33,7 @@ bool SavePayloadToFile(const char* fileName, const char* payload, const int payl
 
 typedef int(*CommandCallback)(void* context);
 
+// If called from the main process thread the timeoutSeconds and callback arguments are ignored
 int ExecuteCommand(void* context, const char* command, bool replaceEol, bool forJson, unsigned int maxTextResultBytes, unsigned int timeoutSeconds, char** textResult, CommandCallback callback, void* log);
 
 int RestrictFileAccessToCurrentAccountOnly(const char* fileName);

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -19,22 +19,6 @@ using ::testing::Invoke;
 
 namespace OSConfig::Platform::Tests
 {
-    static void SignalDoWork(int signal)
-    {
-        UNUSED(signal);
-    }
-
-    class CommandRunnerTests : public ::testing::Test
-    {
-    public:
-        void SetUp() override;
-    };
-
-    void CommandRunnerTests::SetUp()
-    {
-        signal(SIGUSR1, SignalDoWork);
-    }
-
     TEST_F(CommandRunnerTests, Execute)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -19,7 +19,7 @@ using ::testing::Invoke;
 
 namespace OSConfig::Platform::Tests
 {
-    TEST_F(CommandRunnerTests, Execute)
+    TEST(CommandRunnerTests, Execute)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::Execute", nullptr);
@@ -32,7 +32,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Succeeded, cmdStatus->commandState);
     }
 
-    TEST_F(CommandRunnerTests, CommandStatusUpdated)
+    TEST(CommandRunnerTests, CommandStatusUpdated)
     {
         CommandRunner cmdRunner("CommandRunnerTests::CommandStatusUpdated", nullptr);
 
@@ -59,7 +59,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ(cmdArgs2.commandId.c_str(), cmdRunner.GetCommandIdToRefresh().c_str());
     }
 
-    TEST_F(CommandRunnerTests, ExecuteCommandLimitedPayload)
+    TEST(CommandRunnerTests, ExecuteCommandLimitedPayload)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo test", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::ExecuteCommandLimitedPayload", nullptr, LIMITED_PAYLOAD_SIZE);
@@ -72,7 +72,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Succeeded, cmdStatus->commandState);
     }
 
-    TEST_F(CommandRunnerTests, CachedCommandStatus)
+    TEST(CommandRunnerTests, CachedCommandStatus)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "echo 1", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner cmdRunner("CommandRunnerTests::CachedCommandStatus", nullptr, LIMITED_PAYLOAD_SIZE);
@@ -86,7 +86,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Succeeded, status.commandState);
     }
 
-    TEST_F(CommandRunnerTests, OverwriteBufferCommandStatus)
+    TEST(CommandRunnerTests, OverwriteBufferCommandStatus)
     {
         constexpr int CommandArgumentsListSize = COMMANDSTATUS_CACHE_MAX + 1;
         std::array<CommandRunner::CommandArguments, CommandArgumentsListSize> commandArgumentList;
@@ -110,7 +110,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_NE(nullptr, cmd2);
     }
 
-    TEST_F(CommandRunnerTests, WorkerThreadExecution)
+    TEST(CommandRunnerTests, WorkerThreadExecution)
     {
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 1s && echo 1", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner::CommandArguments cmdArgs2{ "2", "sleep 1s && echo 2", CommandRunner::Action::RunCommand, 0, true };
@@ -142,7 +142,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ("2 ", cmdStatus2->textResult.c_str());
     }
 
-    TEST_F(CommandRunnerTests, CommandTimeoutSeconds)
+    TEST(CommandRunnerTests, CommandTimeoutSeconds)
     {
         // Sleep for 10s, timeout in 1s
         // Actual timeout in 5s due to COMMAND_CALLBACK_INTERVAL = 5
@@ -158,7 +158,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::TimedOut, cmdStatus->commandState);
     }
 
-    TEST_F(CommandRunnerTests, CancelRunningCommand)
+    TEST(CommandRunnerTests, CancelRunningCommand)
     {
         CommandRunner::CommandArguments cmdArgs{ "1", "sleep 10s", CommandRunner::Action::RunCommand, 15, true };
         CommandRunner cmdRunner("CommandRunnerTests::CancelRunningCommand", nullptr);
@@ -178,7 +178,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Canceled, cmdStatus->commandState);
     }
 
-    TEST_F(CommandRunnerTests, CancelQueuedCommand)
+    TEST(CommandRunnerTests, CancelQueuedCommand)
     {
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 10s", CommandRunner::Action::RunCommand, 20, true };
         CommandRunner::CommandArguments cmdArgs2{ "2", "sleep 10s", CommandRunner::Action::RunCommand, 20, true };
@@ -213,7 +213,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(CommandRunner::CommandState::Canceled, cmdStatus1->commandState);
     }
 
-    TEST_F(CommandRunnerTests, SingleLineTextResult)
+    TEST(CommandRunnerTests, SingleLineTextResult)
     {
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 1s && echo 'single\\nline'", CommandRunner::Action::RunCommand, 0, true };
         CommandRunner::CommandArguments cmdArgs2{ "2", "sleep 1s && echo 'multiple\\nlines'", CommandRunner::Action::RunCommand, 0, false };
@@ -236,7 +236,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ("multiple\nlines\n", cmdStatus2->textResult.c_str());
     }
 
-    TEST_F(CommandRunnerTests, PersistedCommandStatus)
+    TEST(CommandRunnerTests, PersistedCommandStatus)
     {
         CommandRunner cmdRunner("CommandRunnerTests::PersistedCommandStatus", nullptr);
         CommandRunner::CommandArguments cmdArgs1{ "1", "sleep 10s", CommandRunner::Action::RunCommand, 10, true };

--- a/src/modules/settings/tests/CommonUtilsUT.cpp
+++ b/src/modules/settings/tests/CommonUtilsUT.cpp
@@ -310,11 +310,9 @@ public:
 
 void* TestCancelCommand(void*)
 {
-    CallbackContext context;
-
     char* textResult = nullptr;
 
-    EXPECT_EQ(ECANCELED, ExecuteCommand((void*)(&context), "sleep 30", false, true, 0, 120, &textResult, &(CallbackContext::TestCommandCallback), nullptr));
+    EXPECT_EQ(ECANCELED, ExecuteCommand(nullptr, "sleep 20", false, true, 0, 120, &textResult, &(CallbackContext::TestCommandCallback), nullptr));
 
     if (nullptr != textResult)
     {
@@ -331,6 +329,31 @@ TEST_F(CommonUtilsTest, CancelCommand)
     ::numberOfTimes = 0;
 
     EXPECT_EQ(0, pthread_create(&tid, NULL, &TestCancelCommand, NULL));
+}
+
+void* TestCancelCommandWithContext(void*)
+{
+    CallbackContext context;
+
+    char* textResult = nullptr;
+
+    EXPECT_EQ(ECANCELED, ExecuteCommand((void*)(&context), "sleep 30", false, true, 0, 120, &textResult, &(CallbackContext::TestCommandCallback), nullptr));
+
+    if (nullptr != textResult)
+    {
+        free(textResult);
+    }
+
+    return nullptr;
+}
+
+TEST_F(CommonUtilsTest, CancelCommandWithContext)
+{
+    pthread_t tid = 0;
+
+    ::numberOfTimes = 0;
+
+    EXPECT_EQ(0, pthread_create(&tid, NULL, &TestCancelCommandWithContext, NULL));
 }
 
 TEST_F(CommonUtilsTest, ExecuteCommandWithTextResultWithAllCharacters)

--- a/src/modules/settings/tests/CommonUtilsUT.cpp
+++ b/src/modules/settings/tests/CommonUtilsUT.cpp
@@ -258,7 +258,7 @@ TEST_F(CommonUtilsTest, ExecuteCommandWithStdErrOutput)
     }
 }
 
-TEST_F(CommonUtilsTest, ExecuteCommandThatTimesOut)
+void* TestTimeoutCommand(void*)
 {
     char* textResult = nullptr;
 
@@ -268,6 +268,14 @@ TEST_F(CommonUtilsTest, ExecuteCommandThatTimesOut)
     {
         free(textResult);
     }
+
+    return nullptr;
+}
+
+TEST_F(CommonUtilsTest, ExecuteCommandThatTimesOut)
+{
+    pthread_t tid = 0;
+    EXPECT_EQ(0, pthread_create(&tid, NULL, &TestTimeoutCommand, NULL));
 }
 
 static int numberOfTimes = 0;
@@ -278,20 +286,6 @@ static int TestCommandCallback(void* context)
 
     numberOfTimes += 1;
     return (3 == numberOfTimes) ? 1 : 0;
-}
-
-TEST_F(CommonUtilsTest, CancelCommand)
-{
-    char* textResult = nullptr;
-
-    ::numberOfTimes = 0;
-
-    EXPECT_EQ(ECANCELED, ExecuteCommand(nullptr, "sleep 20", false, true, 0, 120, &textResult, TestCommandCallback, nullptr));
-
-    if (nullptr != textResult)
-    {
-        free(textResult);
-    }
 }
 
 class CallbackContext
@@ -314,7 +308,7 @@ public:
     }
 };
 
-void* TestCancelCommand(void *arg)
+void* TestCancelCommand(void*)
 {
     CallbackContext context;
 
@@ -330,13 +324,13 @@ void* TestCancelCommand(void *arg)
     return nullptr;
 }
 
-TEST_F(CommonUtilsTest, CancelCommandWithContext)
+TEST_F(CommonUtilsTest, CancelCommand)
 {
     pthread_t tid = 0;
 
     ::numberOfTimes = 0;
 
-    EXPECT_NE(0, pthread_create(&tid, NULL, &TestCancelCommand, NULL));
+    EXPECT_EQ(0, pthread_create(&tid, NULL, &TestCancelCommand, NULL));
 }
 
 TEST_F(CommonUtilsTest, ExecuteCommandWithTextResultWithAllCharacters)


### PR DESCRIPTION
Restricting system commands with timeout or cancelation executed from main process thread

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.