### PR TITLE
Fix range in Adhs E2E test 

### DIFF
--- a/src/tests/e2etest/AdhsTests.cs
+++ b/src/tests/e2etest/AdhsTests.cs
@@ -23,7 +23,7 @@ namespace E2eTesting
         [Test]
         public void AdhsTest_Get()
         {
-            Adhs reported = GetReported(_componentName, (Adhs adhs) => (adhs.OptIn == 1 || adhs.OptIn == 2 || adhs.OptIn == 3));
+            Adhs reported = GetReported(_componentName, (Adhs adhs) => (adhs.OptIn == 0 || adhs.OptIn == 1 || adhs.OptIn == 2));
 
             Assert.Multiple(() =>
             {


### PR DESCRIPTION
## Description

Valid range for `optIn` values is `0-2`. Previous check was incorrect and may cause timeouts as it would miss valid values in `optIn`. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.