### PR TITLE
Added binary baseline validations

### DIFF
--- a/.github/actions/footprint-check/action.yml
+++ b/.github/actions/footprint-check/action.yml
@@ -1,0 +1,65 @@
+name: Footprint check
+description: Checks built binary footprint size against a delta threshold
+
+inputs:
+  allowedDelta:
+    description: The allowed delta expressed in %, workflow will fail if the delta is greater than this value
+    required: true
+  distroName:
+    description: The distribution name
+    required: true
+  arch:
+    description: The architecture of the binary
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Normalize the distronames + architectures to match the published packages
+    # Published architectures: [amd64, arm64, armv]
+    # Built architectures:     [x86_64, aarch64, armv7l]
+    - name: Normalize distribution + architecture naming
+      id: normalize-distro-arch
+      run: |
+        distroName=${{ inputs.distroName }}
+        arch=${{ inputs.arch }}
+
+        # Normalize distro name
+        case $distroName in
+          ("ubuntu18.04") distroName="ubuntu-18.04";;
+          ("ubuntu20.04") distroName="ubuntu-20.04";;
+          ("debian9")     distroName="debian-9";;
+        esac
+
+        # Normalize architecture
+        case $arch in
+          ("amd64") arch="x86_64";;
+          ("arm64") arch="aarch64";;
+          ("arm")   arch="armv7l";;
+        esac
+
+        echo ::set-output name=distroName::${distroName}
+        echo ::set-output name=arch::${arch}
+      shell: bash
+
+    - name: Footprint delta validation
+      run: |
+        # Get footprint size
+        target=`jq '.[] | select(.distro=="${{ steps.normalize-distro-arch.outputs.distroName }}" and .arch=="${{ steps.normalize-distro-arch.outputs.arch }}" )' ${{ github.workspace }}/devops/binary-footprint-baseline/baseline.json`
+        echo "Using Target JSON: `echo $target | jq .`"
+        remoteSize=`echo $target | jq .sizeBytes | tr -d \"`
+
+        # Get local file
+        file=$(find ./build -name "*.deb" | head -n 1)
+        echo Using $file
+        localSize=$(wc -c $file | awk '{print $1}')
+
+        delta=$(bc -l <<< "remote=$remoteSize;local=$localSize;delta=local/remote;print delta;")
+        echo Local: $localSize, Remote: $remoteSize, Delta: $delta
+
+        # Check if the delta is greater than defined threshold
+        result=`bc -l <<< "delta=$delta;high=1+(0.${{ inputs.allowedDelta }});low=1-(0.${{ inputs.allowedDelta }});if(high > delta && delta > low) print 0 else print 1;"`
+        if [ "$result" == 1 ]; then
+          echo "::error Binary footprint validation failed. Delta: $delta" && exit 1
+        fi
+      shell: bash

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -74,7 +74,7 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           cmd: |
             mkdir build && cd build
-            cmake ../src -DCMAKE_build-type=${{ inputs.build-type }} -DTWEAK_VERSION=${{ steps.version.outputs.tweak }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF -DBUILD_AGENTS=ON -G Ninja
+            cmake ../src -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} -DTWEAK_VERSION=${{ steps.version.outputs.tweak }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=OFF -DBUILD_SAMPLES=OFF -DBUILD_AGENTS=ON -G Ninja
 
       - name: Build azure-osconfig
         uses: ./.github/actions/container-exec
@@ -89,6 +89,13 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           working-directory: ${{ env.container-workspace }}/build
           cmd: cpack -G DEB
+
+      - name: Binary footprint delta validation
+        uses: ./.github/actions/footprint-check
+        with:
+          allowedDelta: 10
+          distroName: ${{ matrix.os }}
+          arch: ${{ matrix.variant.arch }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/devops/binary-footprint-baseline/baseline.json
+++ b/devops/binary-footprint-baseline/baseline.json
@@ -1,0 +1,56 @@
+[
+  {
+    "distro": "ubuntu-18.04",
+    "arch": "x86_64",
+    "sizeBytes": 1772612,
+    "file": "osconfig_1.0.3.2022061601_bionic_x86_64.deb"
+  },
+  {
+    "distro": "ubuntu-18.04",
+    "arch": "aarch64",
+    "sizeBytes": 1711064,
+    "file": "osconfig_1.0.3.2022061601_bionic_aarch64.deb"
+  },
+  {
+    "distro": "ubuntu-18.04",
+    "arch": "armv7l",
+    "sizeBytes": 1553622,
+    "file": "osconfig_1.0.3.2022061601_bionic_armv7l.deb"
+  },
+  {
+    "distro": "ubuntu-20.04",
+    "arch": "x86_64",
+    "sizeBytes": 1873928,
+    "file": "osconfig_1.0.3.2022061601_focal_x86_64.deb"
+  },
+  {
+    "distro": "ubuntu-20.04",
+    "arch": "aarch64",
+    "sizeBytes": 1939420,
+    "file": "osconfig_1.0.3.2022061601_focal_aarch64.deb"
+  },
+  {
+    "distro": "ubuntu-20.04",
+    "arch": "armv7l",
+    "sizeBytes": 1753084,
+    "file": "osconfig_1.0.3.2022061601_focal_armv7l.deb"
+  },
+  {
+    "distro": "debian-9",
+    "arch": "x86_64",
+    "sizeBytes": 1872506,
+    "file": "osconfig_1.0.3.2022061601_stretch_x86_64.deb"
+  },
+  {
+    "distro": "debian-9",
+    "arch": "aarch64",
+    "sizeBytes": 1766474,
+    "file": "osconfig_1.0.3.2022061601_stretch_aarch64.deb"
+  },
+  {
+    "distro": "debian-9",
+    "arch": "armv7l",
+    "sizeBytes": 1632330,
+    "file": "osconfig_1.0.3.2022061601_stretch_armv7l.deb"
+  }
+]

--- a/devops/scripts/generate_binary_footprints.sh
+++ b/devops/scripts/generate_binary_footprints.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Generates the binary footprints used to check for binary size issues
+# By default, uses the latest published package (prod/insiders-fast) unless
+# regex filter is given.
+# Usage: ./generate_binary_footprint [filter]
+if ! [ -x "$(command -v jq)" ]; then
+  echo 'Error: jq is not installed.' >&2
+  exit 1
+fi
+
+# Absolute path to this script
+SCRIPT=$(readlink -f $0)
+SCRIPTPATH=`dirname $SCRIPT`
+BaseDir=`realpath $SCRIPTPATH/../binary-footprint-baseline`
+
+distros=("ubuntu-18.04", "ubuntu-20.04", "debian-9")
+distroPathUbuntu1804="https://packages.microsoft.com/ubuntu/18.04/prod/pool/main/o/osconfig/"
+distroPathUbuntu2004="https://packages.microsoft.com/ubuntu/20.04/prod/pool/main/o/osconfig/"
+distroPathDebian9="https://packages.microsoft.com/debian/9/multiarch/prod/pool/main/o/osconfig/"
+JSON="[]"
+for distro in ${distros[@]}; do distro=$(echo $distro | tr -d ',');
+
+  case $distro in
+    ("ubuntu-18.04") distroPath=$distroPathUbuntu1804;;
+    ("ubuntu-20.04") distroPath=$distroPathUbuntu2004;;
+    ("debian-9")     distroPath=$distroPathDebian9;;
+  esac
+
+  for arch in "x86_64", "aarch64", "armv7l"; do arch=$(echo $arch | tr -d ',');
+    wget -q -O tmp.html $distroPath
+    size=$((tr -s ' ' <<< `cat tmp.html | grep -E ">osconfig.*$1$arch.deb<" | tail -1`) | cut -d ' ' -f 5 | tr -d '\r\n')
+    file=$((tr -s ' ' <<< `cat tmp.html | grep -E ">osconfig.*$1$arch.deb<" | tail -1`) | grep -o '>osconfig.*<' | tr -d '<>')
+    rm tmp.html
+    echo "Generating binary footprint for $file ($distro/$arch): $size bytes"
+    json="[{ \"distro\": \"$distro\", \"arch\": \"$arch\", \"sizeBytes\": $size, \"file\": \"$file\"}]"
+    JSON=$(echo $JSON | jq --argjson packageInfo "$json" '. |= . + $packageInfo')
+  done
+done
+
+echo $JSON | jq '.' > $BaseDir/baseline.json


### PR DESCRIPTION
## Description

* Adds binary baseline validation to `Package` workflow, using `1.0.3.2022061601` as current baseline.
* Binary baselines published in `devops/binary-footprint-baseline/baseline.json`
* Added script to update binary baselines (using latest published as default or by using an optional regex filter as first argument)
* Using current delta as 10%, meaning package workflows will fail if they exceed/drop the current footprint by more than 10%
* Fixed package build to use correct `CMAKE_BUILD_TYPE` argument

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.