### PR TITLE
Fixing payload validation for ModulesTest app

### DIFF
--- a/.github/workflows/e2etest-run-modulestest.yml
+++ b/.github/workflows/e2etest-run-modulestest.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Run modulestest
         if: success()
         run: |
-          mkdir -p /etc/osconfig/
           cd build
           function checkResult(){
             if [[ $1 -ne 0 ]]; then

--- a/src/modules/test/RecipeInvoker.cpp
+++ b/src/modules/test/RecipeInvoker.cpp
@@ -32,14 +32,12 @@ void RecipeInvoker::TestBody()
                 EXPECT_NE(0, m_recipe.m_mimObjects->at(m_recipe.m_componentName)->size()) << "No MimObjects for " << m_recipe.m_componentName << "!";
                 auto map = m_recipe.m_mimObjects->at(m_recipe.m_componentName)->at(m_recipe.m_objectName);
 
-                std::string payloadStr(payload, payloadSize);
-
                 // Validate settings + supported values
                 TestLogInfo("Validating settings and supported values for '%s'", m_recipe.m_objectName.c_str());
                 if ((map.m_type.compare("array") == 0) ||
                     (map.m_type.compare("map") == 0))
                 {
-                    EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl << "JSON: " << payloadStr;
+                    EXPECT_EQ(JSONArray, json_value_get_type(root_value)) << "Expecting '" << m_recipe.m_objectName << "' to contain an array" << std::endl << "JSON: " << payloadString;
                 }
                 else
                 {
@@ -47,23 +45,23 @@ void RecipeInvoker::TestBody()
                     {
                         if (setting.second.type.compare("string") == 0)
                         {
-                            EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
+                            EXPECT_NE(nullptr, json_object_get_string(jsonObject, setting.second.name.c_str())) << "Expecting '" << m_recipe.m_objectName << "' to contain string setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadString;
 
                             std::string value = json_object_get_string(jsonObject, setting.second.name.c_str());
                             if (setting.second.allowedValues->size() && std::find(setting.second.allowedValues->begin(), setting.second.allowedValues->end(), value) == setting.second.allowedValues->end())
                             {
-                                FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl << "JSON: " << payloadStr;
+                                FAIL() << "Field '" << setting.second.name << "' contains unsupported value '" << value << "'" << std::endl << "JSON: " << payloadString;
                             }
                         }
                         else if (setting.second.type.compare("integer") == 0)
                         {
                             JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
-                            EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
+                            EXPECT_EQ(JSONNumber, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain integer setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadString;
                         }
                         else if (setting.second.type.compare("boolean") == 0)
                         {
                             JSON_Value *value = json_object_get_value(jsonObject, setting.second.name.c_str());
-                            EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadStr;
+                            EXPECT_EQ(JSONBoolean, json_value_get_type(value)) << "Expecting '" << m_recipe.m_objectName << "' to contain boolean setting '" << setting.second.name << "'" << std::endl << "JSON: " << payloadString;
                         }
                     }
                 }
@@ -80,13 +78,12 @@ void RecipeInvoker::TestBody()
             if (m_recipe.m_payload.size())
             {
                 JSON_Value *recipe_payload = json_parse_string(m_recipe.m_payload.c_str());
-                JSON_Value *returned_payload = json_parse_string(payload);
+                JSON_Value *returned_payload = json_parse_string(payloadString.c_str());
 
-                std::string recipe_payload_str(payload, payloadSize);
                 EXPECT_NE(nullptr, recipe_payload) << "Failed to parse recipe payload" << std::endl << "JSON: " << m_recipe.m_payload.c_str() << std::endl;
-                EXPECT_NE(nullptr, returned_payload) << "Failed to parse returned payload" << std::endl << "JSON: " << recipe_payload_str.c_str() << std::endl;
+                EXPECT_NE(nullptr, returned_payload) << "Failed to parse returned payload" << std::endl << "JSON: " << payloadString.c_str() << std::endl;
                 EXPECT_EQ(json_value_get_type(returned_payload), json_value_get_type(recipe_payload)) << "Non matching payload types. Recipe payload: " << json_value_get_type(recipe_payload) << ", returned payload: " << json_value_get_type(returned_payload) << std::endl;
-                EXPECT_EQ(json_value_equals(recipe_payload, returned_payload), 1) << "Non matching recipe payload" << std::endl << "Recipe   payload: " << m_recipe.m_payload << std::endl << "Returned payload: " << recipe_payload_str.c_str() << std::endl;
+                EXPECT_EQ(json_value_equals(recipe_payload, returned_payload), 1) << "Non matching recipe payload" << std::endl << "Recipe   payload: " << m_recipe.m_payload << std::endl << "Returned payload: " << payloadString.c_str() << std::endl;
 
                 json_value_free(recipe_payload);
                 json_value_free(returned_payload);


### PR DESCRIPTION
## Description

* Fixing the recipe payload validation to use standard string comparison instead of parsons `json_value_equals` which fails on occasion despite the JSON strings being equivalent.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.