### PR TITLE
Removed test filter from GitHub-Main

### DIFF
--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -8,7 +8,6 @@
         "device_id": "ubuntu2004",
         "package_path": "*focal_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
-        "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
@@ -27,7 +26,6 @@
         "device_id": "ubuntu1804",
         "package_path": "*bionic_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
-        "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
@@ -46,7 +44,6 @@
         "device_id": "ubuntu2004arm64",
         "package_path": "*focal_aarch64.deb",
         "vm_size": "Standard_D2plds_v5",
-        "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
         "vm_script":
         [


### PR DESCRIPTION
## Description

* Noticed latest e2e on `[GitHub-Main](https://github.com/Azure/azure-osconfig/actions/workflows/deploy-github-main.yml)` are only running the TpmTests. Remove the test filter.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.