### PR TITLE
Disable Adhs and DeliveryOptimization E2E tests

### DIFF
--- a/src/tests/e2etest/AdhsTests.cs
+++ b/src/tests/e2etest/AdhsTests.cs
@@ -1,52 +1,52 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-using NUnit.Framework;
+// using NUnit.Framework;
 
-namespace E2eTesting
-{
-    [TestFixture, Category("Adhs")]
-    public class AdhsTests : E2ETest
-    {
-        private static readonly string _componentName = "Adhs";
+// namespace E2eTesting
+// {
+//     [TestFixture, Category("Adhs")]
+//     public class AdhsTests : E2ETest
+//     {
+//         private static readonly string _componentName = "Adhs";
 
-        public class Adhs
-        {
-            public int OptIn { get; set; }
-        }
+//         public class Adhs
+//         {
+//             public int OptIn { get; set; }
+//         }
 
-        public class DesiredAdhs
-        {
-            public int DesiredOptIn { get; set; }
-        }
+//         public class DesiredAdhs
+//         {
+//             public int DesiredOptIn { get; set; }
+//         }
 
-        [Test]
-        public void AdhsTest_Get()
-        {
-            Adhs reported = GetReported(_componentName, (Adhs adhs) => (adhs.OptIn == 0 || adhs.OptIn == 1 || adhs.OptIn == 2));
+//         [Test]
+//         public void AdhsTest_Get()
+//         {
+//             Adhs reported = GetReported(_componentName, (Adhs adhs) => (adhs.OptIn == 0 || adhs.OptIn == 1 || adhs.OptIn == 2));
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(reported.OptIn, Is.InRange(0, 2));
-            });
-        }
+//             Assert.Multiple(() =>
+//             {
+//                 Assert.That(reported.OptIn, Is.InRange(0, 2));
+//             });
+//         }
         
-        [Test]
-        public void AdhsTest_Set()
-        {
-            var desired = new DesiredAdhs
-            {
-                DesiredOptIn = 1 
-            };
+//         [Test]
+//         public void AdhsTest_Set()
+//         {
+//             var desired = new DesiredAdhs
+//             {
+//                 DesiredOptIn = 1 
+//             };
 
-            SetDesired(_componentName, desired);
+//             SetDesired(_componentName, desired);
 
-            Adhs reported = GetReported(_componentName, (Adhs adhs) => (adhs.OptIn == 1));
+//             Adhs reported = GetReported(_componentName, (Adhs adhs) => (adhs.OptIn == 1));
 
-            Assert.Multiple(() =>
-            {
-                Assert.AreEqual(desired.DesiredOptIn, reported.OptIn);
-            });
-        }
-    }
-}
+//             Assert.Multiple(() =>
+//             {
+//                 Assert.AreEqual(desired.DesiredOptIn, reported.OptIn);
+//             });
+//         }
+//     }
+// }

--- a/src/tests/e2etest/DeliveryOptimizationTests.cs
+++ b/src/tests/e2etest/DeliveryOptimizationTests.cs
@@ -1,77 +1,77 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// // Copyright (c) Microsoft Corporation. All rights reserved.
+// // Licensed under the MIT License.
 
-using NUnit.Framework;
+// using NUnit.Framework;
 
-namespace E2eTesting
-{
-    [TestFixture, Category("DeliveryOptimization")]
-    public class DeliveryOptimizationTests : E2ETest
-    {
-        private static readonly string _componentName = "DeliveryOptimization";
+// namespace E2eTesting
+// {
+//     [TestFixture, Category("DeliveryOptimization")]
+//     public class DeliveryOptimizationTests : E2ETest
+//     {
+//         private static readonly string _componentName = "DeliveryOptimization";
 
-        public class DeliveryOptimization
-        {
-            public string CacheHost { get; set; }
-            public int CacheHostSource { get; set; }
-            public int CacheHostFallback { get; set; }
-            public int PercentageDownloadThrottle { get; set; }
-        }
+//         public class DeliveryOptimization
+//         {
+//             public string CacheHost { get; set; }
+//             public int CacheHostSource { get; set; }
+//             public int CacheHostFallback { get; set; }
+//             public int PercentageDownloadThrottle { get; set; }
+//         }
 
-        public class DesiredDeliveryOptimizationPolicies
-        {
-            public string CacheHost { get; set; }
-            public int CacheHostSource { get; set; }
-            public int CacheHostFallback { get; set; }
-            public int PercentageDownloadThrottle { get; set; }
-        }
+//         public class DesiredDeliveryOptimizationPolicies
+//         {
+//             public string CacheHost { get; set; }
+//             public int CacheHostSource { get; set; }
+//             public int CacheHostFallback { get; set; }
+//             public int PercentageDownloadThrottle { get; set; }
+//         }
 
-        public class DesiredDeliveryOptimization
-        {
-            public DesiredDeliveryOptimizationPolicies DesiredDeliveryOptimizationPolicies { get; set; }
-        }
+//         public class DesiredDeliveryOptimization
+//         {
+//             public DesiredDeliveryOptimizationPolicies DesiredDeliveryOptimizationPolicies { get; set; }
+//         }
 
-        [Test]
-        public void DeliveryOptimizationTest_Get()
-        {
-            DeliveryOptimization reported = GetReported(_componentName, (DeliveryOptimization deliveryOptimization) => (deliveryOptimization.CacheHost != null));
+//         [Test]
+//         public void DeliveryOptimizationTest_Get()
+//         {
+//             DeliveryOptimization reported = GetReported(_componentName, (DeliveryOptimization deliveryOptimization) => (deliveryOptimization.CacheHost != null));
 
-            Assert.Multiple(() =>
-            {
-                Assert.NotNull(reported.CacheHost);
-                Assert.That(reported.CacheHostSource, Is.InRange(0, 3));
-                Assert.That(reported.PercentageDownloadThrottle, Is.InRange(0, 100));
-            });
-        }
+//             Assert.Multiple(() =>
+//             {
+//                 Assert.NotNull(reported.CacheHost);
+//                 Assert.That(reported.CacheHostSource, Is.InRange(0, 3));
+//                 Assert.That(reported.PercentageDownloadThrottle, Is.InRange(0, 100));
+//             });
+//         }
         
-        [Test]
-        public void DeliveryOptimizationTest_Set()
-        {
-            var desired = new DesiredDeliveryOptimization
-            {
-                DesiredDeliveryOptimizationPolicies = new DesiredDeliveryOptimizationPolicies
-                {
-                    CacheHost = "10.0.0.0:80,host.com:8080",
-                    CacheHostSource = 1,
-                    CacheHostFallback = 2,
-                    PercentageDownloadThrottle = 3
-                }   
-            };
+//         [Test]
+//         public void DeliveryOptimizationTest_Set()
+//         {
+//             var desired = new DesiredDeliveryOptimization
+//             {
+//                 DesiredDeliveryOptimizationPolicies = new DesiredDeliveryOptimizationPolicies
+//                 {
+//                     CacheHost = "10.0.0.0:80,host.com:8080",
+//                     CacheHostSource = 1,
+//                     CacheHostFallback = 2,
+//                     PercentageDownloadThrottle = 3
+//                 }   
+//             };
 
-            SetDesired(_componentName, desired);
+//             SetDesired(_componentName, desired);
 
-            DeliveryOptimization reported = GetReported(_componentName, (DeliveryOptimization deliveryOptimization) => (deliveryOptimization.CacheHost == desired.DesiredDeliveryOptimizationPolicies.CacheHost && 
-                deliveryOptimization.CacheHostSource == desired.DesiredDeliveryOptimizationPolicies.CacheHostSource && 
-                deliveryOptimization.CacheHostFallback == desired.DesiredDeliveryOptimizationPolicies.CacheHostFallback && 
-                deliveryOptimization.PercentageDownloadThrottle == desired.DesiredDeliveryOptimizationPolicies.PercentageDownloadThrottle));
+//             DeliveryOptimization reported = GetReported(_componentName, (DeliveryOptimization deliveryOptimization) => (deliveryOptimization.CacheHost == desired.DesiredDeliveryOptimizationPolicies.CacheHost && 
+//                 deliveryOptimization.CacheHostSource == desired.DesiredDeliveryOptimizationPolicies.CacheHostSource && 
+//                 deliveryOptimization.CacheHostFallback == desired.DesiredDeliveryOptimizationPolicies.CacheHostFallback && 
+//                 deliveryOptimization.PercentageDownloadThrottle == desired.DesiredDeliveryOptimizationPolicies.PercentageDownloadThrottle));
 
-            Assert.Multiple(() =>
-            {
-                Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.CacheHost, reported.CacheHost);
-                Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.CacheHostSource, reported.CacheHostSource);
-                Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.CacheHostFallback, reported.CacheHostFallback);
-                Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.PercentageDownloadThrottle, reported.PercentageDownloadThrottle);
-            });
-        }
-    }
-}
+//             Assert.Multiple(() =>
+//             {
+//                 Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.CacheHost, reported.CacheHost);
+//                 Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.CacheHostSource, reported.CacheHostSource);
+//                 Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.CacheHostFallback, reported.CacheHostFallback);
+//                 Assert.AreEqual(desired.DesiredDeliveryOptimizationPolicies.PercentageDownloadThrottle, reported.PercentageDownloadThrottle);
+//             });
+//         }
+//     }
+// }


### PR DESCRIPTION
## Description

Temporarily removing the `Adhs` and `DeliveryOptimization` module E2E tests.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.