### PR TITLE
fixed spec to create ais folder if not present

### DIFF
--- a/src/cmake/templates/osconfig.spec.in
+++ b/src/cmake/templates/osconfig.spec.in
@@ -65,6 +65,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %post
 if [ ! -e /etc/aziot/identityd/config.d/osconfig.toml ]; then
+    mkdir -p /etc/aziot/identityd/config.d
     cp /etc/osconfig/osconfig.toml /etc/aziot/identityd/config.d/
 fi
 %systemd_post osconfig-platform.service


### PR DESCRIPTION
## Description

* Fixes RPM spec to also create AIS config.d folder if AIS is not installed

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.