### PR TITLE
Added E2E ARM64 support

### DIFF
--- a/.github/workflows/deploy-github-main.yml
+++ b/.github/workflows/deploy-github-main.yml
@@ -1,17 +1,20 @@
 name: E2E (GitHub-main)
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Package"]
+    types:
+      - completed
 
 jobs:
   fetch-targets:
+    name: Fetch Test Targets
     uses: ./.github/workflows/e2etest-fetch-targets.yml
     with:
       environment: e2e-github-main
     secrets: inherit
 
   provision-hub:
+    name: Provision IoT Hub
     uses: ./.github/workflows/e2etest-provision-hub.yml
     needs:
       - fetch-targets
@@ -21,6 +24,7 @@ jobs:
     secrets: inherit
 
   provision-hosts:
+    name: Provision Host VM
     uses: ./.github/workflows/e2etest-provision-hosts.yml
     needs:
       - fetch-targets
@@ -31,6 +35,7 @@ jobs:
     secrets: inherit
 
   run-tests:
+    name: Run Tests
     uses: ./.github/workflows/e2etest-run-tests.yml
     needs:
       - fetch-targets

--- a/.github/workflows/deploy-insiders-fast.yml
+++ b/.github/workflows/deploy-insiders-fast.yml
@@ -5,12 +5,14 @@ on:
 
 jobs:
   fetch-targets:
+    name: Fetch Test Targets
     uses: ./.github/workflows/e2etest-fetch-targets.yml
     with:
       environment: e2e-insiders-fast
     secrets: inherit
 
   provision-hub:
+    name: Provision IoT Hub
     uses: ./.github/workflows/e2etest-provision-hub.yml
     needs:
       - fetch-targets
@@ -20,6 +22,7 @@ jobs:
     secrets: inherit
 
   provision-hosts:
+    name: Provision Host VM
     uses: ./.github/workflows/e2etest-provision-hosts.yml
     needs:
       - fetch-targets
@@ -30,6 +33,7 @@ jobs:
     secrets: inherit
 
   run-tests:
+    name: Run Tests
     uses: ./.github/workflows/e2etest-run-tests.yml
     needs:
       - fetch-targets

--- a/.github/workflows/e2etest-fetch-targets.yml
+++ b/.github/workflows/e2etest-fetch-targets.yml
@@ -21,7 +21,6 @@ on:
 
 jobs:
   fetch-targets:
-    name: Fetch Test Targets
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     outputs:
@@ -52,4 +51,4 @@ jobs:
         uses: azure/CLI@v1
         with:
           inlineScript: |
-            az group create --name ${{ steps.set-resource-group.outputs.resourceGroupName }} --location ${{ inputs.location }}
+            az group create --name ${{ steps.set-resource-group.outputs.resourceGroupName }} --location ${{ inputs.location }} --tags environment="osconfig-e2etest"

--- a/.github/workflows/e2etest-provision-hosts.yml
+++ b/.github/workflows/e2etest-provision-hosts.yml
@@ -17,16 +17,16 @@ on:
 
 jobs:
   provision-hosts:
-    name: Provision Host VM
+    name: ${{ matrix.distroName }}
     runs-on: ubuntu-latest
-    environment: e2e-prod
+    environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
       matrix:
         distroName: ${{ fromJson(inputs.distroName) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v1
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v2
@@ -39,10 +39,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         id: runner_token
         run: |
-          echo ::set-output name=RUNNER_TOKEN::$(gh api --method POST -H "Accept: application/vnd.github.v3+json" /repos/Azure/azure-osconfig/actions/runners/registration-token | jq '.token')
+          RUNNER_TOKEN=$(gh api --method POST -H "Accept: application/vnd.github.v3+json" /repos/Azure/azure-osconfig/actions/runners/registration-token | jq '.token')
+          echo ::set-output name=RUNNER_TOKEN::$RUNNER_TOKEN
+          echo ::add-mask::$RUNNER_TOKEN
 
       - name: Provision VM - ${{ matrix.distroName }}
-        id: provisionm-vm
+        id: provision-vm
         env:
           ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
           ARM_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
@@ -52,6 +54,7 @@ jobs:
         run: |
           target=`jq '.[] | select(.distroName=="${{ matrix.distroName }}")' ${{ github.workspace }}/devops/e2e/${{ secrets.E2E_ENV_FILE }}`
           distroName=${{ matrix.distroName }}
+          echo "Using Target JSON: `echo $target | jq .`"
           rg=${{ inputs.resourceGroupName }}
           image_publisher=`echo $target | jq .image_publisher | tr -d \"`
           image_offer=`echo $target | jq .image_offer | tr -d \"`
@@ -59,19 +62,29 @@ jobs:
           image_version=`echo $target | jq .image_version | tr -d \"`
           packagePattern=`echo $target | jq .packagePattern | tr -d \"`
           device_id=`echo $target | jq .device_id | tr -d \"`
+          vm_size=`echo $target | jq .vm_size | tr -d \"`
+          github_runner_tar_gz=`echo $target | jq .github_runner_tar_gz | tr -d \"`
           vm_script=`echo $target | jq -r '.vm_script | join(" && ")'`
 
-          echo ::set-output name=distroName::$distroName
-          echo ::set-output name=image_publisher::$image_publisher
-          echo ::set-output name=image_offer::$image_offer
-          echo ::set-output name=image_sku::$image_sku
-          echo ::set-output name=image_version::$image_version
-          echo ::set-output name=packagePattern::$packagePattern
           echo ::set-output name=device_id::$device_id
-          echo ::set-output name=vm_script::$vm_script
 
           terraform init
-          terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token="${{ steps.runner_token.outputs.RUNNER_TOKEN }}" -var image_offer=$image_offer -var image_publisher=$image_publisher -var image_sku=$image_sku -var image_version=$image_version -var vm_script="$vm_script" -var github_runner_tar_gz_package="${{ secrets.GH_RUNNER_TAR_GZ }}" -auto-approve
+          terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token=${{ steps.runner_token.outputs.RUNNER_TOKEN }} -var image_offer=$image_offer -var image_publisher=$image_publisher -var image_sku=$image_sku -var image_version=$image_version -var vm_size=$vm_size -var vm_script="$vm_script" -var github_runner_tar_gz_package="$github_runner_tar_gz" -auto-approve
 
           runner=$rg-$distroName
           echo Created self-hosted runner "$runner"
+        
+      - name: Create device identity
+        run: |
+          az login --service-principal -u ${{ secrets.CLIENT_ID }} -p ${{ secrets.CLIENT_SECRET }} --tenant ${{ secrets.TENANT_ID }}
+          az extension add --name azure-iot
+          
+          # VM + IotHub provisioning happen in parallel - loop until hub is available
+          echo -n 'Creating Iot Hub Identity - ${{ inputs.resourceGroupName }}-${{ steps.provision-vm.outputs.device_id }}'
+          function create_identity () { az iot hub device-identity create --device-id "${{ steps.provision-vm.outputs.device_id }}" --hub-name ${{ inputs.resourceGroupName }}-iothub --output none; }
+          create_identity
+          while [ $? -ne 0 ]; do echo -n '.'; sleep 5s && create_identity; done
+
+          device_conn_str="`az iot hub device-identity connection-string show --hub-name ${{ inputs.resourceGroupName }}-iothub --device-id ${{ steps.provision-vm.outputs.device_id }} --output tsv`"
+          echo '' && echo Adding to Key Vault
+          az keyvault secret set --name "${{ inputs.resourceGroupName }}-${{ steps.provision-vm.outputs.device_id }}" --vault-name ${{ secrets.KEY_VAULT_NAME }} --value $device_conn_str > /dev/null

--- a/.github/workflows/e2etest-provision-hosts.yml
+++ b/.github/workflows/e2etest-provision-hosts.yml
@@ -79,7 +79,7 @@ jobs:
           az login --service-principal -u ${{ secrets.CLIENT_ID }} -p ${{ secrets.CLIENT_SECRET }} --tenant ${{ secrets.TENANT_ID }}
           az extension add --name azure-iot
           
-          # VM + IotHub provisioning happen in parallel - loop until hub is available
+          # VM + IotHub provisioning happening in parallel - loop until the IoT Hub is available
           echo -n 'Creating Iot Hub Identity - ${{ inputs.resourceGroupName }}-${{ steps.provision-vm.outputs.device_id }}'
           function create_identity () { az iot hub device-identity create --device-id "${{ steps.provision-vm.outputs.device_id }}" --hub-name ${{ inputs.resourceGroupName }}-iothub --output none; }
           create_identity

--- a/.github/workflows/e2etest-provision-hub.yml
+++ b/.github/workflows/e2etest-provision-hub.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
   provision-hub:
-    name: Provision Iot Hub
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
 

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run-tests:
-    name: Run Tests
+    name: ${{ matrix.distroName }}
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
@@ -43,23 +43,17 @@ jobs:
           echo Using package path: $package_path
           echo ::set-output name=package_path::$package_path
 
-      - name: Create device identity
+      - name: Retreive device identity
         id: hub-identity
-        env:
-          ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
         run: |
-          az login --service-principal -u ${{ secrets.CLIENT_ID }} -p ${{ secrets.CLIENT_SECRET }} --tenant ${{ secrets.TENANT_ID }}
-          az config set extension.use_dynamic_install=yes_without_prompt
-          az iot hub device-identity create --device-id "${{ steps.get-test-data.outputs.device_id }}" --hub-name ${{ inputs.resourceGroupName }}-iothub --output none
-          # VM + IotHub provisioning happen in parallel - loop until iothub connection string is present in keyvault
-          iothubowner_connection_string=`az keyvault secret show --vault-name "osconfige2e-infra" --name "${{ inputs.resourceGroupName }}-iothubowner" --query value`
-          while [ $? -ne 0 ]; do sleep 5s && !!; done
+          token=`curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' https://login.microsoftonline.com/${{ secrets.TENANT_ID }}/oauth2/v2.0/token --data-urlencode 'grant_type=client_credentials' --data-urlencode 'client_id=${{ secrets.CLIENT_ID }}' --data-urlencode 'client_secret=${{ secrets.CLIENT_SECRET }}' --data-urlencode 'scope=https://vault.azure.net/.default' | jq .access_token | tr -d \"`
+
+          iothubowner_connection_string=`curl -s "https://${{ secrets.KEY_VAULT_NAME }}.vault.azure.net/secrets/${{ inputs.resourceGroupName }}-iothubowner?api-version=2016-10-01" -H "Authorization: Bearer $token" | jq .value | tr -d \"`
+          echo iothubowner_connection_string=$iothubowner_connection_string
           echo ::set-output name=iothubowner_connection_string::$iothubowner_connection_string
-          device_conn_str=`az iot hub device-identity connection-string show --hub-name ${{ inputs.resourceGroupName }}-iothub --device-id ${{ 
-          steps.get-test-data.outputs.device_id }} --output tsv`
+
+          device_conn_str=`curl -s "https://${{ secrets.KEY_VAULT_NAME }}.vault.azure.net/secrets/${{ inputs.resourceGroupName }}-${{ steps.get-test-data.outputs.device_id }}?api-version=2016-10-01" -H "Authorization: Bearer $token" | jq .value | tr -d \"`
+          echo device_conn_str=$device_conn_str
           echo ::set-output name=device_conn_str::$device_conn_str
 
       - name: Apply device identity

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -7,12 +7,11 @@
         "image_version": "latest",
         "device_id": "ubuntu2004",
         "package_path": "*focal_x86_64.deb",
+        "vm_size": "Standard_DS1_v2",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
-            "export DEBIAN_FRONTEND=noninteractive",
-            "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-            "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-            "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
             "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
@@ -27,15 +26,32 @@
         "image_version": "latest",
         "device_id": "ubuntu1804",
         "package_path": "*bionic_x86_64.deb",
+        "vm_size": "Standard_DS1_v2",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
-            "export DEBIAN_FRONTEND=noninteractive",
-            "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-            "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-            "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
             "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
+            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
+        ]
+    },
+    {
+        "distroName": "ubuntu-20.04-arm64",
+        "image_publisher": "canonical",
+        "image_offer": "0001-com-ubuntu-server-arm-preview-focal",
+        "image_sku": "20_04-lts",
+        "image_version": "latest",
+        "device_id": "ubuntu2004arm64",
+        "package_path": "*focal_aarch64.deb",
+        "vm_size": "Standard_D2plds_v5",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "vm_script":
+        [
+            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
+            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
         ]
     }

--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -6,13 +6,11 @@
         "image_sku": "20_04-lts-gen2",
         "image_version": "latest",
         "device_id": "ubuntu2004",
+        "vm_size": "Standard_DS1_v2",
         "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
-            "export DEBIAN_FRONTEND=noninteractive",
-            "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-            "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-            "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
             "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "curl https://packages.microsoft.com/config/ubuntu/18.04/insiders-fast.list > ./microsoft-insiders-fast.list",
@@ -28,18 +26,36 @@
         "image_sku": "18.04-LTS",
         "image_version": "latest",
         "device_id": "ubuntu1804",
+        "vm_size": "Standard_DS1_v2",
         "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
-            "export DEBIAN_FRONTEND=noninteractive",
-            "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-            "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-            "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
             "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "curl https://packages.microsoft.com/config/ubuntu/18.04/insiders-fast.list > ./microsoft-insiders-fast.list",
             "sudo cp ./microsoft-insiders-fast.list /etc/apt/sources.list.d/",
             "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
+            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
+        ]
+    },
+    {
+        "distroName": "ubuntu-20.04-arm64",
+        "image_publisher": "canonical",
+        "image_offer": "0001-com-ubuntu-server-arm-preview-focal",
+        "image_sku": "20_04-lts",
+        "image_version": "latest",
+        "device_id": "ubuntu2004arm64",
+        "package_path": "*focal_aarch64.deb",
+        "vm_size": "Standard_D2plds_v5",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "vm_script":
+        [
+            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
+            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
+            "curl https://packages.microsoft.com/config/ubuntu/18.04/insiders-fast.list > ./microsoft-insiders-fast.list",
+            "sudo cp ./microsoft-insiders-fast.list /etc/apt/sources.list.d/",
             "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
         ]
     }

--- a/devops/e2e/prod.json
+++ b/devops/e2e/prod.json
@@ -9,10 +9,6 @@
         "test_filter": "TpmTest",
         "vm_script":
         [
-            "export DEBIAN_FRONTEND=noninteractive",
-            "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-            "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-            "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
             "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
@@ -29,13 +25,27 @@
         "test_filter": "TpmTest",
         "vm_script":
         [
-            "export DEBIAN_FRONTEND=noninteractive",
-            "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-            "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-            "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
             "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
+            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
+        ]
+    },
+    {
+        "distroName": "ubuntu-20.04-arm64",
+        "image_publisher": "canonical",
+        "image_offer": "0001-com-ubuntu-server-arm-preview-focal",
+        "image_sku": "20_04-lts",
+        "image_version": "latest",
+        "device_id": "ubuntu2004arm64",
+        "package_path": "*focal_aarch64.deb",
+        "vm_size": "Standard_D2plds_v5",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "vm_script":
+        [
+            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
+            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
         ]
     }

--- a/devops/terraform/host/variables.tf
+++ b/devops/terraform/host/variables.tf
@@ -40,6 +40,14 @@ variable "vm_script" {
     default = ""
 }
 
+variable "vm_size" {
+    default = "Standard_DS1_v2"
+}
+
+variable "location" {
+    default = "West US 2"
+}
+
 variable "github_runner_tar_gz_package" {
     default = "https://github.com/actions/runner/releases/download/v2.290.1/actions-runner-linux-x64-2.290.1.tar.gz"
 }


### PR DESCRIPTION
## Description

* Added ARM64 test target
* Refactored Terraform to support variable VM sizes/location
* Moved hub-identity creation to hub-provisioning job as ARM64 hosts do not have full AZ CLI support
* Improved E2E workflow job naming to make it prettier

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.