### PR TITLE
Fixed missing log files in e2e tests

### DIFF
--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -99,6 +99,10 @@ jobs:
         working-directory: ./src/tests/e2etest
         run: | 
           dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx"
+
+      - name: Stage logs
+        if: always()
+        run: | 
           sudo cp -f /var/log/osconfig*.log ${{ runner.temp }}
           sudo chown $USER:$USER ${{ runner.temp }}/osconfig*.log
 


### PR DESCRIPTION
## Description

* When e2e tests failed, the logs were never copied over to the staging directory. Added a separate step to stage logs.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.