### PR TITLE
Fixed E2E PmcTests

### DIFF
--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -96,6 +96,7 @@ jobs:
           E2E_OSCONFIG_IOTHUB_CONNSTR: ${{ steps.hub-identity.outputs.iothubowner_connection_string }}
           E2E_OSCONFIG_DEVICE_ID: ${{ steps.get-test-data.outputs.device_id }}
           E2E_OSCONFIG_TWIN_TIMEOUT: ${{ secrets.TWIN_TIMEOUT }}
+          E2E_OSCONFIG_DISTRIBUTION_NAME: ${{ matrix.distroName }}
         working-directory: ./src/tests/e2etest
         run: | 
           dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx"


### PR DESCRIPTION
## Description

* Added missing environment variable `E2E_OSCONFIG_DISTRIBUTION_NAME` to E2E test, needed for PmcTests

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.