### PR TITLE
Re-enable CI tests in pipeline

### DIFF
--- a/devops/pipeline/source_packaging.yaml
+++ b/devops/pipeline/source_packaging.yaml
@@ -25,6 +25,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/ubuntu20.04-dev-amd64:latest
     platform: linux/amd64
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -35,6 +36,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/ubuntu20.04-dev-arm:latest
     platform: linux/arm/v7
     publishArtifact: false
+    runUnitTests: false
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -45,6 +47,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/ubuntu20.04-dev-arm64:latest
     platform: linux/arm64/v8
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -55,6 +58,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/ubuntu18.04-dev-amd64:latest
     platform: linux/amd64
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -65,6 +69,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/ubuntu18.04-dev-arm:latest
     platform: linux/arm/v7
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -75,6 +80,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/ubuntu18.04-dev-arm64:latest
     platform: linux/arm64/v8
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -85,6 +91,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/debian9-dev-amd64:latest
     platform: linux/amd64
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -95,6 +102,7 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/debian9-dev-arm:latest
     platform: linux/arm/v7
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg
 
 - template: stages/binary_build.yaml
@@ -105,4 +113,5 @@ stages:
     containerPath: $(CONTAINER_REGISTRY)/debian9-dev-arm64:latest
     platform: linux/arm64/v8
     publishArtifact: false
+    runUnitTests: true
     prefix: pkg


### PR DESCRIPTION
## Description

Re-enable CI tests in pipeline (excluding `Ubuntu 20.04 ARM` due to a known bug).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.