### PR TITLE
Updated 18.04 image tag for more reliability

### DIFF
--- a/.github/workflows/deploy-github-main.yml
+++ b/.github/workflows/deploy-github-main.yml
@@ -1,16 +1,16 @@
 name: E2E (GitHub-main)
-on:
-  workflow_run:
-    workflows: ["Package"]
-    types:
-      - completed
-    conclusions:
-      - success
-  push:
-    branches:
-      - main
-    paths:
-      - devops/e2e/**
+on: [push]
+  # workflow_run:
+  #   workflows: ["Package"]
+  #   types:
+  #     - completed
+  #   conclusions:
+  #     - success
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - devops/e2e/**
 
 jobs:
   fetch-targets:

--- a/.github/workflows/deploy-github-main.yml
+++ b/.github/workflows/deploy-github-main.yml
@@ -1,16 +1,16 @@
 name: E2E (GitHub-main)
-on: [push]
-  # workflow_run:
-  #   workflows: ["Package"]
-  #   types:
-  #     - completed
-  #   conclusions:
-  #     - success
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - devops/e2e/**
+on:
+  workflow_run:
+    workflows: ["Package"]
+    types:
+      - completed
+    conclusions:
+      - success
+  push:
+    branches:
+      - main
+    paths:
+      - devops/e2e/**
 
 jobs:
   fetch-targets:

--- a/devops/e2e/github-main.json
+++ b/devops/e2e/github-main.json
@@ -17,7 +17,7 @@
         "image_publisher": "Canonical",
         "image_offer": "UbuntuServer",
         "image_sku": "18.04-LTS",
-        "image_version": "latest",
+        "image_version": "18.04.202210140",
         "device_id": "ubuntu1804",
         "package_path": "*bionic_x86_64.deb",
         "vm_size": "Standard_DS1_v2",

--- a/devops/e2e/insiders-fast.json
+++ b/devops/e2e/insiders-fast.json
@@ -17,7 +17,7 @@
         "image_publisher": "Canonical",
         "image_offer": "UbuntuServer",
         "image_sku": "18.04-LTS",
-        "image_version": "latest",
+        "image_version": "18.04.202210140",
         "device_id": "ubuntu1804",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",

--- a/devops/e2e/modulestest.json
+++ b/devops/e2e/modulestest.json
@@ -15,7 +15,7 @@
         "image_publisher": "Canonical",
         "image_offer": "UbuntuServer",
         "image_sku": "18.04-LTS",
-        "image_version": "latest",
+        "image_version": "18.04.202210140",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",
         "github_runner_tar_gz": "https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz",

--- a/devops/e2e/prod.json
+++ b/devops/e2e/prod.json
@@ -17,7 +17,7 @@
         "image_publisher": "Canonical",
         "image_offer": "UbuntuServer",
         "image_sku": "18.04-LTS",
-        "image_version": "latest",
+        "image_version": "18.04.202210140",
         "device_id": "ubuntu1804",
         "vm_size": "Standard_DS1_v2",
         "location": "East US",


### PR DESCRIPTION
## Description

* The `latest` version of the test target `Canonical:UbuntuServer:18.04-LTS:18.04.202210180` was always running into apt/dpkg lock issues. Downgraded the version to the previous working version `18.04.202210140`

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.