### PR TITLE
Fixed broken identity on upgrade

### DIFF
--- a/devops/debian/postinst
+++ b/devops/debian/postinst
@@ -36,6 +36,11 @@ esac
 
 # Automatically added by dh_installsystemd/12.10ubuntu1
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# MSFT change: binplace osconfig.toml for the azure-identity-service only if not present
+	# Binplacing a pre-existing install breaks the current identity
+	if [ ! -e /etc/aziot/identityd/config.d/osconfig.toml ]; then
+		cp /etc/osconfig/osconfig.toml /etc/aziot/identityd/config.d/
+	fi
 	if [ -d /run/systemd/system ]; then
 		systemctl --system daemon-reload >/dev/null || true
 		if [ -n "$2" ]; then

--- a/src/agents/pnp/CMakeLists.txt
+++ b/src/agents/pnp/CMakeLists.txt
@@ -109,5 +109,6 @@ install(TARGETS ${target_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES daemon/${target_name}.conn DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/osconfig)
 install(FILES daemon/${target_name}.json DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/osconfig)
 install(FILES daemon/${target_name}.service DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/systemd/system)
-install(FILES daemon/${target_name}.toml DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/aziot/identityd/config.d)
+# install osconfig.toml breaks a current install only binplace to final destination (${CMAKE_INSTALL_SYSCONFDIR}/aziot/identityd/config.d) if non-existent
+install(FILES daemon/${target_name}.toml DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/osconfig)
 install(FILES telemetryevents/OsConfigAgentTelemetry.conf DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/azure-device-telemetryd)

--- a/src/cmake/templates/osconfig.spec.in
+++ b/src/cmake/templates/osconfig.spec.in
@@ -63,6 +63,9 @@ rm -rf $RPM_BUILD_ROOT
 %systemd_preun osconfig.service
 
 %post
+if [ ! -e /etc/aziot/identityd/config.d/osconfig.toml ]; then
+    cp /etc/osconfig/osconfig.toml /etc/aziot/identityd/config.d/
+fi
 %systemd_post osconfig.service
 systemctl enable osconfig.service
 systemctl start osconfig.service
@@ -73,11 +76,11 @@ systemctl start osconfig.service
 %files
 %defattr(-, root, root, -)
 %{_bindir}/osconfig
-/etc/aziot/identityd/config.d/osconfig.toml
 /etc/azure-device-telemetryd/OsConfigAgentTelemetry.conf
 /etc/osconfig/osconfig_commandrunner.cache
 /etc/osconfig/osconfig.conn
 /etc/osconfig/osconfig.json
+/etc/osconfig/osconfig.toml
 /etc/systemd/system/osconfig.service
 /usr/lib/osconfig/commandrunner.so
 /usr/lib/osconfig/firewall.so


### PR DESCRIPTION
## Description

* When upgrading osconfig (Debian/RPM) do not replace the osconfig identity used by the azure-identity-service as it breaks the currently used identity forcing the user to reconfigure the identity.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.