### PR TITLE
[Networking] Add support for variable line break patterns in source data for dnsServers

### DIFF
--- a/src/modules/networking/src/lib/Networking.cpp
+++ b/src/modules/networking/src/lib/Networking.cpp
@@ -629,18 +629,23 @@ void NetworkingObjectBase::GetGlobalDnsServers(std::string dnsServersData, std::
         std::smatch dnsServersPrefixMatch;
         if (std::regex_search(globalDnsServersData, dnsServersPrefixMatch, g_dnsServersPrefixPattern))
         {
-            std::string dnsServer;
+            std::string dnsServers;
             std::stringstream globalDnsServersStream(dnsServersPrefixMatch.suffix().str());
-            while(std::getline(globalDnsServersStream, dnsServer))
+            while(std::getline(globalDnsServersStream, dnsServers))
             {
-                dnsServer.erase(remove(dnsServer.begin(), dnsServer.end(), g_spaceCharacter), dnsServer.end());
-                if ((std::regex_match(dnsServer, g_ipv4Pattern)) || (std::regex_match(dnsServer, g_ipv6Pattern)))
+                std::string dnsServer;
+                std::stringstream line(dnsServers);
+                while (std::getline(line, dnsServer, g_spaceCharacter))
                 {
-                    globalDnsServers.push_back(dnsServer);
-                }
-                else
-                {
-                    break;
+                    dnsServer.erase(remove(dnsServer.begin(), dnsServer.end(), g_spaceCharacter), dnsServer.end());
+                    if ((std::regex_match(dnsServer, g_ipv4Pattern)) || (std::regex_match(dnsServer, g_ipv6Pattern)))
+                    {
+                        globalDnsServers.push_back(dnsServer);
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
         }
@@ -674,30 +679,35 @@ void NetworkingObjectBase::GenerateDnsServersMap()
         if (IsKnownInterfaceName(interfaceName))
         {
             std::map<std::string, std::vector<std::string>>::iterator dnsServersMapIterator;
-            std::string dnsServer;
+            std::string dnsServers;
             std::smatch dnsServersPrefixMatch;
             if (std::regex_search(interfaceData, dnsServersPrefixMatch, g_dnsServersPrefixPattern))
             {
                 std::stringstream dnsServerStream(dnsServersPrefixMatch.suffix().str());
-                while(std::getline(dnsServerStream, dnsServer))
+                while(std::getline(dnsServerStream, dnsServers))
                 {
-                    dnsServer.erase(remove(dnsServer.begin(), dnsServer.end(), g_spaceCharacter), dnsServer.end());
-                    if ((std::regex_match(dnsServer, g_ipv4Pattern)) || (std::regex_match(dnsServer, g_ipv6Pattern)))
+                    std::string dnsServer;
+                    std::stringstream line(dnsServers);
+                    while (std::getline(line, dnsServer, g_spaceCharacter))
                     {
-                        dnsServersMapIterator = this->m_dnsServersMap.find(interfaceName);
-                        if (dnsServersMapIterator != this->m_dnsServersMap.end())
+                        dnsServer.erase(remove(dnsServer.begin(), dnsServer.end(), g_spaceCharacter), dnsServer.end());
+                        if ((std::regex_match(dnsServer, g_ipv4Pattern)) || (std::regex_match(dnsServer, g_ipv6Pattern)))
                         {
-                            (dnsServersMapIterator->second).push_back(dnsServer);
+                            dnsServersMapIterator = this->m_dnsServersMap.find(interfaceName);
+                            if (dnsServersMapIterator != this->m_dnsServersMap.end())
+                            {
+                                (dnsServersMapIterator->second).push_back(dnsServer);
+                            }
+                            else
+                            {
+                                std::vector<std::string> dnsServers{ dnsServer };
+                                this->m_dnsServersMap.insert(std::pair<std::string, std::vector<std::string>>(interfaceName, dnsServers));
+                            }
                         }
                         else
                         {
-                            std::vector<std::string> dnsServers{ dnsServer };
-                            this->m_dnsServersMap.insert(std::pair<std::string, std::vector<std::string>>(interfaceName, dnsServers));
+                            break;
                         }
-                    }
-                    else
-                    {
-                        break;
                     }
                 }
             }

--- a/src/modules/networking/src/lib/Networking.cpp
+++ b/src/modules/networking/src/lib/Networking.cpp
@@ -629,9 +629,10 @@ void NetworkingObjectBase::GetGlobalDnsServers(std::string dnsServersData, std::
         std::smatch dnsServersPrefixMatch;
         if (std::regex_search(globalDnsServersData, dnsServersPrefixMatch, g_dnsServersPrefixPattern))
         {
+            bool isValidData = true;
             std::string dnsServers;
             std::stringstream globalDnsServersStream(dnsServersPrefixMatch.suffix().str());
-            while(std::getline(globalDnsServersStream, dnsServers))
+            while(isValidData && std::getline(globalDnsServersStream, dnsServers))
             {
                 std::string dnsServer;
                 std::stringstream line(dnsServers);
@@ -644,6 +645,7 @@ void NetworkingObjectBase::GetGlobalDnsServers(std::string dnsServersData, std::
                     }
                     else
                     {
+                        isValidData = false;
                         break;
                     }
                 }
@@ -683,8 +685,9 @@ void NetworkingObjectBase::GenerateDnsServersMap()
             std::smatch dnsServersPrefixMatch;
             if (std::regex_search(interfaceData, dnsServersPrefixMatch, g_dnsServersPrefixPattern))
             {
+                bool isValidData = true;
                 std::stringstream dnsServerStream(dnsServersPrefixMatch.suffix().str());
-                while(std::getline(dnsServerStream, dnsServers))
+                while(isValidData && std::getline(dnsServerStream, dnsServers))
                 {
                     std::string dnsServer;
                     std::stringstream line(dnsServers);
@@ -706,6 +709,7 @@ void NetworkingObjectBase::GenerateDnsServersMap()
                         }
                         else
                         {
+                            isValidData = false;
                             break;
                         }
                     }

--- a/src/modules/networking/tests/NetworkingTests.cpp
+++ b/src/modules/networking/tests/NetworkingTests.cpp
@@ -340,7 +340,7 @@ namespace OSConfig::Platform::Tests
             "\"ipAddresses\":\"docker0=172.32.233.234,::1;eth0=172.27.181.213,10.1.1.2,fe80::5e42:4bf7:dddd:9b0f\","
             "\"subnetMasks\":\"docker0=/8,/128;eth0=/20,/16,/64\","
             "\"defaultGateways\":\"docker0=172.17.128.1;eth0=172.13.145.1\","
-            "\"dnsServers\":\"docker0=1.1.1.1,10.20.20.20,172.29.64.1,8.8.8.8;eth0=1.1.1.1,10.20.20.20,172.127.41.161,172.32.64.165,8.8.8.8\","
+            "\"dnsServers\":\"docker0=1.1.1.1,10.20.30.40,100.10.20.30,2.2.2.2;eth0=1.1.1.1,10.20.30.40,100.40.50.60,2.2.2.2,3.3.3.3\","
             "\"dhcpEnabled\":\"br-1234=unknown;docker0=true;eth0=false;veth=unknown\","
             "\"enabled\":\"br-1234=unknown;docker0=true;eth0=false;veth=unknown\","
             "\"connected\":\"br-1234=unknown;docker0=true;eth0=false;veth=unknown\"}";
@@ -505,7 +505,7 @@ namespace OSConfig::Platform::Tests
             "DNSSEC setting: no\n"
             "DNSSEC supported: no\n"
             "Current DNS Server: 1.1.1.1\n"
-            "DNS Servers: 1.1.1.1 8.8.8.8\n"
+            "DNS Servers: 1.1.1.1 2.2.2.2\n"
             "DNSSEC NTA: 10.in-addr.arpa\n"
             "Link 1 (docker0)\n"
             "Current Scopes: DNS\n"
@@ -515,8 +515,8 @@ namespace OSConfig::Platform::Tests
             "DNSOverTLS setting: no\n"
             "DNSSEC setting: no\n"
             "DNSSEC supported: no\n"
-            "Current DNS Server: 172.29.64.1\n"
-            "DNS Servers: 172.29.64.1 10.20.20.20\n"
+            "Current DNS Server: 10.20.30.40\n"
+            "DNS Servers: 10.20.30.40 100.10.20.30\n"
             "DNS Domain: mshome.net\n"
             "Link 2 (eth0)\n"
             "Current Scopes: DNS\n"
@@ -526,10 +526,12 @@ namespace OSConfig::Platform::Tests
             "DNSOverTLS setting: no\n"
             "DNSSEC setting: no\n"
             "DNSSEC supported: no\n"
-            "Current DNS Server: 172.127.41.161\n"
-            "DNS Servers: 172.127.41.161 10.20.20.20\n"
-            "172.32.64.165\n"
+            "Current DNS Server: 10.20.30.40\n"
+            "DNS Servers: 10.20.30.40 100.40.50.60\n"
+            "2.2.2.2 3.3.3.3\n"
             "DNS Domain: mshome.net\n";
+
+
 
         MMI_JSON_STRING payload;
         int payloadSizeBytes;


### PR DESCRIPTION
## Description

In some environments, multiple DNS servers are listed on a single line in output from "systemd-resolve --status," which is not expected by the current module and causes the parsing method for Networking.dnsServers to return empty data. This PR updates Networking to support the scenario.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.