### PR TITLE
Fix unused constant variables in platform and modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ option(BUILD_TESTS "Build test collateral" ON)
 option(BUILD_SAMPLES "Build samples" OFF)
 option(COVERAGE "Enable code coverage" OFF)
 
-add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Wunused;-Werror;-Wformat;-Wformat-security;-Wreorder;-Wno-nonnull;-Wno-unused-result;-Wunused-macros>")
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Wunused;-Werror;-Wformat;-Wformat-security;-Wreorder;-Wno-nonnull;-Wno-unused-result;-Wunused-macros;-Wunused-const-variable=2>")
 
 if (CMAKE_COMPILER_IS_GNUCC)
     add_compile_options("-Wno-psabi;-fPIC")

--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -7,6 +7,17 @@
 #include <bits/stdc++.h>
 #include "Firewall.h"
 
+const char* FirewallObjectBase::m_firewallInfo = R""""({
+    "Name": "Firewall",
+    "Description": "Provides functionality to remotely manage firewall rules on device",
+    "Manufacturer": "Microsoft",
+    "VersionMajor": 2,
+    "VersionMinor": 0,
+    "VersionInfo": "Nickel",
+    "Components": ["Firewall"],
+    "Lifetime": 1,
+    "UserAccount": 0})"""";
+
 const char g_firewallComponent[] = "Firewall";
 const char g_firewallState[] = "firewallState";
 const char g_firewallFingerprint[] = "firewallFingerprint";
@@ -45,7 +56,7 @@ int FirewallObjectBase::GetInfo(const char* clientName, MMI_JSON_STRING* payload
     }
     else
     {
-        size_t len = strlen(g_firewallInfo);
+        size_t len = strlen(m_firewallInfo);
         *payload = new (std::nothrow) char[len];
 
         if (nullptr == *payload)
@@ -55,7 +66,7 @@ int FirewallObjectBase::GetInfo(const char* clientName, MMI_JSON_STRING* payload
         }
         else
         {
-            std::memcpy(*payload, g_firewallInfo, len);
+            std::memcpy(*payload, m_firewallInfo, len);
             *payloadSizeBytes = len;
         }
     }

--- a/src/modules/firewall/src/lib/Firewall.h
+++ b/src/modules/firewall/src/lib/Firewall.h
@@ -14,17 +14,6 @@
 #define FIREWALL_LOGFILE "/var/log/osconfig_firewall.log"
 #define FIREWALL_ROLLEDLOGFILE "/var/log/osconfig_firewall.bak"
 
-constexpr const char g_firewallInfo[] = R""""({
-    "Name": "Firewall",
-    "Description": "Provides functionality to remotely manage firewall rules on device",
-    "Manufacturer": "Microsoft",
-    "VersionMajor": 2,
-    "VersionMinor": 0,
-    "VersionInfo": "Nickel",
-    "Components": ["Firewall"],
-    "Lifetime": 1,
-    "UserAccount": 0})"""";
-
 class FirewallLog
 {
 public:
@@ -155,6 +144,8 @@ private:
 class FirewallObjectBase
 {
 public:
+    static const char* m_firewallInfo;
+
     virtual ~FirewallObjectBase() {};
     static int GetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloadSizeBytes);
     int Get(const char* componentName, const char* objectName, MMI_JSON_STRING* payload, int* payloadSizeBytes);

--- a/src/modules/firewall/tests/FirewallTests.cpp
+++ b/src/modules/firewall/tests/FirewallTests.cpp
@@ -119,8 +119,8 @@ TEST(FirewallTests, GetInfo)
     int payloadSizeBytes = 0;
 
     FirewallObject::GetInfo(clientName, &payload, &payloadSizeBytes);
-    EXPECT_STREQ(payload, g_firewallInfo);
-    EXPECT_EQ(payloadSizeBytes, strlen(g_firewallInfo));
+    EXPECT_STREQ(payload, FirewallObject::m_firewallInfo);
+    EXPECT_EQ(payloadSizeBytes, strlen(FirewallObject::m_firewallInfo));
 }
 
 TEST(FirewallTests, DetectUtility)

--- a/src/modules/hostname/src/lib/HostNameBase.cpp
+++ b/src/modules/hostname/src/lib/HostNameBase.cpp
@@ -24,6 +24,12 @@
 #define ERROR_SET_RETURNED "%s(%s) returned %d"
 #define ERROR_INVALID_JSON "%s parse failed: '%s' (offset %u)"
 
+const char* HostNameBase::m_componentName = "HostName";
+const char* HostNameBase::m_propertyDesiredName = "desiredName";
+const char* HostNameBase::m_propertyDesiredHosts = "desiredHosts";
+const char* HostNameBase::m_propertyName = "name";
+const char* HostNameBase::m_propertyHosts = "hosts";
+
 constexpr const char* g_commandGetName = "cat /etc/hostname";
 constexpr const char* g_commandGetHosts = "cat /etc/hosts";
 constexpr const char* g_commandSetName = "hostnamectl set-hostname --static '$value'";
@@ -81,13 +87,13 @@ int HostNameBase::Set(
 
     if (!IsValidComponentName(componentName))
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_COMPONENT, "Set", componentName, g_componentName);
+        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_COMPONENT, "Set", componentName, m_componentName);
         return EINVAL;
     }
 
     if (!IsValidObjectName(objectName, true))
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Set", objectName ? objectName : "-", g_propertyDesiredName, g_propertyDesiredHosts);
+        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Set", objectName ? objectName : "-", m_propertyDesiredName, m_propertyDesiredHosts);
         return EINVAL;
     }
 
@@ -107,11 +113,11 @@ int HostNameBase::Set(
     else
     {
         std::string data(payload, payloadSizeBytes);
-        if (std::strcmp(objectName, g_propertyDesiredName) == 0)
+        if (std::strcmp(objectName, m_propertyDesiredName) == 0)
         {
             status = SetName(data);
         }
-        else if (std::strcmp(objectName, g_propertyDesiredHosts) == 0)
+        else if (std::strcmp(objectName, m_propertyDesiredHosts) == 0)
         {
             status = SetHosts(data);
         }
@@ -136,7 +142,7 @@ int HostNameBase::Get(
     {
         if (IsFullLoggingEnabled())
         {
-            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_COMPONENT, "Get", componentName, g_componentName);
+            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_COMPONENT, "Get", componentName, m_componentName);
         }
         return EINVAL;
     }
@@ -145,7 +151,7 @@ int HostNameBase::Get(
     {
         if (IsFullLoggingEnabled())
         {
-            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Get", objectName ? objectName : "-", g_propertyName, g_propertyHosts);
+            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Get", objectName ? objectName : "-", m_propertyName, m_propertyHosts);
         }
         return EINVAL;
     }
@@ -160,11 +166,11 @@ int HostNameBase::Get(
     }
 
     std::string data;
-    if (std::strcmp(objectName, g_propertyName) == 0)
+    if (std::strcmp(objectName, m_propertyName) == 0)
     {
         data = GetName();
     }
-    else if (std::strcmp(objectName, g_propertyHosts) == 0)
+    else if (std::strcmp(objectName, m_propertyHosts) == 0)
     {
         data = GetHosts();
     }
@@ -336,12 +342,12 @@ bool HostNameBase::IsValidClientSession(MMI_HANDLE clientSession)
 
 bool HostNameBase::IsValidComponentName(const char* componentName)
 {
-    return (componentName && (std::strcmp(componentName, g_componentName) == 0));
+    return (componentName && (std::strcmp(componentName, m_componentName) == 0));
 }
 
 bool HostNameBase::IsValidObjectName(const char* objectName, const bool desired)
 {
-    return (objectName && (desired ? (std::strcmp(objectName, g_propertyDesiredName) == 0 || std::strcmp(objectName, g_propertyDesiredHosts) == 0) : (std::strcmp(objectName, g_propertyName) == 0 || std::strcmp(objectName, g_propertyHosts) == 0)));
+    return (objectName && (desired ? (std::strcmp(objectName, m_propertyDesiredName) == 0 || std::strcmp(objectName, m_propertyDesiredHosts) == 0) : (std::strcmp(objectName, m_propertyName) == 0 || std::strcmp(objectName, m_propertyHosts) == 0)));
 }
 
 bool HostNameBase::IsValidJsonString(const char* data, const int size)

--- a/src/modules/hostname/src/lib/HostNameBase.h
+++ b/src/modules/hostname/src/lib/HostNameBase.h
@@ -11,12 +11,6 @@
 #define HOST_NAME_CONFIGURATOR_LOGFILE "/var/log/osconfig_hostname.log"
 #define HOST_NAME_CONFIGURATOR_ROLLEDLOGFILE "/var/log/osconfig_hostname.bak"
 
-constexpr const char* g_componentName = "HostName";
-constexpr const char* g_propertyDesiredName = "desiredName";
-constexpr const char* g_propertyDesiredHosts = "desiredHosts";
-constexpr const char* g_propertyName = "name";
-constexpr const char* g_propertyHosts = "hosts";
-
 class HostNameLog
 {
 public:
@@ -42,6 +36,12 @@ private:
 class HostNameBase
 {
 public:
+    static const char* m_componentName;
+    static const char* m_propertyDesiredName;
+    static const char* m_propertyDesiredHosts;
+    static const char* m_propertyName;
+    static const char* m_propertyHosts;
+
     HostNameBase(size_t maxPayloadSizeBytes);
     virtual ~HostNameBase();
     virtual int RunCommand(const char* command, bool replaceEol, std::string* textResult) = 0;

--- a/src/modules/hostname/src/so/HostNameModule.cpp
+++ b/src/modules/hostname/src/so/HostNameModule.cpp
@@ -31,7 +31,6 @@ constexpr const char g_moduleInfo[] = R""""({
     "Components": ["HostName"],
     "Lifetime": 2,
     "UserAccount": 0})"""";
-constexpr const char g_emptyPayload[] = "\"\"";
 
 void __attribute__((constructor)) InitModule()
 {

--- a/src/modules/hostname/tests/HostNameBaseTests.cpp
+++ b/src/modules/hostname/tests/HostNameBaseTests.cpp
@@ -66,7 +66,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyName, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyName, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -87,7 +87,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyName, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyName, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -108,7 +108,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyName, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyName, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -136,7 +136,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyHosts, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyHosts, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -164,7 +164,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyHosts, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyHosts, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -192,7 +192,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyHosts, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyHosts, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -221,7 +221,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyHosts, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyHosts, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -244,7 +244,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyHosts, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyHosts, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -263,7 +263,7 @@ namespace OSConfig::Platform::Tests
             };
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, nullptr, nullptr, 0);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, nullptr, nullptr, 0);
 
         EXPECT_EQ(status, EINVAL);
     }
@@ -276,7 +276,7 @@ namespace OSConfig::Platform::Tests
             };
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyName, nullptr, 0);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyName, nullptr, 0);
 
         EXPECT_EQ(status, EINVAL);
     }
@@ -299,7 +299,7 @@ namespace OSConfig::Platform::Tests
         int payloadSizeBytes;
 
         HostNameBaseTests testModule(textResults, 1);
-        int status = testModule.Get(&testModule, g_componentName, g_propertyHosts, &payload, &payloadSizeBytes);
+        int status = testModule.Get(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyHosts, &payload, &payloadSizeBytes);
 
         std::string result(payload, payloadSizeBytes);
 
@@ -323,7 +323,7 @@ namespace OSConfig::Platform::Tests
         std::memcpy(payload, name.c_str(), payloadSizeBytes);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredName, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredName, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, MMI_OK);
 
@@ -344,7 +344,7 @@ namespace OSConfig::Platform::Tests
         std::memcpy(payload, hosts.c_str(), payloadSizeBytes);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredHosts, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredHosts, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, MMI_OK);
 
@@ -365,7 +365,7 @@ namespace OSConfig::Platform::Tests
         std::memcpy(payload, hosts.c_str(), payloadSizeBytes);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredHosts, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredHosts, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, MMI_OK);
 
@@ -383,7 +383,7 @@ namespace OSConfig::Platform::Tests
         std::memcpy(payload, name.c_str(), payloadSizeBytes);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, nullptr, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, nullptr, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, EINVAL);
 
@@ -398,7 +398,7 @@ namespace OSConfig::Platform::Tests
             };
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredName, nullptr, 0);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredName, nullptr, 0);
 
         EXPECT_EQ(status, EINVAL);
     }
@@ -414,7 +414,7 @@ namespace OSConfig::Platform::Tests
         std::memcpy(payload, name.c_str(), payloadSizeBytes);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredName, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredName, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, EINVAL);
 
@@ -434,7 +434,7 @@ namespace OSConfig::Platform::Tests
         std::memcpy(payload, hosts.c_str(), payloadSizeBytes);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredHosts, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredHosts, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, EINVAL);
 
@@ -450,7 +450,7 @@ namespace OSConfig::Platform::Tests
         std::fill(payload, payload + payloadSizeBytes, 0);
 
         HostNameBaseTests testModule(textResults, g_maxPayloadSizeBytes);
-        int status = testModule.Set(&testModule, g_componentName, g_propertyDesiredHosts, payload, payloadSizeBytes);
+        int status = testModule.Set(&testModule, HostNameBase::m_componentName, HostNameBase::m_propertyDesiredHosts, payload, payloadSizeBytes);
 
         EXPECT_EQ(status, E2BIG);
 

--- a/src/modules/settings/src/lib/Settings.h
+++ b/src/modules/settings/src/lib/Settings.h
@@ -13,9 +13,6 @@ const std::string g_cacheHostSource = "cacheHostSource";
 const std::string g_cacheHost = "cacheHost";
 const std::string g_cacheHostFallback = "cacheHostFallback";
 
-static const char g_healthTelemetryConfigFile[] = "/etc/azure-device-health-services/config.toml";
-static const char g_doConfigFile[] = "/etc/deliveryoptimization-agent/admin-config.json";
-
 #define SETTINGS_LOGFILE "/var/log/osconfig_settings.log"
 #define SETTINGS_ROLLEDLOGFILE "/var/log/osconfig_settings.bak"
 

--- a/src/modules/settings/src/so/SettingsModule.cpp
+++ b/src/modules/settings/src/so/SettingsModule.cpp
@@ -36,6 +36,9 @@ constexpr const char g_moduleInfo[] = R""""({
     "Lifetime": 0,
     "UserAccount": 0})"""";
 
+static const char g_healthTelemetryConfigFile[] = "/etc/azure-device-health-services/config.toml";
+static const char g_doConfigFile[] = "/etc/deliveryoptimization-agent/admin-config.json";
+
 int MmiGetInfo(
     const char* clientName,
     MMI_JSON_STRING* payload,

--- a/src/platform/tests/ManagementModuleTests.cpp
+++ b/src/platform/tests/ManagementModuleTests.cpp
@@ -49,7 +49,7 @@ namespace Tests
 
     TEST_F(ManagementModuleTests, LoadModule)
     {
-        ManagementModule module(g_validModulePathV1);
+        ManagementModule module(TEST_VALID_MODULE_PATH_V1);
         EXPECT_EQ(0, module.Load());
 
         ManagementModule::Info info = module.GetInfo();
@@ -60,20 +60,20 @@ namespace Tests
 
     TEST_F(ManagementModuleTests, LoadModuleInvalidPath)
     {
-        const std::string invalidPath = g_moduleDir;
+        const std::string invalidPath = TEST_MODULE_DIR;
         ManagementModule invalidModule(invalidPath + "/blah.so");
         EXPECT_EQ(EINVAL, invalidModule.Load());
     }
 
     TEST_F(ManagementModuleTests, LoadModuleInvalidMmi)
     {
-        ManagementModule invalidModule(g_invalidModulePath);
+        ManagementModule invalidModule(TEST_INVALID_MODULE_PATH);
         EXPECT_EQ(EINVAL, invalidModule.Load());
     }
 
     TEST_F(ManagementModuleTests, LoadModuleInvalidModuleInfo)
     {
-        ManagementModule invalidModule(g_invalidGetInfoModulePath);
+        ManagementModule invalidModule(TEST_INVALID_GETINFO_MODULE_PATH);
         EXPECT_EQ(EINVAL, invalidModule.Load());
     }
 
@@ -152,15 +152,15 @@ namespace Tests
     {
         MockManagementModule mockModule;
         std::vector<std::pair<std::string, std::string>> objects = {
-            {g_string, g_stringPayload},
-            {g_integer, g_integerPayload},
-            {g_boolean, g_booleanPayload},
-            {g_integerArray, g_integerArrayPayload},
-            {g_stringArray, g_stringArrayPayload},
-            {g_integerMap, g_integerMapPayload},
-            {g_stringMap, g_stringMapPayload},
-            {g_object, g_objectPayload},
-            {g_objectArray, g_objectArrayPayload}
+            {TEST_OBJECT_STRING, TEST_OBJECT_STRING_PAYLOAD},
+            {TEST_OBJECT_INTEGER, TEST_OBJECT_INTEGER_PAYLOAD},
+            {TEST_OBJECT_BOOLEAN, TEST_OBJECT_BOOLEAN_PAYLOAD},
+            {TEST_OBJECT_INTEGER_ARRAY, TEST_OBJECT_INTEGER_ARRAY_PAYLOAD},
+            {TEST_OBJECT_STRING_ARRAY, TEST_OBJECT_STRING_ARRAY_PAYLOAD},
+            {TEST_OBJECT_INTEGER_MAP, TEST_OBJECT_INTEGER_MAP_PAYLOAD},
+            {TEST_OBJECT_STRING_MAP, TEST_OBJECT_STRING_MAP_PAYLOAD},
+            {TEST_OBJECT, TEST_OBJECT_PAYLOAD},
+            {TEST_OBJECT_ARRAY, TEST_OBJECT_ARRAY_PAYLOAD}
         };
 
         mockModule.MmiSet(

--- a/src/platform/tests/ModulesManagerTests.cpp
+++ b/src/platform/tests/ModulesManagerTests.cpp
@@ -364,7 +364,7 @@ namespace Tests
         int payloadSizeBytes = 0;
         const char emptyPayload[] = "{}";
 
-        ASSERT_EQ(MPI_OK, m_mockModuleManager->LoadModules(g_moduleDir, g_configJsonNoneReported));
+        ASSERT_EQ(MPI_OK, m_mockModuleManager->LoadModules(TEST_MODULE_DIR, TEST_CONFIG_JSON_NONE_REPORTED));
 
         std::shared_ptr<MpiSession> mpiSession = std::make_shared<MpiSession>(*m_mockModuleManager, m_defaultClient);
         EXPECT_EQ(0, mpiSession->Open());
@@ -381,16 +381,16 @@ namespace Tests
         MPI_JSON_STRING payload = nullptr;
         int payloadSizeBytes = 0;
 
-        ASSERT_EQ(MPI_OK, m_mockModuleManager->LoadModules(g_moduleDir, g_configJsonSingleReported));
+        ASSERT_EQ(MPI_OK, m_mockModuleManager->LoadModules(TEST_MODULE_DIR, TEST_CONFIG_JSON_SINGLE_REPORTED));
 
         std::shared_ptr<MpiSession> mpiSession = std::make_shared<MpiSession>(*m_mockModuleManager, m_defaultClient);
         EXPECT_EQ(0, mpiSession->Open());
 
-        EXPECT_EQ(MPI_OK, mpiSession->SetDesired((MPI_JSON_STRING)g_singleObjectPayload, strlen(g_singleObjectPayload)));
+        EXPECT_EQ(MPI_OK, mpiSession->SetDesired((MPI_JSON_STRING)TEST_SINGLE_OBJECT_PAYLOAD, strlen(TEST_SINGLE_OBJECT_PAYLOAD)));
         EXPECT_EQ(MPI_OK, mpiSession->GetReported(&payload, &payloadSizeBytes));
 
         std::string actual(payload, payloadSizeBytes);
-        EXPECT_TRUE(JSON_EQ(g_singleObjectPayload, actual));
+        EXPECT_TRUE(JSON_EQ(TEST_SINGLE_OBJECT_PAYLOAD, actual));
     }
 
     TEST_F(ModuleManagerTests, LoadModulesMultipleReported)
@@ -398,30 +398,30 @@ namespace Tests
         MPI_JSON_STRING payload = nullptr;
         int payloadSizeBytes = 0;
 
-        ASSERT_EQ(MPI_OK, m_mockModuleManager->LoadModules(g_moduleDir, g_configJsonMultipleReported));
+        ASSERT_EQ(MPI_OK, m_mockModuleManager->LoadModules(TEST_MODULE_DIR, TEST_CONFIG_JSON_MULTIPLE_REPORTED));
 
         std::shared_ptr<MpiSession> mpiSession = std::make_shared<MpiSession>(*m_mockModuleManager, m_defaultClient);
         EXPECT_EQ(0, mpiSession->Open());
 
-        EXPECT_EQ(MPI_OK, mpiSession->SetDesired((MPI_JSON_STRING)g_multipleObjectsPayload, strlen(g_multipleObjectsPayload)));
+        EXPECT_EQ(MPI_OK, mpiSession->SetDesired((MPI_JSON_STRING)TEST_MULTIPLE_OBJECT_PAYLOAD, strlen(TEST_MULTIPLE_OBJECT_PAYLOAD)));
         EXPECT_EQ(MPI_OK, mpiSession->GetReported(&payload, &payloadSizeBytes));
 
         std::string actual(payload, payloadSizeBytes);
-        EXPECT_TRUE(JSON_EQ(g_multipleObjectsPayload, actual));
+        EXPECT_TRUE(JSON_EQ(TEST_MULTIPLE_OBJECT_PAYLOAD, actual));
     }
 
     TEST_F(ModuleManagerTests, LoadModulesInvalidDirectory)
     {
-        ASSERT_EQ(ENOENT, m_mockModuleManager->LoadModules("/invalid/path", g_configJsonNoneReported));
+        ASSERT_EQ(ENOENT, m_mockModuleManager->LoadModules("/invalid/path", TEST_CONFIG_JSON_NONE_REPORTED));
     }
 
     TEST_F(ModuleManagerTests, LoadModulesInvalidConfigPath)
     {
-        ASSERT_EQ(ENOENT, m_mockModuleManager->LoadModules(g_moduleDir, "/invalid/path/config.json"));
+        ASSERT_EQ(ENOENT, m_mockModuleManager->LoadModules(TEST_MODULE_DIR, "/invalid/path/config.json"));
     }
 
     TEST_F(ModuleManagerTests, LoadModulesInvalidConfig)
     {
-        ASSERT_EQ(EINVAL, m_mockModuleManager->LoadModules(g_moduleDir, g_configJsonInvalid));
+        ASSERT_EQ(EINVAL, m_mockModuleManager->LoadModules(TEST_MODULE_DIR, TEST_CONFIG_JSON_INVALID));
     }
 } // namespace Tests

--- a/src/platform/tests/cmake/ModulesManagerTests.h.in
+++ b/src/platform/tests/cmake/ModulesManagerTests.h.in
@@ -2,126 +2,126 @@
 #define MODULESMANAGERTESTS_H
 
 // Path to the test modules directory
-const char g_moduleDir[] = "@TEST_MODULES_DIR@";
+#define TEST_MODULE_DIR "@TEST_MODULES_DIR@"
 
 // Path to each test module
-const char g_validModulePathV1[] = "@VALID_MODULE_V1_PATH@";
-const char g_validModulePathV2[] = "@VALID_MODULE_V2_PATH@";
-const char g_invalidModulePath[] = "@INVALID_MODULE_PATH@";
-const char g_invalidGetInfoModulePath[] = "@INVALIDGETINFO_MODULE_PATH@";
+#define TEST_VALID_MODULE_PATH_V1 "@VALID_MODULE_V1_PATH@"
+#define TEST_VALID_MODULE_PATH_V2 "@VALID_MODULE_V2_PATH@"
+#define TEST_INVALID_MODULE_PATH "@INVALID_MODULE_PATH@"
+#define TEST_INVALID_GETINFO_MODULE_PATH "@INVALIDGETINFO_MODULE_PATH@"
 
 // Component names used by all valid modules
-const char g_testModuleComponent1[] = "TestModule_Component_1";
-const char g_testModuleComponent2[] = "TestModule_Component_2";
+#define TEST_MODULE_COMPONENT_1 "TestModule_Component_1"
+#define TEST_MODULE_COMPONENT_2 "TestModule_Component_2"
 
-const char g_configJsonInvalid[] = "@OSCONFIG_JSON_INVALID@";
-const char g_configJsonNoneReported[] = "@OSCONFIG_JSON_NONE_REPORTED@";
-const char g_configJsonSingleReported[] = "@OSCONFIG_JSON_SINGLE_REPORTED@";
-const char g_configJsonMultipleReported[] = "@OSCONFIG_JSON_MULTIPLE_REPORTED@";
+#define TEST_CONFIG_JSON_INVALID "@OSCONFIG_JSON_INVALID@"
+#define TEST_CONFIG_JSON_NONE_REPORTED "@OSCONFIG_JSON_NONE_REPORTED@"
+#define TEST_CONFIG_JSON_SINGLE_REPORTED "@OSCONFIG_JSON_SINGLE_REPORTED@"
+#define TEST_CONFIG_JSON_MULTIPLE_REPORTED "@OSCONFIG_JSON_MULTIPLE_REPORTED@"
 
 // Object names
-const char g_string[] = "string";
-const char g_integer[] = "integer";
-const char g_boolean[] = "boolean";
-const char g_integerEnum[] = "integerEnum";
-const char g_integerArray[] = "integerArray";
-const char g_stringArray[] = "stringArray";
-const char g_integerMap[] = "integerMap";
-const char g_stringMap[] = "stringMap";
-const char g_object[] = "object";
-const char g_objectArray[] = "objectArray";
+#define TEST_OBJECT_STRING "string"
+#define TEST_OBJECT_INTEGER "integer"
+#define TEST_OBJECT_BOOLEAN "boolean"
+#define TEST_OBJECT_INTEGER_ENUM "integerEnum"
+#define TEST_OBJECT_INTEGER_ARRAY "integerArray"
+#define TEST_OBJECT_STRING_ARRAY "stringArray"
+#define TEST_OBJECT_INTEGER_MAP "integerMap"
+#define TEST_OBJECT_STRING_MAP "stringMap"
+#define TEST_OBJECT "object"
+#define TEST_OBJECT_ARRAY "objectArray"
 
 // Object payloads
-const char g_stringPayload[] = "\"string\"";
-const char g_integerPayload[] = "123";
-const char g_booleanPayload[] = "true";
-const char g_integerEnumPayload[] = "1";
-const char g_integerArrayPayload[] = "[1, 2, 3]";
-const char g_stringArrayPayload[] = "[\"a\", \"b\", \"c\"]";
-const char g_integerMapPayload[] = "{\"key1\": 1, \"key2\": 2}";
-const char g_stringMapPayload[] = "{\"key1\": \"a\", \"key2\": \"b\"}";
-const char g_objectPayload[] = R"""({
-        "string": "value",
-        "integer": 1,
-        "boolean": true,
-        "integerEnum": 1,
-        "integerArray": [1, 2, 3],
-        "stringArray": ["a", "b", "c"],
-        "integerMap": { "key1": 1, "key2": 2 },
-        "stringMap": { "key1": "a", "key2": "b" }
-    })""";
-const char g_objectArrayPayload[] = R"""([
-        {
-            "string": "value",
-            "integer": 1,
-            "boolean": true,
-            "integerEnum": 1,
-            "integerArray": [1, 2, 3],
-            "stringArray": ["a", "b", "c"],
-            "integerMap": { "key1": 1, "key2": 2 },
-            "stringMap": { "key1": "a", "key2": "b" }
-        },
-        {
-            "string": "value",
-            "integer": 1,
-            "boolean": true,
-            "integerEnum": 1,
-            "integerArray": [1, 2, 3],
-            "stringArray": ["a", "b", "c"],
-            "integerMap": { "key1": 1, "key2": 2 },
-            "stringMap": { "key1": "a", "key2": "b" }
-        }
-    ])""";
+#define TEST_OBJECT_STRING_PAYLOAD "\"string\""
+#define TEST_OBJECT_INTEGER_PAYLOAD "123"
+#define TEST_OBJECT_BOOLEAN_PAYLOAD "true"
+#define TEST_OBJECT_INTEGER_ENUM_PAYLOAD "1"
+#define TEST_OBJECT_INTEGER_ARRAY_PAYLOAD "[1, 2, 3]"
+#define TEST_OBJECT_STRING_ARRAY_PAYLOAD "[\"a\", \"b\", \"c\"]"
+#define TEST_OBJECT_INTEGER_MAP_PAYLOAD "{\"key1\": 1, \"key2\": 2}"
+#define TEST_OBJECT_STRING_MAP_PAYLOAD "{\"key1\": \"a\", \"key2\": \"b\"}"
+#define TEST_OBJECT_PAYLOAD "{" \
+        "\"string\": \"value\"," \
+        "\"integer\": 1," \
+        "\"boolean\": true," \
+        "\"integerEnum\": 1," \
+        "\"integerArray\": [1, 2, 3]," \
+        "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+        "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+        "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }" \
+    "}"
+#define TEST_OBJECT_ARRAY_PAYLOAD "[" \
+        "{" \
+            "\"string\": \"value\"," \
+            "\"integer\": 1," \
+            "\"boolean\": true," \
+            "\"integerEnum\": 1," \
+            "\"integerArray\": [1, 2, 3]," \
+            "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+            "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+            "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }" \
+        "}," \
+        "{" \
+            "\"string\": \"value\"," \
+            "\"integer\": 1," \
+            "\"boolean\": true," \
+            "\"integerEnum\": 1," \
+            "\"integerArray\": [1, 2, 3]," \
+            "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+            "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+            "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }" \
+        "}" \
+    "]"
 
 // Payloads for testing MpiSetDesired() and MpiGetReported()
-const char g_singleObjectPayload[] = R"""({
-    "TestModule_Component_1": {
-        "string": "string"
-    }
-})""";
-const char g_multipleObjectsPayload[] = R"""({
-    "TestModule_Component_1": {
-        "string": "string",
-        "integer": 123,
-        "boolean": true,
-        "integerEnum": 1,
-        "integerArray": [1, 2, 3],
-        "stringArray": ["a", "b", "c"],
-        "integerMap": { "key1": 1, "key2": 2 },
-        "stringMap": { "key1": "a", "key2": "b" },
-        "object": {
-            "string": "value",
-            "integer": 1,
-            "boolean": true,
-            "integerEnum": 1,
-            "integerArray": [1, 2, 3],
-            "stringArray": ["a", "b", "c"],
-            "integerMap": { "key1": 1, "key2": 2 },
-            "stringMap": { "key1": "a", "key2": "b" }
-        },
-        "objectArray": [
-            {
-                "string": "value",
-                "integer": 1,
-                "boolean": true,
-                "integerEnum": 1,
-                "integerArray": [1, 2, 3],
-                "stringArray": ["a", "b", "c"],
-                "integerMap": { "key1": 1, "key2": 2 },
-                "stringMap": { "key1": "a", "key2": "b" }
-            },
-            {
-                "string": "value",
-                "integer": 1,
-                "boolean": true,
-                "integerEnum": 1,
-                "integerArray": [1, 2, 3],
-                "stringArray": ["a", "b", "c"],
-                "integerMap": { "key1": 1, "key2": 2 },
-                "stringMap": { "key1": "a", "key2": "b" }
-            }
-        ]
-    }
-})""";
+#define TEST_SINGLE_OBJECT_PAYLOAD "{" \
+    "\"TestModule_Component_1\": {" \
+        "\"string\": \"string\"" \
+    "}" \
+"}"
+#define TEST_MULTIPLE_OBJECT_PAYLOAD "{" \
+    "\"TestModule_Component_1\": {" \
+        "\"string\": \"string\"," \
+        "\"integer\": 123," \
+        "\"boolean\": true," \
+        "\"integerEnum\": 1," \
+        "\"integerArray\": [1, 2, 3]," \
+        "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+        "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+        "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }," \
+        "\"object\": {" \
+            "\"string\": \"value\"," \
+            "\"integer\": 1," \
+            "\"boolean\": true," \
+            "\"integerEnum\": 1," \
+            "\"integerArray\": [1, 2, 3]," \
+            "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+            "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+            "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }" \
+        "}," \
+        "\"objectArray\": [" \
+            "{" \
+                "\"string\": \"value\"," \
+                "\"integer\": 1," \
+                "\"boolean\": true," \
+                "\"integerEnum\": 1," \
+                "\"integerArray\": [1, 2, 3]," \
+                "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+                "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+                "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }" \
+            "}," \
+            "{" \
+                "\"string\": \"value\"," \
+                "\"integer\": 1," \
+                "\"boolean\": true," \
+                "\"integerEnum\": 1," \
+                "\"integerArray\": [1, 2, 3]," \
+                "\"stringArray\": [\"a\", \"b\", \"c\"]," \
+                "\"integerMap\": { \"key1\": 1, \"key2\": 2 }," \
+                "\"stringMap\": { \"key1\": \"a\", \"key2\": \"b\" }" \
+            "}" \
+        "]" \
+    "}" \
+"}"
 
 #endif // MODULESMANAGERTESTS_H


### PR DESCRIPTION
## Description

Add the compiler flag `-Wunused-const-variable=2` and fix unused constants in modules manager tests and in modules (firewall, hostname, settings).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.