### PR TITLE
Added missing osconfig-platform ref to spec

### DIFF
--- a/src/cmake/templates/osconfig.spec.in
+++ b/src/cmake/templates/osconfig.spec.in
@@ -81,6 +81,7 @@ systemctl start osconfig.service
 %files
 %defattr(-, root, root, -)
 %{_bindir}/osconfig
+%{_bindir}/osconfig-platform
 /etc/azure-device-telemetryd/OsConfigAgentTelemetry.conf
 /etc/osconfig/osconfig.conn
 /etc/osconfig/osconfig.json


### PR DESCRIPTION
## Description

* Added missing `osconfig-platform` binary to RPM spec

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.