### PR TITLE
Re-add ctest logs to CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
   #     - src/**
 
 env:
-  build-type: Release
-  container-workspace: /azure-osconfig
+  BUILD_TYPE: Release
+  MOUNT: /azure-osconfig
 
 jobs:
   unit-test:
@@ -41,7 +41,7 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.variant.arch }}
           platform: ${{ matrix.variant.platform }}
-          mount: ${{ github.workspace }}:${{ env.container-workspace }}
+          mount: ${{ github.workspace }}:${{ env.MOUNT }}
           tag: "289651"
 
       - name: Generate build
@@ -50,14 +50,14 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           cmd: |
             mkdir build && cd build
-            cmake ../src -DCMAKE_build-type=${{ env.build-type }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_AGENTS=ON -G Ninja
+            cmake ../src -DCMAKE_build-type=${{ env.BUILD_TYPE }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_AGENTS=ON -G Ninja
 
       - name: Build azure-osconfig
         uses: ./.github/actions/container-exec
         with:
           container: ${{ steps.container.outputs.id }}
-          working-directory: ${{ env.container-workspace }}/build
-          cmd: cmake --build . --config ${{ env.build-type }}
+          working-directory: ${{ env.MOUNT }}/build
+          cmd: cmake --build . --config ${{ env.BUILD_TYPE }}
 
       - name: Set test output
         id: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - src/**
-  # pull_request:
-  #   paths:
-  #     - src/**
+    branches:
+      - main
+    paths:
+      - src/**
+  pull_request:
+    paths:
+      - src/**
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - src/**
-  pull_request:
-    paths:
-      - src/**
+  #   branches:
+  #     - main
+  #   paths:
+  #     - src/**
+  # pull_request:
+  #   paths:
+  #     - src/**
 
 env:
   build-type: Release
@@ -61,34 +61,37 @@ jobs:
 
       - name: Set test output
         id: test
-        run: echo '::set-output name=xml::${{ matrix.os }}-${{ matrix.variant.arch }}.xml'
+        run: |
+          echo ::set-output name=log::${{ matrix.os }}-${{ matrix.variant.arch }}.log
+          echo ::set-output name=xml::${{ matrix.os }}-${{ matrix.variant.arch }}.xml
 
       - name: Run ctest
         uses: ./.github/actions/container-exec
+        continue-on-error: true
         with:
           container: ${{ steps.container.outputs.id }}
-          working-directory: ${{ env.container-workspace }}/build
-          cmd: ctest
+          working-directory: ${{ env.MOUNT }}/build
+          cmd: ctest --verbose > ../${{ steps.test.outputs.log }}
 
       - name: Generate test report
         uses: ./.github/actions/gtest-xml
-        if: success() || failure()
         with:
           path: ./build/gtest-output
-          output: ./${{ steps.test.outputs.xml }}
+          output: ${{ steps.test.outputs.xml }}
 
       - uses: actions/upload-artifact@v2
-        if: success() || failure()
+        if: always()
         with:
           name: unit-test
-          path: ./${{ steps.test.outputs.xml }}
+          path: |
+            ${{ steps.test.outputs.log }}
+            ${{ steps.test.outputs.xml }}
 
       - name: Publish test report
         uses: dorny/test-reporter@v1
-        if: success() || failure()
         with:
           name: Test report (${{ matrix.os }}-${{ matrix.variant.arch }})
-          path: ./${{ steps.test.outputs.xml }}
+          path: ${{ steps.test.outputs.xml }}
           reporter: java-junit
 
   coverage:


### PR DESCRIPTION
## Description

Re-add verbose ctest logs to CI `unit-test` artifact. Log artifacts were replaced by XML test output during #256. Both forms of logs are necessary for proper debugging.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.