### PR TITLE
Fixed debian9 e2e package path

### DIFF
--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -44,7 +44,7 @@
         "gallery_name": "osconfigvms",
         "image_name": "debian_9",
         "device_id": "debian9",
-        "package_path": "*stretch_x86_64",
+        "package_path": "*stretch_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",

--- a/devops/e2e/prod.json
+++ b/devops/e2e/prod.json
@@ -43,7 +43,7 @@
         "gallery_name": "osconfigvms",
         "image_name": "debian_9",
         "device_id": "debian9",
-        "package_path": "*stretch_x86_64",
+        "package_path": "*stretch_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",


### PR DESCRIPTION
## Description

* Fix package path for Debian9 on prod/insiders-fast workflows

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.