### PR TITLE
Added map, array field support to moduletest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,22 +5,23 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
     apt-transport-https \
-    git \
-    cmake \
     build-essential \
+    ca-certificates \
+    cmake \
     curl \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    uuid-dev \
-    libgtest-dev \
-    libgmock-dev \
-    liblttng-ust-dev \
-    rapidjson-dev \
-    ninja-build\
-    wget \
     gcovr \
     gdb \
-    ca-certificates \
+    git \
+    jq \
+    libcurl4-openssl-dev \
+    libgmock-dev \
+    libgtest-dev \
+    liblttng-ust-dev \
+    libssl-dev \
+    ninja-build\
+    rapidjson-dev \
+    uuid-dev \
+    wget \
     \
     # .NET dependencies
     libc6 \

--- a/devops/scripts/generate_moduletest_metadata.sh
+++ b/devops/scripts/generate_moduletest_metadata.sh
@@ -2,7 +2,6 @@
 # Generates test metadata for all modules published with MIMs and Test Recipes
 # MIM Path        : src/modules/mim
 # Test Recipe Path: src/modules/test/recipes
-# Requires: jq
 if ! [ -x "$(command -v jq)" ]; then
   echo 'Error: jq is not installed.' >&2
   exit 1

--- a/devops/scripts/generate_moduletest_metadata.sh
+++ b/devops/scripts/generate_moduletest_metadata.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Generates test metadata for all modules published with MIMs and Test Recipes
+# Generates test recipe configuration for all modules published with MIMs and Test Recipes
 # MIM Path        : src/modules/mim
 # Test Recipe Path: src/modules/test/recipes
 if ! [ -x "$(command -v jq)" ]; then
@@ -33,4 +33,4 @@ while IFS= read -r line ;
 done <<< $modules
 
 echo $testJSON | jq '.' > $testMetaDataDestPath
-echo "Test metadata written to $testMetaDataDestPath"
+echo "Test recipe configuration written to $testMetaDataDestPath"

--- a/devops/scripts/generate_moduletest_metadata.sh
+++ b/devops/scripts/generate_moduletest_metadata.sh
@@ -11,11 +11,11 @@ fi
 # Absolute path to this script
 SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
-
-mimBaseDir=$SCRIPTPATH/../../src/modules/mim
-modulesBaseDir=$SCRIPTPATH/../../build/modules
-recipeBaseDir=$SCRIPTPATH/../../src/modules/test/recipes
-testMetaDataDestPath=$SCRIPTPATH/../../build/modules/test/testplate.json
+BaseDir=`realpath $SCRIPTPATH/../..`
+mimBaseDir=$BaseDir/src/modules/mim
+modulesBaseDir=$BaseDir/build/modules
+recipeBaseDir=$BaseDir/src/modules/test/recipes
+testMetaDataDestPath=$BaseDir/build/modules/test/testplate.json
 
 modules=$(find $modulesBaseDir -name '*.so')
 testJSON="[]"
@@ -27,6 +27,7 @@ while IFS= read -r line ;
 
   if [ ! -z "$recipepath" ] && [ ! -z "$mimpath" ]; then
     # Create entry if both mim+recipe are found
+    echo "Found '$modulename' module adding to test metadata"
     json="[{ \"ModulePath\": \"$line\", \"MimPath\": \"$mimpath\", \"TestRecipesPath\": \"$recipepath\" }]"
     testJSON=$(echo $testJSON | jq --argjson testMetadata "$json" '. |= . + $testMetadata')
   fi

--- a/devops/scripts/generate_moduletest_metadata.sh
+++ b/devops/scripts/generate_moduletest_metadata.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Generates test metadata for all modules published with MIMs and Test Recipes
+# MIM Path        : src/modules/mim
+# Test Recipe Path: src/modules/test/recipes
+# Requires: jq
+if ! [ -x "$(command -v jq)" ]; then
+  echo 'Error: jq is not installed.' >&2
+  exit 1
+fi
+
+# Absolute path to this script
+SCRIPT=$(readlink -f $0)
+SCRIPTPATH=`dirname $SCRIPT`
+
+mimBaseDir=$SCRIPTPATH/../../src/modules/mim
+modulesBaseDir=$SCRIPTPATH/../../build/modules
+recipeBaseDir=$SCRIPTPATH/../../src/modules/test/recipes
+testMetaDataDestPath=$SCRIPTPATH/../../build/modules/test/testplate.json
+
+modules=$(find $modulesBaseDir -name '*.so')
+testJSON="[]"
+while IFS= read -r line ;
+  do 
+  modulename=$(basename $line | cut -f1 -d'.');
+  mimpath=$(find $mimBaseDir -name "*$modulename*.json")
+  recipepath=$(find $recipeBaseDir -iname "*$modulename*.json")
+
+  if [ ! -z "$recipepath" ] && [ ! -z "$mimpath" ]; then
+    # Create entry if both mim+recipe are found
+    json="[{ \"ModulePath\": \"$line\", \"MimPath\": \"$mimpath\", \"TestRecipesPath\": \"$recipepath\" }]"
+    testJSON=$(echo $testJSON | jq --argjson testMetadata "$json" '. |= . + $testMetadata')
+  fi
+done <<< $modules
+
+echo $testJSON | jq '.' > $testMetaDataDestPath
+echo "Test metadata written to $testMetaDataDestPath"

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -3,8 +3,8 @@
 
 add_subdirectory(test)
 
-# Function add_module/add_module_custom_target is used to add a module to the build
-# and add the appropriate dependencies in order for module test metadata to be generated. 
+# Function add_module/add_module_custom_target is used to add a module to the build and add
+# the appropriate dependencies in order for module testrecipe configuration to be generated. 
 function(add_module_custom_target moduleDir targetName)
     add_subdirectory(${moduleDir})
     add_dependencies(moduletestmetadata ${targetName})

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,20 +1,31 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+add_subdirectory(test)
+
+# Function add_module/add_module_custom_target is used to add a module to the build
+# and add the appropriate dependencies in order for module test metadata to be generated. 
+function(add_module_custom_target moduleDir targetName)
+    add_subdirectory(${moduleDir})
+    add_dependencies(moduletestmetadata ${targetName})
+endfunction()
+function(add_module moduleDir)
+    add_module_custom_target(${moduleDir} ${moduleDir})
+endfunction()
+
 set(MODULES_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/inc)
 set(MODULES_INSTALL_DIR "/usr/lib/osconfig" CACHE FILEPATH "Directory used for installing modules")
 
-add_subdirectory(commandrunner)
-add_subdirectory(deviceinfo)
-add_subdirectory(firewall)
-add_subdirectory(hostname)
-add_subdirectory(networking)
-add_subdirectory(pmc)
-add_subdirectory(settings)
-add_subdirectory(tpm)
-add_subdirectory(ztsi)
-add_subdirectory(test)
+add_module(commandrunner)
+add_module(deviceinfo)
+add_module(firewall)
+add_module(hostname)
+add_module(networking)
+add_module(pmc)
+add_module(settings)
+add_module(tpm)
+add_module(ztsi)
 
 if (BUILD_SAMPLES)
-    add_subdirectory(samples)
+    add_module_custom_target(samples cppsample)
 endif()

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -7,7 +7,7 @@ add_subdirectory(test)
 # the appropriate dependencies in order for module testrecipe configuration to be generated. 
 function(add_module_custom_target moduleDir targetName)
     add_subdirectory(${moduleDir})
-    add_dependencies(moduletestmetadata ${targetName})
+    add_dependencies(modulerecipeconfiguration ${targetName})
 endfunction()
 function(add_module moduleDir)
     add_module_custom_target(${moduleDir} ${moduleDir})

--- a/src/modules/mim/networking.json
+++ b/src/modules/mim/networking.json
@@ -11,6 +11,7 @@
           "type": "mimObject",
           "desired": false,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "interfaceTypes",

--- a/src/modules/mim/packagemanagerconfiguration.json
+++ b/src/modules/mim/packagemanagerconfiguration.json
@@ -11,6 +11,7 @@
           "type": "mimObject",
           "desired": false,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "packages",

--- a/src/modules/mim/sample.json
+++ b/src/modules/mim/sample.json
@@ -291,7 +291,7 @@
               ]
             }
           }
-        }
+        },
         {
           "name": "reportedArrayObject",
           "type": "mimObject",

--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -21,11 +21,22 @@ target_include_directories(testfactorylib PUBLIC
 add_executable(modulestest main.cpp)
 target_link_libraries(modulestest gtest gtest_main pthread testfactorylib)
 
-add_custom_target(moduletestmetadata
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../../devops/scripts/generate_moduletest_metadata.sh
-    COMMENT "Generating module test metadata"
-)
-add_dependencies(modulestest moduletestmetadata)
+find_program(JQ_EXEC jq)
+if(JQ_EXEC)
+    add_custom_target(moduletestmetadata
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../../devops/scripts/generate_moduletest_metadata.sh
+        COMMENT "Generating module test metadata"
+    )
+    add_dependencies(modulestest moduletestmetadata)
+else()
+    set(jq_error "'jq' application required for generating module test metadata")
+    message(WARNING ${jq_error})
+    add_custom_target(moduletestmetadata
+        COMMAND true
+        COMMENT ${jq_error}
+    )
+endif()
+
 gtest_discover_tests(modulestest
     EXTRA_ARGS ${CMAKE_CURRENT_BINARY_DIR}/testplate.json
 )

--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-project(testfactorylib)
+include(GoogleTest)
+project(modulestest)
 
 set(CMAKE_CXX_STANDARD 17)
 add_library(testfactorylib MimParser.cpp TestRecipeParser.cpp ManagementModule.cpp RecipeInvoker.cpp)
@@ -9,6 +10,7 @@ add_library(testfactorylib MimParser.cpp TestRecipeParser.cpp ManagementModule.c
 target_link_libraries(testfactorylib
     ${CMAKE_DL_LIBS}
     commonutils
+    logging
     pthread
     parsonlib)
 
@@ -18,6 +20,15 @@ target_include_directories(testfactorylib PUBLIC
 
 add_executable(modulestest main.cpp)
 target_link_libraries(modulestest gtest gtest_main pthread testfactorylib)
+
+add_custom_target(moduletestmetadata
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../../devops/scripts/generate_moduletest_metadata.sh
+    COMMENT "Generating module test metadata"
+)
+add_dependencies(modulestest moduletestmetadata)
+gtest_discover_tests(modulestest
+    EXTRA_ARGS ${CMAKE_CURRENT_BINARY_DIR}/testplate.json
+)
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
     target_link_libraries(modulestest stdc++fs)

--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -23,15 +23,15 @@ target_link_libraries(modulestest gtest gtest_main pthread testfactorylib)
 
 find_program(JQ_EXEC jq)
 if(JQ_EXEC)
-    add_custom_target(moduletestmetadata
+    add_custom_target(modulerecipeconfiguration
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../../devops/scripts/generate_moduletest_metadata.sh
-        COMMENT "Generating module test metadata"
+        COMMENT "Generating module recipe configuration"
     )
-    add_dependencies(modulestest moduletestmetadata)
+    add_dependencies(modulestest modulerecipeconfiguration)
 else()
-    set(jq_error "'jq' application required for generating module test metadata")
+    set(jq_error "'jq' application required for generating module recipe configuration")
     message(WARNING ${jq_error})
-    add_custom_target(moduletestmetadata
+    add_custom_target(modulerecipeconfiguration
         COMMAND true
         COMMENT ${jq_error}
     )

--- a/src/modules/test/Common.h
+++ b/src/modules/test/Common.h
@@ -25,6 +25,7 @@
 
 #include <CommonUtils.h>
 #include <Mmi.h>
+#include <Logging.h>
 
 // Use <filesystem> or <experimental/filesystem> based on gcc lib availability
 #if __has_include(<filesystem>)

--- a/src/modules/test/Common.h
+++ b/src/modules/test/Common.h
@@ -31,6 +31,11 @@
 
 constexpr const size_t g_lineLength = 256;
 
+inline void TestLogInfo(const char* log)
+{
+    std::cout << log << std::endl;
+}
+
 inline void TestLogInfo(const char* format, const char* args...)
 {
     char buf[g_lineLength] = {0};
@@ -40,14 +45,14 @@ inline void TestLogInfo(const char* format, const char* args...)
 
 inline void TestLogError(const char* log)
 {
-    std::cerr << log;
+    std::cerr << log << std::endl;
 }
 
 inline void TestLogError(const char* format, const char* args...)
 {
     char buf[g_lineLength] = {0};
     std::snprintf(buf, g_lineLength, format, args);
-    std::cerr << buf;
+    std::cerr << buf << std::endl;
 }
 
 // Use <filesystem> or <experimental/filesystem> based on gcc lib availability

--- a/src/modules/test/MimParser.cpp
+++ b/src/modules/test/MimParser.cpp
@@ -1,5 +1,6 @@
 #include "Common.h"
 
+static const std::string g_array = "array";
 static const std::string g_contents = "contents";
 static const std::string g_desired = "desired";
 static const std::string g_elementSchema_Fields = "elementSchema.fields";
@@ -57,7 +58,7 @@ pMimObjects MimParser::ParseMim(std::string path)
 
                     JSON_Array *jsonSettings = nullptr;
                     if (nullptr != json_object_get_string(schema_object, g_type.c_str()) &&
-                        (0 == strcmp(json_object_get_string(schema_object, g_type.c_str()), "array")) &&
+                        (0 == strcmp(json_object_get_string(schema_object, g_type.c_str()), g_array.c_str())) &&
                         (0 == strcmp(json_object_dotget_string(schema_object, g_elementSchema_Type.c_str()), g_object.c_str())))
                     {
                         mim.m_type = json_object_get_string(schema_object, g_type.c_str()),
@@ -128,7 +129,7 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
                 }
             }
         }
-        else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), "array"))
+        else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), g_array.c_str()))
         {
             if (json_object_has_value_of_type(jsonSchema, "elementSchema", JSONObject))
             {

--- a/src/modules/test/MimParser.cpp
+++ b/src/modules/test/MimParser.cpp
@@ -3,10 +3,16 @@
 static const std::string g_array = "array";
 static const std::string g_contents = "contents";
 static const std::string g_desired = "desired";
+static const std::string g_elementSchema = "elementSchema";
 static const std::string g_elementSchema_Fields = "elementSchema.fields";
 static const std::string g_elementSchema_Type = "elementSchema.type";
+static const std::string g_enum = "enum";
+static const std::string g_enumValue = "enumValue";
 static const std::string g_enumValues = "enumValues";
 static const std::string g_fields = "fields";
+static const std::string g_map = "map";
+static const std::string g_mapKey_Schema = "mapKey.schema";
+static const std::string g_mapValue_Schema = "mapValue.schema";
 static const std::string g_mimModel = "MimModel";
 static const std::string g_mimObject = "mimObject";
 static const std::string g_name = "name";
@@ -111,7 +117,7 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
     {
         JSON_Object *jsonSchema = json_object_get_object(jsonField, g_schema.c_str());
 
-        if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), "enum"))
+        if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), g_enum.c_str()))
         {
             mimField = {
                 json_object_get_string(jsonField, g_name.c_str()),
@@ -125,15 +131,15 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
                 for (size_t a = 0; a < json_array_get_count(supportedValues); a++)
                 {
                     JSON_Object *jsonEnumValues = json_array_get_object(supportedValues, a);
-                    mimField.allowedValues->push_back(std::to_string(json_object_get_number(jsonEnumValues, "enumValue")));
+                    mimField.allowedValues->push_back(std::to_string(json_object_get_number(jsonEnumValues, g_enumValue.c_str())));
                 }
             }
         }
         else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), g_array.c_str()))
         {
-            if (json_object_has_value_of_type(jsonSchema, "elementSchema", JSONObject))
+            if (json_object_has_value_of_type(jsonSchema, g_elementSchema.c_str(), JSONObject))
             {
-                MimParser::ParseMimSetting(json_object_get_object(jsonField, "elementSchema"), mimObject);
+                MimParser::ParseMimSetting(json_object_get_object(jsonField, g_elementSchema.c_str()), mimObject);
             }
             else
             {
@@ -143,10 +149,10 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
                     std::make_shared<std::vector<std::string>>()};
             }
         }
-        else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), "map"))
+        else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), g_map.c_str()))
         {
-            const char* keySchema = json_object_dotget_string(jsonSchema, "mapKey.schema");
-            const char* valueSchema = json_object_dotget_string(jsonSchema, "mapValue.schema");
+            const char* keySchema = json_object_dotget_string(jsonSchema, g_mapKey_Schema.c_str());
+            const char* valueSchema = json_object_dotget_string(jsonSchema, g_mapValue_Schema.c_str());
 
             if (nullptr == keySchema || nullptr == valueSchema)
             {

--- a/src/modules/test/MimParser.cpp
+++ b/src/modules/test/MimParser.cpp
@@ -1,7 +1,18 @@
 #include "Common.h"
 
+static const std::string g_contents = "contents";
+static const std::string g_desired = "desired";
+static const std::string g_elementSchema_Fields = "elementSchema.fields";
+static const std::string g_elementSchema_Type = "elementSchema.type";
+static const std::string g_enumValues = "enumValues";
+static const std::string g_fields = "fields";
 static const std::string g_mimModel = "MimModel";
 static const std::string g_mimObject = "mimObject";
+static const std::string g_name = "name";
+static const std::string g_object = "object";
+static const std::string g_schema = "schema";
+static const std::string g_type = "type";
+static const std::string g_valueSchema = "valueSchema";
 
 pMimObjects MimParser::ParseMim(std::string path)
 {
@@ -17,7 +28,7 @@ pMimObjects MimParser::ParseMim(std::string path)
     }
 
     JSON_Object *root_object = json_value_get_object(root_value);
-    JSON_Array *components = json_object_get_array(root_object, "contents");
+    JSON_Array *components = json_object_get_array(root_object, g_contents.c_str());
     JSON_Array *jsonMimObjects = nullptr;
 
     for (size_t i = 0; i < json_array_get_count(components); i++)
@@ -25,36 +36,36 @@ pMimObjects MimParser::ParseMim(std::string path)
         // Components
         root_object = json_array_get_object(components, i);
 
-        std::string componentName = json_object_get_string(root_object, "name");
+        std::string componentName = json_object_get_string(root_object, g_name.c_str());
 
-        jsonMimObjects = json_object_get_array(root_object, "contents");
+        jsonMimObjects = json_object_get_array(root_object, g_contents.c_str());
         for (size_t y = 0; y < json_array_get_count(jsonMimObjects); y++)
         {
             root_object = json_array_get_object(jsonMimObjects, y);
 
-            if (0 == strcmp(json_object_get_string(root_object, "type"), g_mimObject.c_str()))
+            if (0 == strcmp(json_object_get_string(root_object, g_type.c_str()), g_mimObject.c_str()))
             {
                 MimObject mim = {
-                    json_object_get_string(root_object, "name"),
-                    json_object_get_string(root_object, "type"),
-                    !!json_object_get_boolean(root_object, "desired"),
+                    json_object_get_string(root_object, g_name.c_str()),
+                    json_object_get_string(root_object, g_type.c_str()),
+                    !!json_object_get_boolean(root_object, g_desired.c_str()),
                     std::make_shared<std::map<std::string, MimSetting>>()};
 
-                if (json_object_has_value_of_type(root_object, "schema", JSONObject))
+                if (json_object_has_value_of_type(root_object, g_schema.c_str(), JSONObject))
                 {
-                    JSON_Object *schema_object = json_object_get_object(root_object, "schema");
+                    JSON_Object *schema_object = json_object_get_object(root_object, g_schema.c_str());
 
                     JSON_Array *jsonSettings = nullptr;
-                    if (nullptr != json_object_get_string(schema_object, "type") &&
-                        (0 == strcmp(json_object_get_string(schema_object, "type"), "array")) &&
-                        (0 == strcmp(json_object_dotget_string(schema_object, "elementSchema.type"), "object")))
+                    if (nullptr != json_object_get_string(schema_object, g_type.c_str()) &&
+                        (0 == strcmp(json_object_get_string(schema_object, g_type.c_str()), "array")) &&
+                        (0 == strcmp(json_object_dotget_string(schema_object, g_elementSchema_Type.c_str()), g_object.c_str())))
                     {
-                        mim.m_type = json_object_get_string(schema_object, "type"),
-                        jsonSettings = json_object_dotget_array(schema_object, "elementSchema.fields");
+                        mim.m_type = json_object_get_string(schema_object, g_type.c_str()),
+                        jsonSettings = json_object_dotget_array(schema_object, g_elementSchema_Fields.c_str());
                     }
                     else
                     {
-                        jsonSettings = json_object_get_array(schema_object, "fields");
+                        jsonSettings = json_object_get_array(schema_object, g_fields.c_str());
                     }
 
                     for (size_t z = 0; z < json_array_get_count(jsonSettings); z++)
@@ -86,30 +97,30 @@ pMimObjects MimParser::ParseMim(std::string path)
 void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
 {
     MimSetting mimField;
-    if (json_object_has_value_of_type(jsonField, "schema", JSONString) ||
-        json_object_has_value_of_type(jsonField, "schema", JSONNumber) ||
-        json_object_has_value_of_type(jsonField, "schema", JSONBoolean))
+    if (json_object_has_value_of_type(jsonField, g_schema.c_str(), JSONString) ||
+        json_object_has_value_of_type(jsonField, g_schema.c_str(), JSONNumber) ||
+        json_object_has_value_of_type(jsonField, g_schema.c_str(), JSONBoolean))
     {
         mimField = {
-            json_object_get_string(jsonField, "name"),
-            json_object_get_string(jsonField, "schema"),
+            json_object_get_string(jsonField, g_name.c_str()),
+            json_object_get_string(jsonField, g_schema.c_str()),
             std::make_shared<std::vector<std::string>>()};
     }
-    else if (json_object_has_value_of_type(jsonField, "schema", JSONObject))
+    else if (json_object_has_value_of_type(jsonField, g_schema.c_str(), JSONObject))
     {
-        JSON_Object *jsonSchema = json_object_get_object(jsonField, "schema");
+        JSON_Object *jsonSchema = json_object_get_object(jsonField, g_schema.c_str());
 
-        if (0 == strcmp(json_object_get_string(jsonSchema, "type"), "enum"))
+        if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), "enum"))
         {
             mimField = {
-                json_object_get_string(jsonField, "name"),
-                json_object_get_string(jsonSchema, "valueSchema"),
+                json_object_get_string(jsonField, g_name.c_str()),
+                json_object_get_string(jsonSchema, g_valueSchema.c_str()),
                 std::make_shared<std::vector<std::string>>()};
 
             // Add supported values
-            if (json_object_has_value_of_type(jsonSchema, "enumValues", JSONArray))
+            if (json_object_has_value_of_type(jsonSchema, g_enumValues.c_str(), JSONArray))
             {
-                JSON_Array *supportedValues = json_object_get_array(jsonSchema, "enumValues");
+                JSON_Array *supportedValues = json_object_get_array(jsonSchema, g_enumValues.c_str());
                 for (size_t a = 0; a < json_array_get_count(supportedValues); a++)
                 {
                     JSON_Object *jsonEnumValues = json_array_get_object(supportedValues, a);
@@ -117,7 +128,7 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
                 }
             }
         }
-        else if (0 == strcmp(json_object_get_string(jsonSchema, "type"), "array"))
+        else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), "array"))
         {
             if (json_object_has_value_of_type(jsonSchema, "elementSchema", JSONObject))
             {
@@ -126,29 +137,29 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
             else
             {
                 mimField = {
-                    json_object_get_string(jsonField, "name"),
+                    json_object_get_string(jsonField, g_name.c_str()),
                     std::string("array-") + json_object_dotget_string(jsonField, "schema.elementSchema"),
                     std::make_shared<std::vector<std::string>>()};
             }
         }
-        else if (0 == strcmp(json_object_get_string(jsonSchema, "type"), "map"))
+        else if (0 == strcmp(json_object_get_string(jsonSchema, g_type.c_str()), "map"))
         {
             const char* keySchema = json_object_dotget_string(jsonSchema, "mapKey.schema");
             const char* valueSchema = json_object_dotget_string(jsonSchema, "mapValue.schema");
 
             if (nullptr == keySchema || nullptr == valueSchema)
             {
-                TestLogError("Missing key or value schema for map field '%s'", json_object_get_string(jsonSchema, "name"));
+                TestLogError("Missing key or value schema for map field '%s'", json_object_get_string(jsonSchema, g_name.c_str()));
             }
 
             mimField = {
-                json_object_get_string(jsonField, "name"),
+                json_object_get_string(jsonField, g_name.c_str()),
                 std::string("map-") + keySchema + "-" + valueSchema,
                 std::make_shared<std::vector<std::string>>()};
         }
         else
         {
-            TestLogError("Invalid type '%s'", json_object_get_string(jsonSchema, "type"));
+            TestLogError("Invalid type '%s'", json_object_get_string(jsonSchema, g_type.c_str()));
         }
     }
 

--- a/src/modules/test/MimParser.cpp
+++ b/src/modules/test/MimParser.cpp
@@ -40,13 +40,11 @@ pMimObjects MimParser::ParseMim(std::string path)
                     !!json_object_get_boolean(root_object, "desired"),
                     std::make_shared<std::map<std::string, MimSetting>>()};
 
-                // Get fields -- if present
                 if (json_object_has_value_of_type(root_object, "schema", JSONObject))
                 {
                     JSON_Object *schema_object = json_object_get_object(root_object, "schema");
 
-                    // Can be an embedded object
-                    JSON_Array *jsonFields = nullptr;
+                    JSON_Array *jsonSettings = nullptr;
                     if (nullptr == json_object_get_string(schema_object, "type"))
                     {
                         throw std::runtime_error("MimObject schema missing 'type'");
@@ -54,16 +52,17 @@ pMimObjects MimParser::ParseMim(std::string path)
                     else if ((0 == strcmp(json_object_get_string(schema_object, "type"), "array")) &&
                         (0 == strcmp(json_object_dotget_string(schema_object, "elementSchema.type"), "object")))
                     {
-                        jsonFields = json_object_dotget_array(schema_object, "elementSchema.fields");
+                        mim.m_type = json_object_get_string(schema_object, "type"),
+                        jsonSettings = json_object_dotget_array(schema_object, "elementSchema.fields");
                     }
                     else
                     {
-                        jsonFields = json_object_get_array(schema_object, "fields");
+                        jsonSettings = json_object_get_array(schema_object, "fields");
                     }
 
-                    for (size_t z = 0; z < json_array_get_count(jsonFields); z++)
+                    for (size_t z = 0; z < json_array_get_count(jsonSettings); z++)
                     {
-                        MimParser::ParseMimSetting(json_array_get_object(jsonFields, z), mim);
+                        MimParser::ParseMimSetting(json_array_get_object(jsonSettings, z), mim);
                     }
                 }
 
@@ -90,7 +89,6 @@ pMimObjects MimParser::ParseMim(std::string path)
 void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
 {
     MimSetting mimField;
-    std::cout << "Parsing field: " << json_object_get_string(jsonField, "name") << std::endl;
     if (json_object_has_value_of_type(jsonField, "schema", JSONString) ||
         json_object_has_value_of_type(jsonField, "schema", JSONNumber) ||
         json_object_has_value_of_type(jsonField, "schema", JSONBoolean))
@@ -157,5 +155,5 @@ void MimParser::ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject)
         }
     }
 
-    (*mimObject.m_fields)[mimField.name] = mimField;
+    (*mimObject.m_settings)[mimField.name] = mimField;
 }

--- a/src/modules/test/MimParser.cpp
+++ b/src/modules/test/MimParser.cpp
@@ -45,11 +45,8 @@ pMimObjects MimParser::ParseMim(std::string path)
                     JSON_Object *schema_object = json_object_get_object(root_object, "schema");
 
                     JSON_Array *jsonSettings = nullptr;
-                    if (nullptr == json_object_get_string(schema_object, "type"))
-                    {
-                        throw std::runtime_error("MimObject schema missing 'type'");
-                    }
-                    else if ((0 == strcmp(json_object_get_string(schema_object, "type"), "array")) &&
+                    if (nullptr != json_object_get_string(schema_object, "type") &&
+                        (0 == strcmp(json_object_get_string(schema_object, "type"), "array")) &&
                         (0 == strcmp(json_object_dotget_string(schema_object, "elementSchema.type"), "object")))
                     {
                         mim.m_type = json_object_get_string(schema_object, "type"),

--- a/src/modules/test/MimParser.h
+++ b/src/modules/test/MimParser.h
@@ -18,7 +18,7 @@ struct MimObject
     std::string m_name;
     std::string m_type;
     bool m_desired;
-    std::shared_ptr<std::map<std::string, MimSetting>> m_fields;
+    std::shared_ptr<std::map<std::string, MimSetting>> m_settings;
 };
 
 typedef std::map<std::string, std::shared_ptr<std::map<std::string, MimObject>>> MimObjects;

--- a/src/modules/test/MimParser.h
+++ b/src/modules/test/MimParser.h
@@ -10,6 +10,8 @@ struct MimField
 {
     std::string name;
     std::string type;
+    std::string subType1;    // For arrays: interger or string subtypes (subType1)
+    std::string subType2;    // For maps: key (subType1), value (subType2)
     std::shared_ptr<std::vector<std::string>> allowedValues;
 };
 
@@ -26,6 +28,9 @@ typedef std::shared_ptr<MimObjects> pMimObjects;
 
 class MimParser
 {
+private:
+    static void ParseMimField(JSON_Object* jsonField, MimObject& mimObject);
+
 public:
     static pMimObjects ParseMim(std::string path);
 };

--- a/src/modules/test/MimParser.h
+++ b/src/modules/test/MimParser.h
@@ -6,12 +6,10 @@
 
 #include "Common.h"
 
-struct MimField
+struct MimSetting
 {
     std::string name;
     std::string type;
-    std::string subType1;    // For arrays: interger or string subtypes (subType1)
-    std::string subType2;    // For maps: key (subType1), value (subType2)
     std::shared_ptr<std::vector<std::string>> allowedValues;
 };
 
@@ -20,7 +18,7 @@ struct MimObject
     std::string m_name;
     std::string m_type;
     bool m_desired;
-    std::shared_ptr<std::map<std::string, MimField>> m_fields;
+    std::shared_ptr<std::map<std::string, MimSetting>> m_fields;
 };
 
 typedef std::map<std::string, std::shared_ptr<std::map<std::string, MimObject>>> MimObjects;
@@ -29,7 +27,7 @@ typedef std::shared_ptr<MimObjects> pMimObjects;
 class MimParser
 {
 private:
-    static void ParseMimField(JSON_Object* jsonField, MimObject& mimObject);
+    static void ParseMimSetting(JSON_Object* jsonField, MimObject& mimObject);
 
 public:
     static pMimObjects ParseMim(std::string path);

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -29,51 +29,49 @@ void RecipeInvoker::TestBody()
             EXPECT_NE(0, m_recipe.m_mimObjects->at(m_recipe.m_componentName)->size()) << "No MimObjects for " << m_recipe.m_componentName << "!";
             auto map = m_recipe.m_mimObjects->at(m_recipe.m_componentName)->at(m_recipe.m_objectName);
 
-            // Validate fields + supported values
-            std::cout << "Validating fields and supported values for '" << m_recipe.m_objectName << "'" << std::endl;
-            for (auto field : *map.m_fields)
-            {
-                if (field.second.type.compare("string") == 0)
-                {
-                    EXPECT_NE(nullptr, json_object_get_string(jsonObject, field.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string field '" << field.second.name << "'" << std::endl
-                                                                                                      << "JSON: " << payload;
+            std::string payloadStr(payload, payloadSize);
 
-                    std::string value = json_object_get_string(jsonObject, field.second.name.c_str());
-                    if (field.second.allowedValues->size() && std::find(field.second.allowedValues->begin(), field.second.allowedValues->end(), value) == field.second.allowedValues->end())
+            // Validate settings + supported values
+            TestLogInfo("Validating settings and supported values for '%s'", m_recipe.m_objectName.c_str());
+            if ((map.m_type.compare("array") == 0) ||
+                (map.m_type.compare("map") == 0))
+            {
+                EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl
+                    << "JSON: " << payloadStr;
+            }
+            else
+            {
+                for (auto setting : *map.m_settings)
+                {
+                    if (setting.second.type.compare("string") == 0)
                     {
-                        FAIL() << "Field '" << field.second.name << "' contains unsupported value '" << value << "'" << std::endl
-                               << "JSON: " << payload;
+                        EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl
+                                                                                                        << "JSON: " << payloadStr;
+
+                        std::string value = json_object_get_string(jsonObject, setting.second.name.c_str());
+                        if (setting.second.allowedValues->size() && std::find(setting.second.allowedValues->begin(), setting.second.allowedValues->end(), value) == setting.second.allowedValues->end())
+                        {
+                            FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl
+                                << "JSON: " << payloadStr;
+                        }
                     }
-                }
-                else if (field.second.type.compare("integer") == 0)
-                {
-                    JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
-                    EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer field '" << field.second.name << "'" << std::endl
-                                                                      << "JSON: " << payload;
-                }
-                else if (field.second.type.compare("boolean") == 0)
-                {
-                    JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
-                    EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean field '" << field.second.name << "'" << std::endl
-                                                                       << "JSON: " << payload;
-                }
-                else if (field.second.type.compare("array") == 0)
-                {
-                    JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
-                    EXPECT_EQ(JSONArray, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain array field '" << field.second.name << "'" << std::endl
-                        << "JSON: " << payload;
-                }
-                else if (field.second.type.compare("map") == 0)
-                {
-                    // Maps are formatted as arrays of objects
-                    JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
-                    EXPECT_EQ(JSONArray, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain map field '" << field.second.name << "'" << std::endl
-                        << "JSON: " << payload;
-                }
-                else
-                {
-                    FAIL() << "Unsupported type: " << field.second.type << std::endl
-                           << "JSON: " << payload;
+                    else if (setting.second.type.compare("integer") == 0)
+                    {
+                        JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
+                        EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl
+                                                                        << "JSON: " << payloadStr;
+                    }
+                    else if (setting.second.type.compare("boolean") == 0)
+                    {
+                        JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
+                        EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl
+                                                                        << "JSON: " << payloadStr;
+                    }
+                    else
+                    {
+                        FAIL() << "Unsupported type: " << setting.second.type << std::endl
+                            << "JSON: " << payloadStr;
+                    }
                 }
             }
 

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -25,8 +25,8 @@ void RecipeInvoker::TestBody()
             ASSERT_NE(nullptr, root_value);
             JSON_Object *jsonObject = json_value_get_object(root_value);
 
-            EXPECT_NE(0, m_recipe.m_mimObjects->size());
-            EXPECT_NE(0, m_recipe.m_mimObjects->at(m_recipe.m_componentName)->size());
+            EXPECT_NE(0, m_recipe.m_mimObjects->size()) << "Invalid MIM JSON!";
+            EXPECT_NE(0, m_recipe.m_mimObjects->at(m_recipe.m_componentName)->size()) << "No MimObjects for " << m_recipe.m_componentName << "!";
             auto map = m_recipe.m_mimObjects->at(m_recipe.m_componentName)->at(m_recipe.m_objectName);
 
             // Validate fields + supported values
@@ -56,6 +56,19 @@ void RecipeInvoker::TestBody()
                     JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
                     EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean field '" << field.second.name << "'" << std::endl
                                                                        << "JSON: " << payload;
+                }
+                else if (field.second.type.compare("array") == 0)
+                {
+                    JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
+                    EXPECT_EQ(JSONArray, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain array field '" << field.second.name << "'" << std::endl
+                                                                     << "JSON: " << payload;
+                }
+                else if (field.second.type.compare("map") == 0)
+                {
+                    // Maps are formatted as arrays of objects
+                    JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
+                    EXPECT_EQ(JSONArray, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain map field '" << field.second.name << "'" << std::endl
+                                                                     << "JSON: " << payload;
                 }
                 else
                 {

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -84,9 +84,7 @@ void RecipeInvoker::TestBody()
 
                 std::string recipe_payload_str(payload, payloadSize);
                 EXPECT_NE(nullptr, recipe_payload) << "Failed to parse recipe payload" << std::endl << "JSON: " << m_recipe.m_payload;
-                EXPECT_TRUE(json_value_equals(recipe_payload, returned_payload)) << "Non matching recipe payload" << std::endl
-                                                                                 << "Recipe   payload: " << m_recipe.m_payload << std::endl
-                                                                                 << "Returned payload: " << recipe_payload_str << std::endl;
+                EXPECT_TRUE(json_value_equals(recipe_payload, returned_payload)) << "Non matching recipe payload" << std::endl << "Recipe   payload: " << m_recipe.m_payload << std::endl << "Returned payload: " << recipe_payload_str << std::endl;
 
                 json_value_free(recipe_payload);
                 json_value_free(returned_payload);

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -36,8 +36,7 @@ void RecipeInvoker::TestBody()
             if ((map.m_type.compare("array") == 0) ||
                 (map.m_type.compare("map") == 0))
             {
-                EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl
-                    << "JSON: " << payloadStr;
+                EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl << "JSON: " << payloadStr;
             }
             else
             {
@@ -45,32 +44,27 @@ void RecipeInvoker::TestBody()
                 {
                     if (setting.second.type.compare("string") == 0)
                     {
-                        EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl
-                                                                                                        << "JSON: " << payloadStr;
+                        EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
 
                         std::string value = json_object_get_string(jsonObject, setting.second.name.c_str());
                         if (setting.second.allowedValues->size() && std::find(setting.second.allowedValues->begin(), setting.second.allowedValues->end(), value) == setting.second.allowedValues->end())
                         {
-                            FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl
-                                << "JSON: " << payloadStr;
+                            FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl << "JSON: " << payloadStr;
                         }
                     }
                     else if (setting.second.type.compare("integer") == 0)
                     {
                         JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
-                        EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl
-                                                                        << "JSON: " << payloadStr;
+                        EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
                     }
                     else if (setting.second.type.compare("boolean") == 0)
                     {
                         JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
-                        EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl
-                                                                        << "JSON: " << payloadStr;
+                        EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
                     }
                     else
                     {
-                        FAIL() << "Unsupported type: " << setting.second.type << std::endl
-                            << "JSON: " << payloadStr;
+                        FAIL() << "Unsupported type: " << setting.second.type << std::endl << "JSON: " << payloadStr;
                     }
                 }
             }
@@ -89,8 +83,7 @@ void RecipeInvoker::TestBody()
                 JSON_Value *returned_payload = json_parse_string(payload);
 
                 std::string recipe_payload_str(payload, payloadSize);
-                EXPECT_NE(nullptr, recipe_payload) << "Failed to parse recipe payload" << std::endl
-                                                   << "JSON: " << m_recipe.m_payload;
+                EXPECT_NE(nullptr, recipe_payload) << "Failed to parse recipe payload" << std::endl << "JSON: " << m_recipe.m_payload;
                 EXPECT_TRUE(json_value_equals(recipe_payload, returned_payload)) << "Non matching recipe payload" << std::endl
                                                                                  << "Recipe   payload: " << m_recipe.m_payload << std::endl
                                                                                  << "Returned payload: " << recipe_payload_str << std::endl;

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -61,14 +61,14 @@ void RecipeInvoker::TestBody()
                 {
                     JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
                     EXPECT_EQ(JSONArray, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain array field '" << field.second.name << "'" << std::endl
-                                                                     << "JSON: " << payload;
+                        << "JSON: " << payload;
                 }
                 else if (field.second.type.compare("map") == 0)
                 {
                     // Maps are formatted as arrays of objects
                     JSON_Value *value = json_object_get_value(jsonObject, field.second.name.c_str());
                     EXPECT_EQ(JSONArray, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain map field '" << field.second.name << "'" << std::endl
-                                                                     << "JSON: " << payload;
+                        << "JSON: " << payload;
                 }
                 else
                 {

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -10,7 +10,7 @@ void RegisterRecipesWithGTest(TestRecipes &testRecipes)
         // https://github.com/google/googletest/blob/v1.10.x/googletest/include/gtest/gtest.h#L2438
         std::string testName(recipe.m_componentName + "-" + recipe.m_objectName);
         testing::RegisterTest(
-            "TestRecipes", testName.c_str(), nullptr, testName.c_str(), __FILE__, __LINE__,
+            "TestRecipes", testName.c_str(), nullptr, nullptr, __FILE__, __LINE__,
             [recipe]()->RecipeFixture *
             {
                 return new RecipeInvoker(recipe);
@@ -96,6 +96,8 @@ int main(int argc, char **argv)
         PrintUsage();
     }
 
+    // TODO: add fulllogging on/off?
+    SetFullLogging(true);
     if (argc == 2)
     {
         // Test definitions present - perform more extensive tests using Mim and test recipes
@@ -112,7 +114,7 @@ int main(int argc, char **argv)
             // See gtest.h for details on this test registration
             // https://github.com/google/googletest/blob/v1.10.x/googletest/include/gtest/gtest.h#L2438
             testing::RegisterTest(
-                "TestRecipes", "Basic-Module-Test", nullptr, "Basic-Module-Test", __FILE__, __LINE__,
+                "TestRecipes", "Basic-Module-Test", nullptr, nullptr, __FILE__, __LINE__,
                     [module]()->RecipeFixture*
                     { 
                         return new BasicModuleTester(module); }

--- a/src/modules/test/recipes/FirewallTests.json
+++ b/src/modules/test/recipes/FirewallTests.json
@@ -1,0 +1,16 @@
+[
+    {
+        "ComponentName": "Firewall",
+        "ObjectName": "firewallState",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "Firewall",
+        "ObjectName": "firewallFingerprint",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    }
+]

--- a/src/modules/test/recipes/HostnameTests.json
+++ b/src/modules/test/recipes/HostnameTests.json
@@ -1,0 +1,23 @@
+[
+    {
+        "ComponentName": "HostName",
+        "ObjectName": "name",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "HostName",
+        "ObjectName": "hosts",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "HostName",
+        "ObjectName": "name",
+        "Desired": true,
+        "ExpectedResult": 22,   // name is a reported object, this should fail
+        "WaitSeconds": 0
+    }
+]

--- a/src/modules/test/recipes/HostnameTests.json
+++ b/src/modules/test/recipes/HostnameTests.json
@@ -17,7 +17,8 @@
         "ComponentName": "HostName",
         "ObjectName": "name",
         "Desired": true,
-        "ExpectedResult": 22,   // name is a reported object, this should fail
+        "Payload": "{}",
+        "ExpectedResult": 22,
         "WaitSeconds": 0
     }
 ]

--- a/src/modules/test/recipes/NetworkingTests.json
+++ b/src/modules/test/recipes/NetworkingTests.json
@@ -1,0 +1,9 @@
+[
+    {
+        "ComponentName": "Networking",
+        "ObjectName": "networkConfiguration",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    }
+]

--- a/src/modules/test/recipes/PackageManagerConfigurationTests.json
+++ b/src/modules/test/recipes/PackageManagerConfigurationTests.json
@@ -1,0 +1,9 @@
+[
+    {
+        "ComponentName": "PackageManagerConfiguration",
+        "ObjectName": "state",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    }
+]

--- a/src/modules/test/recipes/SampleTests.json
+++ b/src/modules/test/recipes/SampleTests.json
@@ -8,7 +8,7 @@
     },
     {
         "ComponentName": "SampleComponent",
-        "ObjectName": "desiredIntegerObject",
+        "ObjectName": "reportedIntegerObject",
         "Desired": false,
         "ExpectedResult": 0,
         "WaitSeconds": 0

--- a/src/modules/test/recipes/SampleTests.json
+++ b/src/modules/test/recipes/SampleTests.json
@@ -19,5 +19,12 @@
         "Desired": false,
         "ExpectedResult": 0,
         "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "SampleComponent",
+        "ObjectName": "reportedArrayObject",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
     }
 ]

--- a/src/modules/test/recipes/TpmTests.json
+++ b/src/modules/test/recipes/TpmTests.json
@@ -1,0 +1,9 @@
+[
+    {
+        "ComponentName": "Tpm",
+        "ObjectName": "tpmStatus",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    }
+]

--- a/src/modules/test/unit-tests/CMakeLists.txt
+++ b/src/modules/test/unit-tests/CMakeLists.txt
@@ -11,5 +11,5 @@ target_include_directories(testfactorytests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/.
 target_link_libraries(testfactorytests gtest gtest_main pthread testfactorylib)
 gtest_discover_tests(testfactorytests)
 
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../mim/commandrunner.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/mim/)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../mim/sample.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/mim/)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/recipes/test.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/recipes/)

--- a/src/modules/test/unit-tests/MimParserTests.cpp
+++ b/src/modules/test/unit-tests/MimParserTests.cpp
@@ -12,9 +12,9 @@ namespace Tests
 
     TEST(MimParserTests, LoadMim)
     {
-        pMimObjects mimObjects = MimParser::ParseMim("./mim/commandrunner.json");
+        pMimObjects mimObjects = MimParser::ParseMim("./mim/sample.json");
 
-        // Should have one component and 2 MimObjects
+        // Should have one component and 10 MimObjects
         ASSERT_EQ(mimObjects->size(), 1);
 
         size_t mimCount = 0;
@@ -22,17 +22,27 @@ namespace Tests
         {
             mimCount += c.second->size();
         }
-        ASSERT_EQ(mimCount, 2);
-        
-        ASSERT_EQ((*mimObjects)["CommandRunner"]->size(), 2);
+        ASSERT_EQ(mimCount, 10);
+        ASSERT_EQ((*mimObjects)["SampleComponent"]->size(), 10);
 
-        ASSERT_EQ((*mimObjects)["CommandRunner"]->at("commandStatus").m_fields->size(), 4);
+        ASSERT_EQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->size(), 8);
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("stringSetting").name.c_str(), "stringSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerSetting").name.c_str(), "integerSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("booleanSetting").name.c_str(), "booleanSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerEnumerationSetting").name.c_str(), "integerEnumerationSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("stringsArraySetting").name.c_str(), "stringsArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerArraySetting").name.c_str(), "integerArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("stringMapSetting").name.c_str(), "stringMapSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerMapSetting").name.c_str(), "integerMapSetting");
 
-        ASSERT_STREQ((*mimObjects)["CommandRunner"]->at("commandStatus").m_fields->at("commandId").name.c_str(), "commandId");
-        ASSERT_STREQ((*mimObjects)["CommandRunner"]->at("commandStatus").m_fields->at("resultCode").name.c_str(), "resultCode");
-        ASSERT_STREQ((*mimObjects)["CommandRunner"]->at("commandStatus").m_fields->at("textResult").name.c_str(), "textResult");
-        ASSERT_STREQ((*mimObjects)["CommandRunner"]->at("commandStatus").m_fields->at("currentState").name.c_str(), "currentState");
-        
-        ASSERT_EQ((*mimObjects)["CommandRunner"]->at("commandStatus").m_fields->at("currentState").allowedValues->size(), 6);
+        ASSERT_EQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->size(), 8);
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("stringSetting").name.c_str(), "stringSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerSetting").name.c_str(), "integerSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("booleanSetting").name.c_str(), "booleanSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerEnumerationSetting").name.c_str(), "integerEnumerationSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("stringsArraySetting").name.c_str(), "stringsArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerArraySetting").name.c_str(), "integerArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("stringMapSetting").name.c_str(), "stringMapSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerMapSetting").name.c_str(), "integerMapSetting");
     }
 }

--- a/src/modules/test/unit-tests/MimParserTests.cpp
+++ b/src/modules/test/unit-tests/MimParserTests.cpp
@@ -25,24 +25,25 @@ namespace Tests
         ASSERT_EQ(mimCount, 10);
         ASSERT_EQ((*mimObjects)["SampleComponent"]->size(), 10);
 
-        ASSERT_EQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->size(), 8);
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("stringSetting").name.c_str(), "stringSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerSetting").name.c_str(), "integerSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("booleanSetting").name.c_str(), "booleanSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerEnumerationSetting").name.c_str(), "integerEnumerationSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("stringsArraySetting").name.c_str(), "stringsArraySetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerArraySetting").name.c_str(), "integerArraySetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("stringMapSetting").name.c_str(), "stringMapSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_fields->at("integerMapSetting").name.c_str(), "integerMapSetting");
+        ASSERT_EQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->size(), 8);
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("stringSetting").name.c_str(), "stringSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("integerSetting").name.c_str(), "integerSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("booleanSetting").name.c_str(), "booleanSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("integerEnumerationSetting").name.c_str(), "integerEnumerationSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("stringsArraySetting").name.c_str(), "stringsArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("integerArraySetting").name.c_str(), "integerArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("stringMapSetting").name.c_str(), "stringMapSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("ReportedObject").m_settings->at("integerMapSetting").name.c_str(), "integerMapSetting");
 
-        ASSERT_EQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->size(), 8);
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("stringSetting").name.c_str(), "stringSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerSetting").name.c_str(), "integerSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("booleanSetting").name.c_str(), "booleanSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerEnumerationSetting").name.c_str(), "integerEnumerationSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("stringsArraySetting").name.c_str(), "stringsArraySetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerArraySetting").name.c_str(), "integerArraySetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("stringMapSetting").name.c_str(), "stringMapSetting");
-        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_fields->at("integerMapSetting").name.c_str(), "integerMapSetting");
+        ASSERT_EQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->size(), 8);
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_type.c_str(), "array");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("stringSetting").name.c_str(), "stringSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("integerSetting").name.c_str(), "integerSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("booleanSetting").name.c_str(), "booleanSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("integerEnumerationSetting").name.c_str(), "integerEnumerationSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("stringsArraySetting").name.c_str(), "stringsArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("integerArraySetting").name.c_str(), "integerArraySetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("stringMapSetting").name.c_str(), "stringMapSetting");
+        ASSERT_STREQ((*mimObjects)["SampleComponent"]->at("desiredArrayObject").m_settings->at("integerMapSetting").name.c_str(), "integerMapSetting");
     }
 }


### PR DESCRIPTION
## Description

* Added map and array field support for MimObjects
* Added support for embedded objects
* Added additional test recipes for Firewall, Hostname, PMC, Networking, Tpm
* Changed Mim parsing tests to use the Sample module for more complete coverage

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.