### PR TITLE
Increase firewall logging during parsing and bug fixes

### DIFF
--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -572,7 +572,7 @@ int IpTables::SetDefaultPolicies(const std::vector<IpTablesPolicy> policies)
             int commandStatus = 0;
             char* textResult = nullptr;
 
-            if (0 != (commandStatus = ExecuteCommand(nullptr, command.c_str(), false, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
+            if (0 != (commandStatus = ExecuteCommand(nullptr, command.c_str(), true, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
             {
                 errors.push_back("Failed to set default policy (" + specification + "): " + std::string(textResult));
                 status = commandStatus;
@@ -611,7 +611,7 @@ bool IpTables::Exists(const IpTables::Rule& rule) const
     char* textResult = nullptr;
     std::string command = "iptables -C " + rule.Specification();
 
-    if (0 == ExecuteCommand(nullptr, command.c_str(), false, false, 0, 0, &textResult, nullptr, FirewallLog::Get()))
+    if (0 == ExecuteCommand(nullptr, command.c_str(), true, false, 0, 0, &textResult, nullptr, FirewallLog::Get()))
     {
         exists = true;
     }
@@ -627,7 +627,7 @@ int IpTables::Add(const IpTables::Rule& rule, std::string& error)
     std::string command = "iptables -I " + rule.Specification();
     char* textResult = nullptr;
 
-    if (0 != (status = ExecuteCommand(nullptr, command.c_str(), false, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
+    if (0 != (status = ExecuteCommand(nullptr, command.c_str(), true, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
     {
         if (IsFullLoggingEnabled())
         {
@@ -652,7 +652,7 @@ int IpTables::Remove(const IpTables::Rule& rule, std::string& error)
     std::string command = "iptables -D " + rule.Specification();
     char* textResult = nullptr;
 
-    if (0 != (status = ExecuteCommand(nullptr, command.c_str(), false, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
+    if (0 != (status = ExecuteCommand(nullptr, command.c_str(), true, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
     {
         if (IsFullLoggingEnabled())
         {

--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -624,7 +624,7 @@ bool IpTables::Exists(const IpTables::Rule& rule) const
 int IpTables::Add(const IpTables::Rule& rule, std::string& error)
 {
     int status = 0;
-    std::string command = "iptables -A " + rule.Specification();
+    std::string command = "iptables -I " + rule.Specification();
     char* textResult = nullptr;
 
     if (0 != (status = ExecuteCommand(nullptr, command.c_str(), false, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))

--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -247,7 +247,6 @@ int FirewallModuleBase::Set(const char* componentName, const char* objectName, c
             OsConfigLogError(FirewallLog::Get(), "Invalid component name: %s", componentName);
             status = EINVAL;
         }
-
     }
 
     return status;
@@ -402,9 +401,12 @@ GenericRule& GenericRule::Parse(const rapidjson::Value& value)
         m_parseError.push_back("Rule JSON is not an object");
     }
 
-    for (auto& error : m_parseError)
+    if (IsFullLoggingEnabled())
     {
-        OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+        for (auto& error : m_parseError)
+        {
+            OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+        }
     }
 
     return *this;
@@ -592,7 +594,10 @@ int IpTables::SetDefaultPolicies(const std::vector<IpTablesPolicy> policies)
     for (const std::string& error : errors)
     {
         errorMessage += error + "\n";
-        OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+        }
     }
 
     m_policyStatusMessage = errorMessage;
@@ -735,7 +740,10 @@ int IpTables::SetRules(const std::vector<IpTables::Rule>& rules)
         for (const std::string& error : errors)
         {
             errorMessage += error + "\n";
-            OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+            if (IsFullLoggingEnabled())
+            {
+                OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+            }
         }
 
         m_ruleStatusMessage = errorMessage;
@@ -905,7 +913,10 @@ GenericPolicy& GenericPolicy::Parse(const rapidjson::Value& value)
 
     for (auto& error : m_parseError)
     {
-        OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+        }
     }
 
     return *this;

--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -407,6 +407,11 @@ GenericRule& GenericRule::Parse(const rapidjson::Value& value)
         m_parseError.push_back("Rule JSON is not an object");
     }
 
+    for (auto& error : m_parseError)
+    {
+        OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
+    }
+
     return *this;
 }
 
@@ -592,6 +597,7 @@ int IpTables::SetDefaultPolicies(const std::vector<IpTablesPolicy> policies)
     for (const std::string& error : errors)
     {
         errorMessage += error + "\n";
+        OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
     }
 
     m_policyStatusMessage = errorMessage;
@@ -734,6 +740,7 @@ int IpTables::SetRules(const std::vector<IpTables::Rule>& rules)
         for (const std::string& error : errors)
         {
             errorMessage += error + "\n";
+            OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
         }
 
         m_ruleStatusMessage = errorMessage;
@@ -899,6 +906,11 @@ GenericPolicy& GenericPolicy::Parse(const rapidjson::Value& value)
     else
     {
         m_parseError.push_back("Policy must contain direction");
+    }
+
+    for (auto& error : m_parseError)
+    {
+        OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
     }
 
     return *this;

--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -751,7 +751,7 @@ int IpTables::SetRules(const std::vector<IpTables::Rule>& rules)
     }
     else
     {
-        m_policyStatusMessage = "";
+        m_ruleStatusMessage = "";
     }
 
     return status;

--- a/src/modules/firewall/src/lib/Firewall.h
+++ b/src/modules/firewall/src/lib/Firewall.h
@@ -314,7 +314,6 @@ protected:
 
 private:
     unsigned int m_maxPayloadSizeBytes;
-    size_t m_lastPayloadHash;
 };
 
 template<class T>


### PR DESCRIPTION
## Description

Increase logging (during full logging) to not rely on reported `configurationStatusDetail` for error messages that occur during parsing and `iptables` command execution.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.