### PR TITLE
Incrementing OSConfig model version to 10 to include DeviceInfo v3

### DIFF
--- a/src/agents/pnp/daemon/osconfig.json
+++ b/src/agents/pnp/daemon/osconfig.json
@@ -1,7 +1,7 @@
 {
   "FullLogging": 0,  
   "LocalManagement": 0,
-  "ModelVersion": 9,
+  "ModelVersion": 10,
   "Protocol": 2,
   "Reported": [
     {


### PR DESCRIPTION
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.