### PR TITLE
Update xml parsing for CI test reports 

### DIFF
--- a/.github/actions/gtest-xml/action.yml
+++ b/.github/actions/gtest-xml/action.yml
@@ -46,7 +46,7 @@ runs:
             time += float(test_suites.attrib['time'])
 
             for test_suite in test_suites:
-                suites[test_suite.attrib['name']].append(test_suite.getchildren())
+                suites[test_suite.attrib['name']].append(list(test_suite))
 
         new_root = ET.Element('testsuites')
         new_root.attrib['failures'] = '%s' % failures


### PR DESCRIPTION
## Description

`getchildren()` method was removed from `xml.etree.ElementTree.Element` (deprecated in version version 3.2 and then removed in 3.9). Fixed with `list()`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.