### PR TITLE
Improved E2E reliability

### DIFF
--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -45,7 +45,7 @@ jobs:
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
       cpuThreshold: 50
       memThreshold: 50
-      repeatForXHours: 4
+      repeatForXHours: 1
       testNameSuffix: (reliability-platform)
     secrets: inherit
 

--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -45,7 +45,7 @@ jobs:
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
       cpuThreshold: 50
       memThreshold: 50
-      repeatForXHours: 1
+      repeatForXHours: 2
       testNameSuffix: (reliability-platform)
     secrets: inherit
 

--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -1,7 +1,7 @@
 name: Platform Reliability Tests
-on:
-  schedule:
-    - cron: '0 10 * * *' #10am UTC / 6pm PST
+on: [push]
+  # schedule:
+  #   - cron: '0 10 * * *' #10am UTC / 6pm PST
 
 jobs:
   fetch-targets:

--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -1,7 +1,7 @@
 name: Platform Reliability Tests
-on: [push]
-  # schedule:
-  #   - cron: '0 10 * * *' #10am UTC / 6pm PST
+on:
+  schedule:
+    - cron: '0 10 * * *' #10am UTC / 6pm PST
 
 jobs:
   fetch-targets:

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -123,22 +123,21 @@ jobs:
         working-directory: ./src/tests/e2etest
         run: |
           function checkResult(){
-            if [[ $result -ne 0 ]]; then
+            if [[ $1 -ne 0 ]]; then
               echo '::error title=E2E Test Failure::The E2E tests failed at run number $runNumber'
-              exit $result
+              exit $1
             fi
           }
-          result=0
           if [[ ${{ inputs.repeatForXHours }} -gt 0 ]];then
             end=`date -d "+${{inputs.repeatForXHours}} hours" +%s`
             while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
-              result=`sudo E2E_OSCONFIG_IOTHUB_CONNSTR="${{ steps.hub-identity.outputs.iothubowner_connection_string }}" E2E_OSCONFIG_DEVICE_ID="${{ steps.get-test-data.outputs.device_id }}" E2E_OSCONFIG_DISTRIBUTION_NAME="${{ matrix.distroName }}" E2E_OSCONFIG_TWIN_TIMEOUT=${{ secrets.TWIN_TIMEOUT }} dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx" --logger "console;verbosity=detailed"`
-              checkResult
+              sudo E2E_OSCONFIG_IOTHUB_CONNSTR="${{ steps.hub-identity.outputs.iothubowner_connection_string }}" E2E_OSCONFIG_DEVICE_ID="${{ steps.get-test-data.outputs.device_id }}" E2E_OSCONFIG_DISTRIBUTION_NAME="${{ matrix.distroName }}" E2E_OSCONFIG_TWIN_TIMEOUT=${{ secrets.TWIN_TIMEOUT }} dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx" --logger "console;verbosity=detailed"
+              checkResult $?
             done
           else
-            result=`sudo E2E_OSCONFIG_IOTHUB_CONNSTR="${{ steps.hub-identity.outputs.iothubowner_connection_string }}" E2E_OSCONFIG_DEVICE_ID="${{ steps.get-test-data.outputs.device_id }}" E2E_OSCONFIG_DISTRIBUTION_NAME="${{ matrix.distroName }}" E2E_OSCONFIG_TWIN_TIMEOUT=${{ secrets.TWIN_TIMEOUT }} dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx" --logger "console;verbosity=detailed"`
-            checkResult
+            sudo E2E_OSCONFIG_IOTHUB_CONNSTR="${{ steps.hub-identity.outputs.iothubowner_connection_string }}" E2E_OSCONFIG_DEVICE_ID="${{ steps.get-test-data.outputs.device_id }}" E2E_OSCONFIG_DISTRIBUTION_NAME="${{ matrix.distroName }}" E2E_OSCONFIG_TWIN_TIMEOUT=${{ secrets.TWIN_TIMEOUT }} dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx" --logger "console;verbosity=detailed"
+            checkResult $?
           fi
 
       - name: Stop performance sampling

--- a/src/tests/e2etest/CommandRunnerTests.cs
+++ b/src/tests/e2etest/CommandRunnerTests.cs
@@ -144,7 +144,7 @@ namespace E2eTesting
         public void CommandRunnerTest_RunCommand(string arguments, int timeout, bool singleLineTextResult, int resultCode, string textResult, CommandState state, DataSourceType dataSourceType)
         {
             var command = CreateCommand(arguments, Action.RunCommand, timeout, singleLineTextResult);
-            SendCommand(command);
+            SendCommand(command, dataSourceType);
 
             CommandStatus status = WaitForStatus(command.CommandId, state);
             JsonAssert.AreEqual(CreateCommandStatus(command.CommandId, textResult, state, resultCode), status);

--- a/src/tests/e2etest/datasource/IotHubDataSource.cs
+++ b/src/tests/e2etest/datasource/IotHubDataSource.cs
@@ -127,7 +127,7 @@ namespace E2eTesting
 
             if (!updatedTwin.Properties.Desired.Contains(componentName))
             {
-                Assert.Warn("[SetDesired] {0} not found in desired properties", componentName);
+                Assert.Warn("[SetDesired-IotHubDataSource] {0} not found in desired properties", componentName);
             }
 
             while (!PropertyExists(reported, componentName) && !IsUpdated(reported, componentName, previousUpdate))
@@ -140,14 +140,14 @@ namespace E2eTesting
                 }
                 else
                 {
-                    Assert.Warn("[SetDesired] Time limit reached while waiting for desired update for {0} (start: {1} | end: {2} | last updated: {3})", componentName, start, DateTime.Now, reported[componentName].GetLastUpdated());
+                    Assert.Warn("[SetDesired-IotHubDataSource] Time limit reached while waiting for desired update for {0} (start: {1} | end: {2} | last updated: {3}) | reported: {4} | desired: {5}", componentName, start, DateTime.Now, reported[componentName].GetLastUpdated(), reported[componentName], updatedTwin.Properties.Desired[componentName]);
                     break;
                 }
             }
 
             if (!reported.Contains(componentName))
             {
-                Assert.Warn("[SetDesired] {0} not found in reported properties", componentName);
+                Assert.Warn("[SetDesired-IotHubDataSource] {0} not found in reported properties", componentName);
             }
         }
 
@@ -166,7 +166,7 @@ namespace E2eTesting
 
             if (!updatedTwin.Properties.Desired.Contains(componentName) && !updatedTwin.Properties.Desired[componentName].Contains(objectName))
             {
-                Assert.Warn("[SetDesired] {0}.{1} not found in desired properties", componentName, objectName);
+                Assert.Warn("[SetDesired-IotHubDataSource] {0}.{1} not found in desired properties. reported: {2}", componentName, objectName, reported);
             }
 
             while (!PropertyExists(reported, componentName, objectName) || !IsUpdated(reported, componentName, objectName, previousUpdate))
@@ -178,14 +178,15 @@ namespace E2eTesting
                 }
                 else
                 {
-                    Assert.Warn("[SetDesired] Time limit reached while waiting for desired update for {0}.{1} (start: {2} | end: {3} | last updated: {4})", componentName, objectName, start, DateTime.Now, reported[componentName][objectName].GetLastUpdated());
+                    updatedTwin = await _registryManager.GetTwinAsync(_deviceId, _moduleId);
+                    Assert.Warn("[SetDesired-IotHubDataSource] Time limit reached while waiting for desired update for {0}.{1} (start: {2} | end: {3} | last updated: {4}) | reported: {5} | desired: {6}", componentName, objectName, start, DateTime.Now, reported[componentName][objectName].GetLastUpdated(), reported[componentName], updatedTwin.Properties.Desired[componentName]);
                     break;
                 }
             }
 
             if (!reported.Contains(componentName) || !reported[componentName].Contains(objectName))
             {
-                Assert.Warn("[SetDesired] {0}.{1} not found in reported properties", componentName, objectName);
+                Assert.Warn("[SetDesired-IotHubDataSource] {0}.{1} not found in reported properties", componentName, objectName);
             }
 
             return Deserialize<GenericResponse<T>>(reported[componentName][objectName]);
@@ -212,7 +213,8 @@ namespace E2eTesting
                 }
                 else
                 {
-                    Assert.Warn("[GetReported] Time limit reached while waiting for reported update for {0}.{1} (start: {2} | end: {3})", componentName, objectName, start, DateTime.Now);
+                    var updatedTwin = await _registryManager.GetTwinAsync(_deviceId, _moduleId);
+                    Assert.Warn("[GetReported-IotHubDataSource] Time limit reached while waiting for reported update for {0}.{1} (start: {2} | end: {3}). reported: {4}. desired {5}", componentName, objectName, start, DateTime.Now, JsonConvert.SerializeObject(reported),JsonConvert.SerializeObject(updatedTwin.Properties.Desired[componentName]));
                     break;
                 }
             }

--- a/src/tests/e2etest/datasource/LocalDataSource.cs
+++ b/src/tests/e2etest/datasource/LocalDataSource.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Serialization;
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Text;
 
 namespace E2eTesting
 {
@@ -14,41 +15,84 @@ namespace E2eTesting
     {
         private readonly string _reportedPath = "/etc/osconfig/osconfig_reported.json";
         private readonly string _desiredPath = "/etc/osconfig/osconfig_desired.json";
+        private const int POLL_INTERVAL_MS = 1000;
+        
         public override void Initialize()
         {
             if (!File.Exists(_reportedPath))
             {
                 Assert.Fail("[LocalDataSource] reported path is missing: ", _reportedPath);
             }
+            if (!File.Exists(_desiredPath))
+            {
+                using (FileStream fs = File.Create(_desiredPath))
+                {
+                    Byte[] info = new UTF8Encoding(true).GetBytes("{}");
+                    fs.Write(info, 0, info.Length);
+                }
+            }
         }
 
         public override bool SetDesired<T>(string componentName, string objectName, T value, int maxWaitSeconds)
         {
             JObject local = JObject.Parse(File.ReadAllText(_desiredPath));
-            if (String.IsNullOrEmpty(objectName))
-            {
-                local[componentName] = JObject.FromObject(value);
-            }
-            else
-            {
-                local[componentName][objectName] = JObject.FromObject(value);
-            }
+
+            string json = $@"{{
+                ""{componentName}"": {{
+                    ""{objectName}"": {JsonConvert.SerializeObject(value)}
+                    }}
+                }}";
+
+            local.Merge(JObject.Parse(json), new JsonMergeSettings
+                {
+                    MergeArrayHandling = MergeArrayHandling.Union,
+                }
+            );
             File.WriteAllText(_desiredPath, local.ToString());
             return true;
         }
 
         public override T GetReported<T>(string componentName, string objectName, Func<T, bool> condition, int maxWaitSeconds)
         {
-            JObject local = JObject.Parse(File.ReadAllText(_reportedPath));
-            Assert.IsTrue(local.ContainsKey(componentName), "[LocalDataSource] does not contain component: " + componentName);
+            DateTime start = DateTime.Now;
+            JObject reported = JObject.Parse(File.ReadAllText(_reportedPath));
+
+            Assert.IsTrue(reported.ContainsKey(componentName), "[LocalDataSource] does not contain component: " + componentName);
             if (String.IsNullOrEmpty(objectName))
             {
-                return local[componentName].ToObject<T>();
+                while((maxWaitSeconds > 0 && (DateTime.Now - start).TotalSeconds < maxWaitSeconds)
+                     && !(condition(reported[componentName].ToObject<T>())))
+                {
+                    System.Threading.Thread.Sleep(POLL_INTERVAL_MS);
+                    reported = JObject.Parse(File.ReadAllText(_reportedPath));
+                }
+
+                if ((DateTime.Now - start).TotalSeconds > maxWaitSeconds)
+                {
+                    JObject desired = JObject.Parse(File.ReadAllText(_desiredPath));
+                    Assert.Warn("[GetReported-LocalDataSource] Time limit reached while waiting for reported update for {0}.{1} (start: {2} | end: {3}). reported: {4}. desired {5}", componentName, objectName, start, DateTime.Now, reported[componentName], desired[componentName]);
+                }
+
+                return reported[componentName].ToObject<T>();
             }
             else
             {
-                Assert.IsTrue(local[componentName].ToObject<JObject>().ContainsKey(objectName));
-                return local[componentName][objectName].ToObject<T>();
+                Assert.IsTrue(reported[componentName].ToObject<JObject>().ContainsKey(objectName));
+
+                while((maxWaitSeconds > 0 && (DateTime.Now - start).TotalSeconds < maxWaitSeconds) 
+                    && !(condition(reported[componentName][objectName].ToObject<T>())))
+                {
+                    System.Threading.Thread.Sleep(POLL_INTERVAL_MS);
+                    reported = JObject.Parse(File.ReadAllText(_reportedPath));
+                }
+
+                if ((DateTime.Now - start).TotalSeconds > maxWaitSeconds)
+                {
+                    JObject desired = JObject.Parse(File.ReadAllText(_desiredPath));
+                    Assert.Warn("[GetReported-LocalDataSource] Time limit reached while waiting for reported update for {0}.{1} (start: {2} | end: {3}). reported: {4}. desired {5}", componentName, objectName, start, DateTime.Now, reported[componentName][objectName], desired[componentName][objectName]);
+                }
+
+                return reported[componentName][objectName].ToObject<T>();
             }
         }
     }


### PR DESCRIPTION
## Description

* Added additional logging to capture reported/desired on timeouts for both Hub/Local datasources
* Improved local datasource reliability
* Reduced platform reliability tests to run for 2hrs

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.