### PR TITLE
Improved modulestest recipe naming

### DIFF
--- a/src/modules/test/TestRecipeParser.cpp
+++ b/src/modules/test/TestRecipeParser.cpp
@@ -44,3 +44,11 @@ TestRecipes TestRecipeParser::ParseTestRecipe(std::string path)
     json_value_free(root_value);
     return testRecipes;
 }
+
+std::string TestRecipeParser::GetTestName(TestRecipe &recipe)
+{
+    std::string componentName = recipe.m_componentName.empty() ? "<null>" : recipe.m_componentName;
+    std::string objectName = recipe.m_objectName.empty() ? "<null>" : recipe.m_objectName;
+    
+    return recipe.m_metadata.m_moduleName + "." + componentName + "." + objectName;
+}

--- a/src/modules/test/TestRecipeParser.cpp
+++ b/src/modules/test/TestRecipeParser.cpp
@@ -7,6 +7,7 @@ static const std::string g_payload = "Payload";
 static const std::string g_payloadSizeBytes = "PayloadSizeBytes";
 static const std::string g_expectedResult = "ExpectedResult";
 static const std::string g_waitSeconds = "WaitSeconds";
+static const std::string g_nullValue = "<null>";
 
 TestRecipes TestRecipeParser::ParseTestRecipe(std::string path)
 {
@@ -47,8 +48,8 @@ TestRecipes TestRecipeParser::ParseTestRecipe(std::string path)
 
 std::string TestRecipeParser::GetTestName(TestRecipe &recipe)
 {
-    std::string componentName = recipe.m_componentName.empty() ? "<null>" : recipe.m_componentName;
-    std::string objectName = recipe.m_objectName.empty() ? "<null>" : recipe.m_objectName;
+    std::string componentName = recipe.m_componentName.empty() ? g_nullValue : recipe.m_componentName;
+    std::string objectName = recipe.m_objectName.empty() ? g_nullValue : recipe.m_objectName;
     
     return recipe.m_metadata.m_moduleName + "." + componentName + "." + objectName;
 }

--- a/src/modules/test/TestRecipeParser.h
+++ b/src/modules/test/TestRecipeParser.h
@@ -35,6 +35,7 @@ class TestRecipeParser
 {
 public:
     static TestRecipes ParseTestRecipe(std::string path);
+    static std::string GetTestName(TestRecipe &recipe);
 };
 
 #endif // TESTRECIPEPARSER_H

--- a/src/modules/test/main.cpp
+++ b/src/modules/test/main.cpp
@@ -5,7 +5,8 @@ std::string g_configFile = "/etc/osconfig/osconfig.json";
 std::string g_defaultPath = "testplate.json";
 std::string g_fullLogging = "FullLogging";
 
-static std::string str_tolower(std::string s) {
+static std::string str_tolower(std::string s)
+{
     std::transform(s.begin(), s.end(), s.begin(), 
                    [](unsigned char c){ return std::tolower(c); }
                   );
@@ -18,9 +19,8 @@ void RegisterRecipesWithGTest(TestRecipes &testRecipes)
     {
         // See gtest.h for details on this test registration
         // https://github.com/google/googletest/blob/v1.10.x/googletest/include/gtest/gtest.h#L2438
-        std::string testName(recipe.m_componentName + "." + recipe.m_objectName);
         testing::RegisterTest(
-            "ModulesTest", testName.c_str(), nullptr, nullptr, __FILE__, __LINE__,
+            "ModulesTest", TestRecipeParser::GetTestName(recipe).c_str(), nullptr, nullptr, __FILE__, __LINE__,
             [recipe]()->RecipeFixture *
             {
                 return new RecipeInvoker(recipe);

--- a/src/modules/test/unit-tests/TestRecipeParserTests.cpp
+++ b/src/modules/test/unit-tests/TestRecipeParserTests.cpp
@@ -25,4 +25,45 @@ namespace Tests
         EXPECT_STRCASEEQ("", testRecipes->at(1).m_payload.c_str());
         EXPECT_EQ(0, testRecipes->at(1).m_payloadSizeBytes);
     }
+
+    TEST(TestRecipeParserTests, TestNaming)
+    {
+        TestRecipe recipe = {
+            "ComponentName",
+            "ObjectName",
+            true,
+            "Payload",
+            0,
+            0,
+            0,
+            { "TestModule", "TestModulePath", "TestMimPath", "TestRecipesPath", nullptr },
+            {}
+        };
+        TestRecipe recipeNoComponentNoObject = {
+            "",
+            "",
+            true,
+            "Payload",
+            0,
+            0,
+            0,
+            { "TestModule", "TestModulePath", "TestMimPath", "TestRecipesPath", nullptr },
+            {}
+        };
+        TestRecipe recipeNoComponent = {
+            "",
+            "ObjectName",
+            true,
+            "Payload",
+            0,
+            0,
+            0,
+            { "TestModule", "TestModulePath", "TestMimPath", "TestRecipesPath", nullptr },
+            {}
+        };
+
+        EXPECT_STRCASEEQ("TestModule.ComponentName.ObjectName", TestRecipeParser::GetTestName(recipe).c_str());
+        EXPECT_STRCASEEQ("TestModule.<null>.<null>", TestRecipeParser::GetTestName(recipeNoComponentNoObject).c_str());
+        EXPECT_STRCASEEQ("TestModule.<null>.ObjectName", TestRecipeParser::GetTestName(recipeNoComponent).c_str());
+    }
 }


### PR DESCRIPTION
## Description

* Previously, test recipes would use a `ComponentName.ObjectName` naming. Which can be confusing in the global test namespace if similar recipes include recipes without a `ComponentName` and/or `ObjectName` or a conflicting name. The new convention uses `ModuleName.ComponentName.ObjectName` and uses `<null>` values if `ComponentName` and/or `ObjectName` is blank (empty string "")

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.