### PR TITLE
Daemon config module set

### DIFF
--- a/src/modules/daemonconfiguration/src/common.rs
+++ b/src/modules/daemonconfiguration/src/common.rs
@@ -36,7 +36,8 @@ impl From<serde_json::Error> for MmiError {
 }
 
 impl From<std::io::Error> for MmiError {
-    fn from(_err: std::io::Error) -> MmiError {
+    fn from(err: std::io::Error) -> MmiError {
+        println!("{}",err);
         MmiError::SystemctlError
     }
 }

--- a/src/modules/daemonconfiguration/src/common.rs
+++ b/src/modules/daemonconfiguration/src/common.rs
@@ -36,8 +36,7 @@ impl From<serde_json::Error> for MmiError {
 }
 
 impl From<std::io::Error> for MmiError {
-    fn from(err: std::io::Error) -> MmiError {
-        println!("{}",err);
+    fn from(_err: std::io::Error) -> MmiError {
         MmiError::SystemctlError
     }
 }

--- a/src/modules/daemonconfiguration/src/common.rs
+++ b/src/modules/daemonconfiguration/src/common.rs
@@ -11,6 +11,7 @@ pub enum MmiError {
     FailedRead,
     FailedAllocate,
     InvalidArgument,
+    PayloadSizeExceeded,
     SerdeError,
     SystemctlError,
     SystemdError,
@@ -44,6 +45,7 @@ impl Into<c_int> for MmiError {
     fn into(self) -> c_int {
         match self {
             MmiError::FailedAllocate => ENOMEM,
+            MmiError::PayloadSizeExceeded => ENOMEM,
             _ => EINVAL,
         }
     }
@@ -60,6 +62,9 @@ impl fmt::Display for MmiError {
             }
             MmiError::InvalidArgument => {
                 write!(f, "There was an invalid argument")
+            }
+            MmiError::PayloadSizeExceeded => {
+                write!(f, "The payload exceeded max payload bytes size")
             }
             MmiError::SerdeError => {
                 write!(f, "There was an error serializing or deserializing")

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -66,9 +66,11 @@ pub struct DesiredDaemon {
 pub trait SystemctlInfo {
     /// Returns a new SystemctlInfo Instance.
     fn new() -> Self;
+
     /// If successful, returns an Ok(Vec<Daemon>) with all enabled systemd daemons with State not being
     /// Other or dead (Running, failed, or exited). Err(MmiError) if the operation fails.
     fn get_daemons(&self) -> Result<Vec<Daemon>>;
+
     /// If successful, returns an Ok(String) containing the all daemon names, auto start statuses, and vendor preset
     /// auto start statuses. Err(MmiError) if the operation fails.
     /// The string will be formatted as so:
@@ -78,24 +80,31 @@ pub trait SystemctlInfo {
     fn list_unit_files(&self) -> Result<String>;
     /// If successful, returns an Ok(Daemon) representing a current Daemon. Accepts the name of the daemon
     /// and it's auto start statuses as strings. Err(MmiError) if the operation fails.
+
     fn create_daemon(&self, name: &str, auto_start_status: &str) -> Result<Daemon>;
+
     /// If successful, returns an Ok(String) containing the state of the daemon with name "name".
     /// Err(MmiError) if the operation fails.
     /// The string will be formatted as so:
     /// "substate=<state>"
     fn show_substate_property(&self, name: &str) -> Result<String>;
+
     /// Check if a daemon with name "name" exits. Returns Ok(true) if the daemon exists, Ok(false) if the
     /// daemon doesn't exist. Err(MmiError) if the operation fails.
     fn exists(&self, name: &str) -> Result<bool>;
+
     /// Start systemd daemon with name "name". Returns Ok(true) if successful, Ok(false) if the
     /// daemon was already started. Err(MmiError) if the operation fails.
     fn start(&mut self, name: &str) -> Result<bool>;
+
     /// stop systemd daemon with name "name". Returns Ok(true) if successful, Ok(false) if the
     /// daemon was already started. Err(MmiError) if the operation fails.
     fn stop(&mut self, name: &str) -> Result<bool>;
+
     /// enable systemd daemon with name "name". Returns Ok(true) if successful, Ok(false) if the
     /// daemon was already started. Err(MmiError) if the operation fails.
     fn enable(&mut self, name: &str) -> Result<bool>;
+
     /// disable systemd daemon with name "name". Returns Ok(true) if successful, Ok(false) if the
     /// daemon was already started. Err(MmiError) if the operation fails.
     fn disable(&mut self, name: &str) -> Result<bool>;
@@ -348,7 +357,10 @@ mod tests {
                 (String::from("alsa-utils"), String::from("masked")),
                 (String::from("apport-forward@"), String::from("static")),
                 (String::from("apport"), String::from("enabled")),
-                (String::from("netplan-ovs-cleanup"), String::from("enabled-runtime")),
+                (
+                    String::from("netplan-ovs-cleanup"),
+                    String::from("enabled-runtime"),
+                ),
                 (String::from("osconfig"), String::from("disabled")),
                 (String::from("rtkit-daemon"), String::from("enabled")),
                 (String::from("saned"), String::from("enabled")),

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -66,11 +66,11 @@ pub struct DesiredDaemon {
 pub trait SystemctlInfo {
     /// Returns a new SystemctlInfo Instance.
     fn new() -> Self;
-    /// If successful, returns an Ok(Vec<Daemon>) with all enabled systemd daemons with State not being 
+    /// If successful, returns an Ok(Vec<Daemon>) with all enabled systemd daemons with State not being
     /// Other or dead (Running, failed, or exited). Err(MmiError) if the operation fails.
     fn get_daemons(&self) -> Result<Vec<Daemon>>;
     /// If successful, returns an Ok(String) containing the all daemon names, auto start statuses, and vendor preset
-    /// auto start statuses. Err(MmiError) if the operation fails. 
+    /// auto start statuses. Err(MmiError) if the operation fails.
     /// The string will be formatted as so:
     /// "UNIT FILE                                  STATE           VENDOR PRESET
     ///  <daemon_name>                              <auto_start_status> <vendor_auto_start_status>
@@ -80,7 +80,7 @@ pub trait SystemctlInfo {
     /// and it's auto start statuses as strings. Err(MmiError) if the operation fails.
     fn create_daemon(&self, name: &str, auto_start_status: &str) -> Result<Daemon>;
     /// If successful, returns an Ok(String) containing the state of the daemon with name "name".
-    /// Err(MmiError) if the operation fails. 
+    /// Err(MmiError) if the operation fails.
     /// The string will be formatted as so:
     /// "substate=<state>"
     fn show_substate_property(&self, name: &str) -> Result<String>;
@@ -123,7 +123,10 @@ impl SystemctlInfo for Systemctl {
             }
             let daemon = self.create_daemon(&service["service"], &service["status"])?;
             // Only report enabled daemons with State not being Other or dead
-            if (daemon.state != State::Other) && (daemon.state != State::Dead) && (daemon.auto_start_status == AutoStartStatus::Enabled) {
+            if (daemon.state != State::Other)
+                && (daemon.state != State::Dead)
+                && (daemon.auto_start_status == AutoStartStatus::Enabled)
+            {
                 services.push(daemon);
             }
         }
@@ -261,9 +264,13 @@ impl<SystemCaller: SystemctlInfo> DaemonConfiguration<SystemCaller> {
             if (self.max_payload_size_bytes != 0)
                 && (payload.len() as u32 > self.max_payload_size_bytes)
             {
-                println!("Payload size exceeded max payload size bytes in get so it was truncated.");
+                println!(
+                    "Payload size exceeded max payload size bytes in get so it was truncated."
+                );
                 let payload_bytes = payload.into_bytes();
-                let truncated_payload = String::from_utf8((&payload_bytes[0..self.max_payload_size_bytes as usize]).to_vec())?;
+                let truncated_payload = String::from_utf8(
+                    (&payload_bytes[0..self.max_payload_size_bytes as usize]).to_vec(),
+                )?;
                 Ok(truncated_payload)
             } else {
                 Ok(payload)
@@ -271,12 +278,7 @@ impl<SystemCaller: SystemctlInfo> DaemonConfiguration<SystemCaller> {
         }
     }
 
-    pub fn set(
-        &mut self,
-        component_name: &str,
-        object_name: &str,
-        payload: &str,
-    ) -> Result<i32> {
+    pub fn set(&mut self, component_name: &str, object_name: &str, payload: &str) -> Result<i32> {
         if !libsystemd::daemon::booted() {
             // Whether the caller was booted using Systemd
             Err(MmiError::SystemdError)
@@ -410,7 +412,10 @@ mod tests {
                 }
                 let daemon = self.create_daemon(&service["service"], &service["status"])?;
                 // Only report enabled daemons with State not being Other
-                if (daemon.state != State::Other) && (daemon.state != State::Dead) && (daemon.auto_start_status == AutoStartStatus::Enabled) {
+                if (daemon.state != State::Other)
+                    && (daemon.state != State::Dead)
+                    && (daemon.auto_start_status == AutoStartStatus::Enabled)
+                {
                     services.push(daemon);
                 }
             }

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -80,7 +80,7 @@ pub struct Systemctl {}
 
 impl SystemctlInfo for Systemctl {
     fn new() -> Self {
-        Systemctl{}
+        Systemctl {}
     }
 
     fn get_daemons(&self) -> Result<Vec<Daemon>> {
@@ -182,14 +182,11 @@ impl SystemctlInfo for Systemctl {
     // Enable systemd daemon with name "name". Returns true if successful, false otherwise.
     fn enable(&mut self, name: &str) -> Result<bool> {
         let unit = systemctl::Unit::from_systemctl(name)?;
-        println!("entered enable");
         if unit.auto_start == systemctl_crate::AutoStartStatus::Enabled {
-            println!("already enabled");
             // Unit is already enabled
             Ok(false)
         } else {
             let output = Command::new("systemctl").args(["enable", name]).output()?;
-            println!("ran command? naem: {}.\n output: {}", name, std::str::from_utf8(&output.stderr)?);
             Ok(true)
         }
     }
@@ -197,13 +194,10 @@ impl SystemctlInfo for Systemctl {
     // Disable systemd daemon with name "name". Returns true if successful, false otherwise.
     fn disable(&mut self, name: &str) -> Result<bool> {
         let unit = systemctl::Unit::from_systemctl(name)?;
-        println!("entered disable");
         if unit.auto_start == systemctl_crate::AutoStartStatus::Disabled {
             // Unit is already disabled
-            println!("already disabled");
             Ok(false)
         } else {
-            println!("ran command? naem: {}", name);
             Command::new("systemctl").args(["disable", name]).output()?;
             Ok(true)
         }
@@ -232,11 +226,7 @@ impl<SystemCaller: SystemctlInfo> DaemonConfiguration<SystemCaller> {
         Ok(INFO)
     }
 
-    pub fn get(
-        &self,
-        component_name: &str,
-        object_name: &str,
-    ) -> Result<String> {
+    pub fn get(&self, component_name: &str, object_name: &str) -> Result<String> {
         if !libsystemd::daemon::booted() {
             // Whether the caller was booted using Systemd
             Err(MmiError::SystemdError)
@@ -360,24 +350,29 @@ mod tests {
         }
 
         fn list_unit_files(&self) -> Result<String> {
-            let list_unit_output = 
-            format!(
-            "UNIT FILE                                  STATE           VENDOR PRESET
-            alsa-restore.service                       {}          enabled      
-            alsa-utils.service                         {}          enabled      
-            apport-forward@.service                    {}          enabled      
-            apport.service                             {}         enabled      
-            netplan-ovs-cleanup.service                {} enabled
-            osconfig.service                           {}        enabled      
-            rtkit-daemon.service                       {}         enabled      
-            saned.service                              {}         enabled           
-            spice-vdagent.service                      {}        enabled           
-            
-            9 unit files listed.", self.auto_start_statuses["alsa-restore"], self.auto_start_statuses["alsa-utils"],
-            self.auto_start_statuses["apport-forward@"], self.auto_start_statuses["apport"],
-            self.auto_start_statuses["netplan-ovs-cleanup"], self.auto_start_statuses["osconfig"],
-            self.auto_start_statuses["rtkit-daemon"], self.auto_start_statuses["saned"],
-            self.auto_start_statuses["spice-vdagent"]);
+            let list_unit_output = format!(
+                "UNIT FILE                                  STATE           VENDOR PRESET
+                alsa-restore.service                       {}          enabled      
+                alsa-utils.service                         {}          enabled      
+                apport-forward@.service                    {}          enabled      
+                apport.service                             {}         enabled      
+                netplan-ovs-cleanup.service                {} enabled
+                osconfig.service                           {}        enabled      
+                rtkit-daemon.service                       {}         enabled      
+                saned.service                              {}         enabled           
+                spice-vdagent.service                      {}        enabled           
+                
+                9 unit files listed.",
+                self.auto_start_statuses["alsa-restore"],
+                self.auto_start_statuses["alsa-utils"],
+                self.auto_start_statuses["apport-forward@"],
+                self.auto_start_statuses["apport"],
+                self.auto_start_statuses["netplan-ovs-cleanup"],
+                self.auto_start_statuses["osconfig"],
+                self.auto_start_statuses["rtkit-daemon"],
+                self.auto_start_statuses["saned"],
+                self.auto_start_statuses["spice-vdagent"]
+            );
             Ok(list_unit_output)
         }
 
@@ -440,7 +435,8 @@ mod tests {
         }
 
         fn start(&mut self, name: &str) -> Result<bool> {
-            self.states.insert(String::from(name), String::from("running"));
+            self.states
+                .insert(String::from(name), String::from("running"));
             Ok(true)
         }
 
@@ -450,19 +446,22 @@ mod tests {
         }
 
         fn enable(&mut self, name: &str) -> Result<bool> {
-            self.auto_start_statuses.insert(String::from(name), String::from("enabled"));
+            self.auto_start_statuses
+                .insert(String::from(name), String::from("enabled"));
             Ok(true)
         }
 
         fn disable(&mut self, name: &str) -> Result<bool> {
-            self.auto_start_statuses.insert(String::from(name), String::from("disabled"));
+            self.auto_start_statuses
+                .insert(String::from(name), String::from("disabled"));
             Ok(true)
         }
     }
 
     #[test]
     fn build_daemon_config() {
-        let daemon_config = DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
+        let daemon_config =
+            DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
         assert_eq!(
             daemon_config.get_max_payload_size_bytes(),
             MAX_PAYLOAD_BYTES
@@ -471,7 +470,8 @@ mod tests {
 
     #[test]
     fn info_size() {
-        let daemon_config_info: Result<&str> = DaemonConfiguration::<SystemctlTest>::get_info("Test_client_name");
+        let daemon_config_info: Result<&str> =
+            DaemonConfiguration::<SystemctlTest>::get_info("Test_client_name");
         assert!(daemon_config_info.is_ok());
         let daemon_config_info: &str = daemon_config_info.unwrap();
         assert_eq!(INFO, daemon_config_info);
@@ -480,7 +480,8 @@ mod tests {
 
     #[test]
     fn invalid_get() {
-        let daemon_config = DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
+        let daemon_config =
+            DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
         if libsystemd::daemon::booted() {
             let invalid_component_result: Result<String> =
                 daemon_config.get("Invalid component", REPORTED_OBJECT_NAME);
@@ -506,43 +507,32 @@ mod tests {
 
     #[test]
     fn invalid_set() {
-        let mut daemon_config = DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
+        let mut daemon_config =
+            DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
         let valid_json_payload = r#"[{name: "osconfig", started:true, enabled:true}]"#;
         let invalid_json_payload = r#"Invalid payload"#;
         if libsystemd::daemon::booted() {
-            let invalid_component_result: Result<i32> = daemon_config.set(
-                "Invalid component",
-                DESIRED_OBJECT_NAME,
-                valid_json_payload,
-            );
+            let invalid_component_result: Result<i32> =
+                daemon_config.set("Invalid component", DESIRED_OBJECT_NAME, valid_json_payload);
             assert!(invalid_component_result.is_err());
             if let Err(e) = invalid_component_result {
                 assert_eq!(e, MmiError::InvalidArgument);
             }
-            let invalid_object_result: Result<i32> = daemon_config.set(
-                COMPONENT_NAME,
-                "Invalid object",
-                valid_json_payload,
-            );
+            let invalid_object_result: Result<i32> =
+                daemon_config.set(COMPONENT_NAME, "Invalid object", valid_json_payload);
             assert!(invalid_object_result.is_err());
             if let Err(e) = invalid_object_result {
                 assert_eq!(e, MmiError::InvalidArgument);
             }
-            let invalid_payload_result: Result<i32> = daemon_config.set(
-                COMPONENT_NAME,
-                DESIRED_OBJECT_NAME,
-                invalid_json_payload,
-            );
+            let invalid_payload_result: Result<i32> =
+                daemon_config.set(COMPONENT_NAME, DESIRED_OBJECT_NAME, invalid_json_payload);
             assert!(invalid_payload_result.is_err());
             if let Err(e) = invalid_payload_result {
                 assert_eq!(e, MmiError::SerdeError);
             }
         } else {
-            let systemd_result: Result<i32> = daemon_config.set(
-                COMPONENT_NAME,
-                REPORTED_OBJECT_NAME,
-                valid_json_payload,
-            );
+            let systemd_result: Result<i32> =
+                daemon_config.set(COMPONENT_NAME, REPORTED_OBJECT_NAME, valid_json_payload);
             assert!(systemd_result.is_err());
             if let Err(e) = systemd_result {
                 assert_eq!(e, MmiError::SystemdError);
@@ -552,7 +542,8 @@ mod tests {
 
     #[test]
     fn get_set() {
-        let mut daemon_config = DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
+        let mut daemon_config =
+            DaemonConfiguration::<SystemctlTest>::new(MAX_PAYLOAD_BYTES, SystemctlTest::new());
         if libsystemd::daemon::booted() {
             let payload = daemon_config.get(COMPONENT_NAME, REPORTED_OBJECT_NAME);
             assert!(payload.is_ok());
@@ -596,8 +587,9 @@ mod tests {
                     \"autoStartStatus\":\"enabled\"\
                 }\
             ]";
-            let payload: String =
-                daemon_config.get(COMPONENT_NAME, REPORTED_OBJECT_NAME).unwrap();
+            let payload: String = daemon_config
+                .get(COMPONENT_NAME, REPORTED_OBJECT_NAME)
+                .unwrap();
             assert!(json_strings_eq::<Vec<Daemon>>(payload.as_str(), expected));
         }
     }

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -8,8 +8,8 @@ use std::process::Command;
 
 use crate::MmiError;
 
-const COMPONENT_NAME: &str = "DaemonConfiguration";
-const OBJECT_NAME: &str = "dameons";
+const COMPONENT_NAME: &str = "SystemdDaemonConfiguration";
+const OBJECT_NAME: &str = "daemonConfiguration";
 
 // r# Denotes a Rust Raw String
 const INFO: &str = r#"{
@@ -19,7 +19,7 @@ const INFO: &str = r#"{
     "VersionMajor": 1,
     "VersionMinor": 0,
     "VersionInfo": "",
-    "Components": ["DaemonConfiguration"],
+    "Components": ["SystemdDaemonConfiguration"],
     "Lifetime": 1,
     "UserAccount": 0}"#;
 
@@ -164,7 +164,8 @@ impl DaemonConfiguration {
             if self.max_payload_size_bytes != 0
                 && payload.len() as u32 > self.max_payload_size_bytes
             {
-                Err(MmiError::InvalidArgument)
+                println!("Payload size exceeded max payload size bytes in get");
+                Err(MmiError::PayloadSizeExceeded)
             } else {
                 Ok(payload)
             }
@@ -304,9 +305,6 @@ mod tests {
             if let Err(e) = invalid_object_result {
                 assert_eq!(e, MmiError::InvalidArgument);
             }
-            let payload = daemon_config
-                .get::<SystemctlTest>(COMPONENT_NAME, OBJECT_NAME)
-                .unwrap();
         } else {
             let systemd_result: Result<String, MmiError> =
                 daemon_config.get::<SystemctlTest>(COMPONENT_NAME, OBJECT_NAME);

--- a/src/modules/daemonconfiguration/src/daemonconfiguration.rs
+++ b/src/modules/daemonconfiguration/src/daemonconfiguration.rs
@@ -183,7 +183,7 @@ impl SystemctlInfo for Systemctl {
             // Unit is already enabled
             Ok(false)
         } else {
-            let output = Command::new("systemctl").args(["enable", name]).output()?;
+            Command::new("systemctl").args(["enable", name]).output()?;
             Ok(true)
         }
     }
@@ -254,7 +254,7 @@ impl<SystemCaller: SystemctlInfo> DaemonConfiguration<SystemCaller> {
         &mut self,
         component_name: &str,
         object_name: &str,
-        payload_str_slice: &str,
+        payload: &str,
     ) -> Result<i32> {
         if !libsystemd::daemon::booted() {
             // Whether the caller was booted using Systemd
@@ -265,13 +265,13 @@ impl<SystemCaller: SystemctlInfo> DaemonConfiguration<SystemCaller> {
         } else if !DESIRED_OBJECT_NAME.eq(object_name) {
             println!("Invalid object name: {}", object_name);
             Err(MmiError::InvalidArgument)
-        } else if self.max_payload_size_bytes != 0
-            && payload_str_slice.len() as u32 > self.max_payload_size_bytes
+        } else if (self.max_payload_size_bytes != 0)
+            && (payload.len() as u32 > self.max_payload_size_bytes)
         {
             println!("Payload size exceeds max payload size bytes");
-            Err(MmiError::InvalidArgument)
+            Err(MmiError::PayloadSizeExceeded)
         } else {
-            let desired_daemons = serde_json::from_str::<Vec<DesiredDaemon>>(payload_str_slice)?;
+            let desired_daemons = serde_json::from_str::<Vec<DesiredDaemon>>(payload)?;
             for desired_daemon in desired_daemons {
                 if !self.system_caller.exists(&desired_daemon.name)? {
                     println!(
@@ -597,11 +597,10 @@ mod tests {
             let payload = daemon_config.get(COMPONENT_NAME, REPORTED_OBJECT_NAME);
             assert!(payload.is_ok());
             let payload = payload.unwrap();
-            println!("{}", payload);
             let expected = "[\
                 {\
-                    \"name\":\"appor";
-            assert!(json_strings_eq::<Vec<Daemon>>(payload.as_str(), expected));
+                    \"autoStartStat";
+            assert_eq!(payload, expected);
         }
     }
 


### PR DESCRIPTION
## Description
Implemented set for the daemon config module and added unit tests. Fixed component and object names. Modified Systemctlinfo to take instances of self for testing

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.