### PR TITLE
Fix passing files as argument in module-test reliability workflow

### DIFF
--- a/.github/workflows/e2etest-run-modulestest.yml
+++ b/.github/workflows/e2etest-run-modulestest.yml
@@ -76,11 +76,11 @@ jobs:
             end=`date -d "+${{inputs.repeatForXMins}} mins" +%s`
             while [[ $(date +%s) -lt $end ]]; do
               echo Performing test run $((++runNumber))
-              ./moduletest $recipes --bin $bin > ${{ matrix.distroName }}.log
+              echo $recipes | xargs -I {} ./moduletest "{}" --bin $bin > ${{ matrix.distroName }}.log
               checkResult $?
             done
           else
-            ./moduletest $recipes --bin $bin > ${{ matrix.distroName }}.log
+            echo $recipes | xargs -I {} ./moduletest "{}" --bin $bin > ${{ matrix.distroName }}.log
             checkResult $?
           fi
 


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.