### PR TITLE
E2E Test Pipeline Refactoring

### DIFF
--- a/devops/pipeline/e2etest.yaml
+++ b/devops/pipeline/e2etest.yaml
@@ -1,9 +1,7 @@
-# E2E test pipeline - performs end-to-end tests on the following platforms
-#  - Debian 9
-#  - Ubuntu 18.04
-#  - Ubuntu 20.04
-# 
-# Add new distros as needed
+# E2E test pipeline - Performs end-to-end tests
+# Pipeline supports both Cloud and Baremetal targets.
+# Every target host supports using packages from the Package Build pipeline
+# or building from source using the defined 'sourceBranch'
 
 name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
@@ -15,380 +13,110 @@ resources:
     image: mcr.microsoft.com/dotnet/sdk:5.0
 
 parameters:
-- name: SKIP_TEARDOWN
-  displayName: 'Leave test infrastructure in-place'
+- name: runCloudTests
+  displayName: Run Cloud tests
   type: boolean
-  default: false
-- name: TWIN_TIMEOUT
-  displayName: 'Timeout for twin updates'
-  type: number
-  default: 90
-# - name: PRE_SCRIPT
-#   displayName: 'Shell script to execute before osconfig install'
-#   type: string
-#   default: ' '
-- name: POST_SCRIPT
-  displayName: 'Shell script to execute after osconfig install'
+  default: true
+- name: runBaremetalTests
+  displayName: Run Baremetal tests
+  type: boolean
+  default: true
+- name: testExpression
+  displayName: Test expression to use
   type: string
   default: ' '
+- name: skipTeardown
+  displayName: Leave test infrastructure in-place
+  type: boolean
+  default: false
+- name: sourceBranch
+  displayName: 'Branch to use package from (default: source branch if empty)'
+  type: string
+  default: ' '
+- name: twinTimeout
+  displayName: Timeout for twin updates
+  type: number
+  default: 90
+- name: postScript
+  displayName: Shell script to execute after osconfig install
+  type: string
+  default: ' '
+  
+- name: cloud_targets
+  type: object
+  default:
+    - distroName: ubuntu-18.04
+      image_publisher: Canonical
+      image_offer: UbuntuServer
+      image_sku: 18.04-LTS
+      image_version: latest
+      packagePattern: '**/*bionic_x86_64.deb'
+      device_id: ubuntu1804
+      pre_script: >-
+        export DEBIAN_FRONTEND=noninteractive &&
+        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg &&
+        sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ &&
+        curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list &&
+        sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/ &&
+        sudo apt update &&
+        sudo apt install aziot-identity-service
+    - distroName: ubuntu-20.04
+      image_publisher: Canonical
+      image_offer: 0001-com-ubuntu-server-focal
+      image_sku: 20_04-lts-gen2
+      image_version: latest
+      packagePattern: '**/*focal_x86_64.deb'
+      device_id: ubuntu2004
+      pre_script: >-
+        export DEBIAN_FRONTEND=noninteractive &&
+        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg &&
+        sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ &&
+        curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list &&
+        sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/ &&
+        sudo apt update &&
+        sudo apt install aziot-identity-service
+
+- name: baremetal_targets
+  type: object
+  default: []
+    # - jobName: debian9_vm_amd64
+    #   deviceId: debian9_vm_amd64
+    #   packagePattern: '**/*stretch_x86_64.deb'
+    #   environment: debian9-vm-amd64
 
 variables:
   SERVICE_CONNECTION: OSconfig-arm
-  SKIP_TEARDOWN: ${{ parameters.SKIP_TEARDOWN }}
-  # PRE_SCRIPT: ${{ parameters.PRE_SCRIPT }}
-  POST_SCRIPT: ${{ parameters.POST_SCRIPT }}
-  TWIN_TIMEOUT: ${{ parameters.TWIN_TIMEOUT }}
-
-trigger:
-  branches:
-    include:
-    - main
-pr: none
+  IOTHUBOWNER_CONN_STR: $(IOTHUBOWNER_CONNECTION_STRING)
 
 stages:
-- stage: Terraform_iothub
-  displayName: Terraform - Create Hub
-  pool:
-        vmImage: 'ubuntu-18.04'
-  jobs:
-  - job: TerraformJobIotHub
-    steps:
-      - script: |
-          sudo apt update && sudo apt install curl
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-          sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt install terraform
-        displayName: Installing Terraform
+- template: stages/e2etest_iothub_create.yaml
 
-      - script: 'terraform init'
-        displayName: terraform init (IotHub)
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+- ${{ if eq(parameters.runCloudTests, 'true') }}:
+  - ${{ each target in parameters.cloud_targets }}:
+    - template: stages/e2etest_cloud.yaml
+      parameters:
+        testExpression: ${{ parameters.testExpression }}
+        skipTeardown: ${{ parameters.skipTeardown }}
+        twinTimeout: ${{ parameters.twinTimeout }}
+        postScript: ${{ parameters.postScript }}
+        sourceBranch: ${{ parameters.sourceBranch }}
+        target: ${{ target }}
 
-      - script: 'terraform apply -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)" -var key_vault_id="$(KEY_VAULT_ID)" -auto-approve'
-        displayName: terraform apply
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+- ${{ if eq(parameters.runBaremetalTests, 'true') }}:
+  - ${{ each target in parameters.baremetal_targets }}:
+    - template: stages/e2etest_baremetal.yaml
+      parameters:
+        jobName: ${{ target.jobName }}
+        deviceId: ${{ target.deviceId }}
+        packagePattern: ${{ target.packagePattern }}
+        environment: ${{ target.environment }}
+        testExpression: ${{ parameters.testExpression }}
+        sourceBranch: ${{ parameters.sourceBranch }}
 
-      - script: |
-          IOTHUB_NAME=`terraform output iothub_name`
-          echo "##vso[task.setvariable variable=IOTHUB_NAME;isOutput=true]$IOTHUB_NAME"
-        name: iothub_name_step
-        displayName: Retreive IoTHub Name
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
-
-      - script: |
-          IOTHUBOWNER_CONN_STR=`terraform output iothubowner_connection_string`
-          echo "##vso[task.setvariable variable=IOTHUBOWNER_CONN_STR;issecret=true;isOutput=true]$IOTHUBOWNER_CONN_STR"
-        name: iothubowner_conn_str_step
-        displayName: Retreive iothubowner connection string
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
-
-      - script: |
-          RESOURCE_GROUP_NAME=`terraform output resource_group_name`
-          echo "##vso[task.setvariable variable=RESOURCE_GROUP_NAME;isOutput=true]$RESOURCE_GROUP_NAME"
-        name: resource_group_name_step
-        displayName: Retreive Resource Group Name
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
-
-      - script: |
-          mkdir -p $(Build.ArtifactStagingDirectory)/terraform/iothub
-          cp -R $(Build.SourcesDirectory)/devops/terraform/iothub/* $(Build.ArtifactStagingDirectory)/terraform/iothub
-        displayName: Copy terraform state (iothub)
-        continueOnError: true
-
-      - publish: '$(Build.ArtifactStagingDirectory)/terraform/iothub'
-        displayName: 'Publish Terraform state for destroy stage (iothub)'
-        continueOnError: true
-        artifact: terraformStateIoTHub
-
-- stage: Terraform_VM
-  displayName: Terraform - Create Identity + VMs
-  dependsOn: Terraform_iothub
-  variables:
-    IOTHUB_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothub_name_step.IOTHUB_NAME'] ]
-    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
-  pool:
-        vmImage: 'ubuntu-18.04'
-  jobs:
-  - job: TerraformJobVM
-    strategy:
-        matrix:
-          # Find different VM variants on the Azure Marketplace
-          # See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
-          # Add new distros as needed
-          debian-9:
-            distroName: debian-9
-            image_publisher: credativ
-            image_offer: Debian
-            image_sku: 9
-            image_version: 9.20210721.0
-            packagePattern: '**/*stretch_x86_64.deb'
-            device_id: debian9
-            pre_script: >-
-              export DEBIAN_FRONTEND=noninteractive &&
-              sudo apt update && sudo apt upgrade -y && sudo apt install curl wget -y &&
-              wget https://github.com/Azure/azure-iotedge/releases/download/1.2.8/aziot-identity-service_1.2.6-1_debian9_amd64.deb &&
-              sudo apt install ./aziot-identity-service_1.2.6-1_debian9_amd64.deb -y
-          ubuntu-18.04:
-            distroName: ubuntu-18.04
-            image_publisher: Canonical
-            image_offer: UbuntuServer
-            image_sku: 18.04-LTS
-            image_version: latest
-            packagePattern: '**/*bionic_x86_64.deb'
-            device_id: ubuntu1804
-            pre_script: >-
-              export DEBIAN_FRONTEND=noninteractive &&
-              curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg &&
-              sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ &&
-              curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list &&
-              sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/ &&
-              sudo apt update &&
-              sudo apt install aziot-identity-service
-          ubuntu-20.04:
-            distroName: ubuntu-20.04
-            image_publisher: Canonical
-            image_offer: 0001-com-ubuntu-server-focal
-            image_sku: 20_04-lts-gen2
-            image_version: latest
-            packagePattern: '**/*focal_x86_64.deb'
-            device_id: ubuntu2004
-            pre_script: >-
-              export DEBIAN_FRONTEND=noninteractive &&
-              curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg &&
-              sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ &&
-              curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list &&
-              sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/ &&
-              sudo apt update &&
-              sudo apt install aziot-identity-service
-
-    steps:
-      - task: DownloadPipelineArtifact@2
-        displayName: Download OSConfig from pipeline
-        inputs:
-          source: 'specific'
-          project: 'AzOsConfig'
-          pipeline: $(package_pipeline)
-          runVersion: 'latestFromBranch'
-          runBranch: $(Build.SourceBranch)
-          itemPattern: $(packagePattern)
-
-      - script: |
-          cp `find . -name '*.deb' | head -n 1` $(Build.SourcesDirectory)/devops/terraform/host/osconfig.deb
-        displayName: Stage OSConfig
-        workingDirectory: $(Pipeline.Workspace)
-
-      - task: AzureCLI@2
-        displayName: Create device identity
-        name: azcli_device_identity
-        inputs:
-          azureSubscription: $(SERVICE_CONNECTION)
-          scriptType: bash
-          scriptLocation: inlineScript
-          inlineScript: |
-            az config set extension.use_dynamic_install=yes_without_prompt
-            az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "$(TENANT_ID)"
-            az iot hub device-identity create --device-id "$(device_id)" --hub-name $(IOTHUB_NAME) --output none
-            DEVICE_CONN_STR=`az iot hub device-identity connection-string show --hub-name $(IOTHUB_NAME) --device-id $(device_id) --output tsv`
-            echo "##vso[task.setvariable variable=DEVICE_CONN_STR;issecret=true]$DEVICE_CONN_STR"
-
-      - script: 'terraform init'
-        displayName: terraform init (VM)
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/host
-
-      - script: terraform apply -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)" -var key_vault_id="$(KEY_VAULT_ID)" -var device_identity_connstr='$(DEVICE_CONN_STR)' -var resource_group_name=$(RESOURCE_GROUP_NAME) -var osconfig_package_path="./osconfig.deb" -var vm_name=$(distroName) -var image_offer=$(image_offer) -var image_publisher=$(image_publisher) -var image_sku=$(image_sku) -var image_version=$(image_version) -var sas_token="$(SAS_TOKEN)" -var vm_pre_osconfig_install_script="$(pre_script)" -var vm_post_osconfig_install_script="$(POST_SCRIPT)" -auto-approve
-        displayName: terraform apply
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/host
-
-      - script: |
-          mkdir -p $(Build.ArtifactStagingDirectory)/terraform/host
-          cp -R $(Build.SourcesDirectory)/devops/terraform/host/* $(Build.ArtifactStagingDirectory)/terraform/host
-        displayName: Copy terraform state (vm)
-        continueOnError: true
-
-      - publish: '$(Build.ArtifactStagingDirectory)/terraform/host'
-        displayName: 'Publish Terraform state for destroy stage (vm)'
-        continueOnError: true
-        artifact: terraformStateVM_$(distroName)
-
-- stage: Run_Test_Driver
-  displayName: Execute E2E Test
-  dependsOn:
-    - Terraform_iothub
-    - Terraform_VM
-  variables:
-    IOTHUBOWNER_CONN_STR: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothubowner_conn_str_step.IOTHUBOWNER_CONN_STR'] ]
-    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
-  jobs:
-  - job: E2ETestJob
-    strategy:
-      matrix:
-        # Add new distros as needed
-        debian-9:
-          distroName: debian-9
-          device_id: debian9
-        ubuntu-18.04:
-          distroName: ubuntu-18.04
-          device_id: ubuntu1804
-        ubuntu-20.04:
-          distroName: ubuntu-20.04
-          device_id: ubuntu2004
-    container: dotnet
-    steps:
-      - script: 'dotnet test --logger trx'
-        displayName: Run Test Driver
-        env:
-          E2E_OSCONFIG_IOTHUB_CONNSTR: $(IOTHUBOWNER_CONN_STR)
-          E2E_OSCONFIG_DEVICE_ID: $(device_id)
-          E2E_OSCONFIG_SAS_TOKEN: $(SAS_TOKEN)
-          E2E_OSCONFIG_UPLOAD_URL: $(UPLOAD_URL_BASE_PATH)
-          E2E_OSCONFIG_RESOURCE_GROUP_NAME: $(RESOURCE_GROUP_NAME)
-          E2E_OSCONFIG_TWIN_TIMEOUT: $(TWIN_TIMEOUT)
-        workingDirectory: $(Build.SourcesDirectory)/src/tests/e2etest
-
-      - task: PublishTestResults@2
-        condition: or(succeeded(), failed())
-        continueOnError: true
-        inputs:
-          testRunner: VSTest
-          testResultsFiles: '$(Build.SourcesDirectory)/src/tests/e2etest/TestResults/*.trx'
-          failTaskOnFailedTests: true
-          testRunTitle: $(distroName)
-
-      - script: |
-          rg=`echo $(RESOURCE_GROUP_NAME) | sed -r 's/"//g'`
-          mkdir -p $(Build.ArtifactStagingDirectory)/logs
-          wget "$(UPLOAD_URL_BASE_PATH)`echo $rg`-$(device_id).tar.gz?$(SAS_TOKEN)" -O $(Build.ArtifactStagingDirectory)/logs/`echo $rg`-$(device_id).tar.gz
-        displayName: Get OSConfig logs from blobstore
-        condition: or(succeeded(), failed())
-        continueOnError: true
-
-      - publish: '$(Build.ArtifactStagingDirectory)/logs/'
-        displayName: 'Publish OSConfig Logs'
-        condition: or(succeeded(), failed())
-        continueOnError: true
-        artifact: Logs_$(distroName)
-
-- stage: Terraform_stop_vm
-  displayName: Stop VMs
-  condition: succeededOrFailed()
-  dependsOn:
-    - Terraform_iothub
-    - Terraform_VM
-    - Run_Test_Driver
-  variables:
-    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
-  pool:
-    vmImage: 'ubuntu-18.04'
-  jobs:
-  - job: StopVMs
-    steps:
-      - task: AzureCLI@2
-        displayName: Stop running VMs
-        continueOnError: true
-        name: azcli_dt
-        inputs:
-          azureSubscription: $(SERVICE_CONNECTION)
-          scriptType: bash
-          scriptLocation: inlineScript
-          inlineScript: |
-            az config set extension.use_dynamic_install=yes_without_prompt
-            az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "72f988bf-86f1-41af-91ab-2d7cd011db47"
-            # Add new distros as needed
-            az vm deallocate --no-wait --resource-group $(RESOURCE_GROUP_NAME) --name myVM-debian-9
-            az vm deallocate --no-wait --resource-group $(RESOURCE_GROUP_NAME) --name myVM-ubuntu-18.04
-            az vm deallocate --no-wait --resource-group $(RESOURCE_GROUP_NAME) --name myVM-ubuntu-20.04
-
-- stage: Terraform_destroy_vm
-  displayName: Tear down cloud resources (VMs)
-  dependsOn:
-    - Terraform_iothub
-    - Terraform_VM
-    - Run_Test_Driver
-  variables:
-    IOTHUB_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothub_name_step.IOTHUB_NAME'] ]
-    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
-  pool:
-    vmImage: 'ubuntu-18.04'
-  condition: and(succeeded(), eq(variables['SKIP_TEARDOWN'], 'false'))
-  jobs:
-  - job: TerraformDestroy
-    strategy:
-          matrix:
-            debian-9:
-              distroName: debian-9
-              device_id: debian9
-            ubuntu-18.04:
-              distroName: ubuntu-18.04
-              device_id: ubuntu1804
-            ubuntu-20.04:
-              distroName: ubuntu-20.04
-              device_id: ubuntu2004
-    steps:
-      - script: |
-          sudo apt update && sudo apt install curl
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-          sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt install terraform
-        displayName: Installing Terraform
-
-      - download: current
-        artifact: terraformStateVM_$(distroName)
-        displayName: Fetching terraform state (VM)
-
-      - script: |
-          terraform init
-          terraform destroy -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)" -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var key_vault_id="$(KEY_VAULT_ID)" -var device_identity_connstr="null" -var resource_group_name=$(RESOURCE_GROUP_NAME) -var osconfig_package_path="./osconfig.deb" -var sas_token="NULL" -auto-approve || true
-        workingDirectory: $(Pipeline.Workspace)/terraformStateVM_$(distroName)
-        displayName: Destroy cloud resources (VM)
-        continueOnError: true
-
-      - task: AzureCLI@2
-        displayName: Get twin from IoTHub
-        continueOnError: true
-        name: azcli_dt
-        inputs:
-          azureSubscription: $(SERVICE_CONNECTION)
-          scriptType: bash
-          scriptLocation: inlineScript
-          inlineScript: |
-            az config set extension.use_dynamic_install=yes_without_prompt
-            az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "72f988bf-86f1-41af-91ab-2d7cd011db47"
-            az iot hub device-twin show --hub-name $(IOTHUB_NAME) --device-id $(device_id) > $(Build.ArtifactStagingDirectory)/$(device_id)_twin.json
-
-      - publish: '$(Build.ArtifactStagingDirectory)/$(device_id)_twin.json'
-        displayName: 'Publish twin for $(device_id)'
-        continueOnError: true
-        artifact: DeviceTwin_$(distroName)
-
-
-- stage: Terraform_destroy_iothub
-  displayName: Tear down cloud resources (iothub)
-  dependsOn: Terraform_destroy_vm
-  pool:
-      vmImage: 'ubuntu-18.04'
-  condition: succeeded()
-  jobs:
-  - job: TerraformDestroy
-    steps:
-      - script: |
-          sudo apt update && sudo apt install curl
-          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-          sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt install terraform
-        displayName: Installing Terraform
-
-      - download: current
-        artifact: terraformStateIoTHub
-        displayName: Fetching terraform state (IoTHub)
-
-      - script: |
-          terraform init
-          terraform destroy -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)"  -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var key_vault_id="$(KEY_VAULT_ID)" -auto-approve || true
-        workingDirectory: $(Pipeline.Workspace)/terraformStateIoTHub
-        displayName: Destroy cloud resources (IoTHub)
+- template: stages/e2etest_iothub_delete.yaml
+  parameters:
+    dependsOn: 
+    - ${{ each target in parameters.cloud_targets }}:
+      - Run_Test_Driver_${{ target.device_id }}
+    - ${{ each target in parameters.baremetal_targets }}:
+      - Run_Test_Driver_${{ target.deviceId }}

--- a/devops/pipeline/stages/binary_build.yaml
+++ b/devops/pipeline/stages/binary_build.yaml
@@ -11,36 +11,28 @@
 #  - (Optional) publishArtifact [boolean]: publishes the built artifacts (packages) as pipeline artifacts - default: true
 
 parameters:
-  - name: prefix
-    type: string
-    default: binary
-
-  - name: variantName
-    type: string
-
-  - name: friendlyVariantName
-    type: string
-  
-  - name: architecture
-    type: string
-  
-  - name: containerPath
-    type: string
-  
-  - name: platform
-    type: string
-  
-  - name: performCoverage
-    type: boolean
-    default: false
-
-  - name: ignoreTestFailures
-    type: boolean
-    default: false
-
-  - name: publishArtifact
-    type: boolean
-    default: true
+- name: prefix
+  type: string
+  default: binary
+- name: variantName
+  type: string
+- name: friendlyVariantName
+  type: string
+- name: architecture
+  type: string
+- name: containerPath
+  type: string
+- name: platform
+  type: string
+- name: performCoverage
+  type: boolean
+  default: false
+- name: ignoreTestFailures
+  type: boolean
+  default: false
+- name: publishArtifact
+  type: boolean
+  default: true
 
 stages:
 - stage: ${{ parameters.prefix }}_${{ parameters.friendlyVariantName }}_${{ parameters.architecture }}

--- a/devops/pipeline/stages/e2etest_baremetal.yaml
+++ b/devops/pipeline/stages/e2etest_baremetal.yaml
@@ -1,0 +1,138 @@
+# E2E Baremetal Test Stage Definition
+# Parameters:
+#  - (Required) jobName [string]: Name to use for the job and stage
+#  - (Required) deviceId [string]:  the deviceId to use on the IoT Hub (pre-provisioned)
+#  - (Required) packagePattern [string]: the package to stage onto the host
+#  - (Required) environment [string]: the environment to target, targets a pipeline agent with that environment
+#  - (Optional) twinTimeout [number]: Timeout for twin updates - default: 90 seconds
+#  - (Optional) testExpression [string]: the test expression to use to filter the tests (see https://docs.microsoft.com/dotnet/core/testing/selective-unit-tests?pivots=mstest) - default: all tests
+#  - (Optional) sourceBranch [string]: package branch to use - default: Uses source branch
+#  - (Optional) sourceBuild [boolean]: perform a source build instead of using the package - default: false
+
+parameters:
+- name: jobName
+  type: string
+- name: deviceId
+  type: string
+- name: packagePattern
+  type: string
+  default: ' '
+- name: environment
+  type: string
+- name: twinTimeout
+  displayName: Timeout for twin updates
+  type: number
+  default: 90
+- name: testExpression
+  type: string
+  default: ' '
+- name: sourceBranch
+  displayName: 'Branch to use package from (default: source branch if empty)'
+  type: string
+  default: ' '
+- name: sourceBuild
+  displayName: Build and install source
+  type: boolean
+  default: false
+
+stages:
+- stage: Baremetal_${{ parameters.deviceId }}
+  displayName: Baremetal - ${{ parameters.environment }}
+  dependsOn: Terraform_iothub
+  variables:
+    IOTHUB_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothub_name_step.IOTHUB_NAME'] ]
+    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
+  jobs:
+  - job: Baremetal
+
+    pool:
+      name: OSConfig
+      demands:
+      - ${{ parameters.environment }}
+
+    workspace:
+      clean: all
+
+    steps:
+    - task: AzureCLI@2
+      displayName: Create and apply device identity
+      name: azcli_device_identity
+      inputs:
+        azureSubscription: $(SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "$(TENANT_ID)"
+          az iot hub device-identity create --device-id "${{parameters.deviceId}}" --hub-name $(IOTHUB_NAME) --output none
+          DEVICE_CONN_STR=`az iot hub device-identity connection-string show --hub-name $(IOTHUB_NAME) --device-id ${{parameters.deviceId}} --output tsv`
+          sudo aziotctl config mp -c "$DEVICE_CONN_STR" --force
+          sudo aziotctl config apply
+
+    - ${{ if and(eq(parameters.sourceBuild, False), ne(parameters.sourceBranch, ' ')) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download OSConfig from pipeline (${{ parameters.sourceBranch }})
+        inputs:
+          source: 'specific'
+          project: 'AzOsConfig'
+          pipeline: $(package_pipeline)
+          runVersion: 'latestFromBranch'
+          runBranch: ${{ parameters.sourceBranch }}
+          itemPattern: ${{ parameters.packagePattern }}
+    - ${{ if and(eq(parameters.sourceBuild, False), eq(parameters.sourceBranch, ' ')) }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download OSConfig from pipeline ($(Build.SourceBranch))
+        inputs:
+          source: 'specific'
+          project: 'AzOsConfig'
+          pipeline: $(package_pipeline)
+          runVersion: 'latestFromBranch'
+          runBranch: $(Build.SourceBranch)
+          itemPattern: ${{ parameters.packagePattern }}
+
+    - ${{ if eq(parameters.sourceBuild, False) }}:
+      - script: |
+          sudo dpkg -i `find . -name '*.deb' | head -n 1`
+          sudo sed -i '/\"FullLogging\"/c\\  \"FullLogging\": 1,' /etc/osconfig/osconfig.json
+          sudo rm -rf /var/log/osconfig*
+          sudo systemctl daemon-reload
+          sudo systemctl enable osconfig.service
+          sudo systemctl start osconfig
+        displayName: Install OSConfig
+        workingDirectory: $(Pipeline.Workspace)
+        condition: succeeded()
+    - ${{ if eq(parameters.sourceBuild, True) }}:
+      - checkout: self
+        submodules: recursive
+      - script: |
+          sudo systemctl stop osconfig | true
+          cmake -DCMAKE_BUILD_TYPE=Release -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DMAJOR_VERSION=$(MAJORVERSION) -DMINOR_VERSION=$(MINORVERSION) -DPATCH_VERSION=$(PATCHVERSION) -G Ninja -B./build -H./src
+          sudo cmake --build ./build --target install
+          sudo sed -i '/\"FullLogging\"/c\\  \"FullLogging\": 1,' /etc/osconfig/osconfig.json
+          sudo rm -rf /var/log/osconfig*
+          sudo systemctl daemon-reload
+          sudo systemctl enable osconfig.service
+          sudo systemctl start osconfig
+          sudo rm -rf ./build
+        displayName: Build and Install OSConfig (from source)
+        workingDirectory: $(Build.SourcesDirectory)
+        condition: succeeded()
+
+- ${{ if ne(parameters.testExpression, ' ') }}:
+  - template: e2etest_testdriver.yaml
+    parameters:
+      deviceId: ${{parameters.deviceId}}
+      testRunName: ${{parameters.jobName}}
+      deviceStageName: Baremetal_${{ parameters.deviceId }}
+      testExpression: '${{ parameters.testExpression }} & TestCategory != BaremetalExclude'
+      twinTimeout: ${{ parameters.twinTimeout }}
+      environment: ${{ parameters.environment }}
+- ${{ else }}:
+  - template: e2etest_testdriver.yaml
+    parameters:
+      deviceId: ${{parameters.deviceId}}
+      testRunName: ${{parameters.jobName}}
+      deviceStageName: Baremetal_${{ parameters.deviceId }}
+      testExpression: 'TestCategory != BaremetalExclude'
+      twinTimeout: ${{ parameters.twinTimeout }}
+      environment: ${{ parameters.environment }}

--- a/devops/pipeline/stages/e2etest_cloud.yaml
+++ b/devops/pipeline/stages/e2etest_cloud.yaml
@@ -1,0 +1,206 @@
+# E2E Cloud Test Stage Definition
+# Parameters:
+#  - (Required) target [object]: The cloud test target object, defined as follows:
+#       distroName [string]: The name to give this vm cloud distro
+#       image_publisher [string]: The image publisher to use. See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
+#       image_offer [string]: The image offer to use. See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
+#       image_sku [string]: The image sku to use. See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
+#       image_version [string]: the image version to use. See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
+#       packagePattern [string]: Package to install on the target host from the Package Build pipeline (example '**/*focal_x86_64.deb')
+#       device_id [string]: The device ID to use on provisioning the device to the IoT Hub
+#       pre_script [string]: The script to run on the target machine BEFORE OSConfig is installed
+#  - (Optional) skipTeardown [boolean]: Leave test infrastructure in-place - default: false
+#  - (Optional) twinTimeout [number]: Timeout for twin updates - default: 90 seconds
+#  - (Optional) postScript [string]: bash script to perform post osconfig install (before agent start)
+#  - (Optional) testExpression [string]: the test expression to use to filter the tests (see https://docs.microsoft.com/dotnet/core/testing/selective-unit-tests?pivots=mstest) - default: all tests
+#  - (Optional) sourceBranch [string]: package branch to use - default: Uses source branch
+# 
+# Find different VM variants on the Azure Marketplace
+# See https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
+
+parameters:
+- name: target
+  displayName: The Cloud VM to target
+  type: object
+- name: skipTeardown
+  displayName: Leave test infrastructure in-place
+  type: boolean
+  default: false
+- name: twinTimeout
+  displayName: Timeout for twin updates
+  type: number
+  default: 90
+- name: postScript
+  displayName: 'Shell script to execute after osconfig install'
+  type: string
+  default: ' '
+- name: testExpression
+  type: string
+  default: ' '
+- name: sourceBranch
+  displayName: 'Branch to use package from (default: source branch if empty)'
+  type: string
+  default: ' '
+
+stages:
+- stage: Terraform_VM_${{ parameters.target.device_id }}
+  displayName: Cloud ${{ parameters.target.distroName }}
+  dependsOn: Terraform_iothub
+  variables:
+    IOTHUB_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothub_name_step.IOTHUB_NAME'] ]
+    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
+  pool:
+    vmImage: 'ubuntu-18.04'
+  jobs:
+  - job: TerraformJobVM
+    steps:
+      - ${{ if ne(parameters.sourceBranch, ' ') }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: Download OSConfig from pipeline (${{ parameters.sourceBranch }})
+          inputs:
+            source: 'specific'
+            project: 'AzOsConfig'
+            pipeline: $(package_pipeline)
+            runVersion: 'latestFromBranch'
+            runBranch: ${{ parameters.sourceBranch }}
+            itemPattern: ${{ parameters.target.packagePattern }}
+            allowFailedBuilds: true
+      - ${{ if eq(parameters.sourceBranch, ' ') }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: Download OSConfig from pipeline ($(Build.SourceBranch))
+          inputs:
+            source: 'specific'
+            project: 'AzOsConfig'
+            pipeline: $(package_pipeline)
+            runVersion: 'latestFromBranch'
+            runBranch: $(Build.SourceBranch)
+            itemPattern: ${{ parameters.target.packagePattern }}
+            allowFailedBuilds: true
+
+      # Note: Although the output is always osconfig.deb, also works on RPMs as the files are explicitly referenced
+      - script: |
+          cp `find . -name '*.deb' -o -name '*.rpm' | head -n 1` $(Build.SourcesDirectory)/devops/terraform/host/osconfig.deb
+        displayName: Stage OSConfig
+        workingDirectory: $(Pipeline.Workspace)
+
+      - task: AzureCLI@2
+        displayName: Create device identity
+        name: azcli_device_identity
+        inputs:
+          azureSubscription: $(SERVICE_CONNECTION)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            az config set extension.use_dynamic_install=yes_without_prompt
+            az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "$(TENANT_ID)"
+            az iot hub device-identity create --device-id "${{ parameters.target.device_id }}" --hub-name $(IOTHUB_NAME) --output none
+            DEVICE_CONN_STR=`az iot hub device-identity connection-string show --hub-name $(IOTHUB_NAME) --device-id ${{ parameters.target.device_id }} --output tsv`
+            echo "##vso[task.setvariable variable=DEVICE_CONN_STR;issecret=true]$DEVICE_CONN_STR"
+
+      - script: 'terraform init'
+        displayName: terraform init (VM)
+        continueOnError: true
+        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/host
+
+      - script: terraform apply -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)" -var key_vault_id="$(KEY_VAULT_ID)" -var device_identity_connstr='$(DEVICE_CONN_STR)' -var resource_group_name=$(RESOURCE_GROUP_NAME) -var osconfig_package_path="./osconfig.deb" -var vm_name=${{parameters.target.distroName}} -var image_offer=${{parameters.target.image_offer}} -var image_publisher=${{parameters.target.image_publisher}} -var image_sku=${{parameters.target.image_sku}} -var image_version=${{parameters.target.image_version}} -var sas_token="$(SAS_TOKEN)" -var vm_pre_osconfig_install_script="${{parameters.target.pre_script}}" -var vm_post_osconfig_install_script="${{ parameters.postScript }}" -auto-approve
+        displayName: terraform apply
+        continueOnError: false
+        workingDirectory: $(Build.SourcesDirectory)/devops/terraform/host
+
+      - script: |
+          mkdir -p $(Build.ArtifactStagingDirectory)/terraform/host
+          cp -R $(Build.SourcesDirectory)/devops/terraform/host/* $(Build.ArtifactStagingDirectory)/terraform/host
+        displayName: Copy terraform state (vm)
+        continueOnError: false
+
+      - publish: '$(Build.ArtifactStagingDirectory)/terraform/host'
+        displayName: 'Publish Terraform state for destroy stage (vm)'
+        continueOnError: false
+        artifact: terraformStateVM_${{parameters.target.distroName}}
+
+- template: e2etest_testdriver.yaml
+  parameters:
+    deviceId: ${{ parameters.target.device_id }}
+    testRunName: ${{ parameters.target.device_id }}
+    deviceStageName: Terraform_VM_${{ parameters.target.device_id }}
+    testExpression: ${{ parameters.testExpression }}
+    twinTimeout: ${{ parameters.twinTimeout }}
+
+- stage: Terraform_destroy_vm_${{parameters.target.device_id}}
+  displayName: Deallocate ${{ parameters.target.distroName }}
+  dependsOn:
+    - Terraform_iothub
+    - Terraform_VM_${{ parameters.target.device_id }}
+    - Run_Test_Driver_${{ parameters.target.device_id }}
+  variables:
+    IOTHUB_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothub_name_step.IOTHUB_NAME'] ]
+    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
+  pool:
+    vmImage: 'ubuntu-18.04'
+  condition: eq(${{ parameters.skipTeardown }}, False)
+  jobs:
+  - job: TerraformDestroy
+    steps:
+    - script: |
+        sudo apt update && sudo apt install curl
+        curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+        sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+        sudo apt install terraform
+      displayName: Installing Terraform
+
+    - download: current
+      artifact: terraformStateVM_${{parameters.target.distroName}}
+      displayName: Fetching terraform state (VM)
+
+    - script: |
+        terraform init
+        terraform destroy -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)" -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var key_vault_id="$(KEY_VAULT_ID)" -var device_identity_connstr="null" -var resource_group_name=$(RESOURCE_GROUP_NAME) -var osconfig_package_path="./osconfig.deb" -var sas_token="NULL" -auto-approve || true
+      workingDirectory: $(Pipeline.Workspace)/terraformStateVM_${{parameters.target.distroName}}
+      displayName: Destroy cloud resources (VM)
+      continueOnError: true
+
+    - task: AzureCLI@2
+      displayName: Get twin from IoTHub
+      continueOnError: true
+      name: azcli_dt
+      inputs:
+        azureSubscription: $(SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "72f988bf-86f1-41af-91ab-2d7cd011db47"
+          az iot hub device-twin show --hub-name $(IOTHUB_NAME) --device-id ${{ parameters.target.device_id }} > $(Build.ArtifactStagingDirectory)/${{ parameters.target.device_id }}_twin.json
+
+    - publish: '$(Build.ArtifactStagingDirectory)/${{ parameters.target.device_id }}_twin.json'
+      displayName: 'Publish twin for ${{ parameters.target.device_id }}'
+      continueOnError: true
+      artifact: DeviceTwin_${{parameters.target.distroName}}
+
+- stage: Terraform_stop_vm_${{ parameters.target.device_id }}
+  displayName: Stop ${{ parameters.target.distroName }}
+  condition: succeededOrFailed()
+  dependsOn:
+    - Terraform_iothub
+    - Terraform_VM_${{ parameters.target.device_id }}
+    - Run_Test_Driver_${{ parameters.target.device_id }}
+  variables:
+    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
+  pool:
+    vmImage: 'ubuntu-18.04'
+  jobs:
+  - job: StopVMs
+    steps:
+    - task: AzureCLI@2
+      displayName: Stop running VM
+      continueOnError: true
+      name: azcli_dt
+      inputs:
+        azureSubscription: $(SERVICE_CONNECTION)
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az login --service-principal -u "$(CLIENT_ID)" -p "$(CLIENT_SECRET)" --tenant "72f988bf-86f1-41af-91ab-2d7cd011db47"
+          # Add new distros as needed
+          az vm deallocate --no-wait --resource-group $(RESOURCE_GROUP_NAME) --name myVM-${{parameters.target.distroName}}

--- a/devops/pipeline/stages/e2etest_iothub_create.yaml
+++ b/devops/pipeline/stages/e2etest_iothub_create.yaml
@@ -1,0 +1,60 @@
+# IoTHub creation stage definition
+
+stages:
+- stage: Terraform_iothub
+  displayName: Cloud - Create Hub
+  pool:
+        vmImage: 'ubuntu-18.04'
+  jobs:
+  - job: TerraformJobIotHub
+    steps:
+    - script: |
+        sudo apt update && sudo apt install curl
+        curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+        sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+        sudo apt install terraform
+      displayName: Installing Terraform
+
+    - script: 'terraform init'
+      displayName: terraform init (IotHub)
+      workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+
+    - script: 'terraform apply -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)" -var key_vault_id="$(KEY_VAULT_ID)" -auto-approve'
+      displayName: terraform apply
+      continueOnError: true
+      workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+
+    - script: |
+        IOTHUB_NAME=`terraform output iothub_name`
+        echo "##vso[task.setvariable variable=IOTHUB_NAME;isOutput=true]$IOTHUB_NAME"
+      name: iothub_name_step
+      displayName: Retreive IoTHub Name
+      continueOnError: true
+      workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+
+    - script: |
+        IOTHUBOWNER_CONN_STR=`terraform output iothubowner_connection_string`
+        echo "##vso[task.setvariable variable=IOTHUBOWNER_CONN_STR;issecret=true;isOutput=true]$IOTHUBOWNER_CONN_STR"
+      name: iothubowner_conn_str_step
+      displayName: Retreive iothubowner connection string
+      continueOnError: true
+      workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+
+    - script: |
+        RESOURCE_GROUP_NAME=`terraform output resource_group_name`
+        echo "##vso[task.setvariable variable=RESOURCE_GROUP_NAME;isOutput=true]$RESOURCE_GROUP_NAME"
+      name: resource_group_name_step
+      displayName: Retreive Resource Group Name
+      continueOnError: true
+      workingDirectory: $(Build.SourcesDirectory)/devops/terraform/iothub
+
+    - script: |
+        mkdir -p $(Build.ArtifactStagingDirectory)/terraform/iothub
+        cp -R $(Build.SourcesDirectory)/devops/terraform/iothub/* $(Build.ArtifactStagingDirectory)/terraform/iothub
+      displayName: Copy terraform state (iothub)
+      continueOnError: true
+
+    - publish: '$(Build.ArtifactStagingDirectory)/terraform/iothub'
+      displayName: 'Publish Terraform state for destroy stage (iothub)'
+      continueOnError: true
+      artifact: terraformStateIoTHub

--- a/devops/pipeline/stages/e2etest_iothub_delete.yaml
+++ b/devops/pipeline/stages/e2etest_iothub_delete.yaml
@@ -1,0 +1,36 @@
+# IoTHub creation stage definition
+
+parameters:
+- name: dependsOn
+  type: object
+  default: []
+
+stages:
+- stage: Terraform_destroy_iothub
+  displayName: Cloud - Destroy IoT Hub
+  dependsOn:
+  - Terraform_iothub
+  - ${{ each dependency in parameters.dependsOn }}:
+    - ${{ dependency }}
+  pool:
+      vmImage: 'ubuntu-18.04'
+  condition: succeeded()
+  jobs:
+  - job: TerraformDestroy
+    steps:
+      - script: |
+          sudo apt update && sudo apt install curl
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt install terraform
+        displayName: Installing Terraform
+
+      - download: current
+        artifact: terraformStateIoTHub
+        displayName: Fetching terraform state (IoTHub)
+
+      - script: |
+          terraform init
+          terraform destroy -var client_id="$(CLIENT_ID)" -var client_secret="$(CLIENT_SECRET)"  -var subscription_id="$(SUBSCRIPTION_ID)" -var tenant_id="$(TENANT_ID)" -var key_vault_id="$(KEY_VAULT_ID)" -auto-approve || true
+        workingDirectory: $(Pipeline.Workspace)/terraformStateIoTHub
+        displayName: Destroy cloud resources (IoTHub)

--- a/devops/pipeline/stages/e2etest_testdriver.yaml
+++ b/devops/pipeline/stages/e2etest_testdriver.yaml
@@ -1,0 +1,92 @@
+# E2E Test Driver Stage Definition
+# Parameters:
+#  - (Required) deviceId [string]: the deviceId to target on the IoT Hub:
+#  - (Required) testRunName [string]: the name to use for the test run (Name to use on test dashboard)
+#  - (Required) deviceStageName [string]: The name of the stage that provisions the device (Needed as tests depend on successful device provisioning)
+#  - (Optional) twinTimeout [number]: Timeout for twin updates - default: 90 seconds
+#  - (Optional) testExpression [string]: the test expression to use to filter the tests (see https://docs.microsoft.com/dotnet/core/testing/selective-unit-tests?pivots=mstest) - default: all tests
+#  - (Optional) environment [string]: (Required for Baremetal) target a specific environment for the pipeline job
+
+parameters:
+- name: deviceId
+  type: string
+- name: testRunName
+  type: string
+- name: deviceStageName
+  type: string
+- name: twinTimeout
+  displayName: Timeout for twin updates
+  type: number
+  default: 90
+- name: testExpression
+  type: string
+  default: ' '
+- name: environment
+  type: string
+  default: ' '
+
+stages:
+- stage: Run_Test_Driver_${{parameters.deviceId}}
+  displayName: Testing ${{parameters.testRunName}}
+  dependsOn:
+    - Terraform_iothub
+    - ${{parameters.deviceStageName}}
+  variables:
+    IOTHUBOWNER_CONN_STR: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['iothubowner_conn_str_step.IOTHUBOWNER_CONN_STR'] ]
+    RESOURCE_GROUP_NAME: $[ stageDependencies.Terraform_iothub.TerraformJobIotHub.outputs['resource_group_name_step.RESOURCE_GROUP_NAME'] ]
+  jobs:
+  - job: E2ETestJob
+    
+    ${{ if ne(parameters.environment, ' ') }}:
+      pool:
+        name: OSConfig
+        demands:
+        - ${{ parameters.environment }}
+    
+    container: dotnet
+    steps:
+      - ${{ if ne(parameters.testExpression, ' ') }}:
+        - script: dotnet test --filter "${{ parameters.testExpression }}" --logger trx
+          displayName: Run Test Driver (Filtered)
+          env:
+            E2E_OSCONFIG_IOTHUB_CONNSTR: $(IOTHUBOWNER_CONN_STR)
+            E2E_OSCONFIG_DEVICE_ID: ${{ parameters.deviceId }}
+            E2E_OSCONFIG_SAS_TOKEN: $(SAS_TOKEN)
+            E2E_OSCONFIG_UPLOAD_URL: $(UPLOAD_URL_BASE_PATH)
+            E2E_OSCONFIG_RESOURCE_GROUP_NAME: $(RESOURCE_GROUP_NAME)
+            E2E_OSCONFIG_TWIN_TIMEOUT: ${{ parameters.twinTimeout }}
+          workingDirectory: $(Build.SourcesDirectory)/src/tests/e2etest
+      - ${{ if eq(parameters.testExpression, ' ') }}:
+        - script: dotnet test --logger trx
+          displayName: Run Test Driver
+          env:
+            E2E_OSCONFIG_IOTHUB_CONNSTR: $(IOTHUBOWNER_CONN_STR)
+            E2E_OSCONFIG_DEVICE_ID: ${{ parameters.deviceId }}
+            E2E_OSCONFIG_SAS_TOKEN: $(SAS_TOKEN)
+            E2E_OSCONFIG_UPLOAD_URL: $(UPLOAD_URL_BASE_PATH)
+            E2E_OSCONFIG_RESOURCE_GROUP_NAME: $(RESOURCE_GROUP_NAME)
+            E2E_OSCONFIG_TWIN_TIMEOUT: ${{ parameters.twinTimeout }}
+          workingDirectory: $(Build.SourcesDirectory)/src/tests/e2etest
+
+      - task: PublishTestResults@2
+        condition: or(succeeded(), failed())
+        continueOnError: true
+        inputs:
+          testRunner: VSTest
+          testResultsFiles: '$(Build.SourcesDirectory)/src/tests/e2etest/TestResults/*.trx'
+          failTaskOnFailedTests: true
+          testRunTitle: ${{parameters.testRunName}}
+
+      - script: |
+          rg=`echo $(RESOURCE_GROUP_NAME) | sed -r 's/"//g'`
+          mkdir -p $(Build.ArtifactStagingDirectory)/logs
+          wget "$(UPLOAD_URL_BASE_PATH)`echo $rg`-${{parameters.deviceId}}.tar.gz?$(SAS_TOKEN)" -O $(Build.ArtifactStagingDirectory)/logs/`echo $rg`-${{parameters.deviceId}}.tar.gz
+        displayName: Get OSConfig logs from blobstore
+        condition: or(succeeded(), failed())
+        continueOnError: true
+
+      - publish: '$(Build.ArtifactStagingDirectory)/logs/'
+        displayName: 'Publish OSConfig Logs'
+        condition: or(succeeded(), failed())
+        continueOnError: true
+        artifact: Logs_${{parameters.testRunName}}

--- a/devops/scripts/install_deps_debian9.sh
+++ b/devops/scripts/install_deps_debian9.sh
@@ -30,3 +30,7 @@ cmake --build . --target install
 
 # cleanup
 cd ~ && rm -rf googletest CMake rapidjson
+
+# Install Dotnet - Needed for e2e tests
+# See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin

--- a/devops/scripts/install_deps_ubuntu1804.sh
+++ b/devops/scripts/install_deps_ubuntu1804.sh
@@ -5,3 +5,6 @@ apt-get -y install gnupg software-properties-common
 apt-add-repository ppa:lttng/stable-2.10 -y
 apt -y update
 apt-get -y install git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev liblttng-ust-dev rapidjson-dev ninja-build wget
+# Install Dotnet - Needed for e2e tests
+# See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin

--- a/devops/scripts/install_deps_ubuntu2004.sh
+++ b/devops/scripts/install_deps_ubuntu2004.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 # Install build essentials for Ubuntu 20.04 base Docker image
 apt -y update
-apt-get -y install software-properties-common
+apt-get -y install gnupg software-properties-common
 apt-add-repository ppa:lttng/stable-2.10 -y
 apt -y update
 apt-get -y install git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev libgtest-dev libgmock-dev liblttng-ust-dev rapidjson-dev ninja-build wget
+# Install Dotnet - Needed for e2e tests
+# See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin


### PR DESCRIPTION
## Description

* Refactored stages into templates:
  * Allows to easily scale targets be reusing templates (See stages folder below).
  * Allows retry failed targets, in case of timeouts or any other random failures without needing a new run.
  * Base pipelines much smaller and easier to understand (400 lines vs 120)
* Ability to target specific tests (Test Expression)
* Added ability to throw dynamic targets at the pipelines, by default contains:

```
    - distroName: ubuntu-18.04
      image_publisher: Canonical
      image_offer: UbuntuServer
      image_sku: 18.04-LTS
      image_version: latest
      packagePattern: '**/*bionic_x86_64.deb'
      device_id: ubuntu1804
      pre_script: >-
        export DEBIAN_FRONTEND=noninteractive &&
        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg &&
        sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ &&
        curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list &&
        sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/ &&
        sudo apt update &&
        sudo apt install aziot-identity-service
    - distroName: ubuntu-20.04
      image_publisher: Canonical
      image_offer: 0001-com-ubuntu-server-focal
      image_sku: 20_04-lts-gen2
      image_version: latest
      packagePattern: '**/*focal_x86_64.deb'
      device_id: ubuntu2004
      pre_script: >-
        export DEBIAN_FRONTEND=noninteractive &&
        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg &&
        sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ &&
        curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list &&
        sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/ &&
        sudo apt update &&
        sudo apt install aziot-identity-service
```
## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.