### PR TITLE
Fix firewall reported state detection

### DIFF
--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -480,7 +480,7 @@ std::string IpTablesRule::Specification() const
 
 IpTables::State IpTables::Detect() const
 {
-    const char* command = "iptables -S";
+    const char* command = "iptables -S | grep -E \"^-A (INPUT|OUTPUT)\" | wc -l";
 
     State state = State::Unknown;
     char* textResult = nullptr;
@@ -489,7 +489,8 @@ IpTables::State IpTables::Detect() const
     {
         if (textResult && (strlen(textResult) > 0))
         {
-            state = State::Enabled;
+            int ruleCount = atoi(textResult);
+            state = (ruleCount > 0) ? State::Enabled : State::Disabled;
         }
         else
         {


### PR DESCRIPTION
## Description

The firewall module should report `state: enabled` only if `iptables` is present and there are rules specified in the `INPUT/OUTPUT` chains of the `filter` table. This change fixes the module's behavior to report `state: disabled` when no rules are specified in the `INPUT/OUTPUT` chains.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.