### PR TITLE
Removing from the Configuration module ability to restart OSConfig

### DIFF
--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -277,7 +277,6 @@ MMI_HANDLE ConfigurationMmiOpen(const char* clientName, const unsigned int maxPa
 
 static bool IsValidSession(MMI_HANDLE clientSession)
 {
-    CheckAndRestartOsConfig();
     return ((NULL == clientSession) || (0 != strcmp(g_configurationModuleName, (char*)clientSession)) || (g_referenceCount <= 0)) ? false : true;
 }
 
@@ -343,6 +342,8 @@ int ConfigurationMmiGet(MMI_HANDLE clientSession, const char* componentName, con
 
     *payload = NULL;
     *payloadSizeBytes = 0;
+
+    CheckAndRestartOsConfig();
 
     if (!IsValidSession(clientSession))
     {

--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -321,8 +321,6 @@ int ConfigurationMmiGet(MMI_HANDLE clientSession, const char* componentName, con
     *payload = NULL;
     *payloadSizeBytes = 0;
 
-    CheckAndRestartOsConfig();
-
     if (!IsValidSession(clientSession))
     {
         OsConfigLogError(ConfigurationGetLog(), "MmiGet(%s, %s) called outside of a valid session", componentName, objectName);


### PR DESCRIPTION
Removing from the Configuration module ability to restart OSConfig, for that to be done in a safer way with CommandRunner and reboot. 

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.