### PR TITLE
Updated workflows to use new environment files

### DIFF
--- a/.github/actions/container-run/action.yml
+++ b/.github/actions/container-run/action.yml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - name: Login to container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
@@ -49,5 +49,5 @@ runs:
 
     - name: Setup container
       id: container
-      run: echo '::set-output name=id::$(docker run -di --privileged -v ${{ inputs.mount }} --platform=${{ inputs.platform }} ${{ inputs.registry }}/${{ inputs.os }}-dev-${{ inputs.arch }}:${{ inputs.tag }})'
+      run: echo "id=$(docker run -di --privileged -v ${{ inputs.mount }} --platform=${{ inputs.platform }} ${{ inputs.registry }}/${{ inputs.os }}-dev-${{ inputs.arch }}:${{ inputs.tag }})" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/footprint-check/action.yml
+++ b/.github/actions/footprint-check/action.yml
@@ -38,8 +38,8 @@ runs:
           ("arm")   arch="armv7l";;
         esac
 
-        echo ::set-output name=distroName::${distroName}
-        echo ::set-output name=arch::${arch}
+        echo "distroName=${distroName}" >> $GITHUB_OUTPUT
+        echo "arch::${arch}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Footprint delta validation

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -21,7 +21,7 @@ jobs:
           files: ./devops/docker/**/Dockerfile
 
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(echo -n ${{ steps.changed-files.outputs.all_changed_files }} | jq -R -s -c 'split(" ")')"
+        run: echo "matrix=$(echo -n ${{ steps.changed-files.outputs.all_changed_files }} | jq -R -s -c 'split(" ")')" >> $GITHUB_OUTPUT
 
   docker:
     name: Build and push
@@ -37,8 +37,8 @@ jobs:
         id: image
         run: |
           DOCKERFILE=${{ matrix.container }}
-          echo "::set-output name=name::$(echo ${DOCKERFILE%/*}-dev)"
-          echo "::set-output name=path::$(dirname ${DOCKERFILE})"
+          echo "name=$(echo ${DOCKERFILE%/*}-dev)" >> $GITHUB_OUTPUT
+          echo "path=$(dirname ${DOCKERFILE})" >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
@@ -46,7 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to ACR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ secrets.ACR_REGISTRY }}
           username: ${{ secrets.ACR_CLIENT_ID }}

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Set version
         id: version
-        run: echo "::set-output name=tweak::$(echo $(date +'%Y%m%d%H%M'))"
+        run: echo "tweak=$(echo $(date +'%Y%m%d%H%M'))" >> $GITHUB_OUTPUT
 
       - name: Run container
         id: container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Set test output
         id: test
         run: |
-          echo ::set-output name=log::${{ matrix.os }}-${{ matrix.variant.arch }}.log
-          echo ::set-output name=xml::${{ matrix.os }}-${{ matrix.variant.arch }}.xml
+          echo "log=${{ matrix.os }}-${{ matrix.variant.arch }}.log" >> $GITHUB_OUTPUT
+          echo "xml=${{ matrix.os }}-${{ matrix.variant.arch }}.xml" >> $GITHUB_OUTPUT
 
       - name: Run ctest
         uses: ./.github/actions/container-exec

--- a/.github/workflows/e2etest-fetch-targets.yml
+++ b/.github/workflows/e2etest-fetch-targets.yml
@@ -33,14 +33,14 @@ jobs:
       - name: Read E2E target environment definitions
         id: set-matrix
         run: |
-          distroName=`cat ./devops/e2e/${{ secrets.E2E_ENV_FILE }} | jq '.[].distroName' | jq -s .`
-          echo ::set-output name=distroName::${distroName}
+          distroName=`cat ./devops/e2e/${{ secrets.E2E_ENV_FILE }} | jq '.[].distroName' | jq -s . | tr -d '\n'`
+          echo "distroName=$distroName" >> $GITHUB_OUTPUT
 
       - name: Generate random resource group name
         id: set-resource-group
         run: |
           resourceGroupName=`echo osconfig-$(echo $RANDOM | md5sum | head -c 16)`
-          echo ::set-output name=resourceGroupName::${resourceGroupName}
+          echo "resourceGroupName=${resourceGroupName}" >> $GITHUB_OUTPUT
 
       - name: Azure Login
         uses: azure/login@v1

--- a/.github/workflows/e2etest-provision-ais.yml
+++ b/.github/workflows/e2etest-provision-ais.yml
@@ -34,7 +34,7 @@ jobs:
           target=`jq '.[] | select(.distroName=="${{ matrix.distroName }}")' ${{ github.workspace }}/devops/e2e/${{ secrets.E2E_ENV_FILE }}`
           device_id=$(echo $target | jq .device_id | tr -d \")
           echo Using device id: $device_id
-          echo ::set-output name=device_id::$device_id
+          echo "device_id=$device_id" >> $GITHUB_OUTPUT
 
       - name: Create device identity
         id: provision-ais
@@ -48,5 +48,5 @@ jobs:
           DEVICE_CONN_STR="`az iot hub device-identity connection-string show --hub-name ${{ inputs.resourceGroupName }}-iothub --device-id ${{ steps.get-test-data.outputs.device_id }} --output tsv`"
           echo '' && echo Adding to Key Vault
           az keyvault secret set --name "${{ inputs.resourceGroupName }}-${{ steps.get-test-data.outputs.device_id }}" --vault-name ${{ secrets.KEY_VAULT_NAME }} --value $DEVICE_CONN_STR > /dev/null
-          echo ::set-output name=DEVICE_CONN_STR::$DEVICE_CONN_STR
+          echo "DEVICE_CONN_STR=$DEVICE_CONN_STR" >> $GITHUB_OUTPUT
           echo ::add-mask::$DEVICE_CONN_STR

--- a/.github/workflows/e2etest-provision-hosts.yml
+++ b/.github/workflows/e2etest-provision-hosts.yml
@@ -40,7 +40,7 @@ jobs:
         id: runner_token
         run: |
           RUNNER_TOKEN=$(gh api --method POST -H "Accept: application/vnd.github.v3+json" /repos/Azure/azure-osconfig/actions/runners/registration-token | jq '.token')
-          echo ::set-output name=RUNNER_TOKEN::$RUNNER_TOKEN
+          echo "RUNNER_TOKEN=$RUNNER_TOKEN" >> $GITHUB_OUTPUT
           echo ::add-mask::$RUNNER_TOKEN
 
       - name: Provision VM - ${{ matrix.distroName }}
@@ -69,7 +69,7 @@ jobs:
           github_runner_tar_gz=`echo $target | jq .github_runner_tar_gz | tr -d \"`
           cloud_init=`echo $target | jq .cloud_init | tr -d \"`
 
-          echo ::set-output name=device_id::$device_id
+          echo "device_id=$device_id" >> $GITHUB_OUTPUT
 
           terraform init
 

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -55,17 +55,17 @@ jobs:
         id: get-test-data
         run: |
           target=`jq '.[] | select(.distroName=="${{ matrix.distroName }}")' ${{ github.workspace }}/devops/e2e/${{ secrets.E2E_ENV_FILE }}`
-          echo ::set-output name=device_id::$(echo $target | jq .device_id | tr -d \")
+          echo "device_id=$(echo $target | jq .device_id | tr -d \")" >> $GITHUB_OUTPUT
 
           test_filter=$(echo $target | jq .test_filter | tr -d \")
           [[ "$test_filter" != "null" ]] && test_filter="--filter \"${test_filter}\"" || test_filter=""
           echo Using test filter: $test_filter
-          echo ::set-output name=test_filter::$test_filter
+          echo "test_filter=$test_filter" >> $GITHUB_OUTPUT
 
           package_path=$(echo $target | jq .package_path | tr -d \")
           [[ "$package_path" != "null" ]] && package_path="${package_path}" || package_path=""
           echo Using package path: $package_path
-          echo ::set-output name=package_path::$package_path
+          echo "package_path=$package_path" >> $GITHUB_OUTPUT
 
       - name: Retreive device identity
         id: hub-identity
@@ -73,12 +73,12 @@ jobs:
           token=`curl -X POST -H 'Content-Type: application/x-www-form-urlencoded' https://login.microsoftonline.com/${{ secrets.TENANT_ID }}/oauth2/v2.0/token --data-urlencode 'grant_type=client_credentials' --data-urlencode 'client_id=${{ secrets.CLIENT_ID }}' --data-urlencode 'client_secret=${{ secrets.CLIENT_SECRET }}' --data-urlencode 'scope=https://vault.azure.net/.default' | jq .access_token | tr -d \"`
 
           iothubowner_connection_string=`curl -s "https://${{ secrets.KEY_VAULT_NAME }}.vault.azure.net/secrets/${{ inputs.resourceGroupName }}-iothubowner?api-version=2016-10-01" -H "Authorization: Bearer $token" | jq .value | tr -d \"`
-          echo iothubowner_connection_string=$iothubowner_connection_string
-          echo ::set-output name=iothubowner_connection_string::$iothubowner_connection_string
+          echo ::add-mask::$iothubowner_connection_string
+          echo "iothubowner_connection_string=$iothubowner_connection_string" >> $GITHUB_OUTPUT
 
           device_conn_str=`curl -s "https://${{ secrets.KEY_VAULT_NAME }}.vault.azure.net/secrets/${{ inputs.resourceGroupName }}-${{ steps.get-test-data.outputs.device_id }}?api-version=2016-10-01" -H "Authorization: Bearer $token" | jq .value | tr -d \"`
-          echo device_conn_str=$device_conn_str
-          echo ::set-output name=device_conn_str::$device_conn_str
+          echo ::add-mask::$device_conn_str
+          echo "device_conn_str=$device_conn_str" >> $GITHUB_OUTPUT
 
       - name: Apply device identity
         run: |
@@ -107,7 +107,7 @@ jobs:
         id: memory-start
         run: |
           mem_start=`free --kilo | sed -n 2p | cut -c 20-32 | tr -d ' '`
-          echo ::set-output name=mem_start::$mem_start
+          echo "mem_start=$mem_start" >> $GITHUB_OUTPUT
 
       - name: Configure and Start OSConfig
         run: |

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -9,7 +9,7 @@
         "package_path": "*focal_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-focal-cloud-init.tpl"
     },
     {
@@ -22,7 +22,7 @@
         "package_path": "*bionic_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init.tpl"
     },
     {
@@ -35,7 +35,7 @@
         "package_path": "*focal_aarch64.deb",
         "vm_size": "Standard_D2plds_v5",
         "location": "West US 2",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init.tpl"
     },
     {
@@ -46,7 +46,7 @@
         "package_path": "*stretch_x86_64.deb",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/debian-stretch-cloud-init.tpl"
     }
 ]

--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -9,7 +9,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-focal-cloud-init-insiders-fast.tpl"
     },
     {
@@ -22,7 +22,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init-insiders-fast.tpl"
     },
     {
@@ -35,7 +35,7 @@
         "vm_size": "Standard_D2plds_v5",
         "location": "West US 2",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init-insiders-fast.tpl"
     },
     {
@@ -46,7 +46,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/debian-stretch-cloud-init-insiders-fast.tpl"
     }
 ]

--- a/devops/e2e/modulestest.json
+++ b/devops/e2e/modulestest.json
@@ -7,7 +7,7 @@
         "image_version": "latest",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/build-ubuntu-focal-cloud-init.tpl"
     },
     {
@@ -18,7 +18,7 @@
         "image_version": "latest",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/build-ubuntu-bionic-cloud-init.tpl"
     },
     {
@@ -29,7 +29,7 @@
         "image_version": "latest",
         "vm_size": "Standard_D2plds_v5",
         "location": "West US 2",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/build-ubuntu-focal-arm64-cloud-init.tpl"
     },
     {
@@ -38,7 +38,7 @@
         "image_name": "debian_9",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/build-debian-stretch-cloud-init.tpl"
     }
 ]

--- a/devops/e2e/prod.json
+++ b/devops/e2e/prod.json
@@ -9,7 +9,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-focal-cloud-init.tpl"
     },
     {
@@ -22,7 +22,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-bionic-cloud-init.tpl"
     },
     {
@@ -35,7 +35,7 @@
         "vm_size": "Standard_D2plds_v5",
         "location": "West US 2",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-arm64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/ubuntu-focal-arm64-cloud-init.tpl"
     },
     {
@@ -46,7 +46,7 @@
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "test_filter": "TpmTest",
-        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.291.1/actions-runner-linux-x64-2.291.1.tar.gz",
+        "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",
         "cloud_init": "devops/e2e/debian-stretch-cloud-init.tpl"
     }
 ]


### PR DESCRIPTION
## Description

* Removed deprecated `set-output` command, in favor of the new [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)
* Updated e2e github runners (all environments) to `298.2` (from `291.1`)
* Cleaned up github variables

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.