### PR TITLE
Fix wrong argument in error log for Adhs

### DIFF
--- a/src/modules/adhs/src/lib/Adhs.c
+++ b/src/modules/adhs/src/lib/Adhs.c
@@ -185,7 +185,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
             fileContentSizeBytes = strlen(fileContent);
             if (0 == regcomp(&permissionRegex, g_permissionConfigPattern, REG_EXTENDED))
             {
-                if (0 == regexec(&permissionRegex, fileContent, 3, matchGroups, 0))
+                if (0 == regexec(&permissionRegex, fileContent, ARRAY_SIZE(matchGroups), matchGroups, 0))
                 {
                     // Property value is located in the third match group.
                     if ((IsValidMatchOffsets(matchGroups[0], fileContentSizeBytes)) && 

--- a/src/modules/adhs/src/lib/Adhs.c
+++ b/src/modules/adhs/src/lib/Adhs.c
@@ -174,7 +174,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
     }
     else if (0 != strcmp(objectName, g_reportedOptInObjectName))
     {
-        OsConfigLogError(AdhsGetLog(), "MmiGet called for an unsupported object name '%s'", componentName);
+        OsConfigLogError(AdhsGetLog(), "MmiGet called for an unsupported object name '%s'", objectName);
         status = EINVAL;
     }
     else


### PR DESCRIPTION
## Description

When *MmiGet* is called in the *Adhs* module with an invalid MIM object name, the error log would output the MIM component name. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.