### PR TITLE
Added GPG-keys to MIM

### DIFF
--- a/src/modules/mim/packagemanagerconfiguration.json
+++ b/src/modules/mim/packagemanagerconfiguration.json
@@ -102,7 +102,7 @@
                       "enumValue": 7
                     },
                     {
-                      "name": "updatingPackagesLists",
+                      "name": "updatingPackageLists",
                       "enumValue": 8
                     },
                     {

--- a/src/modules/mim/packagemanagerconfiguration.json
+++ b/src/modules/mim/packagemanagerconfiguration.json
@@ -86,20 +86,28 @@
                       "enumValue": 3
                     },
                     {
-                      "name": "deserializingSources",
+                      "name": "deserializingGpgKeys",
                       "enumValue": 4
                     },
                     {
-                      "name": "modifyingSources",
+                      "name": "deserializingSources",
                       "enumValue": 5
                     },
                     {
-                      "name": "updatingPackagesLists",
+                      "name": "downloadingGpgKeys",
                       "enumValue": 6
                     },
                     {
-                      "name": "installingPackages",
+                      "name": "modifyingSources",
                       "enumValue": 7
+                    },
+                    {
+                      "name": "updatingPackagesLists",
+                      "enumValue": 8
+                    },
+                    {
+                      "name": "installingPackages",
+                      "enumValue": 9
                     }
                   ]
                 }
@@ -135,6 +143,20 @@
                   },
                   "mapValue": {
                     "name": "entry",
+                    "schema": "string"
+                  }
+                }
+              },
+              {
+                "name": "gpgKeys",
+                "schema": {
+                  "type": "map",
+                  "mapKey": {
+                    "name": "id",
+                    "schema": "string"
+                  },
+                  "mapValue": {
+                    "name": "url",
                     "schema": "string"
                   }
                 }

--- a/src/modules/pmc/README.md
+++ b/src/modules/pmc/README.md
@@ -37,15 +37,15 @@ The `ExecutionState`, `ExecutionSubState` and `ExecutionSubStateDetails` propert
 | 1 (Running)    | 1 (DeserializingJsonPayload)  | empty                    | Deserializing PackageManagerConfiguration JSON object                                        |
 | 1 (Running)    | 2 (DeserializingDesiredState) | empty                    | Deserializing DesiredState JSON object                                                       |
 | 1 (Running)    | 3 (DeserializingPackages)     | package_name(s)          | Deserializing Packages JSON array                                                            |
-| 1 (Running)    | 4 (UpdatingPackagesLists)     | empty                    | Refreshing list of packages before updating packages (by running `apt-get update` command)   |
+| 1 (Running)    | 4 (UpdatingPackageLists)     | empty                    | Refreshing list of packages before updating packages (by running `apt-get update` command)   |
 | 1 (Running)    | 5 (InstallingPackages)        | package_name(s)          | Installing packages (by running `apt-get install` command)                                   |
 | 2 (Succeeded)  | 0 (None)                      | empty                    | All desired properties were applied successfully                                             |
 | 3 (Failed)     | 1 (DeserializingJsonPayload)  | empty                    | Deserializing PackageManagerConfiguration JSON object failed                                 |
 | 3 (Failed)     | 2 (DeserializingDesiredState) | empty                    | Deserializing DesiredState JSON object failed                                                |
 | 3 (Failed)     | 3 (DeserializingPackages)     | package_name(s)          | Deserializing Packages JSON array failed                                                     |
-| 3 (Failed)     | 4 (UpdatingPackagesLists)     | empty                    | Refreshing list of packages packages failed                                                  |
+| 3 (Failed)     | 4 (UpdatingPackageLists)     | empty                    | Refreshing list of packages packages failed                                                  |
 | 3 (Failed)     | 5 (InstallingPackages)        | package_name(s)          | Installing packages failed                                                                   |
-| 4 (TimedOut)   | 4 (UpdatingPackagesLists)     | empty                    | Refreshing list of packages timed out                                                        |
+| 4 (TimedOut)   | 4 (UpdatingPackageLists)     | empty                    | Refreshing list of packages timed out                                                        |
 | 4 (TimedOut)   | 5 (InstallingPackages)        | package_name(s)          | Installing packages timed out                                                                |
 
 ### Example of reported payload:
@@ -73,7 +73,7 @@ Package Manager Configuration module can fail in different stages. To be able to
 | 3 (Failed)     | 1 (DeserializingJsonPayload)  | empty                    | Payload too large, unabled to parse JSON payload, not specified PackageManagerConfiguration     |
 | 3 (Failed)     | 2 (DeserializingDesiredState) | empty                    | Invalid DesiredState payload, incorrect types specified, not specified Packages                 |
 | 3 (Failed)     | 4 (DeserializingPackages)     | package_name(s)          | Packages is not an array type, invalid array element                                            |
-| 3 (Failed)     | 4 (UpdatingPackagesLists)     | empty                    | Refreshing list of packages (by running `apt-get update` command) failed. A source repository may be unreachable or access may be unauthorized |
+| 3 (Failed)     | 4 (UpdatingPackageLists)     | empty                    | Refreshing list of packages (by running `apt-get update` command) failed. A source repository may be unreachable or access may be unauthorized |
 | 3 (Failed)     | 5 (InstallingPackages)        | package_name(s)          | Installation of package(s) failed because they (or any of their dependencies) weren't found in the source repositories |
-| 4 (TimedOut)   | 4 (UpdatingPackagesLists)     | empty                    | Refreshing list of packages (by running `apt-get update` command) took more than 10 min         |
+| 4 (TimedOut)   | 4 (UpdatingPackageLists)     | empty                    | Refreshing list of packages (by running `apt-get update` command) took more than 10 min         |
 | 4 (TimedOut)   | 5 (InstallingPackages)        | package_name(s)          | Installing packages took more than 10 min                                                       |

--- a/src/modules/pmc/src/lib/ExecutionState.h
+++ b/src/modules/pmc/src/lib/ExecutionState.h
@@ -19,7 +19,7 @@ public:
         deserializingJsonPayload,
         deserializingDesiredState,
         deserializingPackages,
-        updatingPackagesLists,
+        updatingPackageLists,
         installingPackages
     };
 

--- a/src/modules/pmc/src/lib/PmcBase.cpp
+++ b/src/modules/pmc/src/lib/PmcBase.cpp
@@ -369,13 +369,13 @@ int PmcBase::ExecuteUpdates(const std::vector<std::string> packages, bool update
 
     if (updatePackageLists)
     {
-        m_executionState.SetExecutionState(ExecutionState::StateComponent::running, ExecutionState::SubStateComponent::updatingPackagesLists);
+        m_executionState.SetExecutionState(ExecutionState::StateComponent::running, ExecutionState::SubStateComponent::updatingPackageLists);
 
         status = RunCommand(g_commandAptUpdate, nullptr);
         if (status != MMI_OK)
         {
-            status == ETIME ? m_executionState.SetExecutionState(ExecutionState::StateComponent::timedOut, ExecutionState::SubStateComponent::updatingPackagesLists)
-                            : m_executionState.SetExecutionState(ExecutionState::StateComponent::failed, ExecutionState::SubStateComponent::updatingPackagesLists);
+            status == ETIME ? m_executionState.SetExecutionState(ExecutionState::StateComponent::timedOut, ExecutionState::SubStateComponent::updatingPackageLists)
+                            : m_executionState.SetExecutionState(ExecutionState::StateComponent::failed, ExecutionState::SubStateComponent::updatingPackageLists);
             return status;
         }
     }


### PR DESCRIPTION
## Description

Extended MIM with the next feature to be contributed: GPG keys.
The map keys will be used to uniquely name the GPG keys to be downloaded.
The map values will contain the URL where the key can be downloaded from.
The module will implement the recommended approach described here: https://wiki.debian.org/DebianRepository/UseThirdParty

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.