### PR TITLE
Fix failing module test reliability workflow

### DIFF
--- a/.github/workflows/e2etest-run-modulestest.yml
+++ b/.github/workflows/e2etest-run-modulestest.yml
@@ -76,7 +76,6 @@ jobs:
             end=`date -d "+${{inputs.repeatForXMins}} mins" +%s`
             while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
-              # run moduletest with all of the files under ./src/modules/test/recipies as arrguments
               ./moduletest $recipes --bin $bin > ${{ matrix.distroName }}.log
               checkResult $?
             done

--- a/.github/workflows/e2etest-run-modulestest.yml
+++ b/.github/workflows/e2etest-run-modulestest.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Generate build
         run: |
           mkdir build && cd build
-          cmake ../src -DCMAKE_build-type=${{ inputs.buildType }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_AGENTS=ON -G Ninja
+          cmake ../src -DCMAKE_build-type=${{ inputs.buildType }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_AGENTS=ON -G Ninja
 
       - name: Build and install azure-osconfig
         run: |
@@ -59,40 +59,31 @@ jobs:
       - name: Run modulestest
         if: success()
         run: |
-          cd build
+          recipes=$(ls -d ../src/modules/test/recipes/*.json | grep -v SampleTests.json)
+          bin="./modules/bin/"
+          runNumber=1
+
           function checkResult(){
             if [[ $1 -ne 0 ]]; then
               echo '::error title=E2E Test Failure::The E2E tests failed at run number $runNumber'
               exit $1
             fi
           }
-          runNumber=1
+
+          cd build
+
           if [[ ${{ inputs.repeatForXMins }} -gt 0 ]];then
             end=`date -d "+${{inputs.repeatForXMins}} mins" +%s`
             while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
-              ./modulestest --gtest_output=xml:gtest-output/TestRecipes.xml
+              # run moduletest with all of the files under ./src/modules/test/recipies as arrguments
+              ./moduletest $recipes --bin $bin > ${{ matrix.distroName }}.log
               checkResult $?
             done
           else
-            ./modulestest --gtest_output=xml:gtest-output/TestRecipes.xml > ${{ matrix.distroName }}.log
+            ./moduletest $recipes --bin $bin > ${{ matrix.distroName }}.log
             checkResult $?
           fi
-
-      - name: Generate test report
-        uses: ./.github/actions/gtest-xml
-        if: success() || failure()
-        with:
-          path: ./build/gtest-output
-          output: ./${{ matrix.distroName }}.xml
-
-      - name: Publish test report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: Modulestest Test report (${{ matrix.distroName }}) ${{ inputs.testNameSuffix }}
-          path: ./${{ matrix.distroName }}.xml
-          reporter: java-junit
 
       - uses: actions/upload-artifact@v2
         if: success() || failure()


### PR DESCRIPTION
## Description

Update usage of `moduletest` in reliability workflow.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.