### PR TITLE
Consolidating CMake and C/C++ Standard for all of OSConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ For more information on OSConfig see [OSConfig North Star Architecture](docs/arc
 
 For our code of conduct and contributing instructions see [CONTRIBUTING](CONTRIBUTING.md). For our approach to security see [SECURITY](SECURITY.md).
 
+### C Standard
+
+OSConfig's C/C++ code is C11 compliant. C17 and C18 are not currently supported.
+
 ## Getting started
 
 ### Prerequisites
@@ -46,7 +50,6 @@ Build with the following commands issued from under the build subfolder:
 cmake ../src -DCMAKE_BUILD_TYPE=Release|Debug -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DBUILD_TESTS=ON|OFF
 cmake --build . --config Release|Debug  --target install
 ```
-
 The following OSConfig files are binplaced at build time:
 
 Source | Destination | Descriptiopn

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For our code of conduct and contributing instructions see [CONTRIBUTING](CONTRIB
 
 ### C Standard
 
-OSConfig's C/C++ code is C11 compliant. C17 and C18 are not currently supported.
+OSConfig's C/C++ code currently targets compliance with C11.
 
 ## Getting started
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+project(osconfig)
+
 set (CMAKE_C_STANDARD 11)
 set (CMAKE_CXX_STANDARD 11)
 
 cmake_minimum_required(VERSION 3.2)
-
-project(osconfig)
 
 set(MAJOR_VERSION "1" CACHE STRING "Major version")
 set(MINOR_VERSION "0" CACHE STRING "Minor version")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+set (CMAKE_C_STANDARD 11)
+set (CMAKE_CXX_STANDARD 11)
+
 cmake_minimum_required(VERSION 3.2)
 
 project(osconfig)

--- a/src/agents/pnp/CMakeLists.txt
+++ b/src/agents/pnp/CMakeLists.txt
@@ -5,10 +5,7 @@
 # TraceLogging requires C11.
 # To use TraceLogging this component compiles as C11.
 # Without TraceLogging this component can be compiled as C99.
-set (CMAKE_C_STANDARD 11)
-set (CMAKE_CXX_STANDARD 11)
 
-cmake_minimum_required(VERSION 3.2)
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4.7)

--- a/src/agents/pnp/CMakeLists.txt
+++ b/src/agents/pnp/CMakeLists.txt
@@ -3,8 +3,8 @@
 
 # The Azure IoT C SDK requires C99.
 # TraceLogging requires C11.
-# To use TraceLogging this project compiles as C11.
-# Without TraceLogging this project can be compiled as C99.
+# To use TraceLogging this component compiles as C11.
+# Without TraceLogging this component can be compiled as C99.
 set (CMAKE_C_STANDARD 11)
 set (CMAKE_CXX_STANDARD 11)
 

--- a/src/agents/pnp/cmake/FindIotHubClient.cmake
+++ b/src/agents/pnp/cmake/FindIotHubClient.cmake
@@ -4,8 +4,6 @@
 # Find cmake module for the iothub_client library and headers
 # Exports IotHubClient::iothub_client target
 
-cmake_minimum_required(VERSION 3.2)
-
 include (FindPackageHandleStandardArgs)
 
 find_path(

--- a/src/agents/pnp/cmake/FindParson.cmake
+++ b/src/agents/pnp/cmake/FindParson.cmake
@@ -4,8 +4,6 @@
 # Find cmake module for the parson library and header.
 # Exports Parson::parson target
 
-cmake_minimum_required(VERSION 3.2)
-
 include(FindPackageHandleStandardArgs)
 
 find_path(

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
 if (BUILD_TESTS)
     add_compile_options(-D TEST_CODE)
     add_subdirectory(tests)

--- a/src/common/commonutils/CMakeLists.txt
+++ b/src/common/commonutils/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
 project(commonutils)
 
 find_package(RapidJSON REQUIRED)

--- a/src/common/logging/CMakeLists.txt
+++ b/src/common/logging/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
 project(logging)
 add_library(logging STATIC Logging.c)
 target_compile_options(logging PRIVATE -Wno-psabi)

--- a/src/modules/commandrunner/src/lib/CMakeLists.txt
+++ b/src/modules/commandrunner/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(commandrunnerlib)
 add_library(commandrunnerlib STATIC CommandRunner.cpp Command.cpp)
 target_link_libraries(commandrunnerlib PRIVATE logging commonutils)

--- a/src/modules/commandrunner/src/so/CMakeLists.txt
+++ b/src/modules/commandrunner/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(commandrunner)
 
 add_library(commandrunner SHARED CommandRunnerModule.cpp)

--- a/src/modules/firewall/src/lib/CMakeLists.txt
+++ b/src/modules/firewall/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(firewalllib)
 
 add_library(firewalllib STATIC Firewall.cpp)

--- a/src/modules/firewall/src/so/CMakeLists.txt
+++ b/src/modules/firewall/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(firewall)
 
 add_library(firewall SHARED FirewallModule.cpp)

--- a/src/modules/hostname/src/lib/CMakeLists.txt
+++ b/src/modules/hostname/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(hostnamelib)
 
 add_library(hostnamelib STATIC HostName.cpp HostNameBase.cpp)

--- a/src/modules/hostname/src/so/CMakeLists.txt
+++ b/src/modules/hostname/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(hostname)
 
 add_library(hostname SHARED HostNameModule.cpp)

--- a/src/modules/networking/src/lib/CMakeLists.txt
+++ b/src/modules/networking/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(networkinglib)
 add_library(networkinglib STATIC Networking.cpp)
 target_link_libraries(networkinglib PRIVATE logging commonutils)

--- a/src/modules/networking/src/so/CMakeLists.txt
+++ b/src/modules/networking/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(networking)
 
 add_library(networking SHARED NetworkingModule.cpp)

--- a/src/modules/samples/cpp/src/lib/CMakeLists.txt
+++ b/src/modules/samples/cpp/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(cppsamplelib)
 
 add_library(cppsamplelib STATIC Sample.cpp)

--- a/src/modules/samples/cpp/src/so/CMakeLists.txt
+++ b/src/modules/samples/cpp/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(cppsample)
 
 add_library(cppsample SHARED SampleModule.cpp)

--- a/src/modules/settings/src/configfileutils/CMakeLists.txt
+++ b/src/modules/settings/src/configfileutils/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
 project(configfileutils)
 
 if (BUILD_TESTS)

--- a/src/modules/settings/src/lib/CMakeLists.txt
+++ b/src/modules/settings/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(settingslib)
 
 #add_subdirectory(configfileutils)

--- a/src/modules/settings/src/so/CMakeLists.txt
+++ b/src/modules/settings/src/so/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(settings)
 add_library(settings SHARED SettingsModule.cpp)
 target_compile_options(settings PRIVATE -fPIC)

--- a/src/modules/tpm/src/lib/CMakeLists.txt
+++ b/src/modules/tpm/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(tpmlib)
 add_library(tpmlib STATIC Tpm.cpp)
 target_link_libraries(tpmlib PRIVATE logging commonutils)

--- a/src/modules/tpm/src/so/CMakeLists.txt
+++ b/src/modules/tpm/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(tpm)
 
 add_library(tpm SHARED TpmModule.cpp)

--- a/src/modules/ztsi/src/lib/CMakeLists.txt
+++ b/src/modules/ztsi/src/lib/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(ztsilib)
 add_library(ztsilib STATIC Ztsi.cpp)
 target_link_libraries(ztsilib PRIVATE logging commonutils)

--- a/src/modules/ztsi/src/so/CMakeLists.txt
+++ b/src/modules/ztsi/src/so/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set (CMAKE_CXX_STANDARD 11)
 project(ztsi)
 
 add_library(ztsi SHARED ZtsiModule.cpp)

--- a/src/platform/modulesmanager/src/CMakeLists.txt
+++ b/src/platform/modulesmanager/src/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-
-set (CMAKE_CXX_STANDARD 11)
-
 project(modulesmanager)
 set(MODULE_MANAGER_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../inc/)
 set(MODULES_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../modules/inc)

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/CMakeLists.txt
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 project(modulesmanagertests)
 
+set (CMAKE_CXX_STANDARD 14)
+
 include(CTest)
 find_package(GTest REQUIRED)
 

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/CMakeLists.txt
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/CMakeLists.txt
@@ -3,8 +3,6 @@
 
 project(modulesmanagertests)
 
-cmake_minimum_required(VERSION 3.2.0)
-
 include(CTest)
 find_package(GTest REQUIRED)
 

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/modules/invalidgetinfomodule/CMakeLists.txt
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/modules/invalidgetinfomodule/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set(CMAKE_CXX_STANDARD 11)
 project(invalidgetinfo_module)
 
 set(INVALIDGETINFO_MODULE_PATH "${TEST_MODULES_DIR}/${PROJECT_NAME}.so" CACHE FILEPATH "Path to the invalid_module.so module")

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/modules/invalidmodule/CMakeLists.txt
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/modules/invalidmodule/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set(CMAKE_CXX_STANDARD 11)
 project(invalid_module)
 
 set(INVALID_MODULE_PATH "${TEST_MODULES_DIR}/${PROJECT_NAME}.so" CACHE FILEPATH "Path to the invalid_module.so module")

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/modules/validmodule_v1/CMakeLists.txt
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/modules/validmodule_v1/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set(CMAKE_CXX_STANDARD 11)
 project(valid_module_v1)
 
 set(VALID_MODULE_V1_PATH "${TEST_MODULES_DIR}/${PROJECT_NAME}.so" CACHE FILEPATH "Path to the valid_module_v1.so module")

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/modules/validmodule_v2/CMakeLists.txt
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/modules/validmodule_v2/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-cmake_minimum_required(VERSION 3.2)
-set(CMAKE_CXX_STANDARD 11)
 project(valid_module_v2)
 
 set(VALID_MODULE_V2_PATH "${TEST_MODULES_DIR}/${PROJECT_NAME}.so" CACHE FILEPATH "Path to the valid_module_v2.so module")


### PR DESCRIPTION
## Description

The OSConfig code was not uniformly applying same C/C++ standard and as result, we had code that was compiled in whatever local gcc compiler support was available. This PR consolidates that in a single place in the root CMakeList.txt. The only exception is the Module Manager tests that currently can only compile in C14 or newer (we need to fix this).

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.