### PR TITLE
Updated Azure pipelines tag to use latest containers

### DIFF
--- a/devops/pipeline/binary_package.yaml
+++ b/devops/pipeline/binary_package.yaml
@@ -89,7 +89,7 @@ parameters:
 variables:
   SERVICE_CONNECTION: OSConfig-ACR
   CONTAINER_REGISTRY: osconfig.azurecr.io
-  CONTAINER_TAG: 271654
+  CONTAINER_TAG: 289651
 
 trigger:
   branches:


### PR DESCRIPTION
## Description

* Updated Azure Pipelines containers to use the latest tag `289651`

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.