### PR TITLE
Fix inconsistent modulestest failures

### DIFF
--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -19,8 +19,9 @@ void RecipeInvoker::TestBody()
 
         if (0 == m_recipe.m_expectedResult)
         {
-            JSON_Value *root_value = json_parse_string(payload);
-            ASSERT_NE(nullptr, root_value) << "Invalid JSON payload: <null>";
+            std::string payloadString(payload, payloadSize);
+            JSON_Value* root_value = json_parse_string(payloadString.c_str());
+            ASSERT_NE(nullptr, root_value) << "Invalid JSON payload: " << payloadString;
             JSON_Object *jsonObject = json_value_get_object(root_value);
 
             EXPECT_NE(0, m_recipe.m_mimObjects->size()) << "Invalid MIM JSON!";

--- a/src/modules/test/recipes/SampleTests.json
+++ b/src/modules/test/recipes/SampleTests.json
@@ -6,14 +6,13 @@
         "ExpectedResult": 0,
         "WaitSeconds": 0
     },
-    // TODO: Enable this test once the bug is fixed
-    // {
-    //     "ComponentName": "SampleComponent",
-    //     "ObjectName": "reportedIntegerObject",
-    //     "Desired": false,
-    //     "ExpectedResult": 0,
-    //     "WaitSeconds": 0
-    // },
+    {
+        "ComponentName": "SampleComponent",
+        "ObjectName": "reportedIntegerObject",
+        "Desired": false,
+        "ExpectedResult": 0,
+        "WaitSeconds": 0
+    },
     {
         "ComponentName": "SampleComponent",
         "ObjectName": "reportedBooleanObject",


### PR DESCRIPTION
## Description

Use payload size when parsing reported JSON payload.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.