### PR TITLE
Create build-containers workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,0 +1,60 @@
+name: Build Containers
+
+on:
+  push:
+    branches: [main]
+    paths: [devops/docker/**/Dockerfile]
+
+jobs:
+  list-containers:
+    name: List modified containers
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v18.7
+        with:
+          files: ./devops/docker/**/Dockerfile
+
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(echo -n ${{ steps.changed-files.outputs.all_changed_files }} | jq -R -s -c 'split(" ")')"
+
+  docker:
+    name: Build and push
+    needs: list-containers
+    runs-on: [self-hosted, 1ES.Pool=azure-osconfig-pool]
+    strategy:
+        matrix:
+            container: ${{ fromJson(needs.list-containers.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set image
+        id: image
+        run: |
+          DOCKERFILE=${{ matrix.container }}
+          echo "::set-output name=name::$(echo ${DOCKERFILE%/*}-dev)"
+          echo "::set-output name=path::$(dirname ${DOCKERFILE})"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to ACR
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.ACR_REGISTRY }}
+          username: ${{ secrets.ACR_CLIENT_ID }}
+          password: ${{ secrets.ACR_CLIENT_SECRET }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ steps.image.outputs.path }}
+          push: true
+          tags: ${{ steps.image.outputs.name }}:latest, ${{ steps.image.outputs.name }}:${{ github.run_number }}


### PR DESCRIPTION
## Description

Create workflow to build and push devops containers to the OSConfig Azure CR. This workflow is triggered when changes to devops/docker/**/Dockerfile are merged to main.

The `docker` job uses the self-hosted, 1ES managed runner pool (`azure-osconfig-pool`) to build and push updated container images.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.