### PR TITLE
Show ctest logs in workflow output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         with:
           container: ${{ steps.container.outputs.id }}
           working-directory: ${{ env.MOUNT }}/build
-          cmd: ctest --verbose > ../${{ matrix.os }}-${{ matrix.variant.arch }}.log
+          cmd: ctest --output-on-failure --verbose
+
+      - run: cp build/Testing/Temporary/LastTest.log ${{ matrix.os }}-${{ matrix.variant.arch }}.log
 
       - name: Generate test report
         uses: ./.github/actions/gtest-xml


### PR DESCRIPTION
## Description

Make ctest log output visible in the workflow output (do not need to wait until workflow is complete to see logs).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.