### PR TITLE
Resetting the signal for desired configuration

### DIFF
--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -290,14 +290,15 @@ static void SignalChild(int signal)
     UNUSED(signal);
 }
 
-static void SignalProcessDesired(int signal)
+static void SignalProcessDesired(int incomingSignal)
 {
     OsConfigLogInfo(GetLog(), "Processing desired twin updates");
     ProcessDesiredTwinUpdates();
-    UNUSED(signal);
-
+    
     // Reset the signal handler for the next use otherwise the default handler will be invoked instead
     signal(SIGUSR1, SignalProcessDesired);
+
+    UNUSED(incomingSignal);
 }
 
 static void ForkDaemon()

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -229,6 +229,9 @@ static void SignalInterrupt(int signal)
 static void SignalReloadConfiguration(int signal)
 {
     g_refreshSignal = signal;
+    
+    // Reset the handler
+    signal(SIGHUP, SignalReloadConfiguration);
 }
 
 static void RefreshConnection()
@@ -281,7 +284,7 @@ static void RefreshConnection()
 void ScheduleRefreshConnection(void)
 {
     OsConfigLogInfo(GetLog(), "Scheduling refresh connection");
-    SignalReloadConfiguration(SIGHUP);
+    g_refreshSignal = SIGHUP;
 }
 
 static void SignalChild(int signal)

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -295,6 +295,9 @@ static void SignalProcessDesired(int signal)
     OsConfigLogInfo(GetLog(), "Processing desired twin updates");
     ProcessDesiredTwinUpdates();
     UNUSED(signal);
+
+    // Reset the signal handler for the next use otherwise the default handler will be invoked instead
+    signal(SIGUSR1, SignalProcessDesired);
 }
 
 static void ForkDaemon()

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -226,9 +226,9 @@ static void SignalInterrupt(int signal)
     }
 }
 
-static void SignalReloadConfiguration(int signal)
+static void SignalReloadConfiguration(int incomingSignal)
 {
-    g_refreshSignal = signal;
+    g_refreshSignal = incomingSignal;
     
     // Reset the handler
     signal(SIGHUP, SignalReloadConfiguration);


### PR DESCRIPTION
This was observed on HCI to be true: SIGUSR1 once handled once, reverts to default handler - which causes OSConfig to abruptly exit (crash). This PR fixes resetting that event on each handling and also doing this for SIGHUP.

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.