### PR TITLE
Daemon config module switch enum type

### DIFF
--- a/src/modules/daemonconfiguration/Cargo.lock
+++ b/src/modules/daemonconfiguration/Cargo.lock
@@ -73,7 +73,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_repr",
  "systemctl",
 ]
 
@@ -328,17 +327,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
-dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
 ]
 
 [[package]]

--- a/src/modules/daemonconfiguration/Cargo.toml
+++ b/src/modules/daemonconfiguration/Cargo.toml
@@ -17,3 +17,11 @@ systemctl = "0.1"
 
 [lib]
 crate-type = ["cdylib"]
+
+# https://rustrepo.com/repo/johnthagen-min-sized-rust
+[profile.release]
+opt-level = 'z'         # Optimize for size
+lto = true              # Enable link time optimizations
+codegen-units = 1       # Reduce number of codegen units to increase optimization opportunities
+panic = 'abort'         # Abort on panics
+strip = true            # Strip debug symbols

--- a/src/modules/daemonconfiguration/Cargo.toml
+++ b/src/modules/daemonconfiguration/Cargo.toml
@@ -13,7 +13,6 @@ libsystemd = "0.5"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_repr = "0.1"
 systemctl = "0.1"
 
 [lib]

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -4,7 +4,6 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::process::Command;
 
 use crate::MmiError;
@@ -24,22 +23,22 @@ const INFO: &str = r#"{
     "Lifetime": 1,
     "UserAccount": 0}"#;
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, PartialEq, Eq)]
-#[repr(u8)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub enum State {
-    Other = 0,
-    Running = 1,
-    Failed = 2,
-    Exited = 3,
-    Dead = 4,
+    Other,
+    Running,
+    Failed,
+    Exited,
+    Dead,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, PartialEq, Eq)]
-#[repr(u8)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub enum AutoStartStatus {
-    Other = 0,
-    Enabled = 1,
-    Disabled = 2,
+    Other,
+    Enabled,
+    Disabled,
 }
 
 // A daemon_config object with all possible setting types
@@ -328,43 +327,43 @@ mod tests {
             let expected = "[\
                 {\
                     \"name\":\"alsa-restore\",\
-                    \"state\":4,\
-                    \"autoStartStatus\":0\
+                    \"state\":\"dead\",\
+                    \"autoStartStatus\":\"other\"\
                 },\
                 {\
                     \"name\":\"alsa-utils\",\
-                    \"state\":1,\
-                    \"autoStartStatus\":0\
+                    \"state\":\"running\",\
+                    \"autoStartStatus\":\"other\"\
                 },\
                 {\
                     \"name\":\"apport\",\
-                    \"state\":2,\
-                    \"autoStartStatus\":0\
+                    \"state\":\"failed\",\
+                    \"autoStartStatus\":\"other\"\
                 },\
                 {\
                     \"name\":\"netplan-ovs-cleanup\",\
-                    \"state\":3,\
-                    \"autoStartStatus\":0\
+                    \"state\":\"exited\",\
+                    \"autoStartStatus\":\"other\"\
                 },\
                 {\
                     \"name\":\"osconfig\",\
-                    \"state\":4,\
-                    \"autoStartStatus\":1\
+                    \"state\":\"dead\",\
+                    \"autoStartStatus\":\"enabled\"\
                 },\
                 {\
                     \"name\":\"rtkit-daemon\",\
-                    \"state\":3,\
-                    \"autoStartStatus\":2\
+                    \"state\":\"exited\",\
+                    \"autoStartStatus\":\"disabled\"\
                 },\
                 {\
                     \"name\":\"saned\",\
-                    \"state\":1,\
-                    \"autoStartStatus\":0\
+                    \"state\":\"running\",\
+                    \"autoStartStatus\":\"other\"\
                 },\
                 {\
                     \"name\":\"spice-vdagent\",\
-                    \"state\":4,\
-                    \"autoStartStatus\":0\
+                    \"state\":\"dead\",\
+                    \"autoStartStatus\":\"other\"\
                 }\
             ]";
             assert!(json_strings_eq::<Vec<Daemon>>(payload.as_str(), expected));

--- a/src/modules/mim/daemonconfiguration.json
+++ b/src/modules/mim/daemonconfiguration.json
@@ -23,27 +23,27 @@
                   "name": "state",
                   "schema": {
                     "type": "enum",
-                    "valueSchema": "integer",
+                    "valueSchema": "string",
                     "enumValues": [
                       {
                         "name": "other",
-                        "enumValue": 0
+                        "enumValue": "other"
                       },
                       {
                         "name": "running",
-                        "enumValue": 1
+                        "enumValue": "running"
                       },
                       {
                         "name": "failed",
-                        "enumValue": 2
+                        "enumValue": "failed"
                       },
                       {
                         "name": "exited",
-                        "enumValue": 3
+                        "enumValue": "exited"
                       },
                       {
                         "name": "dead",
-                        "enumValue": 4
+                        "enumValue": "dead"
                       }
                     ]
                   }
@@ -52,19 +52,19 @@
                   "name": "autoStartStatus",
                   "schema": {
                     "type": "enum",
-                    "valueSchema": "integer",
+                    "valueSchema": "string",
                     "enumValues": [
                       {
                         "name": "other",
-                        "enumValue": 0
+                        "enumValue": "other"
                       },
                       {
                         "name": "enabled",
-                        "enumValue": 1
+                        "enumValue": "enabled"
                       },
                       {
                         "name": "disabled",
-                        "enumValue": 2
+                        "enumValue": "disabled"
                       }
                     ]
                   }


### PR DESCRIPTION
## Description
Switch the Mim and mmi implementation to use the string enum instead of an int enum. Also optimized crate for build size

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.