### PR TITLE
Remove unit tests from package build

### DIFF
--- a/devops/pipeline/stages/binary_build.yaml
+++ b/devops/pipeline/stages/binary_build.yaml
@@ -81,20 +81,18 @@ stages:
         docker exec $(CONTAINER_ID) bash -c "cmake --build /AzOsConfig/build-${{ parameters.architecture }}"
       displayName: Build osconfig
 
-    - script: |
-        docker exec $(CONTAINER_ID) bash -c "cd /AzOsConfig/build-${{ parameters.architecture }} && cpack -G DEB"
-      displayName: Create Deb package
-      condition: eq(${{ parameters.publishArtifact }}, true)
+    - ${{ if eq(parameters.publishArtifact, True) }}:
+      - script: |
+          docker exec $(CONTAINER_ID) bash -c "cd /AzOsConfig/build-${{ parameters.architecture }} && cpack -G DEB"
+        displayName: Create Deb package
 
-    - script: |
-        cp $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/osconfig_* $(Build.ArtifactStagingDirectory)
-      displayName: Stage Deb package
-      condition: eq(${{ parameters.publishArtifact }}, true)
+      - script: |
+          cp $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/osconfig_* $(Build.ArtifactStagingDirectory)
+        displayName: Stage Deb package
 
-    - publish: $(Build.ArtifactStagingDirectory)
-      displayName: Publishing deb package for ${{ parameters.variantName }}_${{ parameters.architecture }}
-      artifact: OSConfig_$(Build.BuildNumber)_${{ parameters.variantName }}_${{ parameters.architecture }}
-      condition: eq(${{ parameters.publishArtifact }}, true)
+      - publish: $(Build.ArtifactStagingDirectory)
+        displayName: Publishing deb package for ${{ parameters.variantName }}_${{ parameters.architecture }}
+        artifact: OSConfig_$(Build.BuildNumber)_${{ parameters.variantName }}_${{ parameters.architecture }}
 
     - ${{ if eq(parameters.runUnitTests, True) }}:
     # Runs, tests and records in dashboard mode (-T) which will create a report used below (See `PublishTestResults`)
@@ -135,27 +133,25 @@ stages:
           testRunTitle: ${{ parameters.variantName }}-${{ parameters.architecture }}
           platform: ${{ parameters.architecture }}
 
-    - script: |
-        docker exec $(CONTAINER_ID) bash -c "gcovr -r /AzOsConfig/src . -e /AzOsConfig/src/agents/pnp/ --xml /AzOsConfig/build-${{ parameters.architecture }}/coverage.xml"
-      displayName: Run code coverage
-      condition: eq(${{ parameters.performCoverage }}, true)
-      workingDirectory: $(Agent.BuildDirectory)
+    - ${{ if eq(parameters.performCoverage, True) }}:
+      - script: |
+          docker exec $(CONTAINER_ID) bash -c "gcovr -r /AzOsConfig/src . -e /AzOsConfig/src/agents/pnp/ --xml /AzOsConfig/build-${{ parameters.architecture }}/coverage.xml"
+        displayName: Run code coverage
+        workingDirectory: $(Agent.BuildDirectory)
 
-    # Needed for the code coverage report task below (See `PublishCodeCoverageResults`)
-    - task: UseDotNet@2
-      displayName: Use .NET Core SDK
-      condition: eq(${{ parameters.performCoverage }}, true)
-      inputs:
-        packageType: sdk
-        version: 3.1.402
-        installationPath: $(Agent.ToolsDirectory)/dotnet
+      # Needed for the code coverage report task below (See `PublishCodeCoverageResults`)
+      - task: UseDotNet@2
+        displayName: Use .NET Core SDK
+        inputs:
+          packageType: sdk
+          version: 3.1.402
+          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-    # Publish code coverage results
-    - task: PublishCodeCoverageResults@1
-      displayName: Publish code coverage results
-      condition: eq(${{ parameters.performCoverage }}, true)
-      inputs:
-        codeCoverageTool: 'Cobertura'
-        summaryFileLocation: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/coverage.xml
-        pathToSources: $(Build.SourcesDirectory)/src
-        #failIfCoverageEmpty: false # Optional
+      # Publish code coverage results
+      - task: PublishCodeCoverageResults@1
+        displayName: Publish code coverage results
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/coverage.xml
+          pathToSources: $(Build.SourcesDirectory)/src
+          #failIfCoverageEmpty: false # Optional

--- a/devops/pipeline/stages/binary_build.yaml
+++ b/devops/pipeline/stages/binary_build.yaml
@@ -27,6 +27,9 @@ parameters:
 - name: performCoverage
   type: boolean
   default: false
+- name: runUnitTests
+  type: boolean
+  default: false
 - name: ignoreTestFailures
   type: boolean
   default: false
@@ -93,43 +96,44 @@ stages:
       artifact: OSConfig_$(Build.BuildNumber)_${{ parameters.variantName }}_${{ parameters.architecture }}
       condition: eq(${{ parameters.publishArtifact }}, true)
 
+    - ${{ if eq(parameters.runUnitTests, True) }}:
     # Runs, tests and records in dashboard mode (-T) which will create a report used below (See `PublishTestResults`)
     # See ctest test step - https://cmake.org/cmake/help/latest/manual/ctest.1.html#ctest-test-step
-    - script: |
-        docker exec $(CONTAINER_ID) bash -c "cd /AzOsConfig/build-${{ parameters.architecture }} && ctest -T test --verbose > TestOutput.log"
-      condition: and(eq(${{ parameters.ignoreTestFailures }}, false), eq(${{ parameters.performCoverage }}, false))
-      displayName: Run tests
+      - script: |
+          docker exec $(CONTAINER_ID) bash -c "cd /AzOsConfig/build-${{ parameters.architecture }} && ctest -T test --verbose > TestOutput.log"
+        condition: and(eq(${{ parameters.ignoreTestFailures }}, false), eq(${{ parameters.performCoverage }}, false))
+        displayName: Run tests
 
-    - script: |
-        docker exec $(CONTAINER_ID) bash -c "cd /AzOsConfig/build-${{ parameters.architecture }} && ctest -T test --verbose > TestOutput.log || true"
-      condition: and(eq(${{ parameters.ignoreTestFailures }}, true), eq(${{ parameters.performCoverage }}, false))
-      displayName: Run tests (ignore failures)
+      - script: |
+          docker exec $(CONTAINER_ID) bash -c "cd /AzOsConfig/build-${{ parameters.architecture }} && ctest -T test --verbose > TestOutput.log || true"
+        condition: and(eq(${{ parameters.ignoreTestFailures }}, true), eq(${{ parameters.performCoverage }}, false))
+        displayName: Run tests (ignore failures)
 
-    - publish: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/TestOutput.log
-      displayName: Publishing test outputs
-      condition: and(succeededOrFailed(), eq(${{ parameters.performCoverage }}, false))
-      artifact: Test_Logs_${{ parameters.variantName }}_${{ parameters.architecture }}
+      - publish: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/TestOutput.log
+        displayName: Publishing test outputs
+        condition: and(succeededOrFailed(), eq(${{ parameters.performCoverage }}, false))
+        artifact: Test_Logs_${{ parameters.variantName }}_${{ parameters.architecture }}
 
-    # Publishes the results of the ctest test pass to be used in the Azure DevOps dashboard
-    - task: PublishTestResults@2
-      displayName: 'Publish test results'
-      condition: and(succeededOrFailed(), eq(${{ parameters.performCoverage }}, false), eq(${{ parameters.ignoreTestFailures }}, false))
-      inputs:
-        testRunner: cTest
-        testResultsFiles: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/Testing/*/Test.xml
-        failTaskOnFailedTests: true
-        testRunTitle: ${{ parameters.variantName }}-${{ parameters.architecture }}
-        platform: ${{ parameters.architecture }}
+      # Publishes the results of the ctest test pass to be used in the Azure DevOps dashboard
+      - task: PublishTestResults@2
+        displayName: 'Publish test results'
+        condition: and(succeededOrFailed(), eq(${{ parameters.performCoverage }}, false), eq(${{ parameters.ignoreTestFailures }}, false))
+        inputs:
+          testRunner: cTest
+          testResultsFiles: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/Testing/*/Test.xml
+          failTaskOnFailedTests: true
+          testRunTitle: ${{ parameters.variantName }}-${{ parameters.architecture }}
+          platform: ${{ parameters.architecture }}
 
-    - task: PublishTestResults@2
-      displayName: 'Publish test results (ignore failures)'
-      condition: and(succeededOrFailed(), eq(${{ parameters.performCoverage }}, false), eq(${{ parameters.ignoreTestFailures }}, true))
-      inputs:
-        testRunner: cTest
-        testResultsFiles: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/Testing/*/Test.xml
-        failTaskOnFailedTests: false
-        testRunTitle: ${{ parameters.variantName }}-${{ parameters.architecture }}
-        platform: ${{ parameters.architecture }}
+      - task: PublishTestResults@2
+        displayName: 'Publish test results (ignore failures)'
+        condition: and(succeededOrFailed(), eq(${{ parameters.performCoverage }}, false), eq(${{ parameters.ignoreTestFailures }}, true))
+        inputs:
+          testRunner: cTest
+          testResultsFiles: $(Build.SourcesDirectory)/build-${{ parameters.architecture }}/Testing/*/Test.xml
+          failTaskOnFailedTests: false
+          testRunTitle: ${{ parameters.variantName }}-${{ parameters.architecture }}
+          platform: ${{ parameters.architecture }}
 
     - script: |
         docker exec $(CONTAINER_ID) bash -c "gcovr -r /AzOsConfig/src . -e /AzOsConfig/src/agents/pnp/ --xml /AzOsConfig/build-${{ parameters.architecture }}/coverage.xml"


### PR DESCRIPTION
## Description

* Removed the unit tests from the package build pipeline. Allows for building packages without coupling changes the CI pipeline has already validated in order to reduce package build time.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.