### PR TITLE
ModulesTest Test Recipe enhancements

### DIFF
--- a/devops/scripts/generate_moduletest_metadata.sh
+++ b/devops/scripts/generate_moduletest_metadata.sh
@@ -21,7 +21,7 @@ testMetaDataDestPath=$1
 modulesBaseDir=$2
 
 modules=$(find $modulesBaseDir -name '*.so')
-testJSON="[]"
+json="{ \"Modules\" : [], \"Recipes\" : [] }"
 while IFS= read -r line ;
   do 
   modulename=$(basename $line | cut -f1 -d'.');
@@ -31,10 +31,12 @@ while IFS= read -r line ;
   if [ ! -z "$recipepath" ] && [ ! -z "$mimpath" ]; then
     # Create entry if both mim+recipe are found
     echo "Found '$modulename' module adding to recipe configuration"
-    json="[{ \"ModuleName\": \"$modulename\", \"ModulePath\": \"$line\", \"MimPath\": \"$mimpath\", \"TestRecipesPath\": \"$recipepath\" }]"
-    testJSON=$(echo $testJSON | jq --argjson testMetadata "$json" '. |= . + $testMetadata')
+    modulePath="[\"$line\"]"
+    recipes="[{ \"ModuleName\": \"$modulename\", \"ModulePath\": \"$line\", \"MimPath\": \"$mimpath\", \"TestRecipesPath\": \"$recipepath\" }]"
+    json=$(echo $json | jq --argjson modulePath "$modulePath" '.Modules |= . + $modulePath')
+    json=$(echo $json | jq --argjson recipes "$recipes" '.Recipes |= . + $recipes')
   fi
 done <<< $modules
 
-echo $testJSON | jq '.' > $testMetaDataDestPath
+echo $json | jq '.' > $testMetaDataDestPath
 echo "Test recipe configuration written to $testMetaDataDestPath"

--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 project(modulestest)
 
 set(CMAKE_CXX_STANDARD 17)
-add_library(testfactorylib MimParser.cpp TestRecipeParser.cpp ManagementModule.cpp RecipeInvoker.cpp)
+add_library(testfactorylib MimParser.cpp TestRecipeParser.cpp ManagementModule.cpp RecipeModuleSessionLoader.cpp RecipeInvoker.cpp)
 
 target_link_libraries(testfactorylib
     ${CMAKE_DL_LIBS}

--- a/src/modules/test/Common.h
+++ b/src/modules/test/Common.h
@@ -18,6 +18,7 @@
 #include <rapidjson/document.h>
 #include <rapidjson/schema.h>
 #include <sstream>
+#include <stack>
 #include <string.h>
 #include <string>
 #include <thread>

--- a/src/modules/test/Common.h
+++ b/src/modules/test/Common.h
@@ -43,6 +43,7 @@
 #endif
 
 #include "ManagementModule.h"
+#include "RecipeModuleSessionLoader.h"
 #include "TestRecipeParser.h"
 #include "RecipeInvoker.h"
 #include "MimParser.h"

--- a/src/modules/test/Common.h
+++ b/src/modules/test/Common.h
@@ -18,7 +18,6 @@
 #include <rapidjson/document.h>
 #include <rapidjson/schema.h>
 #include <sstream>
-#include <stack>
 #include <string.h>
 #include <string>
 #include <thread>

--- a/src/modules/test/ManagementModule.cpp
+++ b/src/modules/test/ManagementModule.cpp
@@ -30,7 +30,8 @@ ManagementModule::ManagementModule() : ManagementModule("") {}
 
 ManagementModule::ManagementModule(const std::string path) :
     m_modulePath(path),
-    m_handle(nullptr)
+    m_handle(nullptr),
+    m_loaded(false)
 {
     m_info.lifetime = Lifetime::Undefined;
     m_info.userAccount= 0;
@@ -114,6 +115,7 @@ int ManagementModule::Load()
         ss << "]";
 
         TestLogInfo("Loaded '%s' module (v%s) from '%s', supported components: %s", m_info.name.c_str(), m_info.version.ToString().c_str(), m_modulePath.c_str(), ss.str().c_str());
+        m_loaded = true;
     }
     else
     {
@@ -135,6 +137,11 @@ void ManagementModule::Unload()
         dlclose(m_handle);
         m_handle = nullptr;
     }
+}
+
+bool ManagementModule::IsLoaded() const
+{
+    return m_loaded;
 }
 
 ManagementModule::Info ManagementModule::GetInfo() const

--- a/src/modules/test/ManagementModule.cpp
+++ b/src/modules/test/ManagementModule.cpp
@@ -30,8 +30,7 @@ ManagementModule::ManagementModule() : ManagementModule("") {}
 
 ManagementModule::ManagementModule(const std::string path) :
     m_modulePath(path),
-    m_handle(nullptr),
-    m_loaded(false)
+    m_handle(nullptr)
 {
     m_info.lifetime = Lifetime::Undefined;
     m_info.userAccount= 0;
@@ -115,7 +114,6 @@ int ManagementModule::Load()
         ss << "]";
 
         TestLogInfo("Loaded '%s' module (v%s) from '%s', supported components: %s", m_info.name.c_str(), m_info.version.ToString().c_str(), m_modulePath.c_str(), ss.str().c_str());
-        m_loaded = true;
     }
     else
     {
@@ -141,7 +139,7 @@ void ManagementModule::Unload()
 
 bool ManagementModule::IsLoaded() const
 {
-    return m_loaded;
+    return (nullptr != m_handle);
 }
 
 ManagementModule::Info ManagementModule::GetInfo() const
@@ -507,6 +505,11 @@ int MmiSession::Set(const char* componentName, const char* objectName, const MMI
 int MmiSession::Get(const char* componentName, const char* objectName, MMI_JSON_STRING *payload, int *payloadSizeBytes)
 {
     return (nullptr != m_module) ? m_module->CallMmiGet(m_mmiHandle, componentName, objectName, payload, payloadSizeBytes) : EINVAL;
+}
+
+bool MmiSession::IsOpen() const
+{
+    return (nullptr != m_mmiHandle);
 }
 
 ManagementModule::Info MmiSession::GetInfo()

--- a/src/modules/test/ManagementModule.h
+++ b/src/modules/test/ManagementModule.h
@@ -91,7 +91,6 @@ protected:
     Mmi_Free m_mmiFree;
 
     Info m_info;
-    bool m_loaded;
 
     virtual int CallMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloadSizeBytes);
     virtual MMI_HANDLE CallMmiOpen(const char* componentName, unsigned int maxPayloadSizeBytes);
@@ -114,6 +113,7 @@ public:
     int Set(const char* componentName, const char* objectName, const MMI_JSON_STRING payload, const int payloadSizeBytes);
     int Get(const char* componentName, const char* objectName, MMI_JSON_STRING *payload, int *payloadSizeBytes);
 
+    bool IsOpen() const;
     ManagementModule::Info GetInfo();
 private:
     const std::string m_clientName;

--- a/src/modules/test/ManagementModule.h
+++ b/src/modules/test/ManagementModule.h
@@ -72,6 +72,8 @@ public:
     virtual int Load();
     virtual void Unload();
 
+    virtual bool IsLoaded() const;
+
     Info GetInfo() const;
 
 protected:
@@ -89,6 +91,7 @@ protected:
     Mmi_Free m_mmiFree;
 
     Info m_info;
+    bool m_loaded;
 
     virtual int CallMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloadSizeBytes);
     virtual MMI_HANDLE CallMmiOpen(const char* componentName, unsigned int maxPayloadSizeBytes);

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -9,7 +9,6 @@ void RecipeInvoker::TestBody()
     {
         m_module->Load();
         m_session->Open();
-        // TODO: Add to a loaded stack so we can unwind it later.
     }
 
     if (m_recipe.m_desired)

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -5,6 +5,13 @@ void RecipeInvoker::TestBody()
     MMI_JSON_STRING payload = nullptr;
     int payloadSize = 0;
 
+    if (!m_module->IsLoaded())
+    {
+        m_module->Load();
+        m_session->Open();
+        // TODO: Add to a loaded stack so we can unwind it later.
+    }
+
     if (m_recipe.m_desired)
     {
         // If no payloadSizeBytes defined, use the size of the payload

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -93,26 +93,6 @@ void RecipeInvoker::TestBody()
     }
 }
 
-int RecipeInvoker::RunCommand(const std::string &command, std::string* textResult)
-{
-    char* buffer = nullptr;
-    const bool replaceEol = true;
-    const bool forJson = false;
-    int status = ExecuteCommand(nullptr, command.c_str(), replaceEol, forJson, 0, 0, &buffer, nullptr, nullptr);
-
-    if (0 == status)
-    {
-        if (buffer && textResult)
-        {
-            *textResult = buffer;
-        }
-    }
-
-    FREE_MEMORY(buffer);
-
-    return status;
-}
-
 void BasicModuleTester::TestBody()
 {
     EXPECT_EQ(0, m_module->Load()) << "Failed to load module!";

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -2,12 +2,6 @@
 
 void RecipeInvoker::TestBody()
 {
-    ASSERT_STRNE(m_recipe.m_metadata.m_modulePath.c_str(), "") << "No module path defined!";
-    auto module = std::make_shared<ManagementModule>(m_recipe.m_metadata.m_modulePath);
-    MmiSession session(module, g_defaultClient);
-    ASSERT_EQ(0, module->Load()) << "Failed to load module!";
-    ASSERT_EQ(0, session.Open()) << "Failed to open session!";
-
     MMI_JSON_STRING payload = nullptr;
     int payloadSize = 0;
 
@@ -15,11 +9,11 @@ void RecipeInvoker::TestBody()
     {
         // If no payloadSizeBytes defined, use the size of the payload
         m_recipe.m_payloadSizeBytes = (0 == m_recipe.m_payloadSizeBytes) ? std::strlen(m_recipe.m_payload.c_str()) : m_recipe.m_payloadSizeBytes;
-        EXPECT_EQ(m_recipe.m_expectedResult, session.Set(m_recipe.m_componentName.c_str(), m_recipe.m_objectName.c_str(), (MMI_JSON_STRING)m_recipe.m_payload.c_str(), m_recipe.m_payloadSizeBytes)) << "Failed JSON payload: " << m_recipe.m_payload;
+        EXPECT_EQ(m_recipe.m_expectedResult, m_session->Set(m_recipe.m_componentName.c_str(), m_recipe.m_objectName.c_str(), (MMI_JSON_STRING)m_recipe.m_payload.c_str(), m_recipe.m_payloadSizeBytes)) << "Failed JSON payload: " << m_recipe.m_payload;
     }
     else
     {
-        ASSERT_EQ(m_recipe.m_expectedResult, session.Get(m_recipe.m_componentName.c_str(), m_recipe.m_objectName.c_str(), &payload, &payloadSize));
+        ASSERT_EQ(m_recipe.m_expectedResult, m_session->Get(m_recipe.m_componentName.c_str(), m_recipe.m_objectName.c_str(), &payload, &payloadSize));
 
         if (0 == m_recipe.m_expectedResult)
         {
@@ -95,8 +89,6 @@ void RecipeInvoker::TestBody()
         std::cout << "Waiting for " << m_recipe.m_waitSeconds << " seconds" << std::endl;
         std::this_thread::sleep_for(std::chrono::seconds(m_recipe.m_waitSeconds));
     }
-
-    session.Close();
 }
 
 void BasicModuleTester::TestBody()

--- a/src/modules/test/RecipeInvoker.h
+++ b/src/modules/test/RecipeInvoker.h
@@ -16,13 +16,13 @@ class RecipeFixture : public ::testing::Test {};
 class RecipeInvoker : public RecipeFixture
 {
 public:
-    explicit RecipeInvoker(const TestRecipe &recipe, const std::shared_ptr<ManagementModule> module, const std::shared_ptr<MmiSession> session) : m_recipe(recipe), m_module(module), m_session(session) {}
+    explicit RecipeInvoker(const TestRecipe &recipe) : m_recipe(recipe) {}
     void TestBody() override;
 
 private:
     TestRecipe m_recipe;
-    std::shared_ptr<ManagementModule> m_module;
-    std::shared_ptr<MmiSession> m_session;
+
+    int RunCommand(const std::string &command, std::string *textResult);
 };
 
 class BasicModuleTester : public RecipeFixture

--- a/src/modules/test/RecipeInvoker.h
+++ b/src/modules/test/RecipeInvoker.h
@@ -21,8 +21,6 @@ public:
 
 private:
     TestRecipe m_recipe;
-
-    int RunCommand(const std::string &command, std::string *textResult);
 };
 
 class BasicModuleTester : public RecipeFixture

--- a/src/modules/test/RecipeInvoker.h
+++ b/src/modules/test/RecipeInvoker.h
@@ -16,11 +16,13 @@ class RecipeFixture : public ::testing::Test {};
 class RecipeInvoker : public RecipeFixture
 {
 public:
-    explicit RecipeInvoker(const TestRecipe &recipe) : m_recipe(recipe) {}
+    explicit RecipeInvoker(const TestRecipe &recipe, const std::shared_ptr<ManagementModule> module, const std::shared_ptr<MmiSession> session) : m_recipe(recipe), m_module(module), m_session(session) {}
     void TestBody() override;
 
 private:
     TestRecipe m_recipe;
+    std::shared_ptr<ManagementModule> m_module;
+    std::shared_ptr<MmiSession> m_session;
 };
 
 class BasicModuleTester : public RecipeFixture

--- a/src/modules/test/RecipeModuleSessionLoader.cpp
+++ b/src/modules/test/RecipeModuleSessionLoader.cpp
@@ -30,7 +30,6 @@ bool RecipeModuleSessionLoader::Load(const std::vector<std::string> &modulePaths
         mm->Unload();
     }
 
-    // isLoaded = true;
     return true;
 }
 

--- a/src/modules/test/RecipeModuleSessionLoader.cpp
+++ b/src/modules/test/RecipeModuleSessionLoader.cpp
@@ -1,0 +1,71 @@
+#include "Common.h"
+
+bool RecipeModuleSessionLoader::Load(const std::vector<std::string> &modulePaths)
+{
+    for (const auto &modulePath : modulePaths)
+    {
+        std::shared_ptr<ManagementModule> mm = std::make_shared<ManagementModule>(modulePath);
+        if (0 == mm->Load())
+        {
+            ManagementModule::Info info = mm->GetInfo();
+
+            for (const auto &component : info.components)
+            {
+                auto search = g_componentModuleSessionMap.find(component);
+                if (search == g_componentModuleSessionMap.end())
+                {
+                    auto session = std::make_shared<MmiSession>(mm, g_defaultClient);
+                    if (modulePath == _mainModulePath)
+                    {
+                        _mainSession = session;
+                    }
+                    g_componentModuleSessionMap[component] = std::make_pair(mm, session);
+                }
+            }
+        }
+        else
+        {
+            TestLogError("Failed to load module '%s'", modulePath.c_str());
+        }
+        mm->Unload();
+    }
+
+    // isLoaded = true;
+    return true;
+}
+
+void RecipeModuleSessionLoader::Unload()
+{
+    for (auto &moduleSession : g_componentModuleSessionMap)
+    {
+        if (moduleSession.second.second->IsOpen())
+        {
+            TestLogInfo("[RecipeModuleSessionLoader] Closing session for '%s'", moduleSession.second.second->GetInfo().name.c_str());
+            moduleSession.second.second->Close();
+        }
+    }
+}
+
+RecipeModuleSessionLoader::~RecipeModuleSessionLoader()
+{
+    Unload();
+}
+
+std::shared_ptr<MmiSession> RecipeModuleSessionLoader::GetSession(const std::string &componentName)
+{
+    auto search = g_componentModuleSessionMap.find(componentName);
+    if (search != g_componentModuleSessionMap.end())
+    {
+        // Open session if not open yet
+        if (!search->second.second->IsOpen())
+        {
+            TestLogInfo("[RecipeModuleSessionLoader] Opening session for '%s'", search->second.first->GetInfo().name.c_str());
+            search->second.second->Open();
+        }
+
+        return search->second.second;
+    }
+    
+    // Return main recipe module session if the component name is not found
+    return _mainSession;
+}

--- a/src/modules/test/RecipeModuleSessionLoader.h
+++ b/src/modules/test/RecipeModuleSessionLoader.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef RECIPEMODULESESSIONLOADER_H
+#define RECIPEMODULESESSIONLOADER_H
+
+typedef std::pair<std::shared_ptr<ManagementModule>, std::shared_ptr<MmiSession>> ModuleSession;
+
+class RecipeModuleSessionLoader
+{
+public:
+    RecipeModuleSessionLoader(const std::string &mainModulePath) : _mainModulePath(mainModulePath) {};
+    ~RecipeModuleSessionLoader();
+    bool Load(const std::vector<std::string> &modulePaths);
+    void Unload();
+    std::shared_ptr<MmiSession> GetSession(const std::string &componentName);
+
+private:
+    std::map<std::string, ModuleSession> g_componentModuleSessionMap;
+    const std::string _mainModulePath;
+    std::shared_ptr<MmiSession> _mainSession;
+};
+
+#endif // RECIPEMODULESESSIONLOADER_H

--- a/src/modules/test/TestRecipeParser.h
+++ b/src/modules/test/TestRecipeParser.h
@@ -14,6 +14,7 @@ struct TestRecipeMetadata
     std::string m_modulePath;
     std::string m_mimPath;
     std::string m_testRecipesPath;
+    std::shared_ptr<RecipeModuleSessionLoader> m_recipeModuleSessionLoader;
 };
 struct TestRecipe
 {

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -38,10 +38,6 @@ void RegisterRecipesWithGTest(TestRecipes &testRecipes)
             auto moduleSessionPair = std::make_pair(module, session);
             g_moduleSessionMap[recipe.m_metadata.m_modulePath] = moduleSessionPair;
             g_moduleSessionStack.push(moduleSessionPair);
-
-            // Load and open session only before first test
-            // ASSERT_EQ(0, module->Load()) << "Failed to load module!";
-            // ASSERT_EQ(0, session->Open()) << "Failed to open session!";
         }
 
         // See gtest.h for details on this test registration

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -15,7 +15,7 @@ static std::string str_tolower(std::string s) {
 void RegisterRecipesWithGTest(TestRecipes &testRecipes)
 {
     for (TestRecipe recipe : *testRecipes)
-    {   
+    {
         // See gtest.h for details on this test registration
         // https://github.com/google/googletest/blob/v1.10.x/googletest/include/gtest/gtest.h#L2438
         std::string testName(recipe.m_componentName + "." + recipe.m_objectName);

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -26,19 +26,18 @@ void RegisterRecipesWithGTest(TestRecipes &testRecipes)
         if (search != g_moduleSessionMap.end())
         {
             // Module already registered, use existing session
-            TestLogInfo("existing session for: %s", recipe.m_metadata.m_modulePath.c_str());
             module = search->second.first;
             session = search->second.second;
         }
         else
         {
-            TestLogInfo("Registering module: %s", recipe.m_metadata.m_modulePath.c_str());
             module = std::make_shared<ManagementModule>(recipe.m_metadata.m_modulePath);
             session = std::make_shared<MmiSession>(module, g_defaultClient);
             g_moduleSessionMap[recipe.m_metadata.m_modulePath] = std::make_pair(module, session);
 
-            ASSERT_EQ(0, module->Load()) << "Failed to load module!";
-            ASSERT_EQ(0, session->Open()) << "Failed to open session!";
+            // Load and open session only before first test
+            // ASSERT_EQ(0, module->Load()) << "Failed to load module!";
+            // ASSERT_EQ(0, session->Open()) << "Failed to open session!";
         }
 
         // See gtest.h for details on this test registration

--- a/src/modules/test/recipes/CommandRunnerTests.json
+++ b/src/modules/test/recipes/CommandRunnerTests.json
@@ -28,5 +28,13 @@
         "Desired": false,
         "Payload": "{\"commandId\":\"test1\",\"resultCode\":0,\"textResult\":\"Hello World \",\"currentState\":2}",
         "ExpectedResult": 0
+    },
+    {
+        "ComponentName": "CommandRunner",
+        "ObjectName": "commandArguments",
+        "Desired": true,
+        "Payload": "{\"commandId\": \"removeCache\", \"arguments\": \"rm /etc/osconfig/osconfig_commandrunner.cache\", \"timeout\": 0, \"singleLineTextResult\": true, \"action\": 3}",
+        "ExpectedResult": 0,
+        "WaitSeconds": 1
     }
 ]

--- a/src/modules/test/recipes/CommandRunnerTests.json
+++ b/src/modules/test/recipes/CommandRunnerTests.json
@@ -11,7 +11,6 @@
         "ObjectName": "commandArguments",
         "Desired": true,
         "Payload": "{\"commandId\": \"helloworld\", \"arguments\": \"echo Hello World!\", \"timeout\": 0, \"singleLineTextResult\": true, \"action\": 100, }",
-        "PayloadSizeBytes": 0,
         "ExpectedResult": 22,
         "WaitSeconds": 0
     },
@@ -20,7 +19,6 @@
         "ObjectName": "commandArguments",
         "Desired": true,
         "Payload": "{\"commandId\": \"test1\", \"arguments\": \"echo Hello World\", \"timeout\": 0, \"singleLineTextResult\": true, \"action\": 3}",
-        "PayloadSizeBytes": 123,
         "ExpectedResult": 0,
         "WaitSeconds": 5
     },
@@ -28,7 +26,7 @@
         "ComponentName": "CommandRunner",
         "ObjectName": "commandStatus",
         "Desired": false,
-        "Payload": "{\"commandId\":\"test1\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+        "Payload": "{\"commandId\":\"test1\",\"resultCode\":0,\"textResult\":\"Hello World \",\"currentState\":2}",
         "ExpectedResult": 0
     }
 ]


### PR DESCRIPTION
## Description
 * Created separate module sessions for every test recipe
 * Sessions are reused from the same test recipe
 * Added ability to call `ComponentName`'s from other known modules from a test recipe

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.