### PR TITLE
Added location to e2e test targets

### DIFF
--- a/.github/workflows/e2etest-provision-hosts.yml
+++ b/.github/workflows/e2etest-provision-hosts.yml
@@ -63,13 +63,14 @@ jobs:
           packagePattern=`echo $target | jq .packagePattern | tr -d \"`
           device_id=`echo $target | jq .device_id | tr -d \"`
           vm_size=`echo $target | jq .vm_size | tr -d \"`
+          location=`echo $target | jq .location | tr -d \"`
           github_runner_tar_gz=`echo $target | jq .github_runner_tar_gz | tr -d \"`
           vm_script=`echo $target | jq -r '.vm_script | join(" && ")'`
 
           echo ::set-output name=device_id::$device_id
 
           terraform init
-          terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token=${{ steps.runner_token.outputs.RUNNER_TOKEN }} -var image_offer=$image_offer -var image_publisher=$image_publisher -var image_sku=$image_sku -var image_version=$image_version -var vm_size=$vm_size -var vm_script="$vm_script" -var github_runner_tar_gz_package="$github_runner_tar_gz" -auto-approve
+          terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token=${{ steps.runner_token.outputs.RUNNER_TOKEN }} -var image_offer=$image_offer -var image_publisher=$image_publisher -var image_sku=$image_sku -var image_version=$image_version -var vm_size="$vm_size" -var location="$location" -var vm_script="$vm_script" -var github_runner_tar_gz_package="$github_runner_tar_gz" -auto-approve
 
           runner=$rg-$distroName
           echo Created self-hosted runner "$runner"

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -8,6 +8,7 @@
         "device_id": "ubuntu2004",
         "package_path": "*focal_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
+        "location": "East US",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
@@ -26,6 +27,7 @@
         "device_id": "ubuntu1804",
         "package_path": "*bionic_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
+        "location": "East US",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
         [
@@ -44,6 +46,7 @@
         "device_id": "ubuntu2004arm64",
         "package_path": "*focal_aarch64.deb",
         "vm_size": "Standard_D2plds_v5",
+        "location": "West US 2",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
         "vm_script":
         [

--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -7,6 +7,7 @@
         "image_version": "latest",
         "device_id": "ubuntu2004",
         "vm_size": "Standard_DS1_v2",
+        "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
@@ -27,6 +28,7 @@
         "image_version": "latest",
         "device_id": "ubuntu1804",
         "vm_size": "Standard_DS1_v2",
+        "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
@@ -48,6 +50,7 @@
         "device_id": "ubuntu2004arm64",
         "package_path": "*focal_aarch64.deb",
         "vm_size": "Standard_D2plds_v5",
+        "location": "West US 2",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
         "vm_script":

--- a/devops/e2e/prod.json
+++ b/devops/e2e/prod.json
@@ -7,6 +7,7 @@
         "image_version": "latest",
         "device_id": "ubuntu2004",
         "vm_size": "Standard_DS1_v2",
+        "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
@@ -25,6 +26,7 @@
         "image_version": "latest",
         "device_id": "ubuntu1804",
         "vm_size": "Standard_DS1_v2",
+        "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
         "vm_script":
@@ -43,6 +45,7 @@
         "image_version": "latest",
         "device_id": "ubuntu2004arm64",
         "vm_size": "Standard_D2plds_v5",
+        "location": "West US 2",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
         "vm_script":


### PR DESCRIPTION
## Description

* Fixes the `SkuNotAvailable` ARM provisioning error from the `DS1_v2`. Allows us to override the default `West Us 2` used to provision the VMs for the e2e tests

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.