### PR TITLE
Added Modulestest readme and fixes

### DIFF
--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -26,13 +26,6 @@ if(JQ_EXEC)
         COMMENT "Generating module recipe configuration"
     )
     add_dependencies(modulestest modulerecipeconfiguration)
-else()
-    set(jq_error "'jq' application required for generating module recipe configuration")
-    message(WARNING ${jq_error})
-    add_custom_target(modulerecipeconfiguration
-        COMMAND true
-        COMMENT ${jq_error}
-    )
 endif()
 
 if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)

--- a/src/modules/test/README.md
+++ b/src/modules/test/README.md
@@ -1,5 +1,5 @@
-# Modulestest
-The modulestest application is OSConfig’s module testing framework, it allows module authors to write test recipes which in turn, test the modules functionality and conformity (against the published MIM) of the Management Module.
+# modulestest
+The modulestest application is OSConfig’s module testing framework, it allows module authors to write test recipes which in turn, drive testing of the module functionality and conformity (against the published MIM) of the Management Module.
 
 # Prerequisites
 Although modulestest does not require any runtime dependencies, generating the test recipe configuration (testplate.json) does require the `jq` application to be installed when building OSConfig. When installed a `testplate.json` is placed in the `modulestest` directory which includes the test recipe configurations for every module which includes a [MIM](https://github.com/Azure/azure-osconfig/tree/main/src/modules/mim) and [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes).

--- a/src/modules/test/README.md
+++ b/src/modules/test/README.md
@@ -1,0 +1,11 @@
+# Modulestest
+The modulestest application is OSConfig’s module testing framework, it allows module authors to write test recipes which in turn, test the modules functionality and conformity (against the published MIM) of the Management Module.
+
+# Prerequisites
+Although modulestest does not require any runtime dependencies, generating the test recipe configuration (testplate.json) does require the `jq` application to be installed when building OSConfig. When installed a `testplate.json` is placed in the `modulestest` directory which includes the test recipe configurations for every module which includes a [MIM](https://github.com/Azure/azure-osconfig/tree/main/src/modules/mim) and [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes).
+
+# Usage
+1. `modulestest` or `modulestest testplate.json` (equivalent) tests all modules which have [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes) and [MIM](https://github.com/Azure/azure-osconfig/tree/main/src/modules/mim) defined.
+2. `moduletest <module name>` Example: `modulestest tpm` will perform the [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes) defined for the _tpm_ module.
+3. `moduletest <module.so>` Example: `modulestest /azure-osconfig/build/modules/tpm/src/so/tpm.so` performs a basic test on the module ONLY, this ensures the MMI interface is properly defined. No payloads are sent to modules, we simply load the module, ensure _MMIGetInfo_ contains the correct module definitions.
+4. `moduletest <module.so> <mim.json> <recipe.json>` Example: `modulestest "/azure-osconfig/build/modules/tpm/src/so/tpm.so" "/azure-osconfig/src/modules/mim/tpm.json" "/azure-osconfig/src/modules/test/recipes/TpmTests.json"` Equivalent to #2

--- a/src/modules/test/README.md
+++ b/src/modules/test/README.md
@@ -1,8 +1,8 @@
 # modulestest
-The modulestest application is OSConfig’s module testing framework, it allows module authors to write test recipes which in turn, drive testing of the module functionality and conformity (against the published MIM) of the Management Module.
+The `modulestest` application is OSConfig’s module testing framework, it allows module authors to write test recipes which in turn, drive testing of the module functionality and conformity (against the published MIM) of the Management Module.
 
 # Prerequisites
-Although modulestest does not require any runtime dependencies, generating the test recipe configuration (testplate.json) does require the `jq` application to be installed when building OSConfig. When installed a `testplate.json` is placed in the `modulestest` directory which includes the test recipe configurations for every module which includes a [MIM](https://github.com/Azure/azure-osconfig/tree/main/src/modules/mim) and [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes).
+Although `modulestest` does not require any runtime dependencies, generating the test recipe configuration (testplate.json) does require the `jq` application to be installed when building OSConfig. When installed a `testplate.json` is placed in the `modulestest` directory which includes the test recipe configurations for every module which includes a [MIM](https://github.com/Azure/azure-osconfig/tree/main/src/modules/mim) and [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes).
 
 # Usage
 1. `modulestest` or `modulestest testplate.json` (equivalent) tests all modules which have [test recipe](https://github.com/Azure/azure-osconfig/tree/main/src/modules/test/recipes) and [MIM](https://github.com/Azure/azure-osconfig/tree/main/src/modules/mim) defined.

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -21,7 +21,7 @@ void RegisterRecipesWithGTest(TestRecipes &testRecipes)
         std::string testName(recipe.m_componentName + "." + recipe.m_objectName);
         testing::RegisterTest(
             "ModulesTest", testName.c_str(), nullptr, nullptr, __FILE__, __LINE__,
-            [recipe]() -> RecipeFixture *
+            [recipe]()->RecipeFixture *
             {
                 return new RecipeInvoker(recipe);
             });

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -33,7 +33,7 @@ TestRecipes LoadValuesFromConfiguration(std::stringstream& ss, std::string modul
     TestRecipes testRecipes = std::make_shared<std::vector<TestRecipe>>();
     JSON_Value *root_value;
     
-    char buf[PATH_MAX];
+    char buf[PATH_MAX] = {0};
     char *res = realpath("/proc/self/exe", buf);
     if (res == nullptr)
     {
@@ -44,7 +44,7 @@ TestRecipes LoadValuesFromConfiguration(std::stringstream& ss, std::string modul
     fullPath = fullPath.substr(0, fullPath.find_last_of("/") + 1) + g_defaultPath;
     if (!std::filesystem::exists(fullPath.c_str()))
     {
-        TestLogError("Could not find test configuration: %s\n May be missing 'jq' application, install application and perform CMake rebuild (configure+build).", fullPath.c_str());
+        TestLogError("Could not find test configuration: %s\n 'jq' may be missing, install application and rebuild.", fullPath.c_str());
         return testRecipes;
     }
 
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        std::cerr << "No tests found!" << std::endl;
+        std::cerr << "No tests found." << std::endl;
         status = 1;
     }
 

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -44,7 +44,7 @@ TestRecipes LoadValuesFromConfiguration(std::stringstream& ss, std::string modul
     fullPath = fullPath.substr(0, fullPath.find_last_of("/") + 1) + g_defaultPath;
     if (!std::filesystem::exists(fullPath.c_str()))
     {
-        TestLogError("Could not find test configuration: %s", fullPath.c_str());
+        TestLogError("Could not find test configuration: %s\n May be missing 'jq' application, install application and perform CMake rebuild (configure+build).", fullPath.c_str());
         return testRecipes;
     }
 


### PR DESCRIPTION
## Description

* Made `testplate-json` load from the root application path
* Added basic README.md for modulestest with usage examples and prerequisites
* Removed CMake warning for `jq` (needed to generate testplate.json)
* Added warning in `modulestest` when `testplate.json` is missing.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.