### PR TITLE
Adding recipe validation to modulestest

### DIFF
--- a/src/modules/test/TestRecipeParser.cpp
+++ b/src/modules/test/TestRecipeParser.cpp
@@ -9,6 +9,13 @@ static const std::string g_expectedResult = "ExpectedResult";
 static const std::string g_waitSeconds = "WaitSeconds";
 static const std::string g_nullValue = "<null>";
 
+static const std::vector<std::string> g_requiredProperties = {
+    g_componentName,
+    g_objectName,
+    g_desired,
+    g_expectedResult
+};
+
 TestRecipes TestRecipeParser::ParseTestRecipe(std::string path)
 {
     JSON_Value *root_value;
@@ -27,6 +34,23 @@ TestRecipes TestRecipeParser::ParseTestRecipe(std::string path)
     for (size_t i = 0; i < json_array_get_count(jsonTestRecipes); i++)
     {
         jsonTestRecipe = json_array_get_object(jsonTestRecipes, i);
+
+        // Validate recipe contains all required fields
+        bool recipeValid = true;
+        for (auto &requiredProperty : g_requiredProperties)
+        {
+            if (!json_object_has_value(jsonTestRecipe, requiredProperty.c_str()))
+            {
+                std::cerr << "Test recipe '" << path.c_str() << "' [" << i << "] missing required field: " << requiredProperty << std::endl;
+                recipeValid = false;
+            }
+        }
+        if (!recipeValid)
+        {
+            json_value_free(root_value);
+            return testRecipes;
+        }
+
         TestRecipe recipe = {
             json_object_get_string(jsonTestRecipe, g_componentName.c_str()),
             json_object_get_string(jsonTestRecipe, g_objectName.c_str()),

--- a/src/modules/test/unit-tests/CMakeLists.txt
+++ b/src/modules/test/unit-tests/CMakeLists.txt
@@ -13,3 +13,4 @@ gtest_discover_tests(testfactorytests XML_OUTPUT_DIR ${GTEST_OUTPUT_DIR})
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../../mim/sample.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/mim/)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/recipes/test.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/recipes/)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/recipes/testInvalid.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/recipes/)

--- a/src/modules/test/unit-tests/TestRecipeParserTests.cpp
+++ b/src/modules/test/unit-tests/TestRecipeParserTests.cpp
@@ -66,4 +66,19 @@ namespace Tests
         EXPECT_STRCASEEQ("TestModule.<null>.<null>", TestRecipeParser::GetTestName(recipeNoComponentNoObject).c_str());
         EXPECT_STRCASEEQ("TestModule.<null>.ObjectName", TestRecipeParser::GetTestName(recipeNoComponent).c_str());
     }
+
+    TEST(TestRecipeParserTests, RequiredFieldsMissing)
+    {
+        std::stringstream newBuffer;
+        std::streambuf *originalBuffer = std::cerr.rdbuf();
+        // Redirect cerr to our buffer
+        std::cerr.rdbuf(newBuffer.rdbuf());
+
+        TestRecipes testRecipes = TestRecipeParser::ParseTestRecipe("./recipes/testInvalid.json");
+        ASSERT_EQ(testRecipes->size(), 1);
+        EXPECT_STRCASEEQ("Test recipe './recipes/testInvalid.json' [1] missing required field: ObjectName\nTest recipe './recipes/testInvalid.json' [1] missing required field: Desired\nTest recipe './recipes/testInvalid.json' [1] missing required field: ExpectedResult\n", newBuffer.str().c_str());
+
+        // Redirect cerr back to original stream
+        std::cerr.rdbuf(originalBuffer);
+    }
 }

--- a/src/modules/test/unit-tests/TestRecipeParserTests.cpp
+++ b/src/modules/test/unit-tests/TestRecipeParserTests.cpp
@@ -74,9 +74,14 @@ namespace Tests
         // Redirect cerr to our buffer
         std::cerr.rdbuf(newBuffer.rdbuf());
 
+        const std::string expectedStr = 
+            "Test recipe './recipes/testInvalid.json' [1] missing required field: ObjectName\n"
+            "Test recipe './recipes/testInvalid.json' [1] missing required field: Desired\n"
+            "Test recipe './recipes/testInvalid.json' [1] missing required field: ExpectedResult\n";
+
         TestRecipes testRecipes = TestRecipeParser::ParseTestRecipe("./recipes/testInvalid.json");
         ASSERT_EQ(testRecipes->size(), 1);
-        EXPECT_STRCASEEQ("Test recipe './recipes/testInvalid.json' [1] missing required field: ObjectName\nTest recipe './recipes/testInvalid.json' [1] missing required field: Desired\nTest recipe './recipes/testInvalid.json' [1] missing required field: ExpectedResult\n", newBuffer.str().c_str());
+        EXPECT_STRCASEEQ(expectedStr.c_str(), newBuffer.str().c_str());
 
         // Redirect cerr back to original stream
         std::cerr.rdbuf(originalBuffer);

--- a/src/modules/test/unit-tests/recipes/testInvalid.json
+++ b/src/modules/test/unit-tests/recipes/testInvalid.json
@@ -9,10 +9,6 @@
         "WaitSeconds": 0
     },
     {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
+        "ComponentName": "CommandRunner"
     }
 ]


### PR DESCRIPTION
## Description

* Added required properties and validation to `modulestest` recipe parsing

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.