### PR TITLE
Fix map deserialization for null values in Sample module

### DIFF
--- a/src/modules/samples/cpp/src/lib/Sample.cpp
+++ b/src/modules/samples/cpp/src/lib/Sample.cpp
@@ -572,6 +572,10 @@ int Sample::DeserializeObject(rapidjson::Document& document, Object& object)
                 {
                     object.stringMapSetting[member.name.GetString()] = member.value.GetString();
                 }
+                else if (member.value.IsNull())
+                {
+                    object.stringMapSetting.erase(member.name.GetString());
+                }
                 else
                 {
                     OsConfigLogError(SampleLog::Get(), "Invalid string in JSON object string map at key %s", member.name.GetString());
@@ -601,6 +605,10 @@ int Sample::DeserializeObject(rapidjson::Document& document, Object& object)
                 if (member.value.IsInt())
                 {
                     object.integerMapSetting[member.name.GetString()] = member.value.GetInt();
+                }
+                else if (member.value.IsNull())
+                {
+                    object.integerMapSetting.erase(member.name.GetString());
                 }
                 else
                 {

--- a/src/modules/samples/cpp/tests/SampleTests.cpp
+++ b/src/modules/samples/cpp/tests/SampleTests.cpp
@@ -150,6 +150,48 @@ namespace OSConfig::Platform::Tests
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
+    TEST_F(CppSampleTests, GetSetObjectMapNullValues)
+    {
+        char jsonPayload[] = "{"
+            "\"StringSetting\":\"C++ Sample Module\","
+            "\"BooleanSetting\":true,"
+            "\"IntegerSetting\":12345,"
+            "\"IntegerEnumerationSetting\":0,"
+            "\"StringsArraySetting\":[\"C++ Sample Module 1\",\"C++ Sample Module 2\"],"
+            "\"IntegerArraySetting\":[1,2,3,4,5],"
+            "\"StringMapSetting\":{"
+                "\"Key1\":\"C++ Sample Module 1\","
+                "\"Key2\":null"
+            "},"
+            "\"IntegerMapSetting\":{"
+                "\"Key1\":1,"
+                "\"Key2\":null"
+            "}}";
+
+        char expectedPayload[] = "{"
+            "\"StringSetting\":\"C++ Sample Module\","
+            "\"BooleanSetting\":true,"
+            "\"IntegerSetting\":12345,"
+            "\"IntegerEnumerationSetting\":0,"
+            "\"StringsArraySetting\":[\"C++ Sample Module 1\",\"C++ Sample Module 2\"],"
+            "\"IntegerArraySetting\":[1,2,3,4,5],"
+            "\"StringMapSetting\":{"
+                "\"Key1\":\"C++ Sample Module 1\""
+            "},"
+            "\"IntegerMapSetting\":{"
+                "\"Key1\":1"
+            "}}";
+
+        int payloadSizeBytes = 0;
+        MMI_JSON_STRING payload = nullptr;
+
+        ASSERT_EQ(MMI_OK, session->Set(componentName, desiredObjectName, jsonPayload, strlen(jsonPayload)));
+        ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
+
+        std::string payloadString(payload, payloadSizeBytes);
+        ASSERT_STREQ(expectedPayload, payloadString.c_str());
+    }
+
     TEST_F(CppSampleTests, InvalidComponentObjectName)
     {
         std::string invalidName = "invalid";


### PR DESCRIPTION
## Description

To remove a tag or desired property, the value of the item to be removed is set to null. This is not handled by the Sample module and deserialization error is returned whenever null value is specified for `stringMapSetting` or `integerMapSetting`. This PR fixes it and when null value is provided then map element is deleted.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.