### PR TITLE
Making the MPI REST API client library get the MPI result codes from HTTP responses of Get calls that fail with HTTP status 500 (internal server error)

### DIFF
--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -347,8 +347,8 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
 
     char* request = NULL;
     int requestSize = 0;
-    char* statusFromResponse = NULL;
     int status = MPI_OK;
+    char* statusFromResponse = NULL;
     
     if ((NULL == g_mpiHandle) || (0 == strlen((char*)g_mpiHandle)))
     {
@@ -385,9 +385,9 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
 
     if (HTTP_INTERNAL_SERVER_ERROR == status)
     {
-        if ((NULL != payload) && (payloadSizeBytes > 0))
+        if ((NULL != *payload) && (*payloadSizeBytes > 0))
         {
-            statusFromResponse = ParseString(log, payload);
+            statusFromResponse = ParseString(log, *payload);
             status = (NULL == statusFromResponse) ? EINVAL : atoi(statusFromResponse);
             FREE_MEMORY(statusFromResponse);
 
@@ -400,7 +400,7 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
             status = EINVAL;
         }
     }
-    else if ((NULL != *payload) && ((*payloadSizeBytes != (int)strlen(*payload)) || (!IsValidMimObjectPayload(*payload, *payloadSizeBytes, log)))
+    else if ((NULL != *payload) && ((*payloadSizeBytes != (int)strlen(*payload)) || (!IsValidMimObjectPayload(*payload, *payloadSizeBytes, log))))
     {
         status = EINVAL;
         OsConfigLogError(log, "CallMpiGet(%s, %s): invalid response (%d)", componentName, propertyName, status);
@@ -487,6 +487,7 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes, void* lo
     char* request = NULL;
     int requestSize = 0;
     int status = MPI_OK;
+    char* statusFromResponse = NULL;
 
     if ((NULL == g_mpiHandle) || (0 == strlen((char*)g_mpiHandle)))
     {
@@ -523,9 +524,9 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes, void* lo
 
     if (HTTP_INTERNAL_SERVER_ERROR == status)
     {
-        if ((NULL != payload) && (payloadSizeBytes > 0))
+        if ((NULL != *payload) && (*payloadSizeBytes > 0))
         {
-            statusFromResponse = ParseString(log, payload);
+            statusFromResponse = ParseString(log, *payload);
             status = (NULL == statusFromResponse) ? EINVAL : atoi(statusFromResponse);
             FREE_MEMORY(statusFromResponse);
         }

--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -17,6 +17,8 @@
 
 #define MPI_MAX_CONTENT_LENGTH 64
 
+#define HTTP_INTERNAL_SERVER_ERROR 500
+
 extern MPI_HANDLE g_mpiHandle;
 
 static int CallMpi(const char* name, const char* request, char** response, int* responseSize, void* log)
@@ -345,8 +347,9 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
 
     char* request = NULL;
     int requestSize = 0;
+    char* statusFromResponse = NULL;
     int status = MPI_OK;
-
+    
     if ((NULL == g_mpiHandle) || (0 == strlen((char*)g_mpiHandle)))
     {
         status = EPERM;
@@ -380,9 +383,27 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
 
     FREE_MEMORY(request);
 
-    if ((NULL != *payload) && (*payloadSizeBytes != (int)strlen(*payload)))
+    if (HTTP_INTERNAL_SERVER_ERROR == status)
     {
-        OsConfigLogError(log, "CallMpiGet(%s, %s): invalid response length (%p, %d)", componentName, propertyName, *payload, *payloadSizeBytes);
+        if ((NULL != payload) && (payloadSizeBytes > 0))
+        {
+            statusFromResponse = ParseString(log, payload);
+            status = (NULL == statusFromResponse) ? EINVAL : atoi(statusFromResponse);
+            FREE_MEMORY(statusFromResponse);
+
+            FREE_MEMORY(*payload);
+            *payloadSizeBytes = 0;
+        }
+        else
+        {
+            OsConfigLogError(log, "CallMpiGet(%s, %s): invalid response for HTTP internal server error (500)", componentName, propertyName);
+            status = EINVAL;
+        }
+    }
+    else if ((NULL != *payload) && ((*payloadSizeBytes != (int)strlen(*payload)) || (!IsValidMimObjectPayload(*payload, *payloadSizeBytes, log)))
+    {
+        status = EINVAL;
+        OsConfigLogError(log, "CallMpiGet(%s, %s): invalid response (%d)", componentName, propertyName, status);
 
         FREE_MEMORY(*payload);
         *payloadSizeBytes = 0;
@@ -393,14 +414,6 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
         OsConfigLogInfo(log, "CallMpiGet(%p, %s, %s, %.*s, %d bytes): %d", g_mpiHandle, componentName, propertyName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
 
-    if ((NULL != *payload) && (!IsValidMimObjectPayload(*payload, *payloadSizeBytes, log)))
-    {
-        status = EINVAL;
-        OsConfigLogError(log, "CallMpiGet(%s, %s): invalid payload (%d)", componentName, propertyName, status);
-
-        FREE_MEMORY(*payload);
-        *payloadSizeBytes = 0;
-    }
 
     return status;
 };
@@ -508,9 +521,28 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes, void* lo
 
     FREE_MEMORY(request);
 
-    if ((NULL == *payload) || (*payloadSizeBytes != (int)strlen(*payload)))
+    if (HTTP_INTERNAL_SERVER_ERROR == status)
+    {
+        if ((NULL != payload) && (payloadSizeBytes > 0))
+        {
+            statusFromResponse = ParseString(log, payload);
+            status = (NULL == statusFromResponse) ? EINVAL : atoi(statusFromResponse);
+            FREE_MEMORY(statusFromResponse);
+        }
+        else
+        {
+            OsConfigLogError(log, "CallMpiGetReported: invalid response for HTTP internal server error (500)");
+            status = EINVAL;
+        }
+
+        FREE_MEMORY(*payload);
+        *payloadSizeBytes = 0;
+    }
+    else if ((NULL != *payload) && (*payloadSizeBytes != (int)strlen(*payload)))
     {
         OsConfigLogError(log, "CallMpiGetReported: invalid response (%p, %d)", *payload, *payloadSizeBytes);
+
+        status = EINVAL;
 
         FREE_MEMORY(*payload);
         *payloadSizeBytes = 0;

--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -414,7 +414,6 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
         OsConfigLogInfo(log, "CallMpiGet(%p, %s, %s, %.*s, %d bytes): %d", g_mpiHandle, componentName, propertyName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
 
-
     return status;
 };
 

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -345,7 +345,7 @@ HTTP_STATUS HandleMpiCall(const char* uri, const char* requestBody, char** respo
                                 status = HTTP_INTERNAL_SERVER_ERROR;
                                 if (IsFullLoggingEnabled())
                                 {
-                                    OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed to for client '%s'", uri, component, object, client);
+                                    OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed to for client '%s' with %d (returning %d)", uri, component, object, client, mpiStatus, status);
                                 }
                             }
                         }
@@ -355,7 +355,7 @@ HTTP_STATUS HandleMpiCall(const char* uri, const char* requestBody, char** respo
                         status = HTTP_INTERNAL_SERVER_ERROR;
                         if (IsFullLoggingEnabled())
                         {
-                            OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed to for client '%s'", uri, component, object, client);
+                            OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed to for client '%s' with %d (returning %d)", uri, component, object, client, mpiStatus, status);
                         }
                     }
                 }
@@ -374,16 +374,16 @@ HTTP_STATUS HandleMpiCall(const char* uri, const char* requestBody, char** respo
                 }
                 else if (MPI_OK != (mpiStatus = handlers.mpiSetDesired((MPI_HANDLE)client, (MPI_JSON_STRING)payload, strlen(payload))))
                 {
-                    OsConfigLogError(GetPlatformLog(), "%s: failed for client %s, status %d", uri, client, mpiStatus);
                     status = HTTP_INTERNAL_SERVER_ERROR;
+                    OsConfigLogError(GetPlatformLog(), "%s: failed to for client '%s' with %d (returning %d)", uri, client, mpiStatus, status);
                 }
             }
             else if (0 == strcmp(uri, MPI_GET_REPORTED_URI))
             {
                 if (MPI_OK != (mpiStatus = handlers.mpiGetReported((MPI_HANDLE)client, response, responseSize)))
                 {
-                    OsConfigLogError(GetPlatformLog(), "%s: failed for client %s, status %d", uri, client, mpiStatus);
                     status = HTTP_INTERNAL_SERVER_ERROR;
+                    OsConfigLogError(GetPlatformLog(), "%s: failed to for client '%s' with %d (returning %d)", uri, client, mpiStatus, status);
                 }
             }
         }


### PR DESCRIPTION
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.