### PR TITLE
Unify serialization in e2e tests

### DIFF
--- a/src/tests/e2etest/CommandRunnerTests.cs
+++ b/src/tests/e2etest/CommandRunnerTests.cs
@@ -35,19 +35,19 @@ namespace E2eTesting
 
         public class CommandArguments
         {
-            public string commandId { get; set; }
-            public string arguments { get; set; }
-            public Action action { get; set; }
-            public int timeout { get; set; }
-            public bool singleLineTextResult { get; set; }
+            public string CommandId { get; set; }
+            public string Arguments { get; set; }
+            public Action Action { get; set; }
+            public int Timeout { get; set; }
+            public bool SingleLineTextResult { get; set; }
         }
 
         public class CommandStatus
         {
-            public string commandId { get; set; }
-            public long resultCode { get; set; }
-            public string textResult { get; set; }
-            public CommandState currentState { get; set; }
+            public string CommandId { get; set; }
+            public long ResultCode { get; set; }
+            public string TextResult { get; set; }
+            public CommandState CurrentState { get; set; }
         }
 
         public static string GenerateId()
@@ -64,11 +64,11 @@ namespace E2eTesting
         {
             return new CommandArguments
             {
-                commandId = newCommandId,
-                arguments = newArguments,
-                action = newAction,
-                timeout = newTimeout,
-                singleLineTextResult = newSingleLinetextResult
+                CommandId = newCommandId,
+                Arguments = newArguments,
+                Action = newAction,
+                Timeout = newTimeout,
+                SingleLineTextResult = newSingleLinetextResult
             };
         }
 
@@ -76,10 +76,10 @@ namespace E2eTesting
         {
             return new CommandArguments
             {
-                commandId = newCommandId,
-                arguments = "sleep 1000s",
-                action = Action.RunCommand,
-                timeout = newTimeout
+                CommandId = newCommandId,
+                Arguments = "sleep 1000s",
+                Action = Action.RunCommand,
+                Timeout = newTimeout
             };
         }
 
@@ -87,10 +87,10 @@ namespace E2eTesting
         {
             return new CommandArguments
             {
-                commandId = newCommandId,
-                arguments = "",
-                action = Action.CancelCommand,
-                timeout = 0
+                CommandId = newCommandId,
+                Arguments = "",
+                Action = Action.CancelCommand,
+                Timeout = 0
             };
         }
 
@@ -98,10 +98,10 @@ namespace E2eTesting
         {
             return new CommandStatus
             {
-                commandId = newCommandId,
-                textResult = newTextResult,
-                currentState = newCommandState,
-                resultCode = newResultCode
+                CommandId = newCommandId,
+                TextResult = newTextResult,
+                CurrentState = newCommandState,
+                ResultCode = newResultCode
             };
         }
 
@@ -109,7 +109,7 @@ namespace E2eTesting
         {
             int ackCode = -1;
 
-            Console.WriteLine($"{command.action} \"{command.commandId}\" ({command.arguments})");
+            Console.WriteLine($"{command.Action} \"{command.CommandId}\" ({command.Arguments})");
 
             try
             {
@@ -137,9 +137,9 @@ namespace E2eTesting
         {
             var refreshCommand = new CommandArguments
             {
-                commandId = newCommandId,
-                arguments = "",
-                action = Action.RefreshCommandStatus
+                CommandId = newCommandId,
+                Arguments = "",
+                Action = Action.RefreshCommandStatus
             };
 
             SendCommand(refreshCommand, expectedAckCode);
@@ -147,7 +147,7 @@ namespace E2eTesting
 
         public CommandStatus WaitForStatus(string commandId, CommandState state)
         {
-            Func<CommandStatus, bool> condition = (CommandStatus status) => ((status.commandId == commandId) && (status.currentState == state));
+            Func<CommandStatus, bool> condition = (CommandStatus status) => ((status.CommandId == commandId) && (status.CurrentState == state));
             var reportedTask = GetReported<CommandStatus>(_componentName, _reportedObjectName, condition);
             reportedTask.Wait();
             return reportedTask.Result;
@@ -165,8 +165,8 @@ namespace E2eTesting
             var command = CreateCommand(arguments, Action.RunCommand, timeout, singleLineTextResult);
             SendCommand(command);
 
-            CommandStatus status = WaitForStatus(command.commandId, state);
-            JsonAssert.AreEqual(CreateCommandStatus(command.commandId, textResult, state, resultCode), status);
+            CommandStatus status = WaitForStatus(command.CommandId, state);
+            JsonAssert.AreEqual(CreateCommandStatus(command.CommandId, textResult, state, resultCode), status);
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace E2eTesting
             SendCommand(command);
             CommandStatus runningStatus = WaitForStatus(commandId, CommandState.Running);
 
-            CancelCommand(command.commandId);
+            CancelCommand(command.CommandId);
             CommandStatus canceledStatus = WaitForStatus(commandId, CommandState.Canceled);
 
             Assert.Multiple(() =>
@@ -211,28 +211,28 @@ namespace E2eTesting
             var command3 = CreateCommand("sleep 10s && echo 'command 3'", timeout: 1);
             var command4 = CreateCommand("blah");
 
-            var expectedCommandStatus1 = CreateCommandStatus(command1.commandId, "", CommandState.Canceled, 125);
-            var expectedCommandStatus2 = CreateCommandStatus(command2.commandId, "command 2\n", CommandState.Succeeded, 0);
-            var expectedCommandStatus3 = CreateCommandStatus(command3.commandId, "", CommandState.TimedOut, 62);
-            var expectedCommandStatus4 = CreateCommandStatus(command4.commandId, "sh: 1: blah: not found\n", CommandState.Failed, 127);
+            var expectedCommandStatus1 = CreateCommandStatus(command1.CommandId, "", CommandState.Canceled, 125);
+            var expectedCommandStatus2 = CreateCommandStatus(command2.CommandId, "command 2\n", CommandState.Succeeded, 0);
+            var expectedCommandStatus3 = CreateCommandStatus(command3.CommandId, "", CommandState.TimedOut, 62);
+            var expectedCommandStatus4 = CreateCommandStatus(command4.CommandId, "sh: 1: blah: not found\n", CommandState.Failed, 127);
 
             SendCommand(command1);
             SendCommand(command2);
             SendCommand(command3);
             SendCommand(command4);
-            SendCommand(CreateCancelCommand(command1.commandId));
+            SendCommand(CreateCancelCommand(command1.CommandId));
 
             // Wait for the last command to complete before checking all command statuses
-            CommandStatus actualCommandStatus4 = WaitForStatus(command4.commandId, CommandState.Failed);
+            CommandStatus actualCommandStatus4 = WaitForStatus(command4.CommandId, CommandState.Failed);
 
-            RefreshCommandStatus(command1.commandId);
-            CommandStatus actualCommandStatus1 = WaitForStatus(command1.commandId, CommandState.Canceled);
+            RefreshCommandStatus(command1.CommandId);
+            CommandStatus actualCommandStatus1 = WaitForStatus(command1.CommandId, CommandState.Canceled);
 
-            RefreshCommandStatus(command2.commandId);
-            CommandStatus actualCommandStatus2 = WaitForStatus(command2.commandId, CommandState.Succeeded);
+            RefreshCommandStatus(command2.CommandId);
+            CommandStatus actualCommandStatus2 = WaitForStatus(command2.CommandId, CommandState.Succeeded);
 
-            RefreshCommandStatus(command3.commandId);
-            CommandStatus actualCommandStatus3 = WaitForStatus(command3.commandId, CommandState.TimedOut);
+            RefreshCommandStatus(command3.CommandId);
+            CommandStatus actualCommandStatus3 = WaitForStatus(command3.CommandId, CommandState.TimedOut);
 
             Assert.Multiple(() =>
             {

--- a/src/tests/e2etest/CommandRunnerTests.cs
+++ b/src/tests/e2etest/CommandRunnerTests.cs
@@ -115,7 +115,7 @@ namespace E2eTesting
             {
                 var setDesiredTask = SetDesired<CommandArguments>(_componentName, _desiredObjectName, command);
                 setDesiredTask.Wait();
-                ackCode = setDesiredTask.Result.ac;
+                ackCode = setDesiredTask.Result.Ac;
             }
             catch (Exception e)
             {

--- a/src/tests/e2etest/E2ETest.cs
+++ b/src/tests/e2etest/E2ETest.cs
@@ -35,8 +35,8 @@ namespace E2eTesting
 
         public class GenericResponse<T>
         {
-            public T value { get; set; }
-            public int ac { get; set; }
+            public T Value { get; set; }
+            public int Ac { get; set; }
         }
 
         [OneTimeSetUp]
@@ -101,7 +101,7 @@ namespace E2eTesting
             {
                 var desiredResult = SetDesired<CommandRunnerTests.CommandArguments>("CommandRunner", "commandArguments", command);
                 desiredResult.Wait();
-                int ackCode = desiredResult.Result.ac;
+                int ackCode = desiredResult.Result.Ac;
 
                 if (ACK_SUCCESS != ackCode)
                 {

--- a/src/tests/e2etest/E2ETest.cs
+++ b/src/tests/e2etest/E2ETest.cs
@@ -3,9 +3,11 @@
 
 using Microsoft.Azure.Devices;
 using Microsoft.Azure.Devices.Shared;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
 using System;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -40,6 +42,11 @@ namespace E2eTesting
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+
             _registryManager = RegistryManager.CreateFromConnectionString(_iotHubConnectionString);
 
             if (null != Environment.GetEnvironmentVariable("E2E_OSCONFIG_TWIN_TIMEOUT"))
@@ -105,7 +112,7 @@ namespace E2eTesting
                 {
                     Func<CommandRunnerTests.CommandStatus, bool> condition = (CommandRunnerTests.CommandStatus status) =>
                     {
-                        return (status.commandId == command.commandId) && (status.currentState == CommandRunnerTests.CommandState.Succeeded);
+                        return (status.CommandId == command.CommandId) && (status.CurrentState == CommandRunnerTests.CommandState.Succeeded);
                     };
 
                     var reportedResult = GetReported<CommandRunnerTests.CommandStatus>("CommandRunner", "commandStatus", condition, 2 * _maxWaitTimeSeconds);
@@ -114,7 +121,7 @@ namespace E2eTesting
 
                     if (!condition(reportedStatus))
                     {
-                        Console.WriteLine("[ExecuteCommandViaCommandRunner] Command status not reported as succeeded for {0}: '{1}' {2} {3}", command.commandId, reportedStatus.commandId, reportedStatus.currentState, reportedStatus.textResult);
+                        Console.WriteLine("[ExecuteCommandViaCommandRunner] Command status not reported as succeeded for {0}: '{1}' {2} {3}", command.CommandId, reportedStatus.CommandId, reportedStatus.CurrentState, reportedStatus.TextResult);
                         success = false;
                     }
                 }
@@ -170,7 +177,7 @@ namespace E2eTesting
         {
             try
             {
-                return JsonSerializer.Deserialize<T>(twinCollection.ToString());
+                return JsonConvert.DeserializeObject<T>(twinCollection.ToString());
             }
             catch (Exception e)
             {
@@ -243,7 +250,7 @@ namespace E2eTesting
 
             var twinPatch = new Twin();
             twinPatch.Properties.Desired[componentName] = new { __t = 'c' };
-            twinPatch.Properties.Desired[componentName][objectName] = Newtonsoft.Json.Linq.JToken.FromObject(value);
+            twinPatch.Properties.Desired[componentName][objectName] = JToken.FromObject(value);
 
             DateTime start = DateTime.Now;
             Twin updatedTwin = await _registryManager.UpdateTwinAsync(_deviceId, _moduleId, twinPatch, twin.ETag);
@@ -356,8 +363,8 @@ namespace E2eTesting
     {
         public static void AreEqual(object expected, object actual)
         {
-            var expectedJson = JsonSerializer.Serialize(expected);
-            var actualJson = JsonSerializer.Serialize(actual);
+            var expectedJson = JsonConvert.SerializeObject(expected);
+            var actualJson = JsonConvert.SerializeObject(actual);
             Assert.AreEqual(expectedJson, actualJson);
         }
     }
@@ -366,7 +373,7 @@ namespace E2eTesting
     {
         public static void IsMatch(Regex pattern, object value)
         {
-            string jsonValue = JsonSerializer.Serialize(value);
+            string jsonValue = JsonConvert.SerializeObject(value);
             if (!pattern.IsMatch(jsonValue))
             {
                 Assert.Fail("Regex does not match.\nPattern: {0},\n String: {1}", pattern, value);

--- a/src/tests/e2etest/FirewallTests.cs
+++ b/src/tests/e2etest/FirewallTests.cs
@@ -23,19 +23,19 @@ namespace E2eTesting
 
         public partial class Firewall
         {
-            public FirewallStateCode firewallState { get; set; }
-            public string firewallFingerprint { get; set; }
+            public FirewallStateCode FirewallState { get; set; }
+            public string FirewallFingerprint { get; set; }
         }
 
         [Test]
         public async Task FirewallTest_Regex()
         {
-            Firewall reported = await GetReported<Firewall>(_componentName, (Firewall firewall) => (firewall.firewallState != FirewallStateCode.Unknown) && (firewall.firewallFingerprint != null));
+            Firewall reported = await GetReported<Firewall>(_componentName, (Firewall firewall) => (firewall.FirewallState != FirewallStateCode.Unknown) && (firewall.FirewallFingerprint != null));
 
             Assert.Multiple(() =>
             {
-                RegexAssert.IsMatch(_statePattern, reported.firewallState);
-                RegexAssert.IsMatch(_fingerprintPattern, reported.firewallFingerprint);
+                RegexAssert.IsMatch(_statePattern, reported.FirewallState);
+                RegexAssert.IsMatch(_fingerprintPattern, reported.FirewallFingerprint);
             });
         }
     }

--- a/src/tests/e2etest/HostNameTests.cs
+++ b/src/tests/e2etest/HostNameTests.cs
@@ -54,7 +54,7 @@ namespace E2eTesting
 
             await SetDesired<DesiredHostName>(_componentName, desired);
 
-            Func<GenericResponse<string>, bool> condition = (GenericResponse<string> response) => response.ac == ACK_SUCCESS;
+            Func<GenericResponse<string>, bool> condition = (GenericResponse<string> response) => response.Ac == ACK_SUCCESS;
 
             var desiredNameTask = GetReported<GenericResponse<string>>(_componentName, _desiredHostName, condition);
             desiredNameTask.Wait();
@@ -67,8 +67,8 @@ namespace E2eTesting
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(ACK_SUCCESS, desiredNameTask.Result.ac);
-                Assert.AreEqual(ACK_SUCCESS, desiredHostsTask.Result.ac);
+                Assert.AreEqual(ACK_SUCCESS, desiredNameTask.Result.Ac);
+                Assert.AreEqual(ACK_SUCCESS, desiredHostsTask.Result.Ac);
                 Assert.AreEqual(desired.DesiredName, reported.Name);
                 Assert.AreEqual(desired.DesiredHosts, reported.Hosts);
             });

--- a/src/tests/e2etest/HostNameTests.cs
+++ b/src/tests/e2etest/HostNameTests.cs
@@ -21,25 +21,25 @@ namespace E2eTesting
 
         public class HostName
         {
-            public string name { get; set; }
-            public string hosts { get; set; }
+            public string Name { get; set; }
+            public string Hosts { get; set; }
         }
 
         public class DesiredHostName
         {
-            public string desiredName { get; set; }
-            public string desiredHosts { get; set; }
+            public string DesiredName { get; set; }
+            public string DesiredHosts { get; set; }
         }
 
         [Test]
         public async Task HostNameTest_Get()
         {
-            HostName reported = await GetReported<HostName>(_componentName, (HostName hostname) => (hostname.name != null) && (hostname.hosts != null));
+            HostName reported = await GetReported<HostName>(_componentName, (HostName hostname) => (hostname.Name != null) && (hostname.Hosts != null));
 
             Assert.Multiple(() =>
             {
-                RegexAssert.IsMatch(_namePattern, reported.name);
-                RegexAssert.IsMatch(_hostsPattern, reported.hosts);
+                RegexAssert.IsMatch(_namePattern, reported.Name);
+                RegexAssert.IsMatch(_hostsPattern, reported.Hosts);
             });
         }
 
@@ -48,8 +48,8 @@ namespace E2eTesting
         {
             var desired = new DesiredHostName
             {
-                desiredName = "TestHost",
-                desiredHosts = "127.0.0.1 localhost;127.0.1.1 TestHost;::1 ip6-localhost ip6-loopback;fe00::0 ip6-localnet;ff00::0 ip6-mcastprefix;ff02::1 ip6-allnodes;ff02::2 ip6-allrouters"
+                DesiredName = "TestHost",
+                DesiredHosts = "127.0.0.1 localhost;127.0.1.1 TestHost;::1 ip6-localhost ip6-loopback;fe00::0 ip6-localnet;ff00::0 ip6-mcastprefix;ff02::1 ip6-allnodes;ff02::2 ip6-allrouters"
             };
 
             await SetDesired<DesiredHostName>(_componentName, desired);
@@ -62,15 +62,15 @@ namespace E2eTesting
             desiredHostsTask.Wait();
 
             HostName reported = await GetReported<HostName>(_componentName, (HostName hostname) => {
-                return (hostname.name == desired.desiredName) && (hostname.hosts == desired.desiredHosts);
+                return (hostname.Name == desired.DesiredName) && (hostname.Hosts == desired.DesiredHosts);
             });
 
             Assert.Multiple(() =>
             {
                 Assert.AreEqual(ACK_SUCCESS, desiredNameTask.Result.ac);
                 Assert.AreEqual(ACK_SUCCESS, desiredHostsTask.Result.ac);
-                Assert.AreEqual(desired.desiredName, reported.name);
-                Assert.AreEqual(desired.desiredHosts, reported.hosts);
+                Assert.AreEqual(desired.DesiredName, reported.Name);
+                Assert.AreEqual(desired.DesiredHosts, reported.Hosts);
             });
         }
     }

--- a/src/tests/e2etest/NetworkingTests.cs
+++ b/src/tests/e2etest/NetworkingTests.cs
@@ -26,15 +26,15 @@ namespace E2eTesting
 
         public class NetworkConfiguration
         {
-            public string interfaceTypes { get; set; }
-            public string macAddresses { get; set; }
-            public string ipAddresses { get; set; }
-            public string subnetMasks { get; set; }
-            public string defaultGateways { get; set; }
-            public string dnsServers { get; set; }
-            public string dhcpEnabled { get; set; }
-            public string enabled { get; set; }
-            public string connected { get; set; }
+            public string InterfaceTypes { get; set; }
+            public string MacAddresses { get; set; }
+            public string IpAddresses { get; set; }
+            public string SubnetMasks { get; set; }
+            public string DefaultGateways { get; set; }
+            public string DnsServers { get; set; }
+            public string DhcpEnabled { get; set; }
+            public string Enabled { get; set; }
+            public string Connected { get; set; }
         }
 
         public void NetworkPropertyPatternMatch(Regex pattern, string value)
@@ -77,39 +77,39 @@ namespace E2eTesting
         public async Task NetworkingTest_Get()
         {
             NetworkConfiguration reported = await GetReported<NetworkConfiguration>(_componentName, _reportedPropertyName, (NetworkConfiguration network) => {
-                return network.interfaceTypes != null &&
-                       network.macAddresses != null &&
-                       network.ipAddresses != null &&
-                       network.subnetMasks != null &&
-                       network.defaultGateways != null &&
-                       network.dhcpEnabled != null &&
-                       network.enabled != null &&
-                       network.connected != null;
+                return network.InterfaceTypes != null &&
+                       network.MacAddresses != null &&
+                       network.IpAddresses != null &&
+                       network.SubnetMasks != null &&
+                       network.DefaultGateways != null &&
+                       network.DhcpEnabled != null &&
+                       network.Enabled != null &&
+                       network.Connected != null;
             });
 
             Assert.Multiple(() =>
             {
                 // Interface
-                NetworkPropertyPatternMatch(_interfacePattern, reported.interfaceTypes);
+                NetworkPropertyPatternMatch(_interfacePattern, reported.InterfaceTypes);
                 // MacAddress
-                NetworkPropertyPatternMatch(_macAddressPattern, _delimiterPattern, reported.macAddresses);
+                NetworkPropertyPatternMatch(_macAddressPattern, _delimiterPattern, reported.MacAddresses);
                 // IpAddress
-                NetworkPropertyPatternMatch(_ipAddressPattern, _delimiterPattern, reported.ipAddresses);
+                NetworkPropertyPatternMatch(_ipAddressPattern, _delimiterPattern, reported.IpAddresses);
                 // SubnetMask
-                NetworkPropertyPatternMatch(_subnetMaskPattern, _delimiterPattern, reported.subnetMasks);
+                NetworkPropertyPatternMatch(_subnetMaskPattern, _delimiterPattern, reported.SubnetMasks);
                 // DefaultGateway
-                NetworkPropertyPatternMatch(_ipAddressPattern, _delimiterPattern, reported.defaultGateways);
+                NetworkPropertyPatternMatch(_ipAddressPattern, _delimiterPattern, reported.DefaultGateways);
                 // DnsServer
-                if (!string.IsNullOrEmpty(reported.dnsServers))
+                if (!string.IsNullOrEmpty(reported.DnsServers))
                 {
-                    NetworkPropertyPatternMatch(_ipAddressPattern, _delimiterPattern, reported.dnsServers);
+                    NetworkPropertyPatternMatch(_ipAddressPattern, _delimiterPattern, reported.DnsServers);
                 }
                 // dhcpEnabled
-                NetworkPropertyPatternMatch(_statePattern, reported.dhcpEnabled);
+                NetworkPropertyPatternMatch(_statePattern, reported.DhcpEnabled);
                 // enabled
-                NetworkPropertyPatternMatch(_statePattern, reported.enabled);
+                NetworkPropertyPatternMatch(_statePattern, reported.Enabled);
                 // connected
-                NetworkPropertyPatternMatch(_statePattern, reported.connected);
+                NetworkPropertyPatternMatch(_statePattern, reported.Connected);
             });
         }
     }

--- a/src/tests/e2etest/SettingsTests.cs
+++ b/src/tests/e2etest/SettingsTests.cs
@@ -13,16 +13,16 @@ namespace E2eTesting
 
         public class DeliveryOptimizationPolicies
         {
-            public int percentageDownloadThrottle { get; set; }
-            public int cacheHostSource { get; set; }
-            public string cacheHost { get; set; }
-            public int cacheHostFallback { get; set; }
+            public int PercentageDownloadThrottle { get; set; }
+            public int CacheHostSource { get; set; }
+            public string CacheHost { get; set; }
+            public int CacheHostFallback { get; set; }
         }
 
         public class Settings
         {
-            public int deviceHealthTelemetryConfiguration { get; set; }
-            public DeliveryOptimizationPolicies deliveryOptimizationPolicies { get; set; }
+            public int DeviceHealthTelemetryConfiguration { get; set; }
+            public DeliveryOptimizationPolicies DeliveryOptimizationPolicies { get; set; }
         }
 
         [Test]
@@ -39,20 +39,20 @@ namespace E2eTesting
         {
             var desiredDeliveryOptimizationPolicies = new DeliveryOptimizationPolicies
             {
-                percentageDownloadThrottle = 50,
-                cacheHostSource = 1,
-                cacheHost = "127.0.1.1",
-                cacheHostFallback = 90
+                PercentageDownloadThrottle = 50,
+                CacheHostSource = 1,
+                CacheHost = "127.0.1.1",
+                CacheHostFallback = 90
             };
 
             var response = await SetDesired<DeliveryOptimizationPolicies>(_componentName, "DeliveryOptimizationPolicies", desiredDeliveryOptimizationPolicies);
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.percentageDownloadThrottle, response.value.percentageDownloadThrottle);
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.cacheHostSource, response.value.cacheHostSource);
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.cacheHost, response.value.cacheHost);
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.cacheHostFallback, response.value.cacheHostFallback);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.PercentageDownloadThrottle, response.value.PercentageDownloadThrottle);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHostSource, response.value.CacheHostSource);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHost, response.value.CacheHost);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHostFallback, response.value.CacheHostFallback);
             });
         }
     }

--- a/src/tests/e2etest/SettingsTests.cs
+++ b/src/tests/e2etest/SettingsTests.cs
@@ -31,7 +31,7 @@ namespace E2eTesting
             int desiredValue = 2;
             var response = await SetDesired<int>(_componentName, "DeviceHealthTelemetryConfiguration", desiredValue);
 
-            Assert.AreEqual(desiredValue, response.value);
+            Assert.AreEqual(desiredValue, response.Value);
         }
 
         [Test]
@@ -49,10 +49,10 @@ namespace E2eTesting
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.PercentageDownloadThrottle, response.value.PercentageDownloadThrottle);
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHostSource, response.value.CacheHostSource);
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHost, response.value.CacheHost);
-                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHostFallback, response.value.CacheHostFallback);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.PercentageDownloadThrottle, response.Value.PercentageDownloadThrottle);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHostSource, response.Value.CacheHostSource);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHost, response.Value.CacheHost);
+                Assert.AreEqual(desiredDeliveryOptimizationPolicies.CacheHostFallback, response.Value.CacheHostFallback);
             });
         }
     }

--- a/src/tests/e2etest/TpmTests.cs
+++ b/src/tests/e2etest/TpmTests.cs
@@ -25,9 +25,9 @@ namespace E2eTesting
 
         public class Tpm
         {
-            public string tpmVersion { get; set; }
-            public string tpmManufacturer { get; set; }
-            public TpmStatusCode tpmStatus { get; set; }
+            public string TpmVersion { get; set; }
+            public string TpmManufacturer { get; set; }
+            public TpmStatusCode TpmStatus { get; set; }
         }
 
         [Test]
@@ -37,16 +37,16 @@ namespace E2eTesting
 
             Assert.Multiple(() =>
             {
-                RegexAssert.IsMatch(_tpmStatusPattern, reported.tpmStatus);
+                RegexAssert.IsMatch(_tpmStatusPattern, reported.TpmStatus);
 
-                if (!string.IsNullOrEmpty(reported.tpmVersion))
+                if (!string.IsNullOrEmpty(reported.TpmVersion))
                 {
-                    RegexAssert.IsMatch(_tpmVersionPattern, reported.tpmVersion);
+                    RegexAssert.IsMatch(_tpmVersionPattern, reported.TpmVersion);
                 }
 
-                if (!string.IsNullOrEmpty(reported.tpmManufacturer))
+                if (!string.IsNullOrEmpty(reported.TpmManufacturer))
                 {
-                    RegexAssert.IsMatch(_tpmManufacturerPattern, reported.tpmManufacturer);
+                    RegexAssert.IsMatch(_tpmManufacturerPattern, reported.TpmManufacturer);
                 }
             });
         }

--- a/src/tests/e2etest/ZtsiTests.cs
+++ b/src/tests/e2etest/ZtsiTests.cs
@@ -40,7 +40,7 @@ namespace E2eTesting
             {
                 var setDesiredTask = SetDesired<string>(_componentName, _desiredServiceUrl, serviceUrl);
                 setDesiredTask.Wait();
-                return setDesiredTask.Result.ac;
+                return setDesiredTask.Result.Ac;
             }
             catch (Exception e)
             {
@@ -55,7 +55,7 @@ namespace E2eTesting
             {
                 var setDesiredTask = SetDesired<bool>(_componentName, _desiredEnabled, enabled);
                 setDesiredTask.Wait();
-                return setDesiredTask.Result.ac;
+                return setDesiredTask.Result.Ac;
             }
             catch (Exception e)
             {
@@ -77,12 +77,12 @@ namespace E2eTesting
                 var setDesiredTask = SetDesired<DesiredZtsi>(_componentName, desiredConfiguration);
                 setDesiredTask.Wait();
 
-                var desiredEnabledTask = GetReported<GenericResponse<bool>>(_componentName, _desiredEnabled, (GenericResponse<bool> response) => response.ac == ACK_SUCCESS);
+                var desiredEnabledTask = GetReported<GenericResponse<bool>>(_componentName, _desiredEnabled, (GenericResponse<bool> response) => response.Ac == ACK_SUCCESS);
                 desiredEnabledTask.Wait();
-                var desiredServiceUrlTask = GetReported<GenericResponse<string>>(_componentName, _desiredServiceUrl, (GenericResponse<string> response) => response.ac == ACK_SUCCESS);
+                var desiredServiceUrlTask = GetReported<GenericResponse<string>>(_componentName, _desiredServiceUrl, (GenericResponse<string> response) => response.Ac == ACK_SUCCESS);
                 desiredServiceUrlTask.Wait();
 
-                return (desiredServiceUrlTask.Result.ac, desiredEnabledTask.Result.ac);
+                return (desiredServiceUrlTask.Result.Ac, desiredEnabledTask.Result.Ac);
             }
             catch (Exception e)
             {

--- a/src/tests/e2etest/ZtsiTests.cs
+++ b/src/tests/e2etest/ZtsiTests.cs
@@ -24,14 +24,14 @@ namespace E2eTesting
         }
         public class Ztsi
         {
-            public Enabled enabled { get; set; }
-            public string serviceUrl { get; set; }
+            public Enabled Enabled { get; set; }
+            public string ServiceUrl { get; set; }
         }
 
         public class DesiredZtsi
         {
-            public bool desiredEnabled { get; set; }
-            public string desiredServiceUrl { get; set; }
+            public bool DesiredEnabled { get; set; }
+            public string DesiredServiceUrl { get; set; }
         }
 
         public int SetServiceUrl(string serviceUrl)
@@ -70,8 +70,8 @@ namespace E2eTesting
             {
                 var desiredConfiguration = new DesiredZtsi
                 {
-                    desiredEnabled = enabled,
-                    desiredServiceUrl = serviceUrl
+                    DesiredEnabled = enabled,
+                    DesiredServiceUrl = serviceUrl
                 };
 
                 var setDesiredTask = SetDesired<DesiredZtsi>(_componentName, desiredConfiguration);
@@ -95,11 +95,11 @@ namespace E2eTesting
         {
             try
             {
-                var reportedTask = GetReported<Ztsi>(_componentName, (Ztsi ztsi) => ((ztsi.serviceUrl == expectedServiceUrl) && (ztsi.enabled == expectedEnabled)));
+                var reportedTask = GetReported<Ztsi>(_componentName, (Ztsi ztsi) => ((ztsi.ServiceUrl == expectedServiceUrl) && (ztsi.Enabled == expectedEnabled)));
                 reportedTask.Wait();
                 var reportedConfiguration = reportedTask.Result;
 
-                return (reportedConfiguration.serviceUrl, reportedConfiguration.enabled);
+                return (reportedConfiguration.ServiceUrl, reportedConfiguration.Enabled);
             }
             catch (Exception e)
             {
@@ -112,9 +112,9 @@ namespace E2eTesting
         {
             try
             {
-                var reportedTask = GetReported<Ztsi>(_componentName, (Ztsi ztsi) => (ztsi.serviceUrl == expectedServiceUrl));
+                var reportedTask = GetReported<Ztsi>(_componentName, (Ztsi ztsi) => (ztsi.ServiceUrl == expectedServiceUrl));
                 reportedTask.Wait();
-                return reportedTask.Result.serviceUrl;
+                return reportedTask.Result.ServiceUrl;
             }
             catch (Exception e)
             {
@@ -127,9 +127,9 @@ namespace E2eTesting
         {
             try
             {
-                var reportedTask = GetReported<Ztsi>(_componentName, (Ztsi ztsi) => (ztsi.enabled == expectedEnabled));
+                var reportedTask = GetReported<Ztsi>(_componentName, (Ztsi ztsi) => (ztsi.Enabled == expectedEnabled));
                 reportedTask.Wait();
-                return reportedTask.Result.enabled;
+                return reportedTask.Result.Enabled;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Description

* Use PascalCase for C# Properties
* Use camelCase when serializing to or deserializing from json
* Use Newtonsoft json library consistently to benefit from CamelCasePropertyNamesContractResolver

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.