### PR TITLE
Making OSConfig continue to run if connection to the IoT Hub is not possible and local management is enabled and connect to Iot Hub later, eventually, without restarting

### DIFF
--- a/src/agents/pnp/CMakeLists.txt
+++ b/src/agents/pnp/CMakeLists.txt
@@ -18,6 +18,7 @@ project(osconfig)
 
 set(osconfig_files
     ./AisUtils.c
+    ./ConfigUtils.c
     ./MpiProxy.c
     ./PnpAgent.c
     ./PnpUtils.c)

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -33,7 +33,7 @@ int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int 
 
     if (NULL == valueName)
     {
-        LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: no %s value, using default (%d)", valueName, defaultValue);
+        LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: no value name, using the specified default (%d)", defaultValue);
         return valueToReturn;
     }
 

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -167,11 +167,11 @@ int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY** repor
 
                                     if ((NULL != componentName) && (NULL != propertyName))
                                     {
-                                        strncpy(*reportedProperties[i]->componentName, componentName, ARRAY_SIZE(*reportedProperties[i]->componentName) - 1);
-                                        strncpy(*reportedProperties[i]->propertyName, propertyName, ARRAY_SIZE(*reportedProperties[i]->propertyName) - 1);
+                                        strncpy((*reportedProperties)[i].componentName, componentName, ARRAY_SIZE((*reportedProperties)[i].componentName) - 1);
+                                        strncpy((*reportedProperties)[i].propertyName, propertyName, ARRAY_SIZE((*reportedProperties)[i].propertyName) - 1);
 
                                         OsConfigLogInfo(GetLog(), "LoadReportedFromJsonConfig: found report property candidate at position %d of %d: %s.%s", (int)(i + 1),
-                                            numReportedProperties, *reportedProperties[i]->componentName, *reportedProperties[i]->propertyName);
+                                            numReportedProperties, (*reportedProperties)[i].componentName, (*reportedProperties)[i].propertyName);
                                     }
                                     else
                                     {

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -25,7 +25,7 @@ bool IsFullLoggingEnabledInJsonConfig(const char* jsonString)
     return result;
 }
 
-int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int defaultValue, int minValue, int maxValue)
+static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int defaultValue, int minValue, int maxValue)
 {
     JSON_Value* rootValue = NULL;
     JSON_Object* rootObject = NULL;
@@ -88,6 +88,31 @@ int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int 
     }
 
     return valueToReturn;
+}
+
+int GetReportingIntervalFromJsonConfig(const char* jsonString)
+{
+    return GetIntegerFromJsonConfig(REPORTING_INTERVAL_SECONDS, jsonString, DEFAULT_REPORTING_INTERVAL, MIN_REPORTING_INTERVAL, MAX_REPORTING_INTERVAL);
+}
+
+int GetModelVersionFromJsonConfig(const char* jsonString)
+{
+    return GetIntegerFromJsonConfig(MODEL_VERSION_NAME, jsonString, DEFAULT_DEVICE_MODEL_ID, MIN_DEVICE_MODEL_ID, MAX_DEVICE_MODEL_ID);
+}
+
+int GetLocalPriorityFromJsonConfig(const char* jsonString)
+{
+    return GetIntegerFromJsonConfig(LOCAL_PRIORITY, jsonString, 0, 0, 1);
+}
+
+int GetLocalManagementFromJsonConfig(const char* jsonString)
+{
+    return GetIntegerFromJsonConfig(LOCAL_MANAGEMENT, jsonString, 0, 0, 1);
+}
+
+int GetProtocolFromJsonConfig(const char* jsonString)
+{
+    return GetIntegerFromJsonConfig(PROTOCOL, jsonString, PROTOCOL_AUTO, PROTOCOL_AUTO, PROTOCOL_MQTT_WS);
 }
 
 int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* reportedProperties)
@@ -222,3 +247,4 @@ char* GetHttpProxyData()
 
     return proxyData;
 }
+

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -115,7 +115,7 @@ int GetProtocolFromJsonConfig(const char* jsonString)
     return GetIntegerFromJsonConfig(PROTOCOL, jsonString, PROTOCOL_AUTO, PROTOCOL_AUTO, PROTOCOL_MQTT_WS);
 }
 
-int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* reportedProperties)
+int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY** reportedProperties)
 {
     JSON_Value* rootValue = NULL;
     JSON_Object* rootObject = NULL;
@@ -128,7 +128,13 @@ int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* report
     size_t i = 0;
     int numReportedProperties = 0;
 
-    FREE_MEMORY(reportedProperties);
+    if (NULL == reportedProperties)
+    {
+        LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: called with an invalid argument, no properties to report");
+        return 0;
+    }
+    
+    FREE_MEMORY(*reportedProperties);
 
     if (NULL != jsonString)
     {
@@ -145,10 +151,10 @@ int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* report
                     if (numReported > 0)
                     {
                         bufferSize = numReported * sizeof(REPORTED_PROPERTY);
-                        reportedProperties = (REPORTED_PROPERTY*)malloc(bufferSize);
-                        if (NULL != reportedProperties)
+                        *reportedProperties = (REPORTED_PROPERTY*)malloc(bufferSize);
+                        if (NULL != *reportedProperties)
                         {
-                            memset(reportedProperties, 0, bufferSize);
+                            memset(*reportedProperties, 0, bufferSize);
                             numReportedProperties = (int)numReported;
 
                             for (i = 0; i < numReported; i++)
@@ -161,11 +167,11 @@ int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* report
 
                                     if ((NULL != componentName) && (NULL != propertyName))
                                     {
-                                        strncpy(reportedProperties[i].componentName, componentName, ARRAY_SIZE(reportedProperties[i].componentName) - 1);
-                                        strncpy(reportedProperties[i].propertyName, propertyName, ARRAY_SIZE(reportedProperties[i].propertyName) - 1);
+                                        strncpy(*reportedProperties[i].componentName, componentName, ARRAY_SIZE(*reportedProperties[i].componentName) - 1);
+                                        strncpy(*reportedProperties[i].propertyName, propertyName, ARRAY_SIZE(*reportedProperties[i].propertyName) - 1);
 
                                         OsConfigLogInfo(GetLog(), "LoadReportedFromJsonConfig: found report property candidate at position %d of %d: %s.%s", (int)(i + 1),
-                                            numReportedProperties, reportedProperties[i].componentName, reportedProperties[i].propertyName);
+                                            numReportedProperties, *reportedProperties[i].componentName, *reportedProperties[i].propertyName);
                                     }
                                     else
                                     {

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -253,4 +253,3 @@ char* GetHttpProxyData()
 
     return proxyData;
 }
-

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "inc/AgentCommon.h"
+#include "inc/ConfigUtils.h"
+
+bool IsFullLoggingEnabledInJsonConfig(const char* jsonString)
+{
+    bool result = false;
+    JSON_Value* rootValue = NULL;
+    JSON_Object* rootObject = NULL;
+
+    if (NULL != jsonString)
+    {
+        if (NULL != (rootValue = json_parse_string(jsonString)))
+        {
+            if (NULL != (rootObject = json_value_get_object(rootValue)))
+            {
+                result = (0 == (int)json_object_get_number(rootObject, FULL_LOGGING)) ? false : true;
+            }
+            json_value_free(rootValue);
+        }
+    }
+
+    return result;
+}
+
+int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int defaultValue, int minValue, int maxValue)
+{
+    JSON_Value* rootValue = NULL;
+    JSON_Object* rootObject = NULL;
+    int valueToReturn = defaultValue;
+
+    if (NULL == valueName)
+    {
+        LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: no %s value, using default (%d)", valueName, defaultValue);
+        return valueToReturn;
+    }
+
+    if (minValue >= maxValue)
+    {
+        LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: bad min (%d) and/or max (%d) values for %s, using default (%d)",
+            minValue, maxValue, valueName, defaultValue);
+        return valueToReturn;
+    }
+
+    if (NULL != jsonString)
+    {
+        if (NULL != (rootValue = json_parse_string(jsonString)))
+        {
+            if (NULL != (rootObject = json_value_get_object(rootValue)))
+            {
+                valueToReturn = (int)json_object_get_number(rootObject, valueName);
+                if (0 == valueToReturn)
+                {
+                    valueToReturn = defaultValue;
+                    OsConfigLogInfo(GetLog(), "GetIntegerFromJsonConfig: %s value not found or 0, using default (%d)", valueName, defaultValue);
+                }
+                else if (valueToReturn < minValue)
+                {
+                    LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: %s value %d too small, using minimum (%d)", valueName, valueToReturn, minValue);
+                    valueToReturn = minValue;
+                }
+                else if (valueToReturn > maxValue)
+                {
+                    LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: %s value %d too big, using maximum (%d)", valueName, valueToReturn, maxValue);
+                    valueToReturn = maxValue;
+                }
+                else
+                {
+                    OsConfigLogInfo(GetLog(), "GetIntegerFromJsonConfig: %s: %d", valueName, valueToReturn);
+                }
+            }
+            else
+            {
+                LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: json_value_get_object(root) failed, using default (%d) for %s", defaultValue, valueName);
+            }
+            json_value_free(rootValue);
+        }
+        else
+        {
+            LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: json_parse_string failed, using default (%d) for %s", defaultValue, valueName);
+        }
+    }
+    else
+    {
+        LogErrorWithTelemetry(GetLog(), "GetIntegerFromJsonConfig: no configuration data, using default (%d) for %s", defaultValue, valueName);
+    }
+
+    return valueToReturn;
+}
+
+int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* reportedProperties)
+{
+    JSON_Value* rootValue = NULL;
+    JSON_Object* rootObject = NULL;
+    JSON_Object* itemObject = NULL;
+    JSON_Array* reportedArray = NULL;
+    const char* componentName = NULL;
+    const char* propertyName = NULL;
+    size_t numReported = 0;
+    size_t bufferSize = 0;
+    size_t i = 0;
+    int numReportedProperties = 0;
+
+    FREE_MEMORY(reportedProperties);
+
+    if (NULL != jsonString)
+    {
+        if (NULL != (rootValue = json_parse_string(jsonString)))
+        {
+            if (NULL != (rootObject = json_value_get_object(rootValue)))
+            {
+                reportedArray = json_object_get_array(rootObject, REPORTED_NAME);
+                if (NULL != reportedArray)
+                {
+                    numReported = json_array_get_count(reportedArray);
+                    OsConfigLogInfo(GetLog(), "LoadReportedFromJsonConfig: found %d %s entries in configuration", (int)numReported, REPORTED_NAME);
+
+                    if (numReported > 0)
+                    {
+                        bufferSize = numReported * sizeof(REPORTED_PROPERTY);
+                        reportedProperties = (REPORTED_PROPERTY*)malloc(bufferSize);
+                        if (NULL != reportedProperties)
+                        {
+                            memset(reportedProperties, 0, bufferSize);
+                            numReportedProperties = (int)numReported;
+
+                            for (i = 0; i < numReported; i++)
+                            {
+                                itemObject = json_array_get_object(reportedArray, i);
+                                if (NULL != itemObject)
+                                {
+                                    componentName = json_object_get_string(itemObject, REPORTED_COMPONENT_NAME);
+                                    propertyName = json_object_get_string(itemObject, REPORTED_SETTING_NAME);
+
+                                    if ((NULL != componentName) && (NULL != propertyName))
+                                    {
+                                        strncpy(reportedProperties[i].componentName, componentName, ARRAY_SIZE(reportedProperties[i].componentName) - 1);
+                                        strncpy(reportedProperties[i].propertyName, propertyName, ARRAY_SIZE(reportedProperties[i].propertyName) - 1);
+
+                                        OsConfigLogInfo(GetLog(), "LoadReportedFromJsonConfig: found report property candidate at position %d of %d: %s.%s", (int)(i + 1),
+                                            numReportedProperties, reportedProperties[i].componentName, reportedProperties[i].propertyName);
+                                    }
+                                    else
+                                    {
+                                        LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: %s or %s missing at position %d of %d, no property to report",
+                                            REPORTED_COMPONENT_NAME, REPORTED_SETTING_NAME, (int)(i + 1), (int)numReported);
+                                    }
+                                }
+                                else
+                                {
+                                    LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: json_array_get_object failed at position %d of %d, no reported property",
+                                        (int)(i + 1), (int)numReported);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: out of memory, cannot allocate %d bytes for %d reported properties",
+                                (int)bufferSize, (int)numReported);
+                        }
+                    }
+                }
+                else
+                {
+                    LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: no valid %s array in configuration, no properties to report", REPORTED_NAME);
+                }
+            }
+            else
+            {
+                LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: json_value_get_object(root) failed, no properties to report");
+            }
+
+            json_value_free(rootValue);
+        }
+        else
+        {
+            LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: json_parse_string failed, no properties to report");
+        }
+    }
+    else
+    {
+        LogErrorWithTelemetry(GetLog(), "LoadReportedFromJsonConfig: no configuration data, no properties to report");
+    }
+
+    return numReportedProperties;
+}
+
+char* GetHttpProxyData()
+{
+    const char* proxyVariables[] = {
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY"
+    };
+    int proxyVariablesSize = ARRAY_SIZE(proxyVariables);
+
+    char* proxyData = NULL;
+    char* environmentVariable = NULL;
+    int i = 0;
+
+    for (i = 0; i < proxyVariablesSize; i++)
+    {
+        environmentVariable = getenv(proxyVariables[i]);
+        if (NULL != environmentVariable)
+        {
+            // The environment variable string must be treated as read-only, make a copy for our use:
+            proxyData = DuplicateString(environmentVariable);
+            if (NULL == proxyData)
+            {
+                LogErrorWithTelemetry(GetLog(), "Cannot make a copy of the %s variable: %d", proxyVariables[i], errno);
+            }
+            else
+            {
+                OsConfigLogInfo(GetLog(), "Proxy data from %s: %s", proxyVariables[i], proxyData);
+            }
+            break;
+        }
+    }
+
+    return proxyData;
+}

--- a/src/agents/pnp/ConfigUtils.c
+++ b/src/agents/pnp/ConfigUtils.c
@@ -167,11 +167,11 @@ int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY** repor
 
                                     if ((NULL != componentName) && (NULL != propertyName))
                                     {
-                                        strncpy(*reportedProperties[i].componentName, componentName, ARRAY_SIZE(*reportedProperties[i].componentName) - 1);
-                                        strncpy(*reportedProperties[i].propertyName, propertyName, ARRAY_SIZE(*reportedProperties[i].propertyName) - 1);
+                                        strncpy(*reportedProperties[i]->componentName, componentName, ARRAY_SIZE(*reportedProperties[i]->componentName) - 1);
+                                        strncpy(*reportedProperties[i]->propertyName, propertyName, ARRAY_SIZE(*reportedProperties[i]->propertyName) - 1);
 
                                         OsConfigLogInfo(GetLog(), "LoadReportedFromJsonConfig: found report property candidate at position %d of %d: %s.%s", (int)(i + 1),
-                                            numReportedProperties, *reportedProperties[i].componentName, *reportedProperties[i].propertyName);
+                                            numReportedProperties, *reportedProperties[i]->componentName, *reportedProperties[i]->propertyName);
                                     }
                                     else
                                     {

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -255,7 +255,7 @@ static void RefreshConnection()
             {
                 FREE_MEMORY(g_iotHubConnectionString);
             }
-            else
+            else if (!g_localManagement)
             {
                 g_exitState = IotHubInitializationFailure;
                 SignalInterrupt(SIGQUIT);
@@ -380,7 +380,7 @@ static bool InitializeAgent(void)
             {
                 FREE_MEMORY(g_iotHubConnectionString);
             }
-            else
+            else if (!g_localManagement)
             {
                 g_exitState = IotHubInitializationFailure;
                 status = false;

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -378,6 +378,7 @@ static bool InitializeAgent(void)
         {
             if (FromAis == g_connectionStringSource)
             {
+                // We will try to get a new connnection string from AIS and try to connect with that
                 FREE_MEMORY(g_iotHubConnectionString);
             }
             else if (!g_localManagement)
@@ -679,7 +680,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            OsConfigLogError(GetLog(), "Failed to obtain a connection string from AIS, to retry later");
+            OsConfigLogError(GetLog(), "Failed to obtain a connection string from AIS, to retry");
         }
     }
     else
@@ -701,8 +702,12 @@ int main(int argc, char *argv[])
             if (NULL == connectionString)
             {
                 LogErrorWithTelemetry(GetLog(), "Failed to load a connection string from %s", argv[1]);
-                g_exitState = NoConnectionString;
-                goto done;
+
+                if (!g_localManagement)
+                {
+                    g_exitState = NoConnectionString;
+                    goto done;
+                }
             }
         }
     }

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -218,7 +218,7 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CallIotHubInitialize(void)
     if (NULL == moduleHandle)
     {
         LogError(GetLog(), "IotHubInitialize failed, failed to initialize connection to IoT Hub");
-        IotHubDeInitialize(void);
+        IotHubDeInitialize();
     }
 
     return moduleHandle;

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -601,7 +601,7 @@ int main(int argc, char *argv[])
     if (NULL != jsonConfiguration)
     {
         g_modelVersion = GetModelVersionFromJsonConfig(jsonConfiguration);
-        g_numReportedProperties = LoadReportedFromJsonConfig(jsonConfiguration, g_reportedProperties);
+        g_numReportedProperties = LoadReportedFromJsonConfig(jsonConfiguration, &&g_reportedProperties);
         g_reportingInterval = GetReportingIntervalFromJsonConfig(jsonConfiguration);
         g_localPriority = GetLocalPriorityFromJsonConfig(jsonConfiguration);
         g_localManagement = GetLocalManagementFromJsonConfig(jsonConfiguration);

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -490,8 +490,10 @@ static void AgentDoWork(void)
 
     if (intervalTick <= (nowTick - g_lastTick))
     {
-        if ((NULL == g_iotHubConnectionString) && (FromAis == g_connectionStringSource) && (NULL == g_moduleHandle))
+        if ((NULL == g_iotHubConnectionString) && (FromAis == g_connectionStringSource))
         {
+            IotHubDeInitialize();
+
             if (NULL != (connectionString = RequestConnectionStringFromAis(&g_x509Certificate, &g_x509PrivateKeyHandle)))
             {
                 if (0 == mallocAndStrcpy_s(&g_iotHubConnectionString, connectionString))

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -761,6 +761,10 @@ static void AgentDoWork(void)
                     SignalInterrupt(SIGQUIT);
                 }
             }
+            else
+            {
+                OsConfigLogError(GetLog(), "Failed to obtain a connection string from AIS, to retry later");
+            }
         }
 
         // Process desired updates from the local DC file (for Iot Hub this is signaled to be done with SIGUSR1) and reported updates to the RC file
@@ -930,6 +934,10 @@ int main(int argc, char *argv[])
                 goto done;
             }
         }
+        else
+        {
+            OsConfigLogError(GetLog(), "Failed to obtain a connection string from AIS, to retry later");
+        }
     }
     else
     {
@@ -956,7 +964,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (0 != mallocAndStrcpy_s(&g_iotHubConnectionString, connectionString))
+    if (connectionString && (0 != mallocAndStrcpy_s(&g_iotHubConnectionString, connectionString)))
     {
         LogErrorWithTelemetry(GetLog(), "Out of memory making copy of the connection string");
         goto done;

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -217,7 +217,7 @@ static IOTHUB_DEVICE_CLIENT_LL_HANDLE CallIotHubInitialize(void)
 
     if (NULL == moduleHandle)
     {
-        LogError(GetLog(), "IotHubInitialize failed, failed to initialize connection to IoT Hub");
+        OsConfigLogError(GetLog(), "IotHubInitialize failed, failed to initialize connection to IoT Hub");
         IotHubDeInitialize();
     }
 

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -38,24 +38,15 @@ TRACELOGGING_DEFINE_PROVIDER(g_providerHandle, "Microsoft.Azure.OsConfigAgent",
 // The optional second command line argument that when present instructs the agent to run as a traditional daemon
 #define FORK_ARG "fork"
 
-#define MODEL_VERSION_NAME "ModelVersion"
-#define REPORTING_INTERVAL_SECONDS "ReportingIntervalSeconds"
-#define LOCAL_MANAGEMENT "LocalManagement"
-#define LOCAL_PRIORITY "LocalPriority"
-#define FULL_LOGGING "FullLogging"
-
-#define PROTOCOL "Protocol"
-#define PROTOCOL_AUTO 0
-#define PROTOCOL_MQTT 1
-#define PROTOCOL_MQTT_WS 2
-static int g_protocol = PROTOCOL_AUTO;
-
-#define DEFAULT_DEVICE_MODEL_ID 4
-#define MIN_DEVICE_MODEL_ID 3
+#define DEFAULT_DEVICE_MODEL_ID 7
+#define MIN_DEVICE_MODEL_ID 7
 #define MAX_DEVICE_MODEL_ID 999
+
 #define DEVICE_MODEL_ID_SIZE 40
 #define DEVICE_PRODUCT_NAME_SIZE 128
 #define DEVICE_PRODUCT_INFO_SIZE 1024
+
+static int g_protocol = PROTOCOL_AUTO;
 
 static REPORTED_PROPERTY* g_reportedProperties = NULL;
 static int g_numReportedProperties = 0;

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -12,15 +12,6 @@
 TRACELOGGING_DEFINE_PROVIDER(g_providerHandle, "Microsoft.Azure.OsConfigAgent",
     (0xcf452c24, 0x662b, 0x4cc5, 0x97, 0x26, 0x5e, 0xfe, 0x82, 0x7d, 0xb2, 0x81));
 
-// 30 seconds
-#define DEFAULT_REPORTING_INTERVAL 30
-
-// 1 second
-#define MIN_REPORTING_INTERVAL 1
-
-// 24 hours
-#define MAX_REPORTING_INTERVAL 86400
-
 // 100 milliseconds
 #define DOWORK_SLEEP 100
 

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -38,10 +38,6 @@ TRACELOGGING_DEFINE_PROVIDER(g_providerHandle, "Microsoft.Azure.OsConfigAgent",
 // The optional second command line argument that when present instructs the agent to run as a traditional daemon
 #define FORK_ARG "fork"
 
-#define DEFAULT_DEVICE_MODEL_ID 7
-#define MIN_DEVICE_MODEL_ID 7
-#define MAX_DEVICE_MODEL_ID 999
-
 #define DEVICE_MODEL_ID_SIZE 40
 #define DEVICE_PRODUCT_NAME_SIZE 128
 #define DEVICE_PRODUCT_INFO_SIZE 1024
@@ -591,12 +587,12 @@ int main(int argc, char *argv[])
     jsonConfiguration = LoadStringFromFile(CONFIG_FILE, false, GetLog());
     if (NULL != jsonConfiguration)
     {
-        g_modelVersion = GetIntegerFromJsonConfig(MODEL_VERSION_NAME, jsonConfiguration, DEFAULT_DEVICE_MODEL_ID, MIN_DEVICE_MODEL_ID, MAX_DEVICE_MODEL_ID);
+        g_modelVersion = GetModelVersionFromJsonConfig(jsonConfiguration);
         g_numReportedProperties = LoadReportedFromJsonConfig(jsonConfiguration, g_reportedProperties);
-        g_reportingInterval = GetIntegerFromJsonConfig(REPORTING_INTERVAL_SECONDS, jsonConfiguration, DEFAULT_REPORTING_INTERVAL, MIN_REPORTING_INTERVAL, MAX_REPORTING_INTERVAL);
-        g_localPriority = GetIntegerFromJsonConfig(LOCAL_PRIORITY, jsonConfiguration, 0, 0, 1);
-        g_localManagement = GetIntegerFromJsonConfig(LOCAL_MANAGEMENT, jsonConfiguration, 0, 0, 1);
-        g_protocol = GetIntegerFromJsonConfig(PROTOCOL, jsonConfiguration, PROTOCOL_AUTO, PROTOCOL_AUTO, PROTOCOL_MQTT_WS);
+        g_reportingInterval = GetReportingIntervalFromJsonConfig(jsonConfiguration);
+        g_localPriority = GetLocalPriorityFromJsonConfig(jsonConfiguration);
+        g_localManagement = GetLocalManagementFromJsonConfig(jsonConfiguration);
+        g_protocol = GetProtocolFromJsonConfig(jsonConfiguration);
         FREE_MEMORY(jsonConfiguration);
     }
 

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -601,7 +601,7 @@ int main(int argc, char *argv[])
     if (NULL != jsonConfiguration)
     {
         g_modelVersion = GetModelVersionFromJsonConfig(jsonConfiguration);
-        g_numReportedProperties = LoadReportedFromJsonConfig(jsonConfiguration, &&g_reportedProperties);
+        g_numReportedProperties = LoadReportedFromJsonConfig(jsonConfiguration, &g_reportedProperties);
         g_reportingInterval = GetReportingIntervalFromJsonConfig(jsonConfiguration);
         g_localPriority = GetLocalPriorityFromJsonConfig(jsonConfiguration);
         g_localManagement = GetLocalManagementFromJsonConfig(jsonConfiguration);

--- a/src/agents/pnp/inc/ConfigUtils.h
+++ b/src/agents/pnp/inc/ConfigUtils.h
@@ -20,6 +20,10 @@
 
 #define MAX_COMPONENT_NAME 256
 
+#define DEFAULT_DEVICE_MODEL_ID 7
+#define MIN_DEVICE_MODEL_ID 7
+#define MAX_DEVICE_MODEL_ID 999
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -33,8 +37,14 @@ typedef struct REPORTED_PROPERTY
 } REPORTED_PROPERTY;
 
 bool IsFullLoggingEnabledInJsonConfig(const char* jsonString);
-int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int defaultValue, int minValue, int maxValue);
+int GetReportingIntervalFromJsonConfig(const char* jsonString);
+int GetModelVersionFromJsonConfig(const char* jsonString);
+int GetLocalPriorityFromJsonConfig(const char* jsonString);
+int GetLocalManagementFromJsonConfig(const char* jsonString);
+int GetProtocolFromJsonConfig(const char* jsonString);
+
 int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* reportedProperties);
+
 char* GetHttpProxyData(void);
 
 #ifdef __cplusplus

--- a/src/agents/pnp/inc/ConfigUtils.h
+++ b/src/agents/pnp/inc/ConfigUtils.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef CONFIGUTILS_H
+#define CONFIGUTILS_H
+
+#define REPORTED_NAME "Reported"
+#define REPORTED_COMPONENT_NAME "ComponentName"
+#define REPORTED_SETTING_NAME "ObjectName"
+#define MAX_COMPONENT_NAME 256
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct REPORTED_PROPERTY
+{
+    char componentName[MAX_COMPONENT_NAME];
+    char propertyName[MAX_COMPONENT_NAME];
+    size_t lastPayloadHash;
+} REPORTED_PROPERTY;
+
+bool IsFullLoggingEnabledInJsonConfig(const char* jsonString);
+int GetIntegerFromJsonConfig(const char* valueName, const char* jsonString, int defaultValue, int minValue, int maxValue);
+int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* reportedProperties);
+char* GetHttpProxyData(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CONFIGUTILS_H

--- a/src/agents/pnp/inc/ConfigUtils.h
+++ b/src/agents/pnp/inc/ConfigUtils.h
@@ -4,6 +4,15 @@
 #ifndef CONFIGUTILS_H
 #define CONFIGUTILS_H
 
+// 30 seconds
+#define DEFAULT_REPORTING_INTERVAL 30
+
+// 1 second
+#define MIN_REPORTING_INTERVAL 1
+
+// 24 hours
+#define MAX_REPORTING_INTERVAL 86400
+
 #define FULL_LOGGING "FullLogging"
 #define REPORTED_NAME "Reported"
 #define REPORTED_COMPONENT_NAME "ComponentName"

--- a/src/agents/pnp/inc/ConfigUtils.h
+++ b/src/agents/pnp/inc/ConfigUtils.h
@@ -4,9 +4,20 @@
 #ifndef CONFIGUTILS_H
 #define CONFIGUTILS_H
 
+#define FULL_LOGGING "FullLogging"
 #define REPORTED_NAME "Reported"
 #define REPORTED_COMPONENT_NAME "ComponentName"
 #define REPORTED_SETTING_NAME "ObjectName"
+#define MODEL_VERSION_NAME "ModelVersion"
+#define REPORTING_INTERVAL_SECONDS "ReportingIntervalSeconds"
+#define LOCAL_MANAGEMENT "LocalManagement"
+#define LOCAL_PRIORITY "LocalPriority"
+
+#define PROTOCOL "Protocol"
+#define PROTOCOL_AUTO 0
+#define PROTOCOL_MQTT 1
+#define PROTOCOL_MQTT_WS 2
+
 #define MAX_COMPONENT_NAME 256
 
 #ifdef __cplusplus

--- a/src/agents/pnp/inc/ConfigUtils.h
+++ b/src/agents/pnp/inc/ConfigUtils.h
@@ -52,7 +52,7 @@ int GetLocalPriorityFromJsonConfig(const char* jsonString);
 int GetLocalManagementFromJsonConfig(const char* jsonString);
 int GetProtocolFromJsonConfig(const char* jsonString);
 
-int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY* reportedProperties);
+int LoadReportedFromJsonConfig(const char* jsonString, REPORTED_PROPERTY** reportedProperties);
 
 char* GetHttpProxyData(void);
 

--- a/src/agents/pnp/inc/PnpAgent.h
+++ b/src/agents/pnp/inc/PnpAgent.h
@@ -9,9 +9,6 @@ extern "C"
 {
 #endif
 
-int InitializeAgent(const char* connectionString, IOTHUB_CLIENT_TRANSPORT_PROVIDER protocol);
-void AgentDoWork(void);
-void CloseAgent(void);
 void ScheduleRefreshConnection(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description

If a bad connection string is given, and/or if AIS is not properly configured, and local management is enabled, then OSConfig will not fail to start but instead will run and execute local management via the RC/DC files and, if AIS is used, periodically check for a connection string and attempt to connect to IoT Hub.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.