### PR TITLE
Removed module identity on package removal

### DIFF
--- a/devops/debian/postinst
+++ b/devops/debian/postinst
@@ -36,7 +36,7 @@ esac
 
 # Automatically added by dh_installsystemd/12.10ubuntu1
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
-	# MSFT change: binplace osconfig.toml for the azure-identity-service only if not present
+	# OSConfig Core Team change: binplace osconfig.toml for the azure-identity-service only if not present
 	# Binplacing a pre-existing install breaks the current identity
 	# If azure-identity-service is not present, place the identity in the directory anyway so
 	# once the agent is installed, OSConfig makes use of it.
@@ -51,14 +51,14 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
 		else
 			_dh_action=start
 		fi
-		# MSFT change: dh_installsystemd uses deb-systemd-invoke which fails
+		# OSConfig Core Team change: dh_installsystemd uses deb-systemd-invoke which fails
 		# when /usr/sbin/policy-rc.d fails, use systemctl directly
 		systemctl enable 'osconfig-platform.service' >/dev/null || true
 		systemctl $_dh_action 'osconfig-platform.service' >/dev/null || true
 		systemctl enable 'osconfig.service' >/dev/null || true
 		systemctl $_dh_action 'osconfig.service' >/dev/null || true
 	fi
-	# MSFT change: signal aziot to reload module identities
+	# OSConfig Core Team change: signal aziot to reload module identities
 	if command -v aziotctl >/dev/null; then
 		aziotctl system restart >/dev/null || true
 	fi

--- a/devops/debian/prerm
+++ b/devops/debian/prerm
@@ -44,4 +44,9 @@ if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
 fi
 # End automatically added section
 
+# MSFT change: Remove module identity on package removal
+if [ "$1" = remove ]; then
+    rm /etc/aziot/identityd/config.d/osconfig.toml >/dev/null || true
+fi
+
 exit 0

--- a/devops/debian/prerm
+++ b/devops/debian/prerm
@@ -35,7 +35,7 @@ esac
 
 # Automatically added by dh_installsystemd/12.10ubuntu1
 if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
-    # MSFT change: dh_installsystemd uses deb-systemd-invoke which fails
+    # OSConfig Core Team change: dh_installsystemd uses deb-systemd-invoke which fails
     # when /usr/sbin/policy-rc.d fails, use systemctl directly
     systemctl stop 'osconfig.service' >/dev/null || true
     systemctl disable 'osconfig.service' >/dev/null || true
@@ -44,7 +44,7 @@ if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
 fi
 # End automatically added section
 
-# MSFT change: Remove module identity on package removal
+# OSConfig Core Team change: Remove module identity on package removal
 if [ "$1" = remove ]; then
     rm /etc/aziot/identityd/config.d/osconfig.toml >/dev/null || true
 fi

--- a/src/cmake/templates/osconfig.spec.in
+++ b/src/cmake/templates/osconfig.spec.in
@@ -78,6 +78,7 @@ systemctl start osconfig.service
 %postun
 %systemd_postun osconfig.service
 %systemd_postun osconfig-platform.service
+rm /etc/aziot/identityd/config.d/osconfig.toml >/dev/null || true
 
 %files
 %defattr(-, root, root, -)


### PR DESCRIPTION
## Description

* Removed osconfig module identity on Debian/RPM package removal

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.