### PR TITLE
Fix settings module usage of MMI_HANDLE

### DIFF
--- a/src/modules/settings/src/lib/Settings.cpp
+++ b/src/modules/settings/src/lib/Settings.cpp
@@ -31,6 +31,11 @@ Settings::Settings(unsigned int maxSizeInBytes)
     maxPayloadSizeInBytes = maxSizeInBytes;
 }
 
+unsigned int Settings::GetMaxPayloadSizeBytes() const
+{
+    return maxPayloadSizeInBytes;
+}
+
 int Settings::SetDeviceHealthTelemetryConfiguration(std::string payload, const char* fileName, bool &configurationChanged)
 {
     char* valueToWrite = NULL;

--- a/src/modules/settings/src/lib/Settings.h
+++ b/src/modules/settings/src/lib/Settings.h
@@ -4,13 +4,17 @@
 #include <string>
 #include <Logging.h>
 
-const std::string SETTINGS = "Settings";
-const std::string DEVICEHEALTHTELEMETRY = "DeviceHealthTelemetryConfiguration";
-const std::string DELIVERYOPTIMIZATION = "DeliveryOptimizationPolicies";
-const std::string PERCENTAGEDOWNLOADTHROTTLE = "PercentageDownloadThrottle";
-const std::string CACHEHOSTSOURCE = "CacheHostSource";
-const std::string CACHEHOST = "CacheHost";
-const std::string CACHEHOSTFALLBACK = "CacheHostFallback";
+const std::string g_componentName = "Settings";
+const std::string g_deviceHealthTelemetry = "DeviceHealthTelemetryConfiguration";
+const std::string g_deliveryOptimization = "DeliveryOptimizationPolicies";
+
+const std::string g_percentageDownloadThrottle = "PercentageDownloadThrottle";
+const std::string g_cacheHostSource = "CacheHostSource";
+const std::string g_cacheHost = "CacheHost";
+const std::string g_cacheHostFallback = "CacheHostFallback";
+
+static const char g_healthTelemetryConfigFile[] = "/etc/azure-device-health-services/config.toml";
+static const char g_doConfigFile[] = "/etc/deliveryoptimization-agent/admin-config.json";
 
 #define SETTINGS_LOGFILE "/var/log/osconfig_settings.log"
 #define SETTINGS_ROLLEDLOGFILE "/var/log/osconfig_settings.bak"
@@ -50,7 +54,9 @@ class Settings
         Settings(unsigned int maxSizeInBytes = 0);
         virtual ~Settings() = default;
         int SetDeviceHealthTelemetryConfiguration(std::string payload, const char* fileName, bool &configurationChanged);
-        int SetDeliveryOptimizationPolicies(Settings::DeliveryOptimization deliveryoptimization, const char* fileName, bool &configurationChanged);
+        int SetDeliveryOptimizationPolicies(Settings::DeliveryOptimization deliveryoptimization, const char* fileName, bool& configurationChanged);
+
+        unsigned int GetMaxPayloadSizeBytes() const;
 
     private:
         unsigned int maxPayloadSizeInBytes;

--- a/src/modules/settings/tests/SettingsTests.cpp
+++ b/src/modules/settings/tests/SettingsTests.cpp
@@ -121,21 +121,21 @@ TEST(SettingsTests, MmiSet)
     MMI_HANDLE handle = MmiOpen(clientName, maxPayloadSizeBytes);
     EXPECT_NE(handle, nullptr);
 
-    int status = MmiSet(nullptr, SETTINGS.c_str(), DEVICEHEALTHTELEMETRY.c_str(), payload, payloadSizeBytes);
+    int status = MmiSet(nullptr, g_componentName.c_str(), g_deviceHealthTelemetry.c_str(), payload, payloadSizeBytes);
     EXPECT_EQ(status, EINVAL);
 
     const char* componentNameUnknown = "ComponentNameUnknown";
-    status = MmiSet(handle, componentNameUnknown, DEVICEHEALTHTELEMETRY.c_str(), payload, payloadSizeBytes);
+    status = MmiSet(handle, componentNameUnknown, g_deviceHealthTelemetry.c_str(), payload, payloadSizeBytes);
     EXPECT_EQ(status, EINVAL);
 
     const char* objectNameUnknown = "ObjectNameUnknown";
-    status = MmiSet(handle, SETTINGS.c_str(), objectNameUnknown, payload, payloadSizeBytes);
+    status = MmiSet(handle, g_componentName.c_str(), objectNameUnknown, payload, payloadSizeBytes);
     EXPECT_EQ(status, EINVAL);
 
-    status = MmiSet(handle, SETTINGS.c_str(), DEVICEHEALTHTELEMETRY.c_str(), nullptr, payloadSizeBytes);
+    status = MmiSet(handle, g_componentName.c_str(), g_deviceHealthTelemetry.c_str(), nullptr, payloadSizeBytes);
     EXPECT_EQ(status, EINVAL);
 
-    status = MmiSet(handle, SETTINGS.c_str(), DEVICEHEALTHTELEMETRY.c_str(), payload, payloadSizeBytesExceedsMax);
+    status = MmiSet(handle, g_componentName.c_str(), g_deviceHealthTelemetry.c_str(), payload, payloadSizeBytesExceedsMax);
     EXPECT_EQ(status, E2BIG);
 
     MmiClose(handle);


### PR DESCRIPTION
## Description

Fixes settings module `.so` to allocate/delete `MMI_HANDLE` on every `MmiOpen/Close()`. Removed globals and use `clientSession` that is passed to `MmiSet()`

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.