### PR TITLE
Start systemd-resolved service for DnsServers data collection

### DIFF
--- a/src/modules/networking/src/lib/Networking.cpp
+++ b/src/modules/networking/src/lib/Networking.cpp
@@ -31,8 +31,7 @@ const char* g_getIpAddressDetails = "ip addr";
 const char* g_getDefaultGateways = "ip route";
 const char* g_getDnsServers = "systemd-resolve --status";
 
-const char* g_checkSystemdResolvedIsRunning = "systemctl list-units --type=service --state=running | grep systemd-resolved.service";
-const char* g_startSystemdResolved = "systemctl start systemd-resolved.service";
+const char* g_systemdResolvedServiceName = "systemd-resolved.service";
 
 const char* g_macAddressesPrefix = "link/";
 const char* g_ipAddressesPrefix = "inet";
@@ -660,16 +659,10 @@ void NetworkingObjectBase::GetGlobalDnsServers(std::string dnsServersData, std::
 void NetworkingObjectBase::GenerateDnsServersMap()
 {
     this->m_dnsServersMap.clear();
-    
-    std::string serviceName = RunCommand(g_checkSystemdResolvedIsRunning);
-    if (serviceName.empty())
+    if (true != EnableAndStartDaemon(g_systemdResolvedServiceName, NetworkingLog::Get()))
     {
-        std::string errorMessageFromServiceStartup = RunCommand(g_startSystemdResolved);
-        if (errorMessageFromServiceStartup.length() > 0)
-        {
-            OsConfigLogError(NetworkingLog::Get(), "Unable to start systemd-resolved.service: %s. Data for DnsServers will be empty.", errorMessageFromServiceStartup.c_str());
-            return;
-        }
+        OsConfigLogError(NetworkingLog::Get(), "Unable to start service %s. DnsServers data will be empty.", g_systemdResolvedServiceName);
+        return;
     }
 
     std::string dnsServersData = RunCommand(g_getDnsServers);

--- a/src/modules/networking/tests/NetworkingTests.cpp
+++ b/src/modules/networking/tests/NetworkingTests.cpp
@@ -135,11 +135,7 @@ namespace OSConfig::Platform::Tests
         "DNS Servers: 172.29.64.1\n"
         "DNS Domain: mshome.net\n";
 
-    std::string g_systemdResolvedServiceName = "systemd-resolved.service";
-    std::string g_errorMessageFromServiceStartup = "Error text for test";
-    std::string g_emptyString = "";
-
-    std::vector<std::string> g_returnValues = {g_testCommandOutputNames, g_testCommandOutputInterfaceTypesNmcli, g_testIpData, g_testCommandOutputDefaultGateways,  g_systemdResolvedServiceName, g_testCommandOutputDnsServers};
+    std::vector<std::string> g_returnValues = {g_testCommandOutputNames, g_testCommandOutputInterfaceTypesNmcli, g_testIpData, g_testCommandOutputDefaultGateways, g_testCommandOutputDnsServers};
 
     TEST(NetworkingTests, Get_Success)
     {
@@ -260,7 +256,7 @@ namespace OSConfig::Platform::Tests
             "GENERAL.STATE:                          100 (connected)\n"
             "GENERAL.CONNECTION:                     Wired connection 1\n";
 
-        std::vector<std::string> returnValuesDataMissing = {g_testCommandOutputNames, testCommandOutputInterfaceTypesNmcliDataMissing, g_emptyString, g_testIpData, g_testCommandOutputDefaultGateways, g_systemdResolvedServiceName, g_testCommandOutputDnsServers};
+        std::vector<std::string> returnValuesDataMissing = {g_testCommandOutputNames, testCommandOutputInterfaceTypesNmcliDataMissing, "", g_testIpData, g_testCommandOutputDefaultGateways, g_testCommandOutputDnsServers};
 
         MMI_JSON_STRING payload;
         int payloadSizeBytes;
@@ -276,7 +272,7 @@ namespace OSConfig::Platform::Tests
         EXPECT_NE(payload, nullptr);
         delete payload;
 
-        std::vector<std::string> returnValuesNetworkManagerEnabled = {g_testCommandOutputNames, g_testCommandOutputInterfaceTypesNmcli, g_testIpData, g_testCommandOutputDefaultGateways, g_systemdResolvedServiceName, g_testCommandOutputDnsServers};
+        std::vector<std::string> returnValuesNetworkManagerEnabled = {g_testCommandOutputNames, g_testCommandOutputInterfaceTypesNmcli, g_testIpData, g_testCommandOutputDefaultGateways, g_testCommandOutputDnsServers};
         testModule.runCommandCount = 0;
         testModule.returnValues = returnValuesNetworkManagerEnabled;
         result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
@@ -289,7 +285,7 @@ namespace OSConfig::Platform::Tests
         EXPECT_NE(payload, nullptr);
         delete payload;
 
-        std::vector<std::string> returnValuesSystemdNetworkdEnabled = {g_testCommandOutputNames, testCommandOutputInterfaceTypesNmcliDataMissing, g_testCommandOutputInterfaceTypesNetworkctl, g_testIpData, g_testCommandOutputDefaultGateways, g_systemdResolvedServiceName, g_testCommandOutputDnsServers};
+        std::vector<std::string> returnValuesSystemdNetworkdEnabled = {g_testCommandOutputNames, testCommandOutputInterfaceTypesNmcliDataMissing, g_testCommandOutputInterfaceTypesNetworkctl, g_testIpData, g_testCommandOutputDefaultGateways, g_testCommandOutputDnsServers};
         testModule.runCommandCount = 0;
         testModule.returnValues = returnValuesSystemdNetworkdEnabled;
         result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
@@ -535,12 +531,14 @@ namespace OSConfig::Platform::Tests
             "2.2.2.2 3.3.3.3\n"
             "DNS Domain: mshome.net\n";
 
+
+
         MMI_JSON_STRING payload;
         int payloadSizeBytes;
         NetworkingObjectTest testModule(g_maxPayloadSizeBytes);
         testModule.returnValues = g_returnValues;
         testModule.returnValues[0] = testCommandOutputInterfaceNames;
-        testModule.returnValues[5] = testCommandOutputDnsServers;
+        testModule.returnValues[4] = testCommandOutputDnsServers;
 
         int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
@@ -553,7 +551,7 @@ namespace OSConfig::Platform::Tests
         delete payload;
 
         testModule.runCommandCount = 0;
-        testModule.returnValues[5] = testCommandOutputGlobalDnsServers;
+        testModule.returnValues[4] = testCommandOutputGlobalDnsServers;
 
         result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
@@ -566,7 +564,7 @@ namespace OSConfig::Platform::Tests
         delete payload;
 
         testModule.runCommandCount = 0;
-        testModule.returnValues[5] = testCommandOutputOnlyGlobalDnsServers;
+        testModule.returnValues[4] = testCommandOutputOnlyGlobalDnsServers;
 
         result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
@@ -579,7 +577,7 @@ namespace OSConfig::Platform::Tests
         delete payload;
 
         testModule.runCommandCount = 0;
-        testModule.returnValues[5] = testCommandOutputMultipleDnsServersPerLine;
+        testModule.returnValues[4] = testCommandOutputMultipleDnsServersPerLine;
 
         result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
 
@@ -587,71 +585,6 @@ namespace OSConfig::Platform::Tests
 
         resultString = std::string(payload, payloadSizeBytes);
         EXPECT_STREQ(resultString.c_str(), payloadExpectedMultipleDnsServersPerLine);
-
-        EXPECT_NE(payload, nullptr);
-        delete payload;
-    }
-
-    TEST(NetworkingTests, GetDnsServers_SystemdResolved_Disabled)
-    {
-        const char* payloadExpected =
-            "{\"interfaceTypes\":\"docker0=bridge;eth0=ethernet\","
-            "\"macAddresses\":\"docker0=0a:25:3g:6v:2f:89;eth0=00:15:5d:26:cf:89\","
-            "\"ipAddresses\":\"docker0=172.32.233.234,::1;eth0=172.27.181.213,10.1.1.2,fe80::5e42:4bf7:dddd:9b0f\","
-            "\"subnetMasks\":\"docker0=/8,/128;eth0=/20,/16,/64\","
-            "\"defaultGateways\":\"docker0=172.17.128.1;eth0=172.13.145.1\","
-            "\"dnsServers\":\"docker0=8.8.8.8,172.29.64.1;eth0=172.29.64.1\","
-            "\"dhcpEnabled\":\"docker0=true;eth0=false\","
-            "\"enabled\":\"docker0=true;eth0=false\","
-            "\"connected\":\"docker0=true;eth0=false\"}";
-
-        MMI_JSON_STRING payload;
-        int payloadSizeBytes;
-        NetworkingObjectTest testModule(g_maxPayloadSizeBytes);
-
-        testModule.returnValues = g_returnValues;
-        testModule.returnValues[4] = g_emptyString;
-        testModule.returnValues[5] = g_emptyString;
-        testModule.returnValues.emplace_back(g_testCommandOutputDnsServers);
-
-        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
-
-        EXPECT_EQ(result, MMI_OK);
-
-        std::string resultString(payload, payloadSizeBytes);
-        EXPECT_STREQ(resultString.c_str(), payloadExpected);
-
-        EXPECT_NE(payload, nullptr);
-        delete payload;
-    }
-
-    TEST(NetworkingTests, GetDnsServers_SystemdResolved_Unavailable)
-    {
-        const char* payloadExpected =
-            "{\"interfaceTypes\":\"docker0=bridge;eth0=ethernet\","
-            "\"macAddresses\":\"docker0=0a:25:3g:6v:2f:89;eth0=00:15:5d:26:cf:89\","
-            "\"ipAddresses\":\"docker0=172.32.233.234,::1;eth0=172.27.181.213,10.1.1.2,fe80::5e42:4bf7:dddd:9b0f\","
-            "\"subnetMasks\":\"docker0=/8,/128;eth0=/20,/16,/64\","
-            "\"defaultGateways\":\"docker0=172.17.128.1;eth0=172.13.145.1\","
-            "\"dnsServers\":\"\","
-            "\"dhcpEnabled\":\"docker0=true;eth0=false\","
-            "\"enabled\":\"docker0=true;eth0=false\","
-            "\"connected\":\"docker0=true;eth0=false\"}";
-
-        MMI_JSON_STRING payload;
-        int payloadSizeBytes;
-        NetworkingObjectTest testModule(g_maxPayloadSizeBytes);
-
-        testModule.returnValues = g_returnValues;
-        testModule.returnValues[4] = g_emptyString;
-        testModule.returnValues[5] = g_errorMessageFromServiceStartup;
-
-        int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
-
-        EXPECT_EQ(result, MMI_OK);
-
-        std::string resultString(payload, payloadSizeBytes);
-        EXPECT_STREQ(resultString.c_str(), payloadExpected);
 
         EXPECT_NE(payload, nullptr);
         delete payload;
@@ -734,8 +667,9 @@ namespace OSConfig::Platform::Tests
             "\"enabled\":\"\","
             "\"connected\":\"\"}";
 
+        std::string testCommandOutputNamesEmpty = "";
         NetworkingObjectTest testModule(g_maxPayloadSizeBytes);
-        testModule.returnValues = {g_emptyString};
+        testModule.returnValues = {testCommandOutputNamesEmpty};
         MMI_JSON_STRING payload;
         int payloadSizeBytes;
         int result = testModule.Get(NETWORKING, NETWORK_CONFIGURATION, &payload, &payloadSizeBytes);
@@ -809,7 +743,7 @@ namespace OSConfig::Platform::Tests
         testModule.returnValues[1] = testInterfaceTypesDataEth0Empty; 
         testModule.returnValues[2] = testIpDataEth0Empty;
         testModule.returnValues[3] = testCommandOutputDefaultGatewaysEth0Empty;
-        testModule.returnValues[5] = testCommandOutputDnsServersEth0Empty;
+        testModule.returnValues[4] = testCommandOutputDnsServersEth0Empty;
 
         MMI_JSON_STRING payload;
         int payloadSizeBytes;


### PR DESCRIPTION
## Description

Added logic to check if the systemd-resolved service is running before attempting DnsServers data collection. If the service is stopped, the module will start it. If the service is not available on the system, the module will write an error in the Networking log file and continue.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing. 
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.