### PR TITLE
copy AIS toml at build-time

### DIFF
--- a/src/agents/pnp/CMakeLists.txt
+++ b/src/agents/pnp/CMakeLists.txt
@@ -111,3 +111,9 @@ install(FILES daemon/${target_name}.conn DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}
 install(FILES daemon/${target_name}.toml DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/osconfig)
 install(FILES daemon/${target_name}.service DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/systemd/system)
 install(FILES telemetryevents/OsConfigAgentTelemetry.conf DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/azure-device-telemetryd)
+
+add_custom_command(
+    TARGET ${target_name}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/daemon/${target_name}.toml /etc/aziot/identityd/config.d/${target_name}.toml
+)


### PR DESCRIPTION
## Description

* Binplaces the AIS `osconfig.toml` at build-time to `/etc/aziot/identityd/config.d/` similar to our CMake post-install scripts

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.