### PR TITLE
Fix max payload size for MpiSetDesired sessions

### DIFF
--- a/src/platform/modulesmanager/src/ModulesManager.cpp
+++ b/src/platform/modulesmanager/src/ModulesManager.cpp
@@ -159,7 +159,7 @@ int MpiSetDesired(
 
     if (nullptr != clientName)
     {
-        if ((nullptr != (session = new (std::nothrow) MpiSession(modulesManager, clientName, payloadSizeBytes))) && (0 == session->Open()))
+        if ((nullptr != (session = new (std::nothrow) MpiSession(modulesManager, clientName))) && (0 == session->Open()))
         {
             if (MPI_OK != (status = session->SetDesired(payload, payloadSizeBytes)))
             {


### PR DESCRIPTION
## Description

Fix `maxPayloadSizeBytes` that is passed to `MpiSession`'s on `MpiSetDesired()`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.