### PR TITLE
no fail-fast on module-reliability workflows

### DIFF
--- a/.github/workflows/deploy-reliability-modules.yml
+++ b/.github/workflows/deploy-reliability-modules.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1440
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu18.04, ubuntu20.04, debian9]
         variant: [{arch: arm, platform: linux/arm/v7}, {arch: arm64, platform: linux/arm64/v8}, {arch: amd64, platform: linux/amd64}]


### PR DESCRIPTION
## Description

* Current workflows fail if any of the jobs fail - see https://github.com/Azure/azure-osconfig/actions/runs/2731475995

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.