### PR TITLE
Updated e2e tests to use iotedge 1.4

### DIFF
--- a/devops/e2e/debian-stretch-cloud-init-insiders-fast.tpl
+++ b/devops/e2e/debian-stretch-cloud-init-insiders-fast.tpl
@@ -26,7 +26,7 @@ apt_sources:
 package_upgrade: true
 runcmd:
   # Install aziot-identity-service
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_debian9_amd64.deb -O aziot-identity-service.deb
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.4.1/aziot-identity-service_1.4.1-1_debian10_amd64.deb -O aziot-identity-service.deb
   - apt install -y ./aziot-identity-service.deb
   # Install GitHub Actions Runner
   - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz

--- a/devops/e2e/debian-stretch-cloud-init.tpl
+++ b/devops/e2e/debian-stretch-cloud-init.tpl
@@ -3,7 +3,7 @@ apt_update: true
 package_upgrade: true
 runcmd:
   # Install aziot-identity-service
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_debian9_amd64.deb -O aziot-identity-service.deb
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.4.1/aziot-identity-service_1.4.1-1_debian10_amd64.deb -O aziot-identity-service.deb
   - apt install -y ./aziot-identity-service.deb
   # Install GitHub Actions Runner
   - mkdir actions-runner && cd actions-runner && curl -o runner.tar.gz -L ${github_runner_tar_gz_package} && tar xzf ./runner.tar.gz

--- a/devops/e2e/ubuntu-focal-arm64-cloud-init-insiders-fast.tpl
+++ b/devops/e2e/ubuntu-focal-arm64-cloud-init-insiders-fast.tpl
@@ -59,5 +59,5 @@ runcmd:
   - ./svc.sh install
   - ./svc.sh start
   # Install aziot-identity-service - no arm packages available
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.4.1/aziot-identity-service_1.4.1-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
   - apt install -y ./aziot-identity-service.deb

--- a/devops/e2e/ubuntu-focal-arm64-cloud-init.tpl
+++ b/devops/e2e/ubuntu-focal-arm64-cloud-init.tpl
@@ -44,7 +44,7 @@ packages:
   - zlib1g
 runcmd:
   # Install aziot-identity-service - no arm packages available
-  - wget https://github.com/Azure/azure-iotedge/releases/download/1.2.10/aziot-identity-service_1.2.6-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
+  - wget https://github.com/Azure/azure-iotedge/releases/download/1.4.1/aziot-identity-service_1.4.1-1_ubuntu20.04_arm64.deb -O aziot-identity-service.deb
   - apt install -y ./aziot-identity-service.deb
   # Install .NET Core SDK
   - wget https://download.visualstudio.microsoft.com/download/pr/06c4ee8e-bf2c-4e46-ab1c-e14dd72311c1/f7bc6c9677eaccadd1d0e76c55d361ea/dotnet-sdk-6.0.301-linux-arm64.tar.gz -O dotnet-sdk-6.0.tar.gz


### PR DESCRIPTION
## Description

* Updated debian9 (using debian10 package) and ubuntu 20.04 arm64 distros to use IotEdge runtime 1.4
* Tested and works across all distros

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.