### PR TITLE
Daemon config module payload filter

### DIFF
--- a/src/modules/daemonconfiguration/src/common.rs
+++ b/src/modules/daemonconfiguration/src/common.rs
@@ -5,6 +5,7 @@ use libc::{c_int, EINVAL, ENOMEM};
 use std::ffi::NulError;
 use std::fmt;
 use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 
 #[derive(Debug, PartialEq)]
 pub enum MmiError {
@@ -15,6 +16,12 @@ pub enum MmiError {
     SerdeError,
     SystemctlError,
     SystemdError,
+}
+
+impl From<FromUtf8Error> for MmiError {
+    fn from(_err: FromUtf8Error) -> MmiError {
+        MmiError::FailedRead
+    }
 }
 
 impl From<Utf8Error> for MmiError {

--- a/src/modules/daemonconfiguration/src/common.rs
+++ b/src/modules/daemonconfiguration/src/common.rs
@@ -11,6 +11,7 @@ pub enum MmiError {
     FailedRead,
     FailedAllocate,
     InvalidArgument,
+    PayloadSizeExceeded,
     SerdeError,
     SystemctlError,
     SystemdError,
@@ -44,6 +45,7 @@ impl Into<c_int> for MmiError {
     fn into(self) -> c_int {
         match self {
             MmiError::FailedAllocate => ENOMEM,
+            MmiError::PayloadSizeExceeded => ENOMEM,
             _ => EINVAL,
         }
     }
@@ -60,6 +62,9 @@ impl fmt::Display for MmiError {
             }
             MmiError::InvalidArgument => {
                 write!(f, "There was an invalid argument")
+            }
+            MmiError::PayloadSizeExceeded => {
+                write!(f, "The payload exceeded max payload bytes size")
             }
             MmiError::SerdeError => {
                 write!(f, "There was an error serializing or deserializing")

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -8,8 +8,8 @@ use std::process::Command;
 
 use crate::MmiError;
 
-const COMPONENT_NAME: &str = "DaemonConfiguration";
-const OBJECT_NAME: &str = "dameons";
+const COMPONENT_NAME: &str = "SystemdDaemonConfiguration";
+const OBJECT_NAME: &str = "daemonConfiguration";
 
 // r# Denotes a Rust Raw String
 const INFO: &str = r#"{
@@ -19,7 +19,7 @@ const INFO: &str = r#"{
     "VersionMajor": 1,
     "VersionMinor": 0,
     "VersionInfo": "",
-    "Components": ["DaemonConfiguration"],
+    "Components": ["SystemdDaemonConfiguration"],
     "Lifetime": 1,
     "UserAccount": 0}"#;
 
@@ -164,7 +164,8 @@ impl DaemonConfiguration {
             if self.max_payload_size_bytes != 0
                 && payload.len() as u32 > self.max_payload_size_bytes
             {
-                Err(MmiError::InvalidArgument)
+                println!("Payload size exceeded max payload size bytes in get");
+                Err(MmiError::PayloadSizeExceeded)
             } else {
                 Ok(payload)
             }
@@ -304,9 +305,6 @@ mod tests {
             if let Err(e) = invalid_object_result {
                 assert_eq!(e, MmiError::InvalidArgument);
             }
-            let payload = daemon_config
-                .get::<SystemctlTest>(COMPONENT_NAME, OBJECT_NAME)
-                .unwrap();
         } else {
             let systemd_result: Result<String, MmiError> =
                 daemon_config.get::<SystemctlTest>(COMPONENT_NAME, OBJECT_NAME);

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -84,7 +84,7 @@ impl SystemctlInfo for Systemctl {
             }
             let daemon = Self::create_daemon(&service["service"], &service["status"])?;
             // Only report enabled daemons with State not being Other
-            if daemon.state != State::Other && daemon.state != State::Dead && daemon.auto_start_status == AutoStartStatus::Enabled {
+            if (daemon.state != State::Other) && (daemon.state != State::Dead) && (daemon.auto_start_status == AutoStartStatus::Enabled) {
                 services.push(daemon);
             }
         }
@@ -164,8 +164,8 @@ impl DaemonConfiguration {
             let daemons = T::get_daemons()?;
             let json_value = serde_json::to_value::<&Vec<Daemon>>(&daemons)?;
             let payload: String = serde_json::to_string(&json_value)?;
-            if self.max_payload_size_bytes != 0
-                && payload.len() as u32 > self.max_payload_size_bytes
+            if (self.max_payload_size_bytes != 0)
+                && (payload.len() as u32 > self.max_payload_size_bytes)
             {
                 println!("Payload size exceeded max payload size bytes in get");
                 Err(MmiError::PayloadSizeExceeded)
@@ -228,7 +228,7 @@ mod tests {
                 }
                 let daemon = Self::create_daemon(&service["service"], &service["status"])?;
                 // Only report enabled daemons with State not being Other
-                if daemon.state != State::Other && daemon.state != State::Dead && daemon.auto_start_status == AutoStartStatus::Enabled {
+                if (daemon.state != State::Other) && (daemon.state != State::Dead) && (daemon.auto_start_status == AutoStartStatus::Enabled) {
                     services.push(daemon);
                 }
             }


### PR DESCRIPTION
## Description
Added payload filtering to only report enabled daemons that don't have state "other" or "dead". Added a new payload size exceeded error type and message. Fixed wrong component and object names. Changed unit tests to reflect filtering.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.