### PR TITLE
Fix e2e test app vulnerabilities

### DIFF
--- a/src/tests/e2etest/E2ETest.csproj
+++ b/src/tests/e2etest/E2ETest.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
-    <!-- Transitive dependencies (for CVE fixes) -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> <!-- https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.1.2" /> <!-- https://github.com/advisories/GHSA-7mfr-774f-w5r9 -->
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" /> <!-- https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->

--- a/src/tests/e2etest/E2ETest.csproj
+++ b/src/tests/e2etest/E2ETest.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <!-- Transitive dependencies (for CVE fixes) -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" /> <!-- https://github.com/advisories/GHSA-5crp-9r3c-p9vr -->
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.1.2" /> <!-- https://github.com/advisories/GHSA-7mfr-774f-w5r9 -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" /> <!-- https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

* Fix current vulnerabilities for e2e test app
```
➜ dotnet list package --include-transitive --vulnerable

The following sources were used:
   https://api.nuget.org/v3/index.json

Project `E2ETest` has the following vulnerable packages
   [net6.0]: 
   Transitive Package                                   Resolved   Severity   Advisory URL                                     
   > Newtonsoft.Json                                    12.0.3     High       https://github.com/advisories/GHSA-5crp-9r3c-p9vr
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9
   > System.Text.RegularExpressions                     4.3.0      Moderate   https://github.com/advisories/GHSA-cmhx-cq75-c4mj
```
  * [Improper Handling of Exceptional Conditions in Newtonsoft.Json](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)
  * [Improper Certificate Validation](https://github.com/advisories/GHSA-7mfr-774f-w5r9)
  * [Regular Expression Denial of Service (ReDoS)](https://github.com/advisories/GHSA-cmhx-cq75-c4mj)
  
# How Verified:
After fix:
```
➜ dotnet list package --include-transitive --vulnerable

The following sources were used:
   https://api.nuget.org/v3/index.json

The given project `E2ETest` has no vulnerable packages given the current sources
```
## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.