### PR TITLE
Update MIM schema object type

### DIFF
--- a/src/modules/mim/commandrunner.json
+++ b/src/modules/mim/commandrunner.json
@@ -11,6 +11,7 @@
           "type": "mimObject",
           "desired": false,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "commandId",
@@ -30,7 +31,7 @@
                   "type": "enum",
                   "valueSchema": "integer",
                   "enumValues": [
-                    { 
+                    {
                       "name": "unknown",
                       "enumValue": 0
                     },
@@ -65,6 +66,7 @@
           "type": "mimObject",
           "desired": true,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "commandId",
@@ -88,7 +90,7 @@
                   "type": "enum",
                   "valueSchema": "integer",
                   "enumValues": [
-                    { 
+                    {
                       "name": "none",
                       "enumValue": 0
                     },

--- a/src/modules/mim/deliveryoptimization.json
+++ b/src/modules/mim/deliveryoptimization.json
@@ -11,6 +11,7 @@
           "type": "mimObject",
           "desired": true,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "percentageDownloadThrottle",

--- a/src/modules/mim/logcollector.json
+++ b/src/modules/mim/logcollector.json
@@ -11,6 +11,7 @@
           "type": "mimObject",
           "desired": false,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "requestId",
@@ -43,6 +44,7 @@
           "type": "mimObject",
           "desired": false,
           "schema": {
+            "type": "object",
             "fields": [
               {
                 "name": "requestId",
@@ -54,7 +56,7 @@
                   "type": "enum",
                   "valueSchema": "integer",
                   "enumValues": [
-                    { 
+                    {
                       "name": "unknown",
                       "enumValue": 0
                     },

--- a/src/modules/schema/mim.schema.json
+++ b/src/modules/schema/mim.schema.json
@@ -173,6 +173,7 @@
       "title": "MIM object schema",
       "description": "A schema describing the JSON object schema of a MIM object",
       "required": [
+        "type",
         "fields"
       ],
       "properties": {


### PR DESCRIPTION
## Description

- add missing `"type": "object"` to MIM (commandrunner, deliveryoptimization, logcollector)
- update MIM schema to require `"type"` property on object schemas

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.