### PR TITLE
Avoiding re-entrant twin callbacks that can crash us

### DIFF
--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -260,8 +260,6 @@ static void RefreshConnection()
             g_exitState = IotHubInitializationFailure;
             SignalInterrupt(SIGQUIT);
         }
-
-        IotHubDoWork();
     }
     else
     {
@@ -812,8 +810,6 @@ int InitializeAgent(const char* connectionString, IOTHUB_CLIENT_TRANSPORT_PROVID
         g_exitState = IotHubInitializationFailure;
         return -1;
     }
-
-    IotHubDoWork();
 
     tickcounter_get_current_ms(g_tickCounter, &g_lastTick);
 

--- a/src/agents/pnp/PnpUtils.c
+++ b/src/agents/pnp/PnpUtils.c
@@ -590,8 +590,6 @@ IOTHUB_CLIENT_RESULT ReportPropertyToIotHub(const char* componentName, const cha
                     LogErrorWithTelemetry(GetLog(), "%s.%s: IoTHubDeviceClient_LL_SendReportedState failed with %d", componentName, propertyName, result);
                 }
             }
-
-            IotHubDoWork();
         }
         else
         {
@@ -731,8 +729,6 @@ IOTHUB_CLIENT_RESULT AckPropertyUpdateToIotHub(const char* componentName, const 
         {
             LogErrorWithTelemetry(GetLog(), "%s.%s: IoTHubDeviceClient_LL_SendReportedState failed with %d", componentName, propertyName, result);
         }
-
-        IotHubDoWork();
     }
     else
     {


### PR DESCRIPTION
Avoiding re-entrant twin callbacks that can crash us

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.