### PR TITLE
Moved MmiGet argument validation from so to lib

### DIFF
--- a/src/modules/networking/src/lib/Networking.cpp
+++ b/src/modules/networking/src/lib/Networking.cpp
@@ -864,72 +864,106 @@ int NetworkingObjectBase::TruncateValueStrings(std::vector<std::pair<std::string
 }
 
 int NetworkingObjectBase::Get(
-        MMI_HANDLE clientSession,
         const char* componentName,
         const char* objectName,
         MMI_JSON_STRING* payload,
         int* payloadSizeBytes)
 {
-    UNUSED(clientSession);
-    UNUSED(componentName);
-    UNUSED(objectName);
-
     int status = MMI_OK;
 
-    RefreshSettingsStrings();
-
-    std::vector<std::pair<std::string, std::string>> fieldValueVector;
-    fieldValueVector.push_back(make_pair(g_interfaceTypes, m_settings.interfaceTypes));
-    fieldValueVector.push_back(make_pair(g_macAddresses, m_settings.macAddresses));
-    fieldValueVector.push_back(make_pair(g_ipAddresses, m_settings.ipAddresses));
-    fieldValueVector.push_back(make_pair(g_subnetMasks, m_settings.subnetMasks));
-    fieldValueVector.push_back(make_pair(g_defaultGateways, m_settings.defaultGateways));
-    fieldValueVector.push_back(make_pair(g_dnsServers, m_settings.dnsServers));
-    fieldValueVector.push_back(make_pair(g_dhcpEnabled, m_settings.dhcpEnabled));
-    fieldValueVector.push_back(make_pair(g_enabled, m_settings.enabled));
-    fieldValueVector.push_back(make_pair(g_connected, m_settings.connected));
-
-    status = TruncateValueStrings(fieldValueVector);
-    rapidjson::StringBuffer sb;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
-    writer.StartObject();
-    int writeResult = 0;
-    for (size_t i = 0; i < fieldValueVector.size(); i++)
+    if ((nullptr == componentName) || (0 != std::strcmp(componentName, NETWORKING)))
     {
-        writeResult += WriteJsonElement(&writer, fieldValueVector[i].first.c_str(), fieldValueVector[i].second.c_str());
-    }
-    writer.EndObject();
-
-    std::string networkingJsonString(sb.GetString());
-    networkingJsonString.erase(std::find(networkingJsonString.begin(), networkingJsonString.end(), '\0'), networkingJsonString.end());
-
-    *payloadSizeBytes = networkingJsonString.length();
-
-    if (((m_maxPayloadSizeBytes > 0) && (m_maxPayloadSizeBytes <= g_templateWithDotsSize) && ((unsigned int)*payloadSizeBytes != g_templateWithDotsSize)) ||
-        ((m_maxPayloadSizeBytes > g_templateWithDotsSize) && ((unsigned int)*payloadSizeBytes > m_maxPayloadSizeBytes)))
-    {
-        OsConfigLogInfo(NetworkingLog::Get(), "Networking payload to report %u bytes, need to report %u bytes, reporting empty strings", (unsigned int)*payloadSizeBytes, m_maxPayloadSizeBytes);
-        *payloadSizeBytes = g_templateWithDotsSize;
-    }
-
-    if (writeResult > 0)
-    {
-        *payloadSizeBytes = g_templateWithDotsSize;
-    }
-
-    *payload = new (std::nothrow) char[*payloadSizeBytes];
-    if (nullptr == *payload)
-    {
-        if (nullptr != payloadSizeBytes)
+        if (IsFullLoggingEnabled())
         {
-            OsConfigLogError(NetworkingLog::Get(), "Networking::Get insufficient buffer space available to allocate %d bytes", *payloadSizeBytes);
+            OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) componentName %s is invalid, %s is expected",
+                componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), componentName, NETWORKING);
         }
-        status = ENOMEM;
+        status = EINVAL;
+    }
+    else if ((nullptr == objectName) || (0 != std::strcmp(objectName, NETWORK_CONFIGURATION)))
+    {
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) objectName %s is invalid, %s is expected",
+                componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), objectName, NETWORK_CONFIGURATION);
+        }
+        status = EINVAL;
+    }
+    else if (nullptr == payload)
+    {
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) payload %.*s is null",
+                componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), (payloadSizeBytes ? *payloadSizeBytes : 0), *payload);
+        }
+        status = EINVAL;
+    }
+    else if (nullptr == payloadSizeBytes)
+    {
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) payloadSizeBytes %d is null",
+                componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), (payloadSizeBytes ? *payloadSizeBytes : 0));
+        }
+        status = EINVAL;
     }
     else
     {
-        std::fill(*payload, *payload + *payloadSizeBytes, 0);
-        std::memcpy(*payload, ((*payloadSizeBytes) == (int)g_templateWithDotsSize) ? g_templateWithDots : networkingJsonString.c_str(), *payloadSizeBytes);
+        RefreshSettingsStrings();
+
+        std::vector<std::pair<std::string, std::string>> fieldValueVector;
+        fieldValueVector.push_back(make_pair(g_interfaceTypes, m_settings.interfaceTypes));
+        fieldValueVector.push_back(make_pair(g_macAddresses, m_settings.macAddresses));
+        fieldValueVector.push_back(make_pair(g_ipAddresses, m_settings.ipAddresses));
+        fieldValueVector.push_back(make_pair(g_subnetMasks, m_settings.subnetMasks));
+        fieldValueVector.push_back(make_pair(g_defaultGateways, m_settings.defaultGateways));
+        fieldValueVector.push_back(make_pair(g_dnsServers, m_settings.dnsServers));
+        fieldValueVector.push_back(make_pair(g_dhcpEnabled, m_settings.dhcpEnabled));
+        fieldValueVector.push_back(make_pair(g_enabled, m_settings.enabled));
+        fieldValueVector.push_back(make_pair(g_connected, m_settings.connected));
+
+        status = TruncateValueStrings(fieldValueVector);
+        rapidjson::StringBuffer sb;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+        writer.StartObject();
+        int writeResult = 0;
+        for (size_t i = 0; i < fieldValueVector.size(); i++)
+        {
+            writeResult += WriteJsonElement(&writer, fieldValueVector[i].first.c_str(), fieldValueVector[i].second.c_str());
+        }
+        writer.EndObject();
+
+        std::string networkingJsonString(sb.GetString());
+        networkingJsonString.erase(std::find(networkingJsonString.begin(), networkingJsonString.end(), '\0'), networkingJsonString.end());
+
+        *payloadSizeBytes = networkingJsonString.length();
+
+        if (((m_maxPayloadSizeBytes > 0) && (m_maxPayloadSizeBytes <= g_templateWithDotsSize) && ((unsigned int)*payloadSizeBytes != g_templateWithDotsSize)) ||
+            ((m_maxPayloadSizeBytes > g_templateWithDotsSize) && ((unsigned int)*payloadSizeBytes > m_maxPayloadSizeBytes)))
+        {
+            OsConfigLogInfo(NetworkingLog::Get(), "Networking payload to report %u bytes, need to report %u bytes, reporting empty strings", (unsigned int)*payloadSizeBytes, m_maxPayloadSizeBytes);
+            *payloadSizeBytes = g_templateWithDotsSize;
+        }
+
+        if (writeResult > 0)
+        {
+            *payloadSizeBytes = g_templateWithDotsSize;
+        }
+
+        *payload = new (std::nothrow) char[*payloadSizeBytes];
+        if (nullptr == *payload)
+        {
+            if (nullptr != payloadSizeBytes)
+            {
+                OsConfigLogError(NetworkingLog::Get(), "Networking::Get insufficient buffer space available to allocate %d bytes", *payloadSizeBytes);
+            }
+            status = ENOMEM;
+        }
+        else
+        {
+            std::fill(*payload, *payload + *payloadSizeBytes, 0);
+            std::memcpy(*payload, ((*payloadSizeBytes) == (int)g_templateWithDotsSize) ? g_templateWithDots : networkingJsonString.c_str(), *payloadSizeBytes);
+        }
     }
 
     return status;

--- a/src/modules/networking/src/lib/Networking.h
+++ b/src/modules/networking/src/lib/Networking.h
@@ -74,7 +74,6 @@ public:
     virtual std::string RunCommand(const char* command) = 0;
 
     int Get(
-        MMI_HANDLE clientSession,
         const char* componentName,
         const char* objectName,
         MMI_JSON_STRING* payload,

--- a/src/modules/networking/src/so/NetworkingModule.cpp
+++ b/src/modules/networking/src/so/NetworkingModule.cpp
@@ -205,6 +205,23 @@ int MmiGet(
     int status = MMI_OK;
     NetworkingObject* networking = nullptr;
 
+    ScopeGuard sg{[&]()
+    {
+        if ((MMI_OK == status) && (nullptr != payload) && (nullptr != payloadSizeBytes))
+        {
+            if (IsFullLoggingEnabled())
+            {
+                OsConfigLogInfo(NetworkingLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d",
+                    clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
+            }
+        }
+        else if (IsFullLoggingEnabled())
+        {
+            OsConfigLogError(NetworkingLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d",
+                clientSession, componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), status);
+        }
+    }};
+
     if (nullptr == clientSession)
     {
         OsConfigLogError(NetworkingLog::Get(), "MmiGet called with null clientSession");
@@ -226,23 +243,6 @@ int MmiGet(
             return ENODATA;
         }
     }
-
-    ScopeGuard sg{[&]()
-    {
-        if ((MMI_OK == status) && (nullptr != payload) && (nullptr != payloadSizeBytes))
-        {
-            if (IsFullLoggingEnabled())
-            {
-                OsConfigLogInfo(NetworkingLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d",
-                    clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-            }
-        }
-        else if (IsFullLoggingEnabled())
-        {
-            OsConfigLogError(NetworkingLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d",
-                clientSession, componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), status);
-        }
-    }};
 
     return status;
 }

--- a/src/modules/networking/tests/NetworkingTests.cpp
+++ b/src/modules/networking/tests/NetworkingTests.cpp
@@ -154,7 +154,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
         NetworkingObjectTest testModule(g_maxPayloadSizeBytes);
         testModule.returnValues = g_returnValues;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -195,7 +195,7 @@ namespace OSConfig::Platform::Tests
 
         testModule.returnValues = g_returnValues;
         testModule.returnValues[2] = testIpDataMangledNames;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -262,7 +262,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
         NetworkingObjectTest testModule(g_maxPayloadSizeBytes);
         testModule.returnValues = returnValuesDataMissing;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -275,7 +275,7 @@ namespace OSConfig::Platform::Tests
         std::vector<std::string> returnValuesNetworkManagerEnabled = {g_testCommandOutputNames, g_testCommandOutputInterfaceTypesNmcli, g_testIpData, g_testCommandOutputDefaultGateways, g_testCommandOutputDnsServers};
         testModule.runCommandCount = 0;
         testModule.returnValues = returnValuesNetworkManagerEnabled;
-        result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -288,7 +288,7 @@ namespace OSConfig::Platform::Tests
         std::vector<std::string> returnValuesSystemdNetworkdEnabled = {g_testCommandOutputNames, testCommandOutputInterfaceTypesNmcliDataMissing, g_testCommandOutputInterfaceTypesNetworkctl, g_testIpData, g_testCommandOutputDefaultGateways, g_testCommandOutputDnsServers};
         testModule.runCommandCount = 0;
         testModule.returnValues = returnValuesSystemdNetworkdEnabled;
-        result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -493,7 +493,7 @@ namespace OSConfig::Platform::Tests
         testModule.returnValues[0] = testCommandOutputInterfaceNames;
         testModule.returnValues[4] = testCommandOutputDnsServers;
 
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -506,7 +506,7 @@ namespace OSConfig::Platform::Tests
         testModule.runCommandCount = 0;
         testModule.returnValues[4] = testCommandOutputGlobalDnsServers;
 
-        result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -519,7 +519,7 @@ namespace OSConfig::Platform::Tests
         testModule.runCommandCount = 0;
         testModule.returnValues[4] = testCommandOutputOnlyGlobalDnsServers;
 
-        result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -570,7 +570,7 @@ namespace OSConfig::Platform::Tests
         testModule.returnValues = g_returnValues;
         MMI_JSON_STRING payload;
         int payloadSizeBytes;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -583,7 +583,7 @@ namespace OSConfig::Platform::Tests
         testModule.runCommandCount = 0;
         testModule.returnValues[2] = testIpDataDocker0AddedAddress;
 
-        result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -612,7 +612,7 @@ namespace OSConfig::Platform::Tests
         testModule.returnValues = {testCommandOutputNamesEmpty};
         MMI_JSON_STRING payload;
         int payloadSizeBytes;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -687,7 +687,7 @@ namespace OSConfig::Platform::Tests
 
         MMI_JSON_STRING payload;
         int payloadSizeBytes;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -705,7 +705,7 @@ namespace OSConfig::Platform::Tests
         unsigned int maxPayloadSizeBytes = 260;
         NetworkingObjectTest testModule(maxPayloadSizeBytes);
         testModule.returnValues = g_returnValues;
-        int result = testModule.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -729,7 +729,7 @@ namespace OSConfig::Platform::Tests
         maxPayloadSizeBytes = 100;
         NetworkingObjectTest testModule2(maxPayloadSizeBytes);
         testModule2.returnValues = g_returnValues;
-        result = testModule2.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule2.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 
@@ -753,7 +753,7 @@ namespace OSConfig::Platform::Tests
         maxPayloadSizeBytes = 0;
         NetworkingObjectTest testModule3(maxPayloadSizeBytes);
         testModule3.returnValues = g_returnValues;
-        result = testModule3.Get(nullptr, nullptr, nullptr, &payload, &payloadSizeBytes);
+        result = testModule3.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
         EXPECT_EQ(result, MMI_OK);
 

--- a/src/modules/test/recipes/NetworkingTests.json
+++ b/src/modules/test/recipes/NetworkingTests.json
@@ -5,5 +5,26 @@
         "Desired": false,
         "ExpectedResult": 0,
         "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "Networking",
+        "ObjectName": "",
+        "Desired": false,
+        "ExpectedResult": 22,
+        "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "",
+        "ObjectName": "networkConfiguration",
+        "Desired": false,
+        "ExpectedResult": 22,
+        "WaitSeconds": 0
+    },
+    {
+        "ComponentName": "",
+        "ObjectName": "",
+        "Desired": false,
+        "ExpectedResult": 22,
+        "WaitSeconds": 0
     }
 ]


### PR DESCRIPTION
## Description

Moved Networking!MmiGet argument validation from the module's shared-object library to the internal static lib, where core logic is contained. This change minimizes the MMI for Networking and aligns with the pattern illustrated by the rest of the core module set.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.