### PR TITLE
Fix e2e test report path

### DIFF
--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -211,11 +211,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.distroName }}
-          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}-*.trx
+          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}*.trx
 
       - uses: dorny/test-reporter@v1.5.0
         if: always()
         with:
           name: E2E Test Report ${{ matrix.distroName }} ${{ inputs.testNameSuffix }}
-          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}-*.trx
+          path: ./src/tests/e2etest/TestResults/test-results-${{ matrix.distroName }}*.trx
           reporter: dotnet-trx


### PR DESCRIPTION
## Description

* Fixes the test report path when collecting test results, only multiple iteration passes were getting picked up (which contain a suffix `-$runNumber`) and not the single passes (no suffix)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.