### PR TITLE
Added performance tests

### DIFF
--- a/.github/workflows/deploy-github-main.yml
+++ b/.github/workflows/deploy-github-main.yml
@@ -44,6 +44,7 @@ jobs:
       environment: e2e-github-main
       resourceGroupName: ${{ needs.fetch-targets.outputs.resourceGroupName }}
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
+      performanceThreshold: 50
     secrets: inherit
 
   deprovision-resources:

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -14,6 +14,10 @@ on:
         description: The name of the target environment
         type: string
         required: true
+      performanceThreshold:
+        description: The performance threshold
+        type: string
+        default: ""
 
 jobs:
   run-tests:
@@ -90,6 +94,13 @@ jobs:
           sudo sed -i '/\"FullLogging\"/c\\  \"FullLogging\": 1,' /etc/osconfig/osconfig.json
           sudo systemctl daemon-reload
           sudo systemctl start osconfig
+          sudo systemctl start osconfig-platform
+
+      - name: Start performance sampling
+        if: ${{ inputs.performanceThreshold }} != ""
+        run: |
+          pidstat -p `pidof osconfig` 1 > perf-osconfig.log &
+          pidstat -p `pidof osconfig-platform` 1 > perf-osconfig-platform.log &
 
       - name: Run E2E tests
         env:
@@ -100,6 +111,32 @@ jobs:
         working-directory: ./src/tests/e2etest
         run: | 
           dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx"
+
+      - name: Stop performance sampling
+        if: ${{ inputs.performanceThreshold }} != ""
+        run: |
+          kill -SIGINT `pidof pidstat`
+
+      - name: Check performance results - Agent
+        if: ${{ inputs.performanceThreshold }} != ""
+        run: |
+          tail perf-osconfig.log -n1
+          result=`tail perf-osconfig.log -n1 | cut -c62-68`
+          test $(bc <<< "result=$result;if(result < ${{ inputs.performanceThreshold }}) print 0 else print 1;") == 0
+
+      - name: Check performance results - Platform
+        if: ${{ inputs.performanceThreshold }} != "" && (success() || failure())
+        run: |
+          tail perf-osconfig-platform.log -n1
+          result=`tail perf-osconfig-platform.log -n1 | cut -c62-68`
+          test $(bc <<< "result=$result;if(result < ${{ inputs.performanceThreshold }}) print 0 else print 1;") == 0
+
+      - name: Upload performance Logs
+        if: ${{ inputs.performanceThreshold }} != "" && (success() || failure())
+        uses: actions/upload-artifact@v3
+        with:
+          name: perf-logs-${{ matrix.distroName }}
+          path: perf-*.log
 
       - name: Stage logs
         if: always()

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -34,7 +34,7 @@
             "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
             "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
             "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
+            "sudo apt update -y && sudo apt install -y sysstat jq aziot-identity-service azure-cli"
         ]
     },
     {

--- a/devops/terraform/host/GenericRunnerHost.tf
+++ b/devops/terraform/host/GenericRunnerHost.tf
@@ -156,7 +156,7 @@ resource "azurerm_linux_virtual_machine" "osconfigvm" {
     inline = [
       "export DEBIAN_FRONTEND=noninteractive",
       "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-      "sudo apt update && sudo apt install -y ca-certificates curl apt-transport-https lsb-release gnupg",
+      "sudo apt update && sudo apt install -y ca-certificates curl apt-transport-https lsb-release gnupg bc sysstat",
       "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
       "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
       "mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${var.github_runner_tar_gz_package} && tar xzf ./runner.tar.gz",


### PR DESCRIPTION
## Description

* Added performance tests (CPU only) to e2e tests
* Added `performanceThreshold` which defines the %CPU to trigger a failure
* Sampling is performed on both `osconfig` and `osconfig-platform` to ensure the CPU threshold defined is not surpased. Sampling rate is 1s

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.