### PR TITLE
Fix CommandRunner to handle duplicate commands and commands with a duplicate id

### DIFF
--- a/src/modules/commandrunner/src/lib/Command.cpp
+++ b/src/modules/commandrunner/src/lib/Command.cpp
@@ -97,7 +97,6 @@ int Command::Cancel()
     }
     else
     {
-        OsConfigLogError(CommandRunnerLog::Get(), "Command is already in a canceled state: %s", m_status.m_id.c_str());
         status = ECANCELED;
     }
 

--- a/src/modules/commandrunner/src/lib/Command.cpp
+++ b/src/modules/commandrunner/src/lib/Command.cpp
@@ -44,7 +44,7 @@ Command::~Command()
 {
     if (FileExists(m_tmpFile.c_str()) && (0 != remove(m_tmpFile.c_str())))
     {
-        OsConfigLogError(CommandRunnerLog::Get(), "Failed to remove tmp file '%s'", m_tmpFile.c_str());
+        OsConfigLogError(CommandRunnerLog::Get(), "Failed to remove tmp file: %s", m_tmpFile.c_str());
     }
 }
 
@@ -88,16 +88,16 @@ int Command::Execute(unsigned int maxPayloadSizeBytes)
 int Command::Cancel()
 {
     int status = 0;
-    Status currentStatus = GetStatus();
+    std::lock_guard<std::mutex> lock(m_statusMutex);
 
-    if ((Command::State::Canceled != currentStatus.m_state) && !FileExists(m_tmpFile.c_str()))
+    if ((Command::State::Canceled != m_status.m_state) && !FileExists(m_tmpFile.c_str()))
     {
         std::ofstream output(m_tmpFile);
         output.close();
     }
     else
     {
-        OsConfigLogError(CommandRunnerLog::Get(), "Command '%s' is already canceled", currentStatus.m_id.c_str());
+        OsConfigLogError(CommandRunnerLog::Get(), "Command is already in a canceled state: %s", m_status.m_id.c_str());
         status = ECANCELED;
     }
 

--- a/src/modules/commandrunner/src/lib/Command.cpp
+++ b/src/modules/commandrunner/src/lib/Command.cpp
@@ -200,6 +200,11 @@ int ShutdownCommand::Execute(unsigned int maxPayloadSizeBytes)
     return exitCode;
 }
 
+bool Command::operator==(const Command& other) const
+{
+    return (m_status.m_id == other.m_status.m_id) && (m_arguments == other.m_arguments) && (m_timeout == other.m_timeout) && (m_replaceEol == other.m_replaceEol);
+}
+
 Command::Arguments::Arguments(std::string id, std::string command, Command::Action action, unsigned int timeout, bool singleLineTextResult) :
     m_id(id),
     m_arguments(command),

--- a/src/modules/commandrunner/src/lib/Command.cpp
+++ b/src/modules/commandrunner/src/lib/Command.cpp
@@ -44,7 +44,7 @@ Command::~Command()
 {
     if (FileExists(m_tmpFile.c_str()) && (0 != remove(m_tmpFile.c_str())))
     {
-        OsConfigLogError(CommandRunnerLog::Get(), "Failed to remove tmp file: %s", m_tmpFile.c_str());
+        OsConfigLogError(CommandRunnerLog::Get(), "Failed to remove file: %s", m_tmpFile.c_str());
     }
 }
 
@@ -199,9 +199,9 @@ int ShutdownCommand::Execute(unsigned int maxPayloadSizeBytes)
     return exitCode;
 }
 
-bool Command::operator==(const Command& other) const
+bool Command::operator ==(const Command& other) const
 {
-    return (m_status.m_id == other.m_status.m_id) && (m_arguments == other.m_arguments) && (m_timeout == other.m_timeout) && (m_replaceEol == other.m_replaceEol);
+    return ((m_status.m_id == other.m_status.m_id) && (m_arguments == other.m_arguments) && (m_timeout == other.m_timeout) && (m_replaceEol == other.m_replaceEol));
 }
 
 Command::Arguments::Arguments(std::string id, std::string command, Command::Action action, unsigned int timeout, bool singleLineTextResult) :

--- a/src/modules/commandrunner/src/lib/Command.h
+++ b/src/modules/commandrunner/src/lib/Command.h
@@ -122,7 +122,7 @@ public:
     void SetStatus(int exitCode, std::string textResult = "");
     void SetStatus(int exitCode, std::string textResult, State state);
 
-    bool operator==(const Command& other) const;
+    bool operator ==(const Command& other) const;
 
 protected:
     Status m_status;

--- a/src/modules/commandrunner/src/lib/Command.h
+++ b/src/modules/commandrunner/src/lib/Command.h
@@ -109,7 +109,6 @@ public:
     const bool m_replaceEol;
 
     Command(std::string id, std::string command, unsigned int timeout, bool replaceEol);
-    Command(Status status);
     ~Command();
 
     virtual int Execute(unsigned int maxPayloadSizeBytes);
@@ -122,6 +121,8 @@ public:
     Status GetStatus();
     void SetStatus(int exitCode, std::string textResult = "");
     void SetStatus(int exitCode, std::string textResult, State state);
+
+    bool operator==(const Command& other) const;
 
 protected:
     Status m_status;

--- a/src/modules/commandrunner/src/lib/CommandRunner.h
+++ b/src/modules/commandrunner/src/lib/CommandRunner.h
@@ -98,7 +98,9 @@ private:
     const std::string m_clientName;
     const unsigned int m_maxPayloadSizeBytes;
     const bool m_usePersistedCache;
+
     std::string m_commandIdLoadedFromDisk;
+    size_t m_lastPayloadHash;
 
     std::thread m_workerThread;
     SafeQueue<std::weak_ptr<Command>> m_commandQueue;

--- a/src/modules/commandrunner/src/lib/CommandRunner.h
+++ b/src/modules/commandrunner/src/lib/CommandRunner.h
@@ -98,6 +98,7 @@ private:
     const std::string m_clientName;
     const unsigned int m_maxPayloadSizeBytes;
     const bool m_usePersistedCache;
+    std::string m_commandIdLoadedFromDisk;
 
     std::thread m_workerThread;
     SafeQueue<std::weak_ptr<Command>> m_commandQueue;
@@ -118,7 +119,8 @@ private:
     void CancelAll();
     int Refresh(const std::string id);
 
-    bool CommandExists(const std::string& id);
+    bool CommandExists(std::shared_ptr<Command> command);
+    bool CommandIdExists(const std::string& id);
     int ScheduleCommand(std::shared_ptr<Command> command);
     int CacheCommand(std::shared_ptr<Command> command);
 

--- a/src/modules/commandrunner/tests/CommandRunnerTests.cpp
+++ b/src/modules/commandrunner/tests/CommandRunnerTests.cpp
@@ -321,6 +321,25 @@ namespace Tests
         EXPECT_TRUE(IsJsonEq(Command::Status::Serialize(status), std::string(reportedPayload, payloadSizeBytes)));
     }
 
+    TEST_F(CommandRunnerTests, RepeatCommand)
+    {
+        std::string id = Id();
+        Command::Arguments arguments(id, "echo 'hello world'", Command::Action::RunCommand, 0, false);
+        Command::Status status(id, 0, "hello world\n", Command::State::Succeeded);
+
+        std::string desiredPayload = Command::Arguments::Serialize(arguments);
+
+        MMI_JSON_STRING reportedPayload = nullptr;
+        int payloadSizeBytes = 0;
+
+        EXPECT_EQ(MMI_OK, m_commandRunner->Set(m_component, m_desiredObject, (MMI_JSON_STRING)(desiredPayload.c_str()), desiredPayload.size()));
+        m_commandRunner->WaitForCommands();
+        EXPECT_EQ(MMI_OK, m_commandRunner->Set(m_component, m_desiredObject, (MMI_JSON_STRING)(desiredPayload.c_str()), desiredPayload.size()));
+
+        EXPECT_EQ(MMI_OK, m_commandRunner->Get(m_component, m_reportedObject, &reportedPayload, &payloadSizeBytes));
+        EXPECT_TRUE(IsJsonEq(Command::Status::Serialize(status), std::string(reportedPayload, payloadSizeBytes)));
+    }
+
     TEST(CommandRunnerFactory, CreateClients)
     {
         std::string clientName1 = "client1";

--- a/src/modules/commandrunner/tests/CommandTests.cpp
+++ b/src/modules/commandrunner/tests/CommandTests.cpp
@@ -80,6 +80,20 @@ namespace Tests
         EXPECT_EQ(Command::State::Succeeded, m_command->GetStatus().m_state);
     }
 
+    TEST_F(CommandTests, Equality)
+    {
+        std::shared_ptr<Command> command1 = std::make_shared<Command>(m_id, "echo 'test'", 0, false);
+        std::shared_ptr<Command> command2 = std::make_shared<Command>(m_id, "echo 'test'", 0, false);
+        std::shared_ptr<Command> command3 = std::make_shared<Command>(m_id, "echo 'test2'", 0, false);
+        std::shared_ptr<Command> command4 = std::make_shared<Command>(m_id, "echo 'test'", 1, false);
+        std::shared_ptr<Command> command5 = std::make_shared<Command>(m_id, "echo 'test'", 0, true);
+
+        EXPECT_TRUE(*command1 == *command2);
+        EXPECT_FALSE(*command1 == *command3);
+        EXPECT_FALSE(*command1 == *command4);
+        EXPECT_FALSE(*command1 == *command5);
+    }
+
     TEST(CommandArgumentsTests, Deserialize)
     {
         const std::string json = R"""({


### PR DESCRIPTION
## Description

- Duplicate commands (same `CommandArguments` payload from `MmiSet()`): return `MMI_OK` and only log info if full logging is enabled
- Commands with a duplicate `CommandId` (different payload, same ID): return `EINVAL` and log error message

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.