### PR TITLE
Reliability test fixes

### DIFF
--- a/.github/workflows/deploy-reliability-modules.yml
+++ b/.github/workflows/deploy-reliability-modules.yml
@@ -6,7 +6,7 @@ on:
 env:
   build-type: Release
   container-workspace: /azure-osconfig
-  repeat-for-x-hours: 23
+  repeat-for-x-hours: 4
 
 jobs:
   unit-test:
@@ -58,7 +58,6 @@ jobs:
         id: set-variables
         run: |
           echo '::set-output name=xml::${{ matrix.os }}-${{ matrix.variant.arch }}.xml'
-          echo '::set-output name=end-time::`date -d "+${{ env.repeat-for-x-hours }} hours" +%s`'
 
       - name: Run modulestest
         if: success() || failure()
@@ -68,17 +67,18 @@ jobs:
           working-directory: ${{ env.container-workspace }}/build/modules/test
           cmd: |
             function checkResult(){
-            if [ \$result -ne 0 ]; then
-              echo '::error title=E2E Test Failure::The E2E tests failed at run number \$runNumber'
-              exit \$result
-            fi
+              if [[ \$result -ne 0 ]]; then
+                echo '::error title=Module Test Failure::The modules tests failed at run number \$runNumber'
+                exit \$result
+              fi
             }
             result=0
+            end=$(date -d "+${{ env.repeat-for-x-hours }} hours" +%s)
             mkdir -p /etc/osconfig/
-            echo Using date ${{ steps.set-variables.outputs.end-time }}
-            while [ $(date +%s) -lt ${{ steps.set-variables.outputs.end-time }} ]; do
+            echo Using date \$end
+            while [[ \$(date +%s) -lt \$end ]]; do
               echo Performing test run \$((++runNumber))
-              result=\`./modulestest --gtest_output=xml:${{ env.container-workspace }}/build/gtest-output/TestRecipes-\$runNumber.xml testplate.json\`
+              result=\$(./modulestest --gtest_output=xml:${{ env.container-workspace }}/build/gtest-output/TestRecipes-\$runNumber.xml testplate.json)
               checkResult
             done
 

--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -45,7 +45,7 @@ jobs:
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
       cpuThreshold: 50
       memThreshold: 50
-      repeatForXHours: 23
+      repeatForXHours: 4
       testNameSuffix: (reliability-platform)
     secrets: inherit
 

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -123,15 +123,15 @@ jobs:
         working-directory: ./src/tests/e2etest
         run: |
           function checkResult(){
-            if [ $result -ne 0 ]; then
+            if [[ $result -ne 0 ]]; then
               echo '::error title=E2E Test Failure::The E2E tests failed at run number $runNumber'
               exit $result
             fi
           }
           result=0
-          if [ ${{ inputs.repeatForXHours }} -gt 0 ];then
+          if [[ ${{ inputs.repeatForXHours }} -gt 0 ]];then
             end=`date -d "+${{inputs.repeatForXHours}} hours" +%s`
-            while [ $(date +%s) -lt $end ]; do
+            while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
               result=`sudo E2E_OSCONFIG_IOTHUB_CONNSTR="${{ steps.hub-identity.outputs.iothubowner_connection_string }}" E2E_OSCONFIG_DEVICE_ID="${{ steps.get-test-data.outputs.device_id }}" E2E_OSCONFIG_DISTRIBUTION_NAME="${{ matrix.distroName }}" E2E_OSCONFIG_TWIN_TIMEOUT=${{ secrets.TWIN_TIMEOUT }} dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}-$runNumber.trx;verbosity=detailed" --logger "console;verbosity=detailed"`
               checkResult
@@ -211,11 +211,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.distroName }}
-          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}.trx
+          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}-*.trx
 
       - uses: dorny/test-reporter@v1.5.0
         if: always()
         with:
           name: E2E Test Report ${{ matrix.distroName }} ${{ inputs.testNameSuffix }}
-          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}.trx
+          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}-*.trx
           reporter: dotnet-trx


### PR DESCRIPTION
## Description

* Decrease runtime of reliability tests to 4-hours until a fix for the workflow jobs not respecting `timeout-minutes` is found. 23hrs -> 4hrs
* Fixes bash loop arguments
* Fixes test log collection to capture all test iterations

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.