### PR TITLE
Allow null for objects

### DIFF
--- a/src/modules/schema/mim.object.schema.json
+++ b/src/modules/schema/mim.object.schema.json
@@ -65,6 +65,9 @@
           },
           {
             "$ref": "#/definitions/integerMap"
+          },
+          {
+            "type": "null"
           }
         ]
       }


### PR DESCRIPTION
## Description

The customer noticed that setting objects to null is not passing the JSON validation imposed by mim.object.schema.json.

Here's an example json payload (Desired Properties) that doesn't pass the validation:
`{"Packages":["mariadb-client","cowsay-"], "Sources": null }`

which results in this validation output:
`jsonschema --instance wrong.json mim.object.schema.json
{'Packages': ['mariadb-client', 'cowsay-'], 'Sources': None}: {'Packages': ['mariadb-client', 'cowsay-'], 'Sources': None} is not valid under any of the given schemas`

This PR adds `null` as valid object value. We leave it at your discretion to create a new branch to make more changes if required.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [] ~~I added unit-tests to validate my changes.~~ **All unit tests are passing: NO** This test fails: `TEST_F(CommonUtilsTest, OsProperties) `because `/sys/devices/virtual/dmi/id/` doesn't exist on our RPI4 running Ubuntu 20.04. This is not related to the schema change proposed by this PR.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.