### PR TITLE
Add factory for managing client sessions

### DIFF
--- a/src/modules/commandrunner/src/lib/CommandRunner.h
+++ b/src/modules/commandrunner/src/lib/CommandRunner.h
@@ -26,15 +26,49 @@ public:
     static const std::string PERSISTED_COMMANDSTATUS_FILE;
 
     CommandRunner(std::string name, unsigned int maxSizeInBytes = 0, bool usePersistedCache = true);
-    virtual ~CommandRunner();
+    ~CommandRunner();
 
     static int GetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloadSizeBytes);
     int Set(const char* componentName, const char* objectName, const MMI_JSON_STRING payload, const int payloadSizeBytes);
     int Get(const char* componentName, const char* objectName, MMI_JSON_STRING* payload, int* payloadSizeBytes);
-    unsigned int GetMaxPayloadSizeBytes();
 
-    // Helper function to wait for the worker thread during unit tests
+    const std::string& GetClientName() const;
+    unsigned int GetMaxPayloadSizeBytes() const;
+
+    // Helper method to wait for the worker thread during unit tests
     void WaitForCommands();
+
+    class Factory
+    {
+    public:
+        static std::shared_ptr<CommandRunner> Create(std::string clientName, int maxPayloadSizeBytes = 0);
+        static void Destroy(CommandRunner* commandRunner);
+        static void Clear();
+
+    private:
+        class Session
+        {
+        public:
+            Session(std::string clientName, int maxPayloadSizeBytes);
+            ~Session();
+
+            std::shared_ptr<CommandRunner> Get();
+            int Release();
+
+        private:
+            std::mutex m_mutex;
+            int m_clients;
+            std::shared_ptr<CommandRunner> m_instance;
+        };
+
+        static std::map<std::string, std::shared_ptr<Session>> m_sessions;
+        static std::mutex m_mutex;
+
+        Factory() = delete;
+        ~Factory() = delete;
+    };
+
+    friend class Factory;
 
 private:
     template<class T>

--- a/src/modules/commandrunner/src/so/CommandRunnerModule.cpp
+++ b/src/modules/commandrunner/src/so/CommandRunnerModule.cpp
@@ -20,6 +20,7 @@ void __attribute__((constructor)) InitModule()
 void __attribute__((destructor)) DestroyModule()
 {
     OsConfigLogInfo(CommandRunnerLog::Get(), "CommandRunner module unloaded");
+    CommandRunner::Factory::Clear();
     CommandRunnerLog::CloseLog();
 }
 
@@ -83,10 +84,10 @@ MMI_HANDLE MmiOpen(
 
     if (nullptr != clientName)
     {
-        CommandRunner* session = new (std::nothrow) CommandRunner(clientName, maxPayloadSizeBytes);
-        if (nullptr != session)
+        std::shared_ptr<CommandRunner> commandRunner = CommandRunner::Factory::Create(clientName);
+        if (nullptr != commandRunner)
         {
-            handle = reinterpret_cast<MMI_HANDLE>(session);
+            handle = reinterpret_cast<MMI_HANDLE>(commandRunner.get());
         }
         else
         {
@@ -104,10 +105,10 @@ MMI_HANDLE MmiOpen(
 
 void MmiClose(MMI_HANDLE clientSession)
 {
-    CommandRunner* session = reinterpret_cast<CommandRunner*>(clientSession);
-    if (nullptr != session)
+    CommandRunner* commandRunner = reinterpret_cast<CommandRunner*>(clientSession);
+    if (nullptr != commandRunner)
     {
-        delete session;
+        CommandRunner::Factory::Destroy(commandRunner);
     }
 }
 

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -320,4 +320,48 @@ namespace Tests
         EXPECT_EQ(MMI_OK, m_commandRunner->Get(m_component, m_reportedObject, &reportedPayload, &payloadSizeBytes));
         EXPECT_TRUE(IsJsonEq(Command::Status::Serialize(status), std::string(reportedPayload, payloadSizeBytes)));
     }
+
+    TEST(CommandRunnerFactory, CreateClients)
+    {
+        std::string clientName1 = "client1";
+        std::string clientName2 = "client2";
+
+        // Create two sessions for 'client1', each resulting command runner should point to a common instance
+        auto commandRunner1 = CommandRunner::Factory::Create(clientName1);
+        auto commandRunner2 = CommandRunner::Factory::Create(clientName1);
+        EXPECT_NE(nullptr, commandRunner1);
+        EXPECT_NE(nullptr, commandRunner2);
+        EXPECT_EQ(commandRunner1, commandRunner2);
+        EXPECT_STREQ(clientName1.c_str(), commandRunner1->GetClientName().c_str());
+        EXPECT_STREQ(clientName1.c_str(), commandRunner2->GetClientName().c_str());
+
+        // Create a session for 'client2', this command runner should be different from the one for 'client1'
+        auto commandRunner3 = CommandRunner::Factory::Create(clientName2);
+        EXPECT_NE(nullptr, commandRunner3);
+        EXPECT_NE(commandRunner1, commandRunner3);
+        EXPECT_NE(commandRunner2, commandRunner3);
+        EXPECT_STREQ(clientName2.c_str(), commandRunner3->GetClientName().c_str());
+
+        // Destroy a session for 'client1'
+        CommandRunner::Factory::Destroy(commandRunner2.get());
+
+        // Create another session for 'client1'
+        auto commandRunner4 = CommandRunner::Factory::Create(clientName1);
+        EXPECT_NE(nullptr, commandRunner4);
+        EXPECT_EQ(commandRunner1, commandRunner4);
+        EXPECT_STREQ(clientName1.c_str(), commandRunner4->GetClientName().c_str());
+
+        // Destroy all the open sessions
+        CommandRunner::Factory::Destroy(commandRunner1.get());
+        CommandRunner::Factory::Destroy(commandRunner3.get());
+        CommandRunner::Factory::Destroy(commandRunner4.get());
+
+        // Create a session for 'client1' again, this time it should be a new instance
+        auto commandRunner5 = CommandRunner::Factory::Create(clientName1);
+        EXPECT_NE(nullptr, commandRunner5);
+        EXPECT_NE(commandRunner1, commandRunner5);
+        EXPECT_STREQ(clientName1.c_str(), commandRunner5->GetClientName().c_str());
+
+        CommandRunner::Factory::Destroy(commandRunner5.get());
+    }
 } // namespace Tests


### PR DESCRIPTION
## Description

Add `CommandRunner::Factory` for managing client sessions. Sessions created for the same created for the same client name now point to the same `CommandRunner` instance. When all client sessions have been closed, the `CommandRunner` instance is shutdown and destroyed. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.