### PR TITLE
Fixed missing 2-digits in TWEAK_VERSION prefix

### DIFF
--- a/devops/pipeline/stages/binary_build.yaml
+++ b/devops/pipeline/stages/binary_build.yaml
@@ -62,15 +62,20 @@ stages:
         CONTAINER_ID=`docker run -di -v $(Build.SourcesDirectory):/AzOsConfig --platform=${{ parameters.platform }} ${{ parameters.containerPath }}`
         echo CONTAINER_ID=$CONTAINER_ID
         echo "##vso[task.setvariable variable=CONTAINER_ID]$CONTAINER_ID"
+        # Extract TWEAK version from full version string
+        BUILD_VERSION_ARRAY=(`echo $(Build.BuildNumber) | tr '.' ' '`)
+        TWEAK_VERSION=${BUILD_VERSION_ARRAY[-1]}
+        echo TWEAK_VERSION=$TWEAK_VERSION
+        echo "##vso[task.setvariable variable=TWEAK_VERSION]$TWEAK_VERSION"
       displayName: Setup QEMU emulation
 
     - script: |
-        docker exec $(CONTAINER_ID) bash -c "cmake -DCMAKE_BUILD_TYPE=Release -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DMAJOR_VERSION=$(MAJORVERSION) -DMINOR_VERSION=$(MINORVERSION) -DPATCH_VERSION=$(PATCHVERSION) -G Ninja -B/AzOsConfig/build-${{ parameters.architecture }} -H/AzOsConfig/src"
+        docker exec $(CONTAINER_ID) bash -c "cmake -DCMAKE_BUILD_TYPE=Release -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DMAJOR_VERSION=$(MAJORVERSION) -DMINOR_VERSION=$(MINORVERSION) -DPATCH_VERSION=$(PATCHVERSION) -DTWEAK_VERSION=$(TWEAK_VERSION) -G Ninja -B/AzOsConfig/build-${{ parameters.architecture }} -H/AzOsConfig/src"
       displayName: Generate build
       condition: eq(${{ parameters.performCoverage }}, false)
 
     - script: |
-        docker exec $(CONTAINER_ID) bash -c "cmake -DCMAKE_BUILD_TYPE=Debug -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOVERAGE=ON -DCOMPILE_WITH_STRICTNESS=ON -DMAJOR_VERSION=$(MAJORVERSION) -DMINOR_VERSION=$(MINORVERSION) -DPATCH_VERSION=$(PATCHVERSION) -G Ninja -B/AzOsConfig/build-${{ parameters.architecture }} -H/AzOsConfig/src"
+        docker exec $(CONTAINER_ID) bash -c "cmake -DCMAKE_BUILD_TYPE=Debug -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOVERAGE=ON -DCOMPILE_WITH_STRICTNESS=ON -DMAJOR_VERSION=$(MAJORVERSION) -DMINOR_VERSION=$(MINORVERSION) -DPATCH_VERSION=$(PATCHVERSION) -DTWEAK_VERSION=$(TWEAK_VERSION) -G Ninja -B/AzOsConfig/build-${{ parameters.architecture }} -H/AzOsConfig/src"
       displayName: Generate build (with coverage)
       condition: eq(${{ parameters.performCoverage }}, true)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,8 +60,14 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
 endif()
 
 find_package(Git QUIET)
-string(TIMESTAMP _timestamp "%Y%m%d")
-set(CMAKE_PROJECT_VERSION_TWEAK "${_timestamp}")
+
+if(TWEAK_VERSION)
+    set(CMAKE_PROJECT_VERSION_TWEAK "${TWEAK_VERSION}")
+else()
+    string(TIMESTAMP _timestamp "%Y%m%d")
+    set(CMAKE_PROJECT_VERSION_TWEAK "${_timestamp}")
+endif()
+
 
 set(OsConfigProjectName "osconfig")
 set(OsConfigProjectLongName "Azure OSConfig")


### PR DESCRIPTION
## Description

* Fixes the missing last two digits in the TWEAK version. Now contains the daily revision as a prefix.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.