### PR TITLE
Refactoring the test recipes with explicit setup and teardown and running commands without CommandRunner

### DIFF
--- a/src/modules/test/TestRecipeParser.cpp
+++ b/src/modules/test/TestRecipeParser.cpp
@@ -31,7 +31,7 @@ TestRecipes TestRecipeParser::ParseTestRecipe(std::string path)
 
     JSON_Array *jsonTestRecipes = json_value_get_array(root_value);
     JSON_Object *jsonTestRecipe = nullptr;
-    for (size_t i = 0; i < json_array_get_count(jsonTestRecipes); i++)
+    for (size_t i = 1; i < json_array_get_count(jsonTestRecipes); i++)
     {
         jsonTestRecipe = json_array_get_object(jsonTestRecipes, i);
 

--- a/src/modules/test/recipes/AdhsTests.json
+++ b/src/modules/test/recipes/AdhsTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "adhs.so",
     "MimFile": "adhs.json",
-    "ModelName": "AdhsConfigurationModel",
+    "ModelName": "AdhsConfigurationModel"
   },
   {
     "ComponentName": "Adhs",

--- a/src/modules/test/recipes/AdhsTests.json
+++ b/src/modules/test/recipes/AdhsTests.json
@@ -1,85 +1,72 @@
 [
-    {
-        "ComponentName": "Adhs",
-        "ObjectName": "optIn",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Adhs",
-        "ObjectName": "invalidObjectName",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"adhsSaveConfig\",\"arguments\":\"mkdir -p /etc/azure-device-health-services/ && touch /etc/azure-device-health-services/config.toml && cp /etc/azure-device-health-services/config.toml config.toml\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"adhsSaveConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "Adhs",
-        "ObjectName": "desiredOptIn",
-        "Desired": true,
-        "Payload": "1",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"validateOptIn\",\"arguments\":\"cat /etc/azure-device-health-services/config.toml | grep 'Permission = \\\"Required\\\"'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"validateOptIn\",\"resultCode\":0,\"textResult\":\"Permission =  Required  \",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "Adhs",
-        "ObjectName": "desiredOptIn",
-        "Desired": true,
-        "Payload": "-1",
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Adhs",
-        "ObjectName": "desiredOptIn",
-        "Desired": true,
-        "Payload": "3",
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"adhsRestoreConfig\",\"arguments\":\"cp config.toml /etc/azure-device-health-services/config.toml && rm -f config.toml\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"adhsRestoreConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
-        "ExpectedResult": 0
-    }
+  {
+    "ModuleBinary": "adhs.so",
+    "MimFile": "adhs.json",
+    "ModelName": "AdhsConfigurationModel",
+  },
+  {
+    "ComponentName": "Adhs",
+    "ObjectName": "optIn",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Adhs",
+    "ObjectName": "invalidObjectName",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"adhsSaveConfig\",\"arguments\":\"mkdir -p /etc/azure-device-health-services/ && touch /etc/azure-device-health-services/config.toml && cp /etc/azure-device-health-services/config.toml config.toml\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"adhsSaveConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "ComponentName": "Adhs",
+    "ObjectName": "desiredOptIn",
+    "Desired": true,
+    "Payload": "1",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateOptIn\",\"arguments\":\"cat /etc/azure-device-health-services/config.toml | grep 'Permission = \\\"Required\\\"'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateOptIn\",\"resultCode\":0,\"textResult\":\"Permission =  Required  \",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "ComponentName": "Adhs",
+    "ObjectName": "desiredOptIn",
+    "Desired": true,
+    "Payload": "-1",
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Adhs",
+    "ObjectName": "desiredOptIn",
+    "Desired": true,
+    "Payload": "3",
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"adhsRestoreConfig\",\"arguments\":\"cp config.toml /etc/azure-device-health-services/config.toml && rm -f config.toml\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"adhsRestoreConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "ExpectedResult": 0
+  }
 ]

--- a/src/modules/test/recipes/CommandRunnerTests.json
+++ b/src/modules/test/recipes/CommandRunnerTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "commandrunner.so",
     "MimFile": "commandrunner.json",
-    "ModelName": "CommandRunnerModel",
+    "ModelName": "CommandRunnerModel"
   },
   {
     "ComponentName": "CommandRunner",

--- a/src/modules/test/recipes/CommandRunnerTests.json
+++ b/src/modules/test/recipes/CommandRunnerTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "commandrunner.so",
+    "MimFile": "commandrunner.json",
+    "ModelName": "CommandRunnerModel",
+  },
+  {
     "ComponentName": "CommandRunner",
     "ObjectName": "commandStatus",
     "Desired": false,

--- a/src/modules/test/recipes/ConfigurationTests.json
+++ b/src/modules/test/recipes/ConfigurationTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "configuration.so",
+    "MimFile": "configuration.json",
+    "ModelName": "ConfigurationModel",
+  },
+  {
     "ComponentName": "Configuration",
     "ObjectName": "notImplemented",
     "Desired": false,

--- a/src/modules/test/recipes/ConfigurationTests.json
+++ b/src/modules/test/recipes/ConfigurationTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "configuration.so",
     "MimFile": "configuration.json",
-    "ModelName": "ConfigurationModel",
+    "ModelName": "ConfigurationModel"
   },
   {
     "ComponentName": "Configuration",

--- a/src/modules/test/recipes/DeliveryOptimizationTests.json
+++ b/src/modules/test/recipes/DeliveryOptimizationTests.json
@@ -1,151 +1,120 @@
 [
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "cacheHost",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "cacheHostSource",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "cacheHostFallback",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "percentageDownloadThrottle",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "invalidObjectName",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"deliveryOptimizationSaveConfig\",\"arguments\":\"mkdir -p /etc/deliveryoptimization-agent/ && touch /etc/deliveryoptimization-agent/admin-config.json && cp /etc/deliveryoptimization-agent/admin-config.json admin-config.json\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"deliveryOptimizationSaveConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "desiredDeliveryOptimizationPolicies",
-        "Desired": true,
-        "Payload": "{\"cacheHost\":\"10.0.0.0:80,host.com:8080\",\"cacheHostSource\":1,\"cacheHostFallback\":2,\"percentageDownloadThrottle\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"validateDesiredCacheHost\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOCacheHost'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"validateDesiredCacheHost\",\"resultCode\":0,\"textResult\":\"10.0.0.0:80,host.com:8080 \",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"validateDesiredCacheHostSource\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOCacheHostSource'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"validateDesiredCacheHostSource\",\"resultCode\":0,\"textResult\":\"1 \",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"validateDesiredCacheHostFallback\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOCacheHostFallback'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"validateDesiredCacheHostFallback\",\"resultCode\":0,\"textResult\":\"2 \",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"validatePercentageDownloadThrottle\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOPercentageDownloadThrottle'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"validatePercentageDownloadThrottle\",\"resultCode\":0,\"textResult\":\"3 \",\"currentState\":2}",
-        "ExpectedResult": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "desiredDeliveryOptimizationPolicies",
-        "Desired": true,
-        "Payload": "{\"cacheHostSource\":-1}",
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "DeliveryOptimization",
-        "ObjectName": "desiredDeliveryOptimizationPolicies",
-        "Desired": true,
-        "Payload": "{\"percentageDownloadThrottle\":-1}",
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandArguments",
-        "Desired": true,
-        "Payload": "{\"commandId\":\"deliveryOptimizationRestoreConfig\",\"arguments\":\"cp admin-config.json /etc/deliveryoptimization-agent/admin-config.json && rm -f admin-config.json\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 1
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "{\"commandId\":\"deliveryOptimizationRestoreConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
-        "ExpectedResult": 0
-    }
+  {
+    "ModuleBinary": "deliveryoptimization.so",
+    "MimFile": "deliveryoptimization.json",
+    "ModelName": "DeliveryOptimizationModel",
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "cacheHost",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "cacheHostSource",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "cacheHostFallback",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "percentageDownloadThrottle",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "invalidObjectName",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"deliveryOptimizationSaveConfig\",\"arguments\":\"mkdir -p /etc/deliveryoptimization-agent/ && touch /etc/deliveryoptimization-agent/admin-config.json && cp /etc/deliveryoptimization-agent/admin-config.json admin-config.json\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"deliveryOptimizationSaveConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "desiredDeliveryOptimizationPolicies",
+    "Desired": true,
+    "Payload": "{\"cacheHost\":\"10.0.0.0:80,host.com:8080\",\"cacheHostSource\":1,\"cacheHostFallback\":2,\"percentageDownloadThrottle\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateDesiredCacheHost\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOCacheHost'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateDesiredCacheHost\",\"resultCode\":0,\"textResult\":\"10.0.0.0:80,host.com:8080 \",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateDesiredCacheHostSource\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOCacheHostSource'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateDesiredCacheHostSource\",\"resultCode\":0,\"textResult\":\"1 \",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateDesiredCacheHostFallback\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOCacheHostFallback'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validateDesiredCacheHostFallback\",\"resultCode\":0,\"textResult\":\"2 \",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validatePercentageDownloadThrottle\",\"arguments\":\"cat /etc/deliveryoptimization-agent/admin-config.json | jq -r '.DOPercentageDownloadThrottle'\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"validatePercentageDownloadThrottle\",\"resultCode\":0,\"textResult\":\"3 \",\"currentState\":2}",
+    "ExpectedResult": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "desiredDeliveryOptimizationPolicies",
+    "Desired": true,
+    "Payload": "{\"cacheHostSource\":-1}",
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "DeliveryOptimization",
+    "ObjectName": "desiredDeliveryOptimizationPolicies",
+    "Desired": true,
+    "Payload": "{\"percentageDownloadThrottle\":-1}",
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "RunCommand": "{\"commandId\":\"deliveryOptimizationRestoreConfig\",\"arguments\":\"cp admin-config.json /etc/deliveryoptimization-agent/admin-config.json && rm -f admin-config.json\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 1
+  },
+  {
+    "RunCommand": "{\"commandId\":\"deliveryOptimizationRestoreConfig\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "ExpectedResult": 0
+  }
 ]

--- a/src/modules/test/recipes/DeliveryOptimizationTests.json
+++ b/src/modules/test/recipes/DeliveryOptimizationTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "deliveryoptimization.so",
     "MimFile": "deliveryoptimization.json",
-    "ModelName": "DeliveryOptimizationModel",
+    "ModelName": "DeliveryOptimizationModel"
   },
   {
     "ComponentName": "DeliveryOptimization",

--- a/src/modules/test/recipes/DeviceInfoTests.json
+++ b/src/modules/test/recipes/DeviceInfoTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "deviceinfo.so",
     "MimFile": "deviceinfo.json",
-    "ModelName": "DeviceInfoModel",
+    "ModelName": "DeviceInfoModel"
   },
   {
     "ComponentName": "DeviceInfo",

--- a/src/modules/test/recipes/DeviceInfoTests.json
+++ b/src/modules/test/recipes/DeviceInfoTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "deviceinfo.so",
+    "MimFile": "deviceinfo.json",
+    "ModelName": "DeviceInfoModel",
+  },
+  {
     "ComponentName": "DeviceInfo",
     "ObjectName": "osName",
     "Desired": false,

--- a/src/modules/test/recipes/FirewallTests.json
+++ b/src/modules/test/recipes/FirewallTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "firewall.so",
     "MimFile": "firewall.json",
-    "ModelName": "FirewallModel",
+    "ModelName": "FirewallModel"
   },
   {
     "ComponentName": "Firewall",

--- a/src/modules/test/recipes/FirewallTests.json
+++ b/src/modules/test/recipes/FirewallTests.json
@@ -1,110 +1,115 @@
 [
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "state",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "fingerprint",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "invalidComponentName",
-        "ObjectName": "state",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "invalidComponentName",
-        "ObjectName": "fingerprint",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "invalidObjectName",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "",
-        "ObjectName": "state",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "",
-        "ObjectName": "fingerprint",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "",
-        "ObjectName": "invalidObjectName",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "",
-        "ObjectName": "",
-        "Desired": false,
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "defaultPolicies",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "configurationStatus",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "configurationStatusDetail",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "desiredDefaultPolicies",
-        "Desired": true,
-        "Payload": "[{\"action\": \"accept\", \"direction\": \"in\"}, {\"action\": \"accept\", \"direction\": \"out\"}]",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "desiredDefaultPolicies",
-        "Desired": true,
-        "Payload": "[{\"action\": \"reject\", \"direction\": \"in\"}]",
-        "ExpectedResult": 22,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "Firewall",
-        "ObjectName": "desiredRules",
-        "Desired": true,
-        "Payload": "[{\"desiredState\": \"present\", \"action\": \"accept\", \"direction\": \"in\", \"protocol\": \"tcp\", \"sourcePort\": 80, \"sourceAddress\": \"0.0.0.0\"}]",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    }
+  {
+    "ModuleBinary": "firewall.so",
+    "MimFile": "firewall.json",
+    "ModelName": "FirewallModel",
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "state",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "fingerprint",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "invalidComponentName",
+    "ObjectName": "state",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "invalidComponentName",
+    "ObjectName": "fingerprint",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "invalidObjectName",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "",
+    "ObjectName": "state",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "",
+    "ObjectName": "fingerprint",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "",
+    "ObjectName": "invalidObjectName",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "",
+    "ObjectName": "",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "defaultPolicies",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "configurationStatus",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "configurationStatusDetail",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "desiredDefaultPolicies",
+    "Desired": true,
+    "Payload": "[{\"action\": \"accept\", \"direction\": \"in\"}, {\"action\": \"accept\", \"direction\": \"out\"}]",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "desiredDefaultPolicies",
+    "Desired": true,
+    "Payload": "[{\"action\": \"reject\", \"direction\": \"in\"}]",
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Firewall",
+    "ObjectName": "desiredRules",
+    "Desired": true,
+    "Payload": "[{\"desiredState\": \"present\", \"action\": \"accept\", \"direction\": \"in\", \"protocol\": \"tcp\", \"sourcePort\": 80, \"sourceAddress\": \"0.0.0.0\"}]",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  }
 ]

--- a/src/modules/test/recipes/HostNameTests.json
+++ b/src/modules/test/recipes/HostNameTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "hostname.so",
     "MimFile": "hostname.json",
-    "ModelName": "HostNameModel",
+    "ModelName": "HostNameModel"
   },
   {
     "ComponentName": "HostName",

--- a/src/modules/test/recipes/HostNameTests.json
+++ b/src/modules/test/recipes/HostNameTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "hostname.so",
+    "MimFile": "hostname.json",
+    "ModelName": "HostNameModel",
+  },
+  {
     "ComponentName": "HostName",
     "ObjectName": "name",
     "Desired": false,
@@ -49,18 +54,12 @@
     "ExpectedResult": 22
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandArguments",
-    "Desired": true,
-    "Payload": "{\"commandId\":\"saveHostNameInTempFile\",\"arguments\":\"echo $(hostname) > HostNameTestsTemp.txt\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "RunCommand": "{\"commandId\":\"saveHostNameInTempFile\",\"arguments\":\"echo $(hostname) > HostNameTestsTemp.txt\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
     "ExpectedResult": 0,
     "WaitSeconds": 5
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandStatus",
-    "Desired": false,
-    "Payload": "{\"commandId\":\"saveHostNameInTempFile\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "RunCommand": "{\"commandId\":\"saveHostNameInTempFile\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
     "ExpectedResult": 0
   },
   {
@@ -78,63 +77,39 @@
     "ExpectedResult": 0
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandArguments",
-    "Desired": true,
-    "Payload": "{\"commandId\":\"validateDesiredHostName\",\"arguments\":\"hostname | grep -o testHostName\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "RunCommand": "{\"commandId\":\"validateDesiredHostName\",\"arguments\":\"hostname | grep -o testHostName\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
     "ExpectedResult": 0,
     "WaitSeconds": 1
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandStatus",
-    "Desired": false,
-    "Payload": "{\"commandId\":\"validateDesiredHostName\",\"resultCode\":0,\"textResult\":\"testHostName \",\"currentState\":2}",
+    "RunCommand": "{\"commandId\":\"validateDesiredHostName\",\"resultCode\":0,\"textResult\":\"testHostName \",\"currentState\":2}",
     "ExpectedResult": 0
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandArguments",
-    "Desired": true,
-    "Payload": "{\"commandId\":\"resetHostName\",\"arguments\":\"hostnamectl set-hostname $(cat HostNameTestsTemp.txt)\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "RunCommand": "{\"commandId\":\"resetHostName\",\"arguments\":\"hostnamectl set-hostname $(cat HostNameTestsTemp.txt)\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
     "ExpectedResult": 0,
     "WaitSeconds": 5
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandStatus",
-    "Desired": false,
-    "Payload": "{\"commandId\":\"resetHostName\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "RunCommand": "{\"commandId\":\"resetHostName\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
     "ExpectedResult": 0
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandArguments",
-    "Desired": true,
-    "Payload": "{\"commandId\":\"validateHostNameReset\",\"arguments\":\"if hostname | grep $(cat HostNameTestsTemp.txt) > /dev/null; then echo True; else echo False; fi\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "RunCommand": "{\"commandId\":\"validateHostNameReset\",\"arguments\":\"if hostname | grep $(cat HostNameTestsTemp.txt) > /dev/null; then echo True; else echo False; fi\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
     "ExpectedResult": 0,
     "WaitSeconds": 5
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandStatus",
-    "Desired": false,
-    "Payload": "{\"commandId\":\"validateHostNameReset\",\"resultCode\":0,\"textResult\":\"True \",\"currentState\":2}",
+    "RunCommand": "{\"commandId\":\"validateHostNameReset\",\"resultCode\":0,\"textResult\":\"True \",\"currentState\":2}",
     "ExpectedResult": 0
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandArguments",
-    "Desired": true,
-    "Payload": "{\"commandId\":\"removeTempFileHostName\",\"arguments\":\"rm HostNameTestsTemp.txt\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
+    "RunCommand": "{\"commandId\":\"removeTempFileHostName\",\"arguments\":\"rm HostNameTestsTemp.txt\",\"timeout\":0,\"singleLineTextResult\":true,\"action\":3}",
     "ExpectedResult": 0,
     "WaitSeconds": 1
   },
   {
-    "ComponentName": "CommandRunner",
-    "ObjectName": "commandStatus",
-    "Desired": false,
-    "Payload": "{\"commandId\":\"removeTempFileHostName\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
+    "RunCommand": "{\"commandId\":\"removeTempFileHostName\",\"resultCode\":0,\"textResult\":\"\",\"currentState\":2}",
     "ExpectedResult": 0
   }
 ]

--- a/src/modules/test/recipes/NetworkingTests.json
+++ b/src/modules/test/recipes/NetworkingTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "networking.so",
+    "MimFile": "networking.json",
+    "ModelName": "NetworkingModel",
+  },
+  {
     "ComponentName": "Networking",
     "ObjectName": "networkConfiguration",
     "Desired": false,

--- a/src/modules/test/recipes/NetworkingTests.json
+++ b/src/modules/test/recipes/NetworkingTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "networking.so",
     "MimFile": "networking.json",
-    "ModelName": "NetworkingModel",
+    "ModelName": "NetworkingModel"
   },
   {
     "ComponentName": "Networking",

--- a/src/modules/test/recipes/PmcTests.json
+++ b/src/modules/test/recipes/PmcTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "pmc.so",
     "MimFile": "pmc.json",
-    "ModelName": "PackageManagerConfigurationModel",
+    "ModelName": "PackageManagerConfigurationModel"
   },
   {
     "ComponentName": "PackageManagerConfiguration",

--- a/src/modules/test/recipes/PmcTests.json
+++ b/src/modules/test/recipes/PmcTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "pmc.so",
+    "MimFile": "pmc.json",
+    "ModelName": "PackageManagerConfigurationModel",
+  },
+  {
     "ComponentName": "PackageManagerConfiguration",
     "ObjectName": "state",
     "Desired": false,

--- a/src/modules/test/recipes/SampleTests.json
+++ b/src/modules/test/recipes/SampleTests.json
@@ -1,77 +1,82 @@
 [
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "reportedStringObject",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "reportedIntegerObject",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "reportedBooleanObject",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "reportedObject",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "reportedArrayObject",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "desiredStringObject",
-        "Desired": true,
-        "Payload": "\"string\"",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "desiredIntegerObject",
-        "Desired": true,
-        "Payload": "123",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "desiredBooleanObject",
-        "Desired": true,
-        "Payload": "true",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "desiredObject",
-        "Desired": true,
-        "Payload": "{\"stringSetting\":\"string\", \"booleanSetting\":true, \"integerSetting\":123, \"integerEnumerationSetting\":0, \"stringEnumerationSetting\":\"value1\", \"stringsArraySetting\":[\"string1\",\"string2\"], \"integerArraySetting\":[1,2,3], \"stringMapSetting\":{\"key1\":\"value1\", \"key2\":\"value2\"},\"integerMapSetting\":{\"key1\":1,\"key2\":2}}",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "SampleComponent",
-        "ObjectName": "desiredArrayObject",
-        "Desired": true,
-        "Payload": "[\"value1\",\"value2\"]",
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    }
+  {
+    "ModuleBinary": "sample.so",
+    "MimFile": "sample.json",
+    "ModelName": "SampleModel",
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "reportedStringObject",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "reportedIntegerObject",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "reportedBooleanObject",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "reportedObject",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "reportedArrayObject",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "desiredStringObject",
+    "Desired": true,
+    "Payload": "\"string\"",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "desiredIntegerObject",
+    "Desired": true,
+    "Payload": "123",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "desiredBooleanObject",
+    "Desired": true,
+    "Payload": "true",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "desiredObject",
+    "Desired": true,
+    "Payload": "{\"stringSetting\":\"string\", \"booleanSetting\":true, \"integerSetting\":123, \"integerEnumerationSetting\":0, \"stringEnumerationSetting\":\"value1\", \"stringsArraySetting\":[\"string1\",\"string2\"], \"integerArraySetting\":[1,2,3], \"stringMapSetting\":{\"key1\":\"value1\", \"key2\":\"value2\"},\"integerMapSetting\":{\"key1\":1,\"key2\":2}}",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "SampleComponent",
+    "ObjectName": "desiredArrayObject",
+    "Desired": true,
+    "Payload": "[\"value1\",\"value2\"]",
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  }
 ]

--- a/src/modules/test/recipes/SampleTests.json
+++ b/src/modules/test/recipes/SampleTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "sample.so",
     "MimFile": "sample.json",
-    "ModelName": "SampleModel",
+    "ModelName": "SampleModel"
   },
   {
     "ComponentName": "SampleComponent",

--- a/src/modules/test/recipes/TpmTests.json
+++ b/src/modules/test/recipes/TpmTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "tpm.so",
     "MimFile": "tpm.json",
-    "ModelName": "TpmModel",
+    "ModelName": "TpmModel"
   },
   {
     "ComponentName": "Tpm",

--- a/src/modules/test/recipes/TpmTests.json
+++ b/src/modules/test/recipes/TpmTests.json
@@ -1,5 +1,10 @@
 [
   {
+    "ModuleBinary": "tpm.so",
+    "MimFile": "tpm.json",
+    "ModelName": "TpmModel",
+  },
+  {
     "ComponentName": "Tpm",
     "ObjectName": "tpmStatus",
     "Desired": false,

--- a/src/modules/test/recipes/ZtsiTests.json
+++ b/src/modules/test/recipes/ZtsiTests.json
@@ -2,7 +2,7 @@
   {
     "ModuleBinary": "ztsi.so",
     "MimFile": "ztsi.json",
-    "ModelName": "ZtsiModel",
+    "ModelName": "ZtsiModel"
   },
   {
     "ComponentName": "Ztsi",

--- a/src/modules/test/recipes/ZtsiTests.json
+++ b/src/modules/test/recipes/ZtsiTests.json
@@ -1,58 +1,67 @@
 [
-    {
-      "ComponentName": "Ztsi",
-      "ObjectName": "maxScheduledAttestationsPerDay",
-      "Desired": false,
-      "ExpectedResult": 0,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "Ztsi",
-      "ObjectName": "maxManualAttestationsPerDay",
-      "Desired": false,
-      "ExpectedResult": 0,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "Ztsi",
-      "ObjectName": "enabled",
-      "Desired": false,
-      "ExpectedResult": 0,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "Ztsi",
-      "ObjectName": "invalidObjectName",
-      "Desired": false,
-      "ExpectedResult": 22,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "invalidComponentName",
-      "ObjectName": "enabled",
-      "Desired": false,
-      "ExpectedResult": 22,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "Ztsi",
-      "ObjectName": "",
-      "Desired": false,
-      "ExpectedResult": 22,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "",
-      "ObjectName": "enabled",
-      "Desired": false,
-      "ExpectedResult": 22,
-      "WaitSeconds": 0
-    },
-    {
-      "ComponentName": "",
-      "ObjectName": "",
-      "Desired": false,
-      "ExpectedResult": 22,
-      "WaitSeconds": 0
-    }
+  {
+    "ModuleBinary": "ztsi.so",
+    "MimFile": "ztsi.json",
+    "ModelName": "ZtsiModel",
+  },
+  {
+    "ComponentName": "Ztsi",
+    "ObjectName": "maxScheduledAttestationsPerDay",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Ztsi",
+    "ObjectName": "maxManualAttestationsPerDay",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Ztsi",
+    "ObjectName": "enabled",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Ztsi",
+    "ObjectName": "invalidObjectName",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "invalidComponentName",
+    "ObjectName": "enabled",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "Ztsi",
+    "ObjectName": "",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "",
+    "ObjectName": "enabled",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "",
+    "ObjectName": "",
+    "Desired": false,
+    "ExpectedResult": 22,
+    "WaitSeconds": 0
+  },
+  {
+    "Action": "Teardown",
+    "ModuleBinary": "ztsi.so"
+  },
   ]

--- a/src/modules/test/unit-tests/TestRecipeParserTests.cpp
+++ b/src/modules/test/unit-tests/TestRecipeParserTests.cpp
@@ -75,9 +75,9 @@ namespace Tests
         std::cerr.rdbuf(newBuffer.rdbuf());
 
         const std::string expectedStr = 
-            "Test recipe './recipes/testInvalid.json' [1] missing required field: ObjectName\n"
-            "Test recipe './recipes/testInvalid.json' [1] missing required field: Desired\n"
-            "Test recipe './recipes/testInvalid.json' [1] missing required field: ExpectedResult\n";
+            "Test recipe './recipes/testInvalid.json' [2] missing required field: ObjectName\n"
+            "Test recipe './recipes/testInvalid.json' [2] missing required field: Desired\n"
+            "Test recipe './recipes/testInvalid.json' [2] missing required field: ExpectedResult\n";
 
         TestRecipes testRecipes = TestRecipeParser::ParseTestRecipe("./recipes/testInvalid.json");
         ASSERT_EQ(testRecipes->size(), 1);

--- a/src/modules/test/unit-tests/recipes/test.json
+++ b/src/modules/test/unit-tests/recipes/test.json
@@ -1,18 +1,23 @@
 [
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "",  // Optional - Only needed Desired=true
-        "PayloadSizeBytes": 0,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    }
+  {
+    "ModuleBinary": "doesnotexist.so",
+    "MimFile": "doesnotexist.json",
+    "ModelName": "DoesNotExistModel"
+  },
+  {
+    "ComponentName": "CommandRunner",
+    "ObjectName": "commandStatus",
+    "Desired": false,
+    "Payload": "",  // Optional - Only needed Desired=true
+    "PayloadSizeBytes": 0,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "CommandRunner",
+    "ObjectName": "commandStatus",
+    "Desired": false,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  }
 ]

--- a/src/modules/test/unit-tests/recipes/testInvalid.json
+++ b/src/modules/test/unit-tests/recipes/testInvalid.json
@@ -1,14 +1,19 @@
 [
-    {
-        "ComponentName": "CommandRunner",
-        "ObjectName": "commandStatus",
-        "Desired": false,
-        "Payload": "",  // Optional - Only needed Desired=true
-        "PayloadSizeBytes": 0,
-        "ExpectedResult": 0,
-        "WaitSeconds": 0
-    },
-    {
-        "ComponentName": "CommandRunner"
-    }
+  {
+    "ModuleBinary": "doesnotexist.so",
+    "MimFile": "doesnotexist.json",
+    "ModelName": "DoesNotExistModel"
+  },
+  {
+    "ComponentName": "CommandRunner",
+    "ObjectName": "commandStatus",
+    "Desired": false,
+    "Payload": "",  // Optional - Only needed Desired=true
+    "PayloadSizeBytes": 0,
+    "ExpectedResult": 0,
+    "WaitSeconds": 0
+  },
+  {
+    "ComponentName": "CommandRunner"
+  }
 ]


### PR DESCRIPTION
## Description

- Each test recipe gets its first test object for setup of the module under test. Teardown is implied at the end of the recipe.
- CommandRunner invocation from other modules' test recipes is replaced with direct commands to be run by ModulesTest using commonutils.
- Test recipes using 4 spaces per tab are corrected to 2 spaces per tab.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.