### PR TITLE
Fix E2E pipeline trigger for pull-requests

### DIFF
--- a/devops/pipeline/e2etest.yaml
+++ b/devops/pipeline/e2etest.yaml
@@ -5,6 +5,12 @@
 
 name: $(MajorVersion).$(MinorVersion).$(PatchVersion).$(Date:yyyyMMdd)$(Rev:rr)
 
+trigger:
+  branches:
+    include:
+    - main
+pr: none
+
 resources:
   containers:
   - container: ubuntu
@@ -41,7 +47,7 @@ parameters:
   displayName: Shell script to execute after osconfig install
   type: string
   default: ' '
-  
+
 - name: cloud_targets
   type: object
   default:
@@ -115,7 +121,7 @@ stages:
 
 - template: stages/e2etest_iothub_delete.yaml
   parameters:
-    dependsOn: 
+    dependsOn:
     - ${{ each target in parameters.cloud_targets }}:
       - Run_Test_Driver_${{ target.device_id }}
     - ${{ each target in parameters.baremetal_targets }}:


### PR DESCRIPTION
## Description

Fix E2E pipeline triggers to only run-on merges to main (not on every PR).

[Azure Pipelines - Specify events that trigger pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops)
[Azure Pipelines - GitHub (opting out of PR validation)](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#opting-out-of-pr-validation)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.