### PR TITLE
Fixed dev container git integrations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 	"workspaceFolder": "/azure-osconfig",
 	"mounts": ["source=${localWorkspaceFolder},target=/azure-osconfig,type=bind,consistency=cached"],
 	"overrideCommand": true,
-	"postCreateCommand": "git submodule update --init --recursive",
+	"postCreateCommand": "git submodule update --init --recursive && git config --global --add safe.directory /azure-osconfig",
 	"extensions": [
 		"eamodio.gitlens",
 		"GitHub.copilot",


### PR DESCRIPTION
## Description

* Git integrations in vscode do not work without having the `safe.directory` directive in the `.gitconfig`. Added to `postCreateCommand`

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.