### PR TITLE
Fixed E2E tests when multiple packages exist

### DIFF
--- a/devops/pipeline/e2etest.yaml
+++ b/devops/pipeline/e2etest.yaml
@@ -162,14 +162,12 @@ stages:
           itemPattern: $(packagePattern)
 
       - script: |
-          cp `find . -name '*.deb'` $(Build.SourcesDirectory)/devops/terraform/host/osconfig.deb
+          cp `find . -name '*.deb' | head -n 1` $(Build.SourcesDirectory)/devops/terraform/host/osconfig.deb
         displayName: Stage OSConfig
-        continueOnError: true
         workingDirectory: $(Pipeline.Workspace)
 
       - task: AzureCLI@2
         displayName: Create device identity
-        continueOnError: true
         name: azcli_device_identity
         inputs:
           azureSubscription: $(SERVICE_CONNECTION)


### PR DESCRIPTION
## Description

* Multiple packages are being produced by the `Package Build` pipeline, both signed and unsigned as such, the `DownloadPipelineArtifact` stage should pick one of the packages. Added `head -n 1` to capture the first package.
* Removed `continueOnError` to have an explicit failure when packages fail to be copied or device identities fail to be created as they would fail anyways at further stages.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.