### PR TITLE
Allow maps to contain null values

### DIFF
--- a/src/common/commonutils/CommonUtils.cpp
+++ b/src/common/commonutils/CommonUtils.cpp
@@ -40,7 +40,7 @@ bool IsValidClientName(const char* name)
     const std::string clientNamePrefix = OSCONFIG_NAME_PREFIX;
     const std::string modelVersionDelimiter = OSCONFIG_MODEL_VERSION_DELIMITER;
     const std::string semanticVersionDelimeter = OSCONFIG_SEMANTIC_VERSION_DELIMITER;
-        
+
     const int referenceModelVersion = OSCONFIG_REFERENCE_MODEL_VERSION;
     const int referenceReleaseDay = OSCONFIG_REFERENCE_MODEL_RELEASE_DAY;
     const int referenceReleaseMonth = OSCONFIG_REFERENCE_MODEL_RELEASE_MONTH;
@@ -114,7 +114,7 @@ bool IsValidMimObjectPayload(const char* payload, const int payloadSizeBytes, vo
     }
 
     bool isValid = true;
-    
+
     const char schemaJson[] = R"""({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "description": "MIM object JSON payload schema",
@@ -146,13 +146,13 @@ bool IsValidMimObjectPayload(const char* payload, const int payloadSizeBytes, vo
         "stringMap": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         },
         "integerMap": {
           "type": "object",
           "additionalProperties": {
-            "type": "integer"
+            "type": ["integer", "null"]
           }
         },
         "object": {
@@ -229,7 +229,7 @@ bool IsValidMimObjectPayload(const char* payload, const int payloadSizeBytes, vo
     rapidjson::SchemaDocument schema(sd);
     rapidjson::Document document;
 
-    if (document.Parse(payload, payloadSizeBytes).HasParseError()) 
+    if (document.Parse(payload, payloadSizeBytes).HasParseError())
     {
         OsConfigLogError(log, "MIM object JSON payload parser error");
         isValid = false;

--- a/src/modules/schema/mim.object.schema.json
+++ b/src/modules/schema/mim.object.schema.json
@@ -29,13 +29,13 @@
     "stringMap": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "type": ["string", "null"]
       }
     },
     "integerMap": {
       "type": "object",
       "additionalProperties": {
-        "type": "integer"
+        "type": ["integer", "null"]
       }
     },
     "object": {

--- a/src/modules/settings/tests/CommonUtilsUT.cpp
+++ b/src/modules/settings/tests/CommonUtilsUT.cpp
@@ -636,8 +636,8 @@ TEST_F(CommonUtilsTest, ValidateMimObjectPayload)
     ])""";
     const char stringArrayPayload[] = R"""(["value1", "value2"])""";
     const char integerArrayPayload[] = R"""([1, 2])""";
-    const char stringMap[] = R"""({"key1": "value1", "key2" : "value2"})""";
-    const char integerMap[] = R"""({"key1": 1, "key2" : 2})""";
+    const char stringMap[] = R"""({"key1": "value1", "key2" : "value2", "key3": null})""";
+    const char integerMap[] = R"""({"key1": 1, "key2" : 2, "key3": null})""";
 
     ASSERT_TRUE(IsValidMimObjectPayload(stringPayload, sizeof(stringPayload), nullptr));
     ASSERT_TRUE(IsValidMimObjectPayload(integerPayload, sizeof(integerPayload), nullptr));
@@ -648,7 +648,7 @@ TEST_F(CommonUtilsTest, ValidateMimObjectPayload)
     ASSERT_TRUE(IsValidMimObjectPayload(integerArrayPayload, sizeof(integerArrayPayload), nullptr));
     ASSERT_TRUE(IsValidMimObjectPayload(stringMap, sizeof(stringMap), nullptr));
     ASSERT_TRUE(IsValidMimObjectPayload(integerMap, sizeof(integerMap), nullptr));
-    
+
     // Invalid payloads
     const char invalidJson[] = R"""(invalid)""";
     const char invalidstringArrayPayload[] = R"""({"stringArray": ["value1", 1]})""";
@@ -715,7 +715,7 @@ TEST_F(CommonUtilsTest, InvalidHttpProxyData)
     int port = 0;
     char* username = nullptr;
     char* password = nullptr;
-    
+
     const char* badOptions[] = {
         "some random text",
         "http://blah",


### PR DESCRIPTION
## Description

Allow MIM object JSON payloads to contain `null` values in maps.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.