### PR TITLE
Fixed modulestest explicit path

### DIFF
--- a/devops/scripts/generate_moduletest_metadata.sh
+++ b/devops/scripts/generate_moduletest_metadata.sh
@@ -6,15 +6,19 @@ if ! [ -x "$(command -v jq)" ]; then
   echo 'Error: jq is not installed.' >&2
   exit 1
 fi
+if [ $# -ne 2 ]; then
+  echo 'Usage: ./generate_moduletest_metadata.sh testplace.json /azure-osconfig/build/modules' >&2
+  exit 1
+fi
 
 # Absolute path to this script
 SCRIPT=$(readlink -f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 BaseDir=`realpath $SCRIPTPATH/../..`
 mimBaseDir=$BaseDir/src/modules/mim
-modulesBaseDir=$BaseDir/build/modules
 recipeBaseDir=$BaseDir/src/modules/test/recipes
-testMetaDataDestPath=$BaseDir/build/modules/test/testplate.json
+testMetaDataDestPath=$1
+modulesBaseDir=$2
 
 modules=$(find $modulesBaseDir -name '*.so')
 testJSON="[]"

--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(modulestest gtest gtest_main pthread testfactorylib)
 find_program(JQ_EXEC jq)
 if(JQ_EXEC)
     add_custom_target(modulerecipeconfiguration
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../../devops/scripts/generate_moduletest_metadata.sh
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../../../devops/scripts/generate_moduletest_metadata.sh ${CMAKE_CURRENT_BINARY_DIR}/testplate.json ${CMAKE_CURRENT_BINARY_DIR}/..
         COMMENT "Generating module recipe configuration"
     )
     add_dependencies(modulestest modulerecipeconfiguration)


### PR DESCRIPTION
## Description

* Removed explicit build path dependency, now works on any build path

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.