### PR TITLE
Readme instructions for using an HTTP proxy for OSConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ Where the prefix is either lowercase `http` or uppercase `HTTP` and the username
 
 For example: `http://username\@mail.foo:p\@ssw\@rd@www.foo.org:100` where username is `username@mail.foo`, password is `p@ssw@rd`, the proxy server is `www.foo.org` and the port is 100.
 
+The environment variable needs to be set for the root user account. For example, for a fictive proxy server, user and password, the environment variable `http_proxy` can be set for the root user with:
+
+```
+sudo -E su
+export http_proxy=http://user:password@wwww.foo.org:100//
+```
+
 ## Local Management
 
 OSConfig uses two local files as local digital twins in MIM JSON format:

--- a/README.md
+++ b/README.md
@@ -170,22 +170,22 @@ To enable local priority, edit the OSConfig general configuration file `/etc/osc
 ```
 To configure for remote priority, set "LocalPriority" to 0.
 
-## Configuring an HTTP proxy
+## HTTP proxy configuration
 
-OSConfig can read the HTTP proxy information from one of the following environment variables, when starting up attempting to read them in the following order:
+OSConfig can use the HTTP proxy information configured in one of the following environment variables, when starting up attempting to read each one in the following order and stopping at the first found to be locally present:
 
-1. http_proxy
-1. https_proxy
-1. HTTP_PROXY
-1. HTTPS_PROXY
+1. `http_proxy`
+1. `https_proxy`
+1. `HTTP_PROXY`
+1. `HTTPS_PROXY`
 
-When it finds one of these environment variables, OSConfig reads the HTTP proxy configuration from there.
+When OSConfig finds one of these environment variables, OSConfig attempts to use the HTTP proxy configuration from there.
 
 OSConfig supports the HTTP proxy configuration to be in one of the following formats:
 
-`http://server:port`
-`http://username:password@server:port`
-`http://domain\username:password@server:port`
+- `http://server:port`
+- `http://username:password@server:port`
+- `http://domain\username:password@server:port`
 
 Where the prefix is either lowercase `http` or uppercase `HTTP`, the username and password can contain `@` characters escaped as `\@`, and the the proxy server is specified either by name or address.
 

--- a/README.md
+++ b/README.md
@@ -172,14 +172,12 @@ To configure for remote priority, set "LocalPriority" to 0.
 
 ## HTTP proxy configuration
 
-OSConfig can use the HTTP proxy information configured in one of the following environment variables, when starting up attempting to read each one in the following order and stopping at the first found to be locally present:
+OSConfig attempts to use the HTTP proxy information configured in one of the following environment variables, the first such variable that is locally present:
 
 1. `http_proxy`
 1. `https_proxy`
 1. `HTTP_PROXY`
 1. `HTTPS_PROXY`
-
-When OSConfig finds one of these environment variables, OSConfig attempts to use the HTTP proxy configuration from there.
 
 OSConfig supports the HTTP proxy configuration to be in one of the following formats:
 
@@ -187,7 +185,7 @@ OSConfig supports the HTTP proxy configuration to be in one of the following for
 - `http://username:password@server:port`
 - `http://domain\username:password@server:port`
 
-Where the prefix is either lowercase `http` or uppercase `HTTP`, the username and password can contain `@` characters escaped as `\@`, and the the proxy server is specified either by name or address.
+Where the prefix is either lowercase `http` or uppercase `HTTP` and the username and password can contain `@` characters escaped as `\@`.
 
 For example: `http://username\@mail.foo:p\@ssw\@rd@www.foo.org:100` where username is `username@mail.foo`, password is `p@ssw@rd`, the proxy server is `www.foo.org` and the port is 100.
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,27 @@ To enable local priority, edit the OSConfig general configuration file `/etc/osc
 ```
 To configure for remote priority, set "LocalPriority" to 0.
 
+## Configuring an HTTP proxy
+
+OSConfig can read the HTTP proxy information from one of the following environment variables, when starting up attempting to read them in the following order:
+
+1. http_proxy
+1. https_proxy
+1. HTTP_PROXY
+1. HTTPS_PROXY
+
+When it finds one of these environment variables, OSConfig reads the HTTP proxy configuration from there.
+
+OSConfig supports the HTTP proxy configuration to be in one of the following formats:
+
+`http://server:port`
+`http://username:password@server:port`
+`http://domain\username:password@server:port`
+
+Where the prefix is either lowercase `http` or uppercase `HTTP`, the username and password can contain `@` characters escaped as `\@`, and the the proxy server is specified either by name or address.
+
+For example: `http://username\@mail.foo:p\@ssw\@rd@www.foo.org:100` where username is `username@mail.foo`, password is `p@ssw@rd`, the proxy server is `www.foo.org` and the port is 100.
+
 ## Local Management
 
 OSConfig uses two local files as local digital twins in MIM JSON format:

--- a/src/agents/pnp/PnpUtils.c
+++ b/src/agents/pnp/PnpUtils.c
@@ -129,7 +129,7 @@ static IOTHUB_CLIENT_RESULT PropertyUpdateFromIotHubCallback(const char* compone
         return result;
     }
 
-    OsConfigLogInfo(GetLog(), "PropertyUpdateFromIotHubCallback: invoking Settings for property %s, version %d", propertyName, version);
+    OsConfigLogInfo(GetLog(), "PropertyUpdateFromIotHubCallback: invoking %s for property %s, version %d", componentName, propertyName, version);
     result = UpdatePropertyFromIotHub(componentName, propertyName, propertyValue, version);
 
     return result;

--- a/src/common/commonutils/CommonUtils.c
+++ b/src/common/commonutils/CommonUtils.c
@@ -485,7 +485,7 @@ bool ParseHttpProxyData(const char* proxyData, char** proxyHostAddress, int* pro
     // "http://username:password@server:port"
     //
     // ..where the prefix must be either lowercase "http" or uppercase "HTTP"
-    // ..and username and password can contain '@' characters escaled as "\\@"
+    // ..and username and password can contain '@' characters escaped as "\\@"
     //
     // For example:
     //


### PR DESCRIPTION
Readme instructions for using an HTTP proxy for OSConfig

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.