### PR TITLE
Add modulestest logs to CI report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
           working-directory: ${{ env.container-workspace }}/build
           cmd: ctest
 
+      - name: Run modulestest
+        if: success() || failure()
+        uses: ./.github/actions/container-exec
+        with:
+          container: ${{ steps.container.outputs.id }}
+          working-directory: ${{ env.container-workspace }}/build/modules/test
+          cmd: modulestest --gtest_output=xml:${{ env.container-workspace }}/build/gtest-output/TestRecipes.xml testplate.json
+
       - uses: ./.github/actions/gtest-xml
         if: success() || failure()
         with:

--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-include(GoogleTest)
 project(modulestest)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
## Description

* Include the `modulestest` logs in the CI report

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.