### PR TITLE
Added build-time MIM validation

### DIFF
--- a/.github/actions/container-run/action.yml
+++ b/.github/actions/container-run/action.yml
@@ -27,7 +27,7 @@ inputs:
   tag:
     description: The container tag.
     required: false
-    default: latest
+    default: "289651"
 
 outputs:
   id:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           arch: ${{ matrix.variant.arch }}
           platform: ${{ matrix.variant.platform }}
           mount: ${{ github.workspace }}:${{ env.container-workspace }}
-          tag: "270554"
+          tag: "289651"
 
       - name: Generate build
         uses: ./.github/actions/container-exec
@@ -105,7 +105,7 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
     container:
-      image: osconfig.azurecr.io/ubuntu20.04-dev-amd64:270554
+      image: osconfig.azurecr.io/ubuntu20.04-dev-amd64:289651
       credentials:
         username: ${{ secrets.ACR_CLIENT_ID }}
         password: ${{ secrets.ACR_CLIENT_SECRET }}

--- a/.github/workflows/deploy-reliability-modules.yml
+++ b/.github/workflows/deploy-reliability-modules.yml
@@ -38,7 +38,7 @@ jobs:
           arch: ${{ matrix.variant.arch }}
           platform: ${{ matrix.variant.platform }}
           mount: ${{ github.workspace }}:${{ env.container-workspace }}
-          tag: "270554"
+          tag: "289651"
 
       - name: Generate build
         uses: ./.github/actions/container-exec

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -5,8 +5,10 @@ add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wall;-Wextra;-Wunused;-Werror;-Wfo
 
 add_subdirectory(test)
 
+find_program(JSONSCHEMA_EXEC jsonschema)
+
 # Function add_module/add_module_custom_target is used to add a module to the build and add
-# the appropriate dependencies in order for module testrecipe configuration to be generated. 
+# the appropriate dependencies in order for module testrecipe configuration to be generated.
 function(add_module_custom_target moduleDir targetName mimName recipeName)
     message(STATUS "Adding module '${moduleDir}' to the build.")
     string(TOLOWER ${moduleDir} _moduleDir)
@@ -14,6 +16,18 @@ function(add_module_custom_target moduleDir targetName mimName recipeName)
     string(TOLOWER ${targetName} _targetName)
     # Check for MIM
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mim/${_mimName}.json)
+        # Validate MIM
+        if(JSONSCHEMA_EXEC)
+            execute_process(
+                COMMAND ${JSONSCHEMA_EXEC} --instance ${CMAKE_CURRENT_SOURCE_DIR}/mim/${_mimName}.json ${CMAKE_CURRENT_SOURCE_DIR}/schema/mim.schema.json
+                ERROR_VARIABLE JSONSCHEMA_EXEC_ERROR
+            )
+            if(JSONSCHEMA_EXEC_ERROR)
+                message(WARNING "MIM '${_mimName}' is not valid: \n${JSONSCHEMA_EXEC_ERROR}")
+            endif()
+        else()
+            message(WARNING "jsonschema tool not installed. Cannot validate MIM.")
+        endif()
         # Check for Recipe
         if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test/recipes/${recipeName}Tests.json)
             add_subdirectory(${_moduleDir})

--- a/src/modules/mim/commandrunner.json
+++ b/src/modules/mim/commandrunner.json
@@ -1,6 +1,6 @@
 {
   "name": "CommandRunnerModel",
-  "type": "MimModel",
+  "type": "mimModel",
   "contents": [
     {
       "name": "CommandRunner",

--- a/src/modules/mim/deviceinfo.json
+++ b/src/modules/mim/deviceinfo.json
@@ -4,7 +4,7 @@
   "contents": [
     {
       "name": "DeviceInfo",
-      "type": "MimComponent",
+      "type": "mimComponent",
       "contents": [
         {
           "name": "osName",


### PR DESCRIPTION
## Description

* Changed default container to use `289651` (added jsonschema) and not `latest`. We want to make sure we use a specific version tag and not latest which might represent a broken reference.
* Added build-time validation of MIMs when jsonschema is installed (optional, CMake outputs a warning if jsonschema is not installed)
* Corrected `commandrunner` and `deviceinfo` MIMs to pass schema validation

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.