### PR TITLE
Added additional MIM validations and warning for modulestest

### DIFF
--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -83,10 +83,10 @@ void RecipeInvoker::TestBody()
                 JSON_Value *returned_payload = json_parse_string(payload);
 
                 std::string recipe_payload_str(payload, payloadSize);
-                EXPECT_NE(nullptr, recipe_payload) << "Failed to parse recipe payload" << std::endl << "JSON: " << m_recipe.m_payload;
-                EXPECT_NE(nullptr, returned_payload) << "Failed to parse returned payload" << std::endl << "JSON: " << payload;
+                EXPECT_NE(nullptr, recipe_payload) << "Failed to parse recipe payload" << std::endl << "JSON: " << m_recipe.m_payload.c_str() << std::endl;
+                EXPECT_NE(nullptr, returned_payload) << "Failed to parse returned payload" << std::endl << "JSON: " << recipe_payload_str.c_str() << std::endl;
                 EXPECT_EQ(json_value_get_type(returned_payload), json_value_get_type(recipe_payload)) << "Non matching payload types. Recipe payload: " << json_value_get_type(recipe_payload) << ", returned payload: " << json_value_get_type(returned_payload) << std::endl;
-                EXPECT_EQ(json_value_equals(recipe_payload, returned_payload), 1) << "Non matching recipe payload" << std::endl << "Recipe   payload: " << m_recipe.m_payload << std::endl << "Returned payload: " << recipe_payload_str << std::endl;
+                EXPECT_EQ(json_value_equals(recipe_payload, returned_payload), 1) << "Non matching recipe payload" << std::endl << "Recipe   payload: " << m_recipe.m_payload << std::endl << "Returned payload: " << recipe_payload_str.c_str() << std::endl;
 
                 json_value_free(recipe_payload);
                 json_value_free(returned_payload);


### PR DESCRIPTION
## Description

* Solidified MIM parsing for modulestest, will have warnings when parsing invalid MIMs
* Installed osconfig on modulestest CI VM hosts to enable `Configuration` module tests

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.