### PR TITLE
Tests use mins instead of hrs

### DIFF
--- a/.github/workflows/deploy-reliability-modules.yml
+++ b/.github/workflows/deploy-reliability-modules.yml
@@ -32,7 +32,7 @@ jobs:
       environment: modulestest
       resourceGroupName: ${{ needs.fetch-targets.outputs.resourceGroupName }}
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
-      repeatForXHours: 4
+      repeatForXMins: 90
       testNameSuffix: (reliability-modules)
     secrets: inherit
 

--- a/.github/workflows/deploy-reliability-platform.yml
+++ b/.github/workflows/deploy-reliability-platform.yml
@@ -57,7 +57,7 @@ jobs:
       resourceGroupName: ${{ needs.fetch-targets.outputs.resourceGroupName }}
       distroName: ${{ needs.fetch-targets.outputs.distroName }}
       cpuThreshold: 50
-      repeatForXHours: 1
+      repeatForXMins: 80
       allowedMemoryDelta: 0
       testNameSuffix: (reliability-platform)
     secrets: inherit

--- a/.github/workflows/e2etest-run-modulestest.yml
+++ b/.github/workflows/e2etest-run-modulestest.yml
@@ -19,8 +19,8 @@ on:
         type: string
         default: Release
         required: false
-      repeatForXHours:
-        description: Repeat the test suite for X hours, every test run gets a new test-report
+      repeatForXMins:
+        description: Repeat the test suite for X mins, every test run gets a new test-report
         type: number
         required: false
       testNameSuffix:
@@ -67,8 +67,8 @@ jobs:
             fi
           }
           runNumber=1
-          if [[ ${{ inputs.repeatForXHours }} -gt 0 ]];then
-            end=`date -d "+${{inputs.repeatForXHours}} hours" +%s`
+          if [[ ${{ inputs.repeatForXMins }} -gt 0 ]];then
+            end=`date -d "+${{inputs.repeatForXMins}} mins" +%s`
             while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
               ./modulestest --gtest_output=xml:gtest-output/TestRecipes.xml

--- a/.github/workflows/e2etest-run-tests.yml
+++ b/.github/workflows/e2etest-run-tests.yml
@@ -29,8 +29,8 @@ on:
         type: number
         default: 10
         required: false
-      repeatForXHours:
-        description: Repeat the test suite for X hours, every test run gets a new test-report
+      repeatForXMins:
+        description: Repeat the test suite for X mins, every test run gets a new test-report
         type: number
         required: false
       testNameSuffix:
@@ -151,8 +151,8 @@ jobs:
               exit $1
             fi
           }
-          if [[ ${{ inputs.repeatForXHours }} -gt 0 ]];then
-            end=`date -d "+${{inputs.repeatForXHours}} hours" +%s`
+          if [[ ${{ inputs.repeatForXMins }} -gt 0 ]];then
+            end=`date -d "+${{inputs.repeatForXMins}} mins" +%s`
             while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
               sudo E2E_OSCONFIG_IOTHUB_CONNSTR="${{ steps.hub-identity.outputs.iothubowner_connection_string }}" E2E_OSCONFIG_DEVICE_ID="${{ steps.get-test-data.outputs.device_id }}" E2E_OSCONFIG_DISTRIBUTION_NAME="${{ matrix.distroName }}" E2E_OSCONFIG_TWIN_TIMEOUT=${{ secrets.TWIN_TIMEOUT }} dotnet test ${{ steps.get-test-data.outputs.test_filter }} --logger "trx;LogFileName=test-results-${{ matrix.distroName }}.trx" --logger "console;verbosity=detailed"
@@ -204,8 +204,8 @@ jobs:
       - name: Stage logs
         if: always()
         run: |
-          sudo cp -f /var/log/osconfig*.log ${{ runner.temp }}
-          sudo chown $USER:$USER ${{ runner.temp }}/osconfig*.log
+          sudo cp -f /var/log/osconfig* ${{ runner.temp }}
+          sudo chown $USER:$USER ${{ runner.temp }}/osconfig*
 
       - name: Check logs
         if: success() || failure()
@@ -220,7 +220,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-logs-${{ matrix.distroName }}
-          path: ${{ runner.temp }}/osconfig*.log
+          path: ${{ runner.temp }}/osconfig*
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
## Description

* Reliability tests use minutes instead of hours allowing for more accurate timeouts
* Added collection to all osconfig logs (missing backup)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.