### PR TITLE
Fix reported object order from osconfig.json for MpiGetReported

### DIFF
--- a/src/platform/modulesmanager/inc/ModulesManager.h
+++ b/src/platform/modulesmanager/inc/ModulesManager.h
@@ -12,7 +12,7 @@
 #include <mutex>
 #include <queue>
 #include <rapidjson/document.h>
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 #include <CommonUtils.h>
@@ -58,8 +58,8 @@ public:
     void UnloadModules();
 
 protected:
-    // Component name -> vector of reported components according to osconfig.json
-    std::map<std::string, std::unordered_set<std::string>> m_reportedComponents;
+    // Component name -> set of reported components according to osconfig.json
+    std::map<std::string, std::set<std::string>> m_reportedComponents;
 
     // Component name -> module name
     std::map<std::string, std::string> m_moduleComponentName;

--- a/src/platform/modulesmanager/src/ModulesManager.cpp
+++ b/src/platform/modulesmanager/src/ModulesManager.cpp
@@ -348,7 +348,7 @@ int ModulesManager::SetReportedObjects(const std::string& configJson)
 
                     if (m_reportedComponents.find(componentName) == m_reportedComponents.end())
                     {
-                        m_reportedComponents[componentName] = std::unordered_set<std::string>();
+                        m_reportedComponents[componentName] = std::set<std::string>();
                     }
 
                     if (m_reportedComponents[componentName].find(objectName) == m_reportedComponents[componentName].end())
@@ -755,7 +755,7 @@ int MpiSession::GetReportedPayload(MPI_JSON_STRING* payload, int* payloadSizeByt
     for (auto reported : m_modulesManager.m_reportedComponents)
     {
         std::string componentName = reported.first;
-        std::unordered_set<std::string> objectNames = reported.second;
+        std::set<std::string> objectNames = reported.second;
         std::shared_ptr<MmiSession> module = GetSession(componentName);
 
         if ((nullptr != module) && !objectNames.empty())

--- a/src/platform/modulesmanager/tests/ModuleManagerTests/src/MockModulesManager.cpp
+++ b/src/platform/modulesmanager/tests/ModuleManagerTests/src/MockModulesManager.cpp
@@ -21,7 +21,7 @@ namespace Tests
     {
         if (m_reportedComponents.find(componentName) == m_reportedComponents.end())
         {
-            m_reportedComponents[componentName] = std::unordered_set<std::string>();
+            m_reportedComponents[componentName] = std::set<std::string>();
         }
 
         m_reportedComponents[componentName].insert(objectName);


### PR DESCRIPTION
## Description

Fixes reported object order to maintain the order descibed by `osconfig.json` in payloads from `MpiGetReported()`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.