### PR TITLE
Add temporary workaround to retry with MPI C API call when MPI REST API fails

### DIFF
--- a/src/agents/pnp/MpiProxy.c
+++ b/src/agents/pnp/MpiProxy.c
@@ -469,7 +469,7 @@ int CallMpiSetDesired(const MPI_JSON_STRING payload, const int payloadSizeBytes)
     if (MPI_OK != status)
     {
         OsConfigLogError(GetLog(), "CallMpiSetDesired: retry via the MPI C API");
-        status = MpiSetDesired(clientName, payload, payloadSizeBytes);
+        status = MpiSetDesired(g_mpiHandle, payload, payloadSizeBytes);
     }
 
     if (IsFullLoggingEnabled())
@@ -534,7 +534,7 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes)
     if (MPI_OK != status)
     {
         OsConfigLogError(GetLog(), "CallMpiGetReported: retry via the MPI C API");
-        status = MpiGetReported(clientName, maxPayloadSizeBytes, payload, payloadSizeBytes);
+        status = MpiGetReported(g_mpiHandle, payload, payloadSizeBytes);
     }
 
     if (IsFullLoggingEnabled())

--- a/src/agents/pnp/MpiProxy.c
+++ b/src/agents/pnp/MpiProxy.c
@@ -217,6 +217,13 @@ MPI_HANDLE CallMpiOpen(const char* clientName, const unsigned int maxPayloadSize
         OsConfigLogError(GetLog(), "CallMpiOpen: invalid MPI handle '%s'", (char*)mpiHandle);
         mpiHandle = NULL;
     }
+
+    // Temporary workaround
+    if (NULL == mpiHandle)
+    {
+        OsConfigLogError(GetLog(), "CallMpiOpen: retry via the MPI C API");
+        mpiHandle = MpiOpen(clientName, maxPayloadSizeBytes);
+    }
     
     OsConfigLogInfo(GetLog(), "CallMpiOpen(%s, %u): %p ('%s')", clientName, maxPayloadSizeBytes, mpiHandle, mpiHandleValue);
 
@@ -316,6 +323,13 @@ int CallMpiSet(const char* componentName, const char* propertyName, const MPI_JS
         FREE_MEMORY(statusFromResponse);
     }
 
+    // Temporary workaround
+    if (MPI_OK != status)
+    {
+        OsConfigLogError(GetLog(), "CallMpiSet: retry via the MPI C API");
+        status = MpiSet(g_mpiHandle, componentName, propertyName, payload, payloadSizeBytes);
+    }
+
     if (IsFullLoggingEnabled())
     {
         OsConfigLogInfo(GetLog(), "CallMpiSet(%p, %s, %s, %.*s, %d bytes) returned %d", g_mpiHandle, componentName, propertyName, payloadSizeBytes, payload, payloadSizeBytes, status);
@@ -376,6 +390,13 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
 
         FREE_MEMORY(*payload);
         *payloadSizeBytes = 0;
+    }
+
+    // Temporary workaround
+    if (MPI_OK != status)
+    {
+        OsConfigLogError(GetLog(), "CallMpiGet: retry via the MPI C API");
+        status = MpiGet(g_mpiHandle, componentName, propertyName, payload, payloadSizeBytes);
     }
 
     if (IsFullLoggingEnabled())
@@ -444,6 +465,13 @@ int CallMpiSetDesired(const MPI_JSON_STRING payload, const int payloadSizeBytes)
         FREE_MEMORY(statusFromResponse);
     }
 
+    // Temporary workaround
+    if (MPI_OK != status)
+    {
+        OsConfigLogError(GetLog(), "CallMpiSetDesired: retry via the MPI C API");
+        status = MpiSetDesired(clientName, payload, payloadSizeBytes);
+    }
+
     if (IsFullLoggingEnabled())
     {
         OsConfigLogInfo(GetLog(), "CallMpiSetDesired(%p, %.*s, %d bytes) returned %d", g_mpiHandle, payloadSizeBytes, payload, payloadSizeBytes, status);
@@ -500,6 +528,13 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes)
 
         FREE_MEMORY(*payload);
         *payloadSizeBytes = 0;
+    }
+
+    // Temporary workaround
+    if (MPI_OK != status)
+    {
+        OsConfigLogError(GetLog(), "CallMpiGetReported: retry via the MPI C API");
+        status = MpiGetReported(clientName, maxPayloadSizeBytes, payload, payloadSizeBytes);
     }
 
     if (IsFullLoggingEnabled())


### PR DESCRIPTION
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.