### PR TITLE
Adding information to Platform log source of crash that may be initiated during MPI calls

### DIFF
--- a/src/platform/Main.c
+++ b/src/platform/Main.c
@@ -61,7 +61,6 @@ static void SignalInterrupt(int signal)
 {
     int logDescriptor = -1;
     char* errorMessage = NULL;
-    size_t errorMessageSize = 0;
     size_t sizeOfMpiMessage = 0;
     ssize_t writeResult = -1;
 
@@ -97,7 +96,7 @@ static void SignalInterrupt(int signal)
     {
         if (0 < (logDescriptor = open(LOG_FILE, O_APPEND | O_WRONLY | O_NONBLOCK)))
         {
-            if (0 < (writeResult = write(logDescriptor, (const void*)errorMessage, errorMessageSize)))
+            if (0 < (writeResult = write(logDescriptor, (const void*)errorMessage, strlen(errorMessage))))
             {
                 sizeOfMpiMessage = strlen(g_mpiCall);
                 if (sizeOfMpiMessage > 0)

--- a/src/platform/Main.c
+++ b/src/platform/Main.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <PlatformCommon.h>
+#include <MpiServer.h>
 
 // 100 milliseconds
 #define DOWORK_SLEEP 100
@@ -60,6 +61,8 @@ static void SignalInterrupt(int signal)
 {
     int logDescriptor = -1;
     char* errorMessage = NULL;
+    size_t errorMessageSize = 0;
+    size_t sizeOfMpiMessage = 0;
     ssize_t writeResult = -1;
 
     UNUSED(writeResult);

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -29,6 +29,10 @@ static socklen_t g_socketlen = 0;
 static pthread_t g_mpiServerWorker = 0;
 static bool g_serverActive = false;
 
+char g_mpiCall[MPI_CALL_MESSAGE_LENGTH] = {0};
+static const char g_mpiCallObjectTemplate[] = " during %s to %s.%s\n";
+static const char g_mpiCallModelTemplate[] = " during %s\n";
+
 static MPI_HANDLE CallMpiOpen(const char* clientName, const unsigned int maxPayloadSizeBytes)
 {
     MPI_HANDLE handle = NULL;
@@ -53,7 +57,11 @@ static void CallMpiClose(MPI_HANDLE handle)
 
 static int CallMpiSet(MPI_HANDLE handle, const char* componentName, const char* objectName, MPI_JSON_STRING payload, const int payloadSize)
 {
-    int status = MpiSet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
+    int status = MPI_OK;
+
+    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallObjectTemplate, MPI_SET_URI, componentName, propertyName);
+    
+    status = MpiSet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
 
     if (IsFullLoggingEnabled())
     {
@@ -67,12 +75,18 @@ static int CallMpiSet(MPI_HANDLE handle, const char* componentName, const char* 
         }
     }
 
+    memset(g_mpiCall, 0, sizeof(g_mpiCall));
+
     return status;
 }
 
 static int CallMpiGet(MPI_HANDLE handle, const char* componentName, const char* objectName, MPI_JSON_STRING* payload, int* payloadSize)
 {
-    int status = MpiGet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
+    int status = MPI_OK;
+
+    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallObjectTemplate, MPI_GET_URI, componentName, propertyName);
+
+    status = MpiGet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
 
     if (IsFullLoggingEnabled())
     {
@@ -86,12 +100,18 @@ static int CallMpiGet(MPI_HANDLE handle, const char* componentName, const char* 
         }
     }
 
+    memset(g_mpiCall, 0, sizeof(g_mpiCall));
+
     return status;
 }
 
 static int CallMpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, const int payloadSize)
 {
-    int status = MpiSetDesired((MPI_HANDLE)handle, payload, payloadSize);
+    int status = MPI_OK;
+    
+    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallModelTemplate, MPI_SET_DESIRED_URI);
+
+    status = MpiSetDesired((MPI_HANDLE)handle, payload, payloadSize);
 
     if (IsFullLoggingEnabled())
     {
@@ -105,12 +125,18 @@ static int CallMpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, c
         }
     }
 
+    memset(g_mpiCall, 0, sizeof(g_mpiCall));
+
     return status;
 }
 
 static int CallMpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize)
 {
-    int status = MpiGetReported((MPI_HANDLE)handle, payload, payloadSize);
+    int status = MPI_OK;
+
+    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallModelTemplate, MPI_GET_REPORTED_URI);
+
+    status = MpiGetReported((MPI_HANDLE)handle, payload, payloadSize);
 
     if (IsFullLoggingEnabled())
     {
@@ -123,6 +149,8 @@ static int CallMpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* 
             OsConfigLogError(GetPlatformLog(), "MpiGetReported request, session %p ('%s'), failed: %d", handle, (char*)handle, status);
         }
     }
+
+    memset(g_mpiCall, 0, sizeof(g_mpiCall));
 
     return status;
 }

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -59,7 +59,7 @@ static int CallMpiSet(MPI_HANDLE handle, const char* componentName, const char* 
 {
     int status = MPI_OK;
 
-    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallObjectTemplate, MPI_SET_URI, componentName, propertyName);
+    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallObjectTemplate, MPI_SET_URI, componentName, objectName);
     
     status = MpiSet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
 
@@ -84,7 +84,7 @@ static int CallMpiGet(MPI_HANDLE handle, const char* componentName, const char* 
 {
     int status = MPI_OK;
 
-    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallObjectTemplate, MPI_GET_URI, componentName, propertyName);
+    snprintf(g_mpiCall, sizeof(g_mpiCall), g_mpiCallObjectTemplate, MPI_GET_URI, componentName, objectName);
 
     status = MpiGet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
 

--- a/src/platform/inc/MpiServer.h
+++ b/src/platform/inc/MpiServer.h
@@ -6,6 +6,8 @@
 
 #include <Mpi.h>
 
+#define MPI_CALL_MESSAGE_LENGTH 256
+
 #define MPI_OPEN_URI "MpiOpen"
 #define MPI_CLOSE_URI "MpiClose"
 #define MPI_SET_URI "MpiSet"


### PR DESCRIPTION
Examples of traces written to the Platform log when a module crashes the process (here simulated with DeviceInfo) :

[ERROR] OSConfig Platform crash due to segmentation fault (SIGSEGV) during MpiGet to DeviceInfo.osVersion
[ERROR] OSConfig Platform crash due to segmentation fault (SIGSEGV) during MpiGetReported

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.