### PR TITLE
Fixed insiders-fast workflows and arm64 e2e targets

### DIFF
--- a/devops/e2e/debian-stretch-cloud-init-insiders-fast.tpl
+++ b/devops/e2e/debian-stretch-cloud-init-insiders-fast.tpl
@@ -1,7 +1,8 @@
 #cloud-config
+#Based on debian-stretch-cloud-init.tpl with added apt_sources for insiders-fast
 apt_sources:
-  - msftprod:
-    source: deb [arch=arm64] https://packages.microsoft.com/ubuntu/20.04/prod/ $RELEASE main
+  - msftinsiders:
+    source: deb [arch=amd64] https://packages.microsoft.com/debian/9/multiarch/prod insiders-fast main
     key: |
       -----BEGIN PGP PUBLIC KEY BLOCK-----
       Version: GnuPG v1.4.7 (GNU/Linux)
@@ -23,38 +24,13 @@ apt_sources:
       =J6gs
       -----END PGP PUBLIC KEY BLOCK-----
 package_upgrade: true
-packages:
-  - apt-transport-https
-  - azure-cli
-  - bc
-  - ca-certificates
-  - curl
-  - gnupg
-  - jo
-  - jq
-  - lsb-release
-  - sysstat
-# .NET Dependencies
-  - libc6
-  - libgcc1
-  - libgssapi-krb5-2
-  - libicu66
-  - libssl1.1
-  - libstdc++6
-  - zlib1g
 runcmd:
-  # Install aziot-identity-service - no arm packages available
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
+  # Install aziot-identity-service
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_debian9_amd64.deb -O aziot-identity-service.deb
   - apt install -y ./aziot-identity-service.deb
-  # Install .NET Core SDK
-  - wget https://download.visualstudio.microsoft.com/download/pr/06c4ee8e-bf2c-4e46-ab1c-e14dd72311c1/f7bc6c9677eaccadd1d0e76c55d361ea/dotnet-sdk-6.0.301-linux-arm64.tar.gz -O dotnet-sdk-6.0.tar.gz
-  - DOTNET_FILE=dotnet-sdk-6.0.tar.gz
-  - export DOTNET_ROOT=/opt/.dotnet
-  - mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
-  - ln -s /opt/.dotnet/dotnet /usr/bin/dotnet
   # Install GitHub Actions Runner
   - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
-  - export RUNNER_ALLOW_RUNASROOT=\"1\"
+  - export RUNNER_ALLOW_RUNASROOT="1"
   - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
   - ./svc.sh install
   - ./svc.sh start

--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -10,7 +10,7 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "cloud_init": "devops/e2e/ubuntu-focal-cloud-init.tpl"
+        "cloud_init": "devops/e2e/ubuntu-focal-cloud-init-insiders-fast.tpl"
     },
     {
         "distroName": "ubuntu-18.04",
@@ -23,7 +23,7 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init.tpl"
+        "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init-insiders-fast.tpl"
     },
     {
         "distroName": "ubuntu-20.04-arm64",
@@ -36,7 +36,7 @@
         "location": "West US 2",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
-        "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init.tpl"
+        "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init-insiders-fast.tpl"
     },
     {
         "distroName": "debian-9",
@@ -47,6 +47,6 @@
         "location": "East US",
         "test_filter": "TpmTest",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
-        "cloud_init": "devops/e2e/debian-stretch-cloud-init.tpl"
+        "cloud_init": "devops/e2e/debian-stretch-cloud-init-insiders-fast.tpl"
     }
 ]

--- a/devops/e2e/ubuntu-bionic-cloud-init-insiders-fast.tpl
+++ b/devops/e2e/ubuntu-bionic-cloud-init-insiders-fast.tpl
@@ -1,7 +1,8 @@
 #cloud-config
+#Based on ubuntu-bionic-cloud-init.tpl with added msftprodmultiarchinsidersfast apt source for insiders-fast
 apt_sources:
-  - msftprod:
-    source: deb [arch=arm64] https://packages.microsoft.com/ubuntu/20.04/prod/ $RELEASE main
+  - azcli:
+    source: deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $RELEASE main
     key: |
       -----BEGIN PGP PUBLIC KEY BLOCK-----
       Version: GnuPG v1.4.7 (GNU/Linux)
@@ -22,39 +23,30 @@ apt_sources:
       NdCFTW7wY0Fb1fWJ+/KTsC4=
       =J6gs
       -----END PGP PUBLIC KEY BLOCK-----
+  - msftprod:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod $RELEASE main
+  - msftprodmultiarch:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/multiarch/prod $RELEASE main
+  - msftprodmultiarchinsidersfast:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/multiarch/prod insiders-fast main
 package_upgrade: true
 packages:
   - apt-transport-https
+  - aziot-identity-service
   - azure-cli
   - bc
   - ca-certificates
   - curl
+  - dotnet-sdk-6.0
   - gnupg
   - jo
   - jq
   - lsb-release
   - sysstat
-# .NET Dependencies
-  - libc6
-  - libgcc1
-  - libgssapi-krb5-2
-  - libicu66
-  - libssl1.1
-  - libstdc++6
-  - zlib1g
 runcmd:
-  # Install aziot-identity-service - no arm packages available
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
-  - apt install -y ./aziot-identity-service.deb
-  # Install .NET Core SDK
-  - wget https://download.visualstudio.microsoft.com/download/pr/06c4ee8e-bf2c-4e46-ab1c-e14dd72311c1/f7bc6c9677eaccadd1d0e76c55d361ea/dotnet-sdk-6.0.301-linux-arm64.tar.gz -O dotnet-sdk-6.0.tar.gz
-  - DOTNET_FILE=dotnet-sdk-6.0.tar.gz
-  - export DOTNET_ROOT=/opt/.dotnet
-  - mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
-  - ln -s /opt/.dotnet/dotnet /usr/bin/dotnet
   # Install GitHub Actions Runner
   - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
-  - export RUNNER_ALLOW_RUNASROOT=\"1\"
+  - export RUNNER_ALLOW_RUNASROOT="1"
   - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
   - ./svc.sh install
   - ./svc.sh start

--- a/devops/e2e/ubuntu-focal-arm64-cloud-init-insiders-fast.tpl
+++ b/devops/e2e/ubuntu-focal-arm64-cloud-init-insiders-fast.tpl
@@ -1,4 +1,5 @@
 #cloud-config
+#Based on ubuntu-focal-arm64-cloud-init.tpl with added msftinsidersfast apt source for insiders-fast
 apt_sources:
   - msftprod:
     source: deb [arch=arm64] https://packages.microsoft.com/ubuntu/20.04/prod/ $RELEASE main
@@ -22,6 +23,8 @@ apt_sources:
       NdCFTW7wY0Fb1fWJ+/KTsC4=
       =J6gs
       -----END PGP PUBLIC KEY BLOCK-----
+  - msftinsidersfast:
+    source: deb [arch=arm64] https://packages.microsoft.com/ubuntu/20.04/prod/ insiders-fast main
 package_upgrade: true
 packages:
   - apt-transport-https
@@ -43,13 +46,10 @@ packages:
   - libstdc++6
   - zlib1g
 runcmd:
-  # Install aziot-identity-service - no arm packages available
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
-  - apt install -y ./aziot-identity-service.deb
   # Install .NET Core SDK
   - wget https://download.visualstudio.microsoft.com/download/pr/06c4ee8e-bf2c-4e46-ab1c-e14dd72311c1/f7bc6c9677eaccadd1d0e76c55d361ea/dotnet-sdk-6.0.301-linux-arm64.tar.gz -O dotnet-sdk-6.0.tar.gz
   - DOTNET_FILE=dotnet-sdk-6.0.tar.gz
-  - export DOTNET_ROOT=/opt/.dotnet
+  - DOTNET_ROOT=/opt/.dotnet
   - mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
   - ln -s /opt/.dotnet/dotnet /usr/bin/dotnet
   # Install GitHub Actions Runner
@@ -58,3 +58,6 @@ runcmd:
   - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
   - ./svc.sh install
   - ./svc.sh start
+  # Install aziot-identity-service - no arm packages available
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
+  - apt install -y ./aziot-identity-service.deb

--- a/devops/e2e/ubuntu-focal-cloud-init-insiders-fast.tpl
+++ b/devops/e2e/ubuntu-focal-cloud-init-insiders-fast.tpl
@@ -1,7 +1,8 @@
 #cloud-config
+#Based on ubuntu-focal-cloud-init.tpl with added msftprodinsidersfast apt source for insiders-fast
 apt_sources:
-  - msftprod:
-    source: deb [arch=arm64] https://packages.microsoft.com/ubuntu/20.04/prod/ $RELEASE main
+  - azcli:
+    source: deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $RELEASE main
     key: |
       -----BEGIN PGP PUBLIC KEY BLOCK-----
       Version: GnuPG v1.4.7 (GNU/Linux)
@@ -22,39 +23,28 @@ apt_sources:
       NdCFTW7wY0Fb1fWJ+/KTsC4=
       =J6gs
       -----END PGP PUBLIC KEY BLOCK-----
+  - msftprod:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod $RELEASE main
+  - msftprodinsidersfast:
+    source: deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod insiders-fast main
 package_upgrade: true
 packages:
   - apt-transport-https
+  - aziot-identity-service
   - azure-cli
   - bc
   - ca-certificates
   - curl
+  - dotnet-sdk-6.0
   - gnupg
   - jo
   - jq
   - lsb-release
   - sysstat
-# .NET Dependencies
-  - libc6
-  - libgcc1
-  - libgssapi-krb5-2
-  - libicu66
-  - libssl1.1
-  - libstdc++6
-  - zlib1g
 runcmd:
-  # Install aziot-identity-service - no arm packages available
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
-  - apt install -y ./aziot-identity-service.deb
-  # Install .NET Core SDK
-  - wget https://download.visualstudio.microsoft.com/download/pr/06c4ee8e-bf2c-4e46-ab1c-e14dd72311c1/f7bc6c9677eaccadd1d0e76c55d361ea/dotnet-sdk-6.0.301-linux-arm64.tar.gz -O dotnet-sdk-6.0.tar.gz
-  - DOTNET_FILE=dotnet-sdk-6.0.tar.gz
-  - export DOTNET_ROOT=/opt/.dotnet
-  - mkdir -p "$DOTNET_ROOT" && tar zxf "$DOTNET_FILE" -C "$DOTNET_ROOT"
-  - ln -s /opt/.dotnet/dotnet /usr/bin/dotnet
   # Install GitHub Actions Runner
   - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz
-  - export RUNNER_ALLOW_RUNASROOT=\"1\"
+  - export RUNNER_ALLOW_RUNASROOT="1"
   - ./config.sh --url https://github.com/Azure/azure-osconfig --unattended --ephemeral --name "${resource_group_name}-${vm_name}" --token "${runner_token}" --labels "${resource_group_name}-${vm_name}"
   - ./svc.sh install
   - ./svc.sh start


### PR DESCRIPTION
## Description

* Added separate cloud-init templates for insiders-fast with the added insiders-fast apt repo
* Fixed arm64 cloud-init script, removed the sudoers `secure_path` override.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.