### PR TITLE
Fix SerializeJsonObject() for unlimited max payload size

### DIFF
--- a/src/modules/ztsi/src/lib/Ztsi.cpp
+++ b/src/modules/ztsi/src/lib/Ztsi.cpp
@@ -41,7 +41,7 @@ int SerializeJsonObject(MMI_JSON_STRING* payload, int* payloadSizeBytes, unsigne
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
     document.Accept(writer);
 
-    if (buffer.GetSize() > maxPayloadSizeBytes)
+    if ((maxPayloadSizeBytes > 0) && (buffer.GetSize() > maxPayloadSizeBytes))
     {
         OsConfigLogError(ZtsiLog::Get(), "Failed to serialize JSON object to buffer");
         status = E2BIG;


### PR DESCRIPTION
## Description

Fix `SerializeJsonObject()` to treat `maxPayloadSizeBytes == 0` as *unlimited* payload size.

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `main` branch prior to this PR submission.
- [ ] I submitted this PR against the `main` branch.