### PR TITLE
Limit validation to module recipe only

### DIFF
--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -24,46 +24,51 @@ void RecipeInvoker::TestBody()
             JSON_Object *jsonObject = json_value_get_object(root_value);
 
             EXPECT_NE(0, m_recipe.m_mimObjects->size()) << "Invalid MIM JSON!";
-            EXPECT_NE(0, m_recipe.m_mimObjects->at(m_recipe.m_componentName)->size()) << "No MimObjects for " << m_recipe.m_componentName << "!";
-            auto map = m_recipe.m_mimObjects->at(m_recipe.m_componentName)->at(m_recipe.m_objectName);
 
-            std::string payloadStr(payload, payloadSize);
+            // Only validate MimObjects from the calling module recipe
+            if (m_recipe.m_mimObjects->end() != m_recipe.m_mimObjects->find(m_recipe.m_objectName))
+            {
+                EXPECT_NE(0, m_recipe.m_mimObjects->at(m_recipe.m_componentName)->size()) << "No MimObjects for " << m_recipe.m_componentName << "!";
+                auto map = m_recipe.m_mimObjects->at(m_recipe.m_componentName)->at(m_recipe.m_objectName);
 
-            // Validate settings + supported values
-            TestLogInfo("Validating settings and supported values for '%s'", m_recipe.m_objectName.c_str());
-            if ((map.m_type.compare("array") == 0) ||
-                (map.m_type.compare("map") == 0))
-            {
-                EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl << "JSON: " << payloadStr;
-            }
-            else
-            {
-                for (auto setting : *map.m_settings)
+                std::string payloadStr(payload, payloadSize);
+
+                // Validate settings + supported values
+                TestLogInfo("Validating settings and supported values for '%s'", m_recipe.m_objectName.c_str());
+                if ((map.m_type.compare("array") == 0) ||
+                    (map.m_type.compare("map") == 0))
                 {
-                    if (setting.second.type.compare("string") == 0)
+                    EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl << "JSON: " << payloadStr;
+                }
+                else
+                {
+                    for (auto setting : *map.m_settings)
                     {
-                        EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
-
-                        std::string value = json_object_get_string(jsonObject, setting.second.name.c_str());
-                        if (setting.second.allowedValues->size() && std::find(setting.second.allowedValues->begin(), setting.second.allowedValues->end(), value) == setting.second.allowedValues->end())
+                        if (setting.second.type.compare("string") == 0)
                         {
-                            FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl << "JSON: " << payloadStr;
+                            EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
+
+                            std::string value = json_object_get_string(jsonObject, setting.second.name.c_str());
+                            if (setting.second.allowedValues->size() && std::find(setting.second.allowedValues->begin(), setting.second.allowedValues->end(), value) == setting.second.allowedValues->end())
+                            {
+                                FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl << "JSON: " << payloadStr;
+                            }
+                        }
+                        else if (setting.second.type.compare("integer") == 0)
+                        {
+                            JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
+                            EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
+                        }
+                        else if (setting.second.type.compare("boolean") == 0)
+                        {
+                            JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
+                            EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
                         }
                     }
-                    else if (setting.second.type.compare("integer") == 0)
-                    {
-                        JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
-                        EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
-                    }
-                    else if (setting.second.type.compare("boolean") == 0)
-                    {
-                        JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
-                        EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
-                    }
                 }
-            }
 
-            json_value_free(root_value);
+                json_value_free(root_value);
+            }
 
             // Validate payload size
             if (m_recipe.m_payloadSizeBytes)


### PR DESCRIPTION
## Description

* Only validate the main recipes MimObjects and not other referenced `ComponentName`'s

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.