### PR TITLE
Ensuring local RC/DC are processed on OSConfig start before the first Desired Twin callback

### DIFF
--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -767,7 +767,7 @@ int main(int argc, char *argv[])
     signal(SIGHUP, SignalReloadConfiguration);
     signal(SIGUSR1, SignalProcessDesired);
 
-    if (RefreshMpiClientSession(NULL))
+    if (!RefreshMpiClientSession(NULL))
     {
         LogErrorWithTelemetry(GetLog(), "Failed to start the platform");
         goto done;

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -270,6 +270,11 @@ static void SignalProcessDesired(int incomingSignal)
 {
     OsConfigLogInfo(GetLog(), "Processing desired twin updates");
     ProcessDesiredTwinUpdates();
+
+    if (g_localManagement)
+    {
+        LoadDesiredConfigurationFromFile();
+    }
     
     // Reset the signal handler for the next use otherwise the default handler will be invoked instead
     signal(SIGUSR1, SignalProcessDesired);
@@ -767,6 +772,18 @@ int main(int argc, char *argv[])
     signal(SIGHUP, SignalReloadConfiguration);
     signal(SIGUSR1, SignalProcessDesired);
 
+    if (RefreshMpiClientSession(NULL))
+    {
+        LogErrorWithTelemetry(GetLog(), "Failed to start the platform");
+        goto done;
+    }
+
+    if (g_localManagement)
+    {
+        LoadDesiredConfigurationFromFile();
+        SaveReportedConfigurationToFile();
+    }
+    
     if (!InitializeAgent())
     {
         LogErrorWithTelemetry(GetLog(), "Failed to initialize the OSConfig PnP Agent");

--- a/src/agents/pnp/PnpAgent.c
+++ b/src/agents/pnp/PnpAgent.c
@@ -271,11 +271,6 @@ static void SignalProcessDesired(int incomingSignal)
     OsConfigLogInfo(GetLog(), "Processing desired twin updates");
     ProcessDesiredTwinUpdates();
 
-    if (g_localManagement)
-    {
-        LoadDesiredConfigurationFromFile();
-    }
-    
     // Reset the signal handler for the next use otherwise the default handler will be invoked instead
     signal(SIGUSR1, SignalProcessDesired);
 

--- a/src/agents/pnp/daemon/osconfig.json
+++ b/src/agents/pnp/daemon/osconfig.json
@@ -1,6 +1,6 @@
 {
-  "CommandLogging": 0,  
-  "FullLogging": 0,  
+  "CommandLogging": 0,
+  "FullLogging": 0,
   "LocalManagement": 0,
   "ModelVersion": 10,
   "Protocol": 2,


### PR DESCRIPTION
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.