### PR TITLE
Added e2e cloud-init support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,24 +21,18 @@ RUN apt -y update && apt-get -y install \
     ninja-build\
     rapidjson-dev \
     uuid-dev \
-    wget \
-    \
-    # .NET dependencies
-    libc6 \
-    libgcc1 \
-    libgssapi-krb5-2 \
-    libicu66 \
-    libssl1.1 \
-    libstdc++6 \
-    zlib1g
+    wget
 
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
 
-# .NET Install~
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 5.0
-ENV PATH="${PATH}:/root/.dotnet"
+# .NET Install
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
+    cp ./microsoft.gpg /etc/apt/trusted.gpg.d/ && \
+    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list && \
+    cp ./microsoft-prod.list /etc/apt/sources.list.d/ && \
+    apt update -y && apt install -y dotnet-sdk-6.0
 
 # ZSH
 ENV SHELL /bin/zsh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 	"workspaceFolder": "/azure-osconfig",
 	"mounts": ["source=${localWorkspaceFolder},target=/azure-osconfig,type=bind,consistency=cached"],
 	"overrideCommand": true,
-	"postCreateCommand": "git submodule update --init --recursive && git config --global --add safe.directory /azure-osconfig",
+	"postCreateCommand": "git config --global --add safe.directory /azure-osconfig && git submodule update --init --recursive",
 	"extensions": [
 		"eamodio.gitlens",
 		"GitHub.copilot",

--- a/.github/workflows/deploy-github-main.yml
+++ b/.github/workflows/deploy-github-main.yml
@@ -27,6 +27,7 @@ jobs:
     name: Provision Host VM
     uses: ./.github/workflows/e2etest-provision-hosts.yml
     needs:
+      - provision-hub
       - fetch-targets
     with:
       environment: e2e-github-main

--- a/.github/workflows/e2etest-provision-hosts.yml
+++ b/.github/workflows/e2etest-provision-hosts.yml
@@ -60,17 +60,26 @@ jobs:
           image_offer=`echo $target | jq .image_offer | tr -d \"`
           image_sku=`echo $target | jq .image_sku | tr -d \"`
           image_version=`echo $target | jq .image_version | tr -d \"`
+          image_name=`echo $target | jq .image_name | tr -d \"`
+          gallery_name=`echo $target | jq .gallery_name | tr -d \"`
           packagePattern=`echo $target | jq .packagePattern | tr -d \"`
           device_id=`echo $target | jq .device_id | tr -d \"`
           vm_size=`echo $target | jq .vm_size | tr -d \"`
           location=`echo $target | jq .location | tr -d \"`
           github_runner_tar_gz=`echo $target | jq .github_runner_tar_gz | tr -d \"`
-          vm_script=`echo $target | jq -r '.vm_script | join(" && ")'`
+          cloud_init=`echo $target | jq .cloud_init | tr -d \"`
 
           echo ::set-output name=device_id::$device_id
 
           terraform init
-          terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token=${{ steps.runner_token.outputs.RUNNER_TOKEN }} -var image_offer=$image_offer -var image_publisher=$image_publisher -var image_sku=$image_sku -var image_version=$image_version -var vm_size="$vm_size" -var location="$location" -var vm_script="$vm_script" -var github_runner_tar_gz_package="$github_runner_tar_gz" -auto-approve
+
+          if [[ "$gallery_name" != "null" ]]; then
+            echo Using compute gallery "$gallery_name"
+            terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token=${{ steps.runner_token.outputs.RUNNER_TOKEN }} -var image_name="$image_name" -var gallery_name="$gallery_name" -var vm_size=$vm_size -var location="$location" -var cloud_init="$cloud_init" -var github_runner_tar_gz_package="$github_runner_tar_gz" -auto-approve
+          else
+            echo Using Azure Marketplace Image
+            terraform apply -var subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var tenant_id="${{ secrets.TENANT_ID }}" -var client_id="${{ secrets.CLIENT_ID }}" -var key_vault_id="${{ secrets.KEY_VAULT_ID }}" -var client_secret="${{ secrets.CLIENT_SECRET }}" -var resource_group_name="$rg" -var vm_name="$distroName" -var runner_token=${{ steps.runner_token.outputs.RUNNER_TOKEN }} -var image_offer=$image_offer -var image_publisher=$image_publisher -var image_sku=$image_sku -var image_version=$image_version -var vm_size=$vm_size -var location="$location" -var cloud_init="$cloud_init" -var github_runner_tar_gz_package="$github_runner_tar_gz" -auto-approve
+          fi
 
           runner=$rg-$distroName
           echo Created self-hosted runner "$runner"
@@ -82,9 +91,7 @@ jobs:
           
           # VM + IotHub provisioning happening in parallel - loop until the IoT Hub is available
           echo -n 'Creating Iot Hub Identity - ${{ inputs.resourceGroupName }}-${{ steps.provision-vm.outputs.device_id }}'
-          function create_identity () { az iot hub device-identity create --device-id "${{ steps.provision-vm.outputs.device_id }}" --hub-name ${{ inputs.resourceGroupName }}-iothub --output none; }
-          create_identity
-          while [ $? -ne 0 ]; do echo -n '.'; sleep 5s && create_identity; done
+          az iot hub device-identity create --device-id "${{ steps.provision-vm.outputs.device_id }}" --hub-name ${{ inputs.resourceGroupName }}-iothub --output none;
 
           device_conn_str="`az iot hub device-identity connection-string show --hub-name ${{ inputs.resourceGroupName }}-iothub --device-id ${{ steps.provision-vm.outputs.device_id }} --output tsv`"
           echo '' && echo Adding to Key Vault

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -71,11 +71,6 @@ jobs:
           sudo aziotctl config mp -c "${{ steps.hub-identity.outputs.device_conn_str }}" --force
           sudo aziotctl config apply
 
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 5.0.x
-
       - name: Download OSConfig from package workflow (main)
         if: startsWith( steps.get-test-data.outputs.package_path, '*')
         uses: dawidd6/action-download-artifact@v2
@@ -118,6 +113,7 @@ jobs:
           E2E_OSCONFIG_DEVICE_ID: ${{ steps.get-test-data.outputs.device_id }}
           E2E_OSCONFIG_TWIN_TIMEOUT: ${{ secrets.TWIN_TIMEOUT }}
           E2E_OSCONFIG_DISTRIBUTION_NAME: ${{ matrix.distroName }}
+          DOTNET_CLI_HOME: /tmp
         working-directory: ./src/tests/e2etest
         run: |
           dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx"

--- a/devops/e2e/debian-stretch-cloud-init.tpl
+++ b/devops/e2e/debian-stretch-cloud-init.tpl
@@ -1,0 +1,13 @@
+#cloud-config
+apt_update: true
+package_upgrade: true
+runcmd:
+  # Install aziot-identity-service
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_debian9_amd64.deb -O aziot-identity-service.deb
+  - apt install -y ./aziot-identity-service.deb
+  # Install GitHub Actions Runner
+  - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
+  - export RUNNER_ALLOW_RUNASROOT="1"
+  - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
+  - ./svc.sh install
+  - ./svc.sh start

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -10,13 +10,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-focal-cloud-init.tpl"
     },
     {
         "distroName": "ubuntu-18.04",
@@ -29,13 +23,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y sysstat jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init.tpl"
     },
     {
         "distroName": "ubuntu-20.04-arm64",
@@ -48,11 +36,17 @@
         "vm_size": "Standard_D2plds_v5",
         "location": "West US 2",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init.tpl"
+    },
+    {
+        "distroName": "debian-9",
+        "gallery_name": "osconfigvms",
+        "image_name": "debian_9",
+        "device_id": "debian9",
+        "package_path": "*stretch_x86_64",
+        "vm_size": "Standard_DS1_v2",
+        "location": "East US",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "cloud_init": "devops/e2e/debian-stretch-cloud-init.tpl"
     }
 ]

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -43,7 +43,7 @@
         "gallery_name": "osconfigvms",
         "image_name": "debian_9",
         "device_id": "debian9",
-        "package_path": "*stretch_x86_64",
+        "package_path": "*stretch_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",

--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -10,15 +10,7 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "curl https://packages.microsoft.com/config/ubuntu/18.04/insiders-fast.list > ./microsoft-insiders-fast.list",
-            "sudo cp ./microsoft-insiders-fast.list /etc/apt/sources.list.d/",
-            "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-focal-cloud-init.tpl"
     },
     {
         "distroName": "ubuntu-18.04",
@@ -31,15 +23,7 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "curl https://packages.microsoft.com/config/ubuntu/18.04/insiders-fast.list > ./microsoft-insiders-fast.list",
-            "sudo cp ./microsoft-insiders-fast.list /etc/apt/sources.list.d/",
-            "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init.tpl"
     },
     {
         "distroName": "ubuntu-20.04-arm64",
@@ -53,13 +37,18 @@
         "location": "West US 2",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "curl https://packages.microsoft.com/config/ubuntu/18.04/insiders-fast.list > ./microsoft-insiders-fast.list",
-            "sudo cp ./microsoft-insiders-fast.list /etc/apt/sources.list.d/",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init.tpl"
+    },
+    {
+        "distroName": "debian-9",
+        "gallery_name": "osconfigvms",
+        "image_name": "debian_9",
+        "device_id": "debian9",
+        "package_path": "*stretch_x86_64",
+        "vm_size": "Standard_DS1_v2",
+        "location": "East US",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "cloud_init": "devops/e2e/debian-stretch-cloud-init.tpl"
     }
 ]

--- a/devops/e2e/prod.json
+++ b/devops/e2e/prod.json
@@ -10,13 +10,7 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-focal-cloud-init.tpl"
     },
     {
         "distroName": "ubuntu-18.04",
@@ -29,13 +23,7 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "AZ_REPO=$(lsb_release -cs) && echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init.tpl"
     },
     {
         "distroName": "ubuntu-20.04-arm64",
@@ -48,11 +36,18 @@
         "location": "West US 2",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
-        "vm_script":
-        [
-            "curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list",
-            "sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/",
-            "sudo apt update -y && sudo apt install -y jq aziot-identity-service azure-cli"
-        ]
+        "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init.tpl"
+    },
+    {
+        "distroName": "debian-9",
+        "gallery_name": "osconfigvms",
+        "image_name": "debian_9",
+        "device_id": "debian9",
+        "package_path": "*stretch_x86_64",
+        "vm_size": "Standard_DS1_v2",
+        "location": "East US",
+        "test_filter": "TpmTest",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "cloud_init": "devops/e2e/debian-stretch-cloud-init.tpl"
     }
 ]

--- a/devops/e2e/ubuntu-bionic-cloud-init.tpl
+++ b/devops/e2e/ubuntu-bionic-cloud-init.tpl
@@ -1,0 +1,49 @@
+#cloud-config
+apt_sources:
+  - azcli:
+    source: deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $RELEASE main
+    key: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Version: GnuPG v1.4.7 (GNU/Linux)
+
+      mQENBFYxWIwBCADAKoZhZlJxGNGWzqV+1OG1xiQeoowKhssGAKvd+buXCGISZJwT
+      LXZqIcIiLP7pqdcZWtE9bSc7yBY2MalDp9Liu0KekywQ6VVX1T72NPf5Ev6x6DLV
+      7aVWsCzUAF+eb7DC9fPuFLEdxmOEYoPjzrQ7cCnSV4JQxAqhU4T6OjbvRazGl3ag
+      OeizPXmRljMtUUttHQZnRhtlzkmwIrUivbfFPD+fEoHJ1+uIdfOzZX8/oKHKLe2j
+      H632kvsNzJFlROVvGLYAk2WRcLu+RjjggixhwiB+Mu/A8Tf4V6b+YppS44q8EvVr
+      M+QvY7LNSOffSO6Slsy9oisGTdfE39nC7pVRABEBAAG0N01pY3Jvc29mdCAoUmVs
+      ZWFzZSBzaWduaW5nKSA8Z3Bnc2VjdXJpdHlAbWljcm9zb2Z0LmNvbT6JATUEEwEC
+      AB8FAlYxWIwCGwMGCwkIBwMCBBUCCAMDFgIBAh4BAheAAAoJEOs+lK2+EinPGpsH
+      /32vKy29Hg51H9dfFJMx0/a/F+5vKeCeVqimvyTM04C+XENNuSbYZ3eRPHGHFLqe
+      MNGxsfb7C7ZxEeW7J/vSzRgHxm7ZvESisUYRFq2sgkJ+HFERNrqfci45bdhmrUsy
+      7SWw9ybxdFOkuQoyKD3tBmiGfONQMlBaOMWdAsic965rvJsd5zYaZZFI1UwTkFXV
+      KJt3bp3Ngn1vEYXwijGTa+FXz6GLHueJwF0I7ug34DgUkAFvAs8Hacr2DRYxL5RJ
+      XdNgj4Jd2/g6T9InmWT0hASljur+dJnzNiNCkbn9KbX7J/qK1IbR8y560yRmFsU+
+      NdCFTW7wY0Fb1fWJ+/KTsC4=
+      =J6gs
+      -----END PGP PUBLIC KEY BLOCK-----
+  - msftprod:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod $RELEASE main
+  - msftprodmultiarch:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/multiarch/prod $RELEASE main
+package_upgrade: true
+packages:
+  - apt-transport-https
+  - aziot-identity-service
+  - azure-cli
+  - bc
+  - ca-certificates
+  - curl
+  - dotnet-sdk-6.0
+  - gnupg
+  - jo
+  - jq
+  - lsb-release
+  - sysstat
+runcmd:
+  # Install GitHub Actions Runner
+  - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
+  - export RUNNER_ALLOW_RUNASROOT="1"
+  - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
+  - ./svc.sh install
+  - ./svc.sh start

--- a/devops/e2e/ubuntu-focal-arm64-cloud-init.tpl
+++ b/devops/e2e/ubuntu-focal-arm64-cloud-init.tpl
@@ -1,0 +1,43 @@
+#cloud-config
+package_upgrade: true
+packages:
+  - apt-transport-https
+  - azure-cli
+  - bc
+  - ca-certificates
+  - curl
+  - gnupg
+  - jo
+  - jq
+  - lsb-release
+  - sysstat
+# .NET Dependencies
+  - libc6
+  - libgcc1
+  - libgssapi-krb5-2
+  - libicu66
+  - libssl1.1
+  - libstdc++6
+  - zlib1g
+runcmd:
+  - curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+  - cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
+  # Install aziot-identity-service - no arm packages available
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
+  - apt install -y ./aziot-identity-service.deb
+  # Install .NET Core SDK
+  - wget https://download.visualstudio.microsoft.com/download/pr/06c4ee8e-bf2c-4e46-ab1c-e14dd72311c1/f7bc6c9677eaccadd1d0e76c55d361ea/dotnet-sdk-6.0.301-linux-arm64.tar.gz -O dotnet-sdk-6.0.tar.gz
+  - DOTNET_FILE=dotnet-sdk-6.0.tar.gz
+  - export DOTNET_ROOT=$(pwd)/.dotnet
+  - mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
+  - export PATH=$PATH:$DOTNET_ROOT
+  # Install Azure CLI
+  - curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list
+  - cp ./microsoft-prod.list /etc/apt/sources.list.d/
+  - apt update -y && apt install -y 
+  # Install GitHub Actions Runner
+  - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
+  - export RUNNER_ALLOW_RUNASROOT=\"1\"
+  - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
+  - ./svc.sh install
+  - ./svc.sh start

--- a/devops/e2e/ubuntu-focal-cloud-init.tpl
+++ b/devops/e2e/ubuntu-focal-cloud-init.tpl
@@ -1,0 +1,47 @@
+#cloud-config
+apt_sources:
+  - azcli:
+    source: deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $RELEASE main
+    key: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Version: GnuPG v1.4.7 (GNU/Linux)
+
+      mQENBFYxWIwBCADAKoZhZlJxGNGWzqV+1OG1xiQeoowKhssGAKvd+buXCGISZJwT
+      LXZqIcIiLP7pqdcZWtE9bSc7yBY2MalDp9Liu0KekywQ6VVX1T72NPf5Ev6x6DLV
+      7aVWsCzUAF+eb7DC9fPuFLEdxmOEYoPjzrQ7cCnSV4JQxAqhU4T6OjbvRazGl3ag
+      OeizPXmRljMtUUttHQZnRhtlzkmwIrUivbfFPD+fEoHJ1+uIdfOzZX8/oKHKLe2j
+      H632kvsNzJFlROVvGLYAk2WRcLu+RjjggixhwiB+Mu/A8Tf4V6b+YppS44q8EvVr
+      M+QvY7LNSOffSO6Slsy9oisGTdfE39nC7pVRABEBAAG0N01pY3Jvc29mdCAoUmVs
+      ZWFzZSBzaWduaW5nKSA8Z3Bnc2VjdXJpdHlAbWljcm9zb2Z0LmNvbT6JATUEEwEC
+      AB8FAlYxWIwCGwMGCwkIBwMCBBUCCAMDFgIBAh4BAheAAAoJEOs+lK2+EinPGpsH
+      /32vKy29Hg51H9dfFJMx0/a/F+5vKeCeVqimvyTM04C+XENNuSbYZ3eRPHGHFLqe
+      MNGxsfb7C7ZxEeW7J/vSzRgHxm7ZvESisUYRFq2sgkJ+HFERNrqfci45bdhmrUsy
+      7SWw9ybxdFOkuQoyKD3tBmiGfONQMlBaOMWdAsic965rvJsd5zYaZZFI1UwTkFXV
+      KJt3bp3Ngn1vEYXwijGTa+FXz6GLHueJwF0I7ug34DgUkAFvAs8Hacr2DRYxL5RJ
+      XdNgj4Jd2/g6T9InmWT0hASljur+dJnzNiNCkbn9KbX7J/qK1IbR8y560yRmFsU+
+      NdCFTW7wY0Fb1fWJ+/KTsC4=
+      =J6gs
+      -----END PGP PUBLIC KEY BLOCK-----
+  - msftprod:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod $RELEASE main
+package_upgrade: true
+packages:
+  - apt-transport-https
+  - aziot-identity-service
+  - azure-cli
+  - bc
+  - ca-certificates
+  - curl
+  - dotnet-sdk-6.0
+  - gnupg
+  - jo
+  - jq
+  - lsb-release
+  - sysstat
+runcmd:
+  # Install GitHub Actions Runner
+  - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
+  - export RUNNER_ALLOW_RUNASROOT="1"
+  - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
+  - ./svc.sh install
+  - ./svc.sh start

--- a/devops/scripts/install_deps_debian9.sh
+++ b/devops/scripts/install_deps_debian9.sh
@@ -33,4 +33,4 @@ cd ~ && rm -rf googletest CMake rapidjson
 
 # Install Dotnet - Needed for e2e tests
 # See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0

--- a/devops/scripts/install_deps_ubuntu1804.sh
+++ b/devops/scripts/install_deps_ubuntu1804.sh
@@ -7,4 +7,4 @@ apt -y update
 apt-get -y install git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev liblttng-ust-dev rapidjson-dev ninja-build wget
 # Install Dotnet - Needed for e2e tests
 # See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0

--- a/devops/scripts/install_deps_ubuntu2004.sh
+++ b/devops/scripts/install_deps_ubuntu2004.sh
@@ -7,4 +7,4 @@ apt -y update
 apt-get -y install git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev libgtest-dev libgmock-dev liblttng-ust-dev rapidjson-dev ninja-build wget
 # Install Dotnet - Needed for e2e tests
 # See https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#1804-
-curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0

--- a/devops/terraform/host/GenericRunnerHost.tf
+++ b/devops/terraform/host/GenericRunnerHost.tf
@@ -34,14 +34,14 @@ data "azurerm_shared_image" "customimage" {
   resource_group_name = "osconfige2e-test-infra"
 }
 
-data template_file "cloudconfig" {
+data "template_file" "cloudconfig" {
   # Script relative to project root
   template = file("../../../${var.cloud_init}")
 
   vars = {
-    resource_group_name = var.resource_group_name
-    runner_token = var.runner_token
-    vm_name = var.vm_name
+    resource_group_name          = var.resource_group_name
+    runner_token                 = var.runner_token
+    vm_name                      = var.vm_name
     github_runner_tar_gz_package = var.github_runner_tar_gz_package
   }
 }
@@ -154,7 +154,7 @@ resource "azurerm_linux_virtual_machine" "osconfigvm" {
     storage_account_type = "Standard_LRS"
   }
 
-  # Only works for Public Azure Marketplace images
+  # source_image_reference only works for public Azure Marketplace images
   # Must use source_image_id for private images
   # see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/shared_image
   dynamic "source_image_reference" {
@@ -166,7 +166,7 @@ resource "azurerm_linux_virtual_machine" "osconfigvm" {
       version   = var.image_version
     }
   }
-  source_image_id        = length(data.azurerm_shared_image.customimage) > 0 ? data.azurerm_shared_image.customimage[0].id : null
+  source_image_id = length(data.azurerm_shared_image.customimage) > 0 ? data.azurerm_shared_image.customimage[0].id : null
 
   computer_name                   = "myvm-${var.vm_name}"
   admin_username                  = "azureuser"
@@ -193,5 +193,5 @@ resource "azurerm_linux_virtual_machine" "osconfigvm" {
 }
 
 output "resource_group_name" {
-    value = var.resource_group_name
+  value = var.resource_group_name
 }

--- a/devops/terraform/host/GenericRunnerHost.tf
+++ b/devops/terraform/host/GenericRunnerHost.tf
@@ -18,6 +18,34 @@ provider "azurerm" {
   client_secret = var.client_secret
 }
 
+locals {
+  marketplace_image = [{
+    publisher = var.image_publisher
+    offer     = var.image_offer
+    sku       = var.image_sku
+    version   = var.image_version
+  }]
+}
+
+data "azurerm_shared_image" "customimage" {
+  count               = var.image_name == "" ? 0 : 1
+  name                = var.image_name
+  gallery_name        = var.gallery_name
+  resource_group_name = "osconfige2e-test-infra"
+}
+
+data template_file "cloudconfig" {
+  # Script relative to project root
+  template = file("../../../${var.cloud_init}")
+
+  vars = {
+    resource_group_name = var.resource_group_name
+    runner_token = var.runner_token
+    vm_name = var.vm_name
+    github_runner_tar_gz_package = var.github_runner_tar_gz_package
+  }
+}
+
 # Create public IPs
 resource "azurerm_public_ip" "osconfigpublicip" {
   name                = "myPublicIP-${var.vm_name}"
@@ -123,15 +151,22 @@ resource "azurerm_linux_virtual_machine" "osconfigvm" {
   os_disk {
     name                 = "myOsDisk-${var.vm_name}"
     caching              = "ReadWrite"
-    storage_account_type = "Premium_LRS"
+    storage_account_type = "Standard_LRS"
   }
 
-  source_image_reference {
-    publisher = var.image_publisher
-    offer     = var.image_offer
-    sku       = var.image_sku
-    version   = var.image_version
+  # Only works for Public Azure Marketplace images
+  # Must use source_image_id for private images
+  # see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/shared_image
+  dynamic "source_image_reference" {
+    for_each = (length(data.azurerm_shared_image.customimage) == 0 ? ["1"] : [])
+    content {
+      publisher = var.image_publisher
+      offer     = var.image_offer
+      sku       = var.image_sku
+      version   = var.image_version
+    }
   }
+  source_image_id        = length(data.azurerm_shared_image.customimage) > 0 ? data.azurerm_shared_image.customimage[0].id : null
 
   computer_name                   = "myvm-${var.vm_name}"
   admin_username                  = "azureuser"
@@ -151,24 +186,7 @@ resource "azurerm_linux_virtual_machine" "osconfigvm" {
     timeout     = "1m"
   }
 
-
-  provisioner "remote-exec" {
-    inline = [
-      "export DEBIAN_FRONTEND=noninteractive",
-      "sudo systemctl stop apt-daily.timer && sudo systemctl disable apt-daily.timer && sudo systemctl mask apt-daily.service && sudo systemctl daemon-reload",
-      "sudo apt update && sudo apt install -y ca-certificates curl apt-transport-https lsb-release gnupg bc sysstat",
-      "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg",
-      "sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/",
-      "mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${var.github_runner_tar_gz_package} && tar xzf ./runner.tar.gz",
-      "./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name \"${var.resource_group_name}-${var.vm_name}\" --token \"${var.runner_token}\" --labels \"${var.resource_group_name}-${var.vm_name}\"",
-      "sudo ./svc.sh install",
-      "sudo ./svc.sh start",
-      "echo \"####################### VM Script #######################\"",
-      var.vm_script,
-      "echo \"#########################################################\""
-    ]
-  }
-
+  custom_data = base64encode(data.template_file.cloudconfig.rendered)
   tags = {
     environment = var.environment_tag
   }

--- a/devops/terraform/host/variables.tf
+++ b/devops/terraform/host/variables.tf
@@ -1,16 +1,24 @@
 # Local testing - must create a SP and plumb client_id/client_secret below using scripts/create-sp-terraform.sh
 variable "client_id" {}
 variable "client_secret" {}
+variable "cloud_init" {}
+variable "key_vault_id" {}
+variable "resource_group_name" {}
+variable "runner_token" {}
 variable "subscription_id" {}
 variable "tenant_id" {}
-variable "key_vault_id" {}
+
+# For making use of Azure Compute Gallery
+variable "image_name" {
+    default = ""
+}
+variable "gallery_name" {
+    default = ""
+}
+
 variable resource_group_name_prefix {
     default = "osconfig"
 }
-variable "runner_token" {}
-
-# Provided by iothub.tf outputs
-variable resource_group_name {}
 
 variable "vm_name" {
     default = "test-device"
@@ -34,10 +42,6 @@ variable "image_version" {
 
 variable "environment_tag" {
     default = "osconfig-e2etest"
-}
-
-variable "vm_script" {
-    default = ""
 }
 
 variable "vm_size" {

--- a/src/tests/e2etest/E2ETest.csproj
+++ b/src/tests/e2etest/E2ETest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## Description

* Added Debian 9 support (amd64)
* Added shared image gallery support in E2E test infrastructure
* Added cloud-init support to test VMs
  * Added cloud-init scripts for Ubuntu 18.04/20.04 (amd64), Debian 9 (amd64) and Ubuntu 18.04 arm64 hosts
* Added DotNet 6.0 support to E2E test application
* Updated container definitions for DotNet 6.0
* Added IoTHub provisioning dependency before VM provisioning

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.