### PR TITLE
Added suffix to test jobs to properly identify report

### DIFF
--- a/.github/workflows/deploy-e2etest-prod.yml
+++ b/.github/workflows/deploy-e2etest-prod.yml
@@ -43,6 +43,7 @@ jobs:
       environment: e2e-prod
       resourceGroupName: ${{ needs.fetch-targets.outputs.resourceGroupName }}
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
+      testNameSuffix: (prod)
     secrets: inherit
 
   deprovision-resources:

--- a/.github/workflows/deploy-github-main.yml
+++ b/.github/workflows/deploy-github-main.yml
@@ -54,6 +54,7 @@ jobs:
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
       cpuThreshold: 50
       memThreshold: 50
+      testNameSuffix: (github-main)
     secrets: inherit
 
   deprovision-resources:

--- a/.github/workflows/deploy-insiders-fast.yml
+++ b/.github/workflows/deploy-insiders-fast.yml
@@ -43,6 +43,7 @@ jobs:
       environment: e2e-insiders-fast
       resourceGroupName: ${{ needs.fetch-targets.outputs.resourceGroupName }}
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
+      testNameSuffix: (insiders-fast)
     secrets: inherit
 
   deprovision-resources:

--- a/.github/workflows/deploy-reliability-modules.yml
+++ b/.github/workflows/deploy-reliability-modules.yml
@@ -99,6 +99,6 @@ jobs:
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
-          name: Test report (${{ matrix.os }}-${{ matrix.variant.arch }})
+          name: Test report (${{ matrix.os }}-${{ matrix.variant.arch }}) (reliability-platform)
           path: ./${{ steps.set-variables.outputs.xml }}
           reporter: java-junit

--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -46,6 +46,7 @@ jobs:
       cpuThreshold: 50
       memThreshold: 50
       repeatForXHours: 23
+      testNameSuffix: (reliability-platform)
     secrets: inherit
 
   deprovision-resources:

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -28,6 +28,10 @@ on:
         description: Repeat the test suite for X hours, every test run gets a new test-report
         type: number
         required: false
+      testNameSuffix:
+        description: The name to use for the suffix of the test report
+        type: string
+        required: false
 
 jobs:
   run-tests:
@@ -212,6 +216,6 @@ jobs:
       - uses: dorny/test-reporter@v1.5.0
         if: always()
         with:
-          name: E2E Test Report ${{ matrix.distroName }}
+          name: E2E Test Report ${{ matrix.distroName }} ${{ inputs.testNameSuffix }}
           path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}.trx
           reporter: dotnet-trx


### PR DESCRIPTION
## Description

* Added suffix to test report names to properly identity variants of the test jobs (github-main, prod, insiders-fast)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.