### PR TITLE
Fixing UrlEncode and UrlDecode for space character and adding support for EOL character

### DIFF
--- a/src/common/commonutils/CommonUtils.c
+++ b/src/common/commonutils/CommonUtils.c
@@ -1009,10 +1009,10 @@ char* UrlEncode(char* target)
                 encodedTarget[j] = target[i];
                 j += 1;
             }
-            else if (' ' == target[i])
+            else if ('\n' == target[i])
             {
-                encodedTarget[j] = '+';
-                j += 1;
+                memcpy(&encodedTarget[j], "%0A", sizeof("%0A"));
+                j += strlen(&encodedTarget[j]);
             }
             else
             {
@@ -1048,18 +1048,21 @@ char* UrlDecode(char* target)
                 decodedTarget[i] = target[j];
                 j += 1;
             }
-            else if ('+' == target[j])
-            {
-                decodedTarget[i] = ' ';
-                j += 1;
-            }
             else if ('%' == target[j])
             {
-                memcpy(buffer, &target[j + 1], 2);
-                buffer[2] = 0;
+                if (((j + 2) < targetLength) && ('0' == target[j + 1]) && ('A' == toupper(target[j + 2])))
+                {
+                    decodedTarget[i] = '\n';
+                }
+                else
+                {
+                    memcpy(buffer, &target[j + 1], 2);
+                    buffer[2] = 0;
+                    
+                    sscanf(buffer, "%x", &value);
+                    sprintf(&decodedTarget[i], "%c", value);
+                }
                 
-                sscanf(buffer, "%x", &value);
-                sprintf(&decodedTarget[i], "%c", value);
                 j += sizeof(buffer);
             }
         }

--- a/src/modules/settings/tests/CommonUtilsUT.cpp
+++ b/src/modules/settings/tests/CommonUtilsUT.cpp
@@ -949,25 +949,22 @@ TEST_F(CommonUtilsTest, UrlEncodeDecode)
 {
     UrlEncoding testUrls[] = {
         { "+", "%2B" },
-        { " ", "+" },
+        { " ", "%20" },
+        { "\n", "%0A" },
         { "abcABC123", "abcABC123" },
         { "~abcd~EFGH-123_456", "~abcd~EFGH-123_456" },
         { "name=value", "name%3Dvalue" },
         { "\"name\"=\"value\"", "%22name%22%3D%22value%22" },
         { "(\"name1\"=\"value1\"&\"name2\"=\"value2\")", "%28%22name1%22%3D%22value1%22%26%22name2%22%3D%22value2%22%29" },
-        { "Azure OSConfig 5;1.0.1.20220228 (\"os_name\"=\"Ubuntu\"&os_version\"=\"20.04.4\"&\"cpu_architecture\"=\"x86_64\"&"
-        "\"kernel_name\"=\"Linux\"&\"kernel_release\"=\"5.13.0-30-generic\"&\"kernel_version\"=\"#33~20.04.1-Ubuntu SMP Mon Feb 7 14:25:10 UTC 2022\"&"
-        "\"product_vendor\"=\"Acme Inc.\"&\"product_name\"=\"FooProduct 123)",
-        "Azure+OSConfig+5%3B1.0.1.20220228+%28%22os_name%22%3D%22Ubuntu%22%26os_version%22%3D%2220.04.4%22%26%22cpu_architecture%22%3D%22x"
-        "86_64%22%26%22kernel_name%22%3D%22Linux%22%26%22kernel_release%22%3D%225.13.0-30-generic%22%26%22kernel_version%22%3D%22%2333~20.04.1"
-        "-Ubuntu+SMP+Mon+Feb+7+14%3A25%3A10+UTC+2022%22%26%22product_vendor%22%3D%22Acme+Inc.%22%26%22product_name%22%3D%22FooProduct+123%29" },
-        {"Azure OSConfig 5;1.0.1.20220301 (\"os_name\"=\"Ubuntu\"&os_version\"=\"20.04.3\"&\"cpu_architecture\"=\"x86_64\"&\"kernel_name\"=\"Linux\"&"
-        "\"kernel_release\"=\"5.13.0-30-generic\"&\"kernel_version\"=\"#33~20.04.1-Ubuntu SMP Mon Feb 7 14:25:10 UTC 2022\"&\"product_vendor\"=\"ACME\"&\"product_name\"=\"10ABC789\")",
-        "Azure+OSConfig+5%3B1.0.1.20220301+%28%22os_name%22%3D%22Ubuntu%22%26os_version%22%3D%2220.04.3%22%26%22cpu_architecture%22%3D%22x86_64%2"
-        "2%26%22kernel_name%22%3D%22Linux%22%26%22kernel_release%22%3D%225.13.0-30-generic%22%26%22kernel_version%22%3D%22%2333~20.04.1-Ubuntu+SMP+"
-        "Mon+Feb+7+14%3A25%3A10+UTC+2022%22%26%22product_vendor%22%3D%22ACME%22%26%22product_name%22%3D%2210ABC789%22%29" },
-        { "`-=~!@#$%^&*()_+,./<>?'[]\{}| qwertyuiopasdfghjklzxcvbnm 1234567890 QWERTYUIOPASDFGHJKLZXCVBNM\n",
-        "%60-%3D~%21%40%23%24%25%5E%26%2A%28%29_%2B%2C.%2F%3C%3E%3F%27%5B%5D%5C%7B%7D%7C%20qwertyuiopasdfghjklzxcvbnm%201234567890%20QWERTYUIOPASDFGHJKLZXCVBNM%5Cn" }
+        { "Azure OSConfig 5;1.0.1.20220308 (\"os_name\"=\"Ubuntu\"&os_version\"=\"20.04.4\"&\"cpu_architecture\"=\"x86_64\"&"
+        "\"kernel_name\"=\"Linux\"&\"kernel_release\"=\"5.13.0-30-generic\"&\"kernel_version\"=\"#33~20.04.1-Ubuntu SMP Mon "
+        "Feb 7 14:25:10 UTC 2022\"&\"product_vendor\"=\"Acme Inc.\"&\"product_name\"=\"Foo 123\")", 
+        "Azure%20OSConfig%205%3B1.0.1.20220308%20%28%22os_name%22%3D%22Ubuntu%22%26os_version%22%3D%2220.04.4%22%26%22cpu_"
+        "architecture%22%3D%22x86_64%22%26%22kernel_name%22%3D%22Linux%22%26%22kernel_release%22%3D%225.13.0-30-generic%22%26"
+        "%22kernel_version%22%3D%22%2333~20.04.1-Ubuntu%20SMP%20Mon%20Feb%207%2014%3A25%3A10%20UTC%202022%22%26%22"
+        "product_vendor%22%3D%22Acme%20Inc.%22%26%22product_name%22%3D%22Foo%20123%22%29" },
+        { "`-=~!@#$%^&*()_+,./<>?'[]{}| qwertyuiopasdfghjklzxcvbnm 1234567890 QWERTYUIOPASDFGHJKLZXCVBNM\n",
+        "%60-%3D~%21%40%23%24%25%5E%26%2A%28%29_%2B%2C.%2F%3C%3E%3F%27%5B%5D%7B%7D%7C%20qwertyuiopasdfghjklzxcvbnm%201234567890%20QWERTYUIOPASDFGHJKLZXCVBNM%0A" }
     };
 
     int testUrlsSize = ARRAY_SIZE(testUrls);

--- a/src/modules/settings/tests/CommonUtilsUT.cpp
+++ b/src/modules/settings/tests/CommonUtilsUT.cpp
@@ -947,7 +947,7 @@ struct UrlEncoding
 
 TEST_F(CommonUtilsTest, UrlEncodeDecode)
 {
-    UrlEncoding validUrls[] = {
+    UrlEncoding testUrls[] = {
         { "+", "%2B" },
         { " ", "+" },
         { "abcABC123", "abcABC123" },
@@ -965,21 +965,23 @@ TEST_F(CommonUtilsTest, UrlEncodeDecode)
         "\"kernel_release\"=\"5.13.0-30-generic\"&\"kernel_version\"=\"#33~20.04.1-Ubuntu SMP Mon Feb 7 14:25:10 UTC 2022\"&\"product_vendor\"=\"ACME\"&\"product_name\"=\"10ABC789\")",
         "Azure+OSConfig+5%3B1.0.1.20220301+%28%22os_name%22%3D%22Ubuntu%22%26os_version%22%3D%2220.04.3%22%26%22cpu_architecture%22%3D%22x86_64%2"
         "2%26%22kernel_name%22%3D%22Linux%22%26%22kernel_release%22%3D%225.13.0-30-generic%22%26%22kernel_version%22%3D%22%2333~20.04.1-Ubuntu+SMP+"
-        "Mon+Feb+7+14%3A25%3A10+UTC+2022%22%26%22product_vendor%22%3D%22ACME%22%26%22product_name%22%3D%2210ABC789%22%29"}
+        "Mon+Feb+7+14%3A25%3A10+UTC+2022%22%26%22product_vendor%22%3D%22ACME%22%26%22product_name%22%3D%2210ABC789%22%29" },
+        { "`-=~!@#$%^&*()_+,./<>?'[]\{}| qwertyuiopasdfghjklzxcvbnm 1234567890 QWERTYUIOPASDFGHJKLZXCVBNM\n",
+        "%60-%3D~%21%40%23%24%25%5E%26%2A%28%29_%2B%2C.%2F%3C%3E%3F%27%5B%5D%5C%7B%7D%7C%20qwertyuiopasdfghjklzxcvbnm%201234567890%20QWERTYUIOPASDFGHJKLZXCVBNM%5Cn" }
     };
 
-    int validUrlsSize = ARRAY_SIZE(validUrls);
+    int testUrlsSize = ARRAY_SIZE(testUrls);
 
     char* url = nullptr;
 
-    for (int i = 0; i < validUrlsSize; i++)
+    for (int i = 0; i < testUrlsSize; i++)
     {
-        EXPECT_NE(nullptr, url = UrlEncode((char*)validUrls[i].decoded));
-        EXPECT_STREQ(url, validUrls[i].encoded);
+        EXPECT_NE(nullptr, url = UrlEncode((char*)testUrls[i].decoded));
+        EXPECT_STREQ(url, testUrls[i].encoded);
         FREE_MEMORY(url);
 
-        EXPECT_NE(nullptr, url = UrlDecode((char*)validUrls[i].encoded));
-        EXPECT_STREQ(url, validUrls[i].decoded);
+        EXPECT_NE(nullptr, url = UrlDecode((char*)testUrls[i].encoded));
+        EXPECT_STREQ(url, testUrls[i].decoded);
         FREE_MEMORY(url);
     }
 


### PR DESCRIPTION
The way we were encoding the space character was correct but not understood by all decoders. This fixes that and also adds support for encoding the EOL character.

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.