### PR TITLE
Plugging-in all remaining 125 remediation checks for the SecurityBaseline

### DIFF
--- a/dtmi/osconfig/securitybaseline-1.json
+++ b/dtmi/osconfig/securitybaseline-1.json
@@ -1228,6 +1228,756 @@
       "name": "remediateEnsureAuditdServiceIsRunning",
       "schema": "string",
       "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureKernelSupportForCpuNx",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllTelnetdPackagesUninstalled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNodevOptionOnHomePartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNodevOptionOnTmpPartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNodevOptionOnVarTmpPartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNosuidOptionOnTmpPartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNosuidOptionOnVarTmpPartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoexecOptionOnVarTmpPartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoexecOptionOnDevShmPartition",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNodevOptionEnabledForAllRemovableMedia",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoexecOptionEnabledForAllRemovableMedia",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNosuidOptionEnabledForAllRemovableMedia",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoDuplicateUidsExist",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoDuplicateGidsExist",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoDuplicateUserNamesExist",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoDuplicateGroupsExist",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureShadowGroupIsEmpty",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRootGroupExists",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllAccountsHavePasswords",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoLegacyPlusEntriesInEtcPasswd",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoLegacyPlusEntriesInEtcShadow",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoLegacyPlusEntriesInEtcGroup",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDefaultRootAccountGroupIsGidZero",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRootIsOnlyUidZeroAccount",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllUsersHomeDirectoriesExist",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureUsersOwnTheirHomeDirectories",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRestrictedUserHomeDirectories",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePasswordHashingAlgorithm",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureMinDaysBetweenPasswordChanges",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureInactivePasswordLockPeriod",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureMaxDaysBetweenPasswordChanges",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePasswordExpiration",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePasswordExpirationWarning",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSystemAccountsAreNonLogin",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAuthenticationRequiredForSingleUserMode",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDotDoesNotAppearInRootsPath",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRemoteLoginWarningBannerIsConfigured",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureLocalLoginWarningBannerIsConfigured",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSuRestrictedToRootGroup",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDefaultUmaskForAllUsers",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAutomountingDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureKernelCompiledFromApprovedSources",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDefaultDenyFirewallPolicyIsSet",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePacketRedirectSendingIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureIcmpRedirectsIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSourceRoutedPacketsIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureIgnoringBogusIcmpBroadcastResponses",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureIgnoringIcmpEchoPingsToMulticast",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureMartianPacketLoggingIsEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureReversePathSourceValidationIsEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureTcpSynCookiesAreEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSystemNotActingAsNetworkSniffer",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllWirelessInterfacesAreDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureIpv6ProtocolIsEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDccpIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSctpIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDisabledSupportForRds",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureTipcIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureZeroconfNetworkingIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePermissionsOnBootloaderConfig",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePasswordReuseIsLimited",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureMountingOfUsbStorageDevicesIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureCoreDumpsAreRestricted",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePasswordCreationRequirements",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureLockoutForFailedPasswordAttempts",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDisabledInstallationOfCramfsFileSystem",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDisabledInstallationOfFreevxfsFileSystem",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDisabledInstallationOfHfsFileSystem",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDisabledInstallationOfHfsplusFileSystem",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureDisabledInstallationOfJffs2FileSystem",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureVirtualMemoryRandomizationIsEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllBootloadersHavePasswordProtectionEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureLoggingIsConfigured",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSyslogPackageIsInstalled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSystemdJournaldServicePersistsLogMessages",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureALoggingServiceIsSnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureFilePermissionsForAllRsyslogLogFiles",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureLoggerConfigurationFilesAreRestricted",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRsyslogNotAcceptingRemoteMessages",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSyslogRotaterServiceIsEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureTelnetServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRcprshServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureTftpServiceisDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAtCronIsRestrictedToAuthorizedUsers",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshBestPracticeProtocol",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshBestPracticeIgnoreRhosts",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshLogLevelIsSet",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshMaxAuthTriesIsSet",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshAccessIsLimited",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshRhostsRsaAuthenticationIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshHostbasedAuthenticationIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshPermitRootLoginIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshPermitEmptyPasswordsIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshIdleTimeoutIntervalIsConfigured",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshLoginGraceTimeIsSet",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSshWarningBannerIsEnabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureUsersCannotSetSshEnvironmentOptions",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAppropriateCiphersForSsh",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureAvahiDaemonServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureCupsServiceisDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePostfixPackageIsUninstalled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePostfixNetworkListeningIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRpcgssdServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRpcidmapdServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsurePortmapServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNetworkFileSystemServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRpcsvcgssdServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSnmpServerIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRsynServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNisServerIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRshClientNotInstalled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureSmbWithSambaIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureUsersDotFilesArentGroupOrWorldWritable",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoUsersHaveDotForwardFiles",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoUsersHaveDotNetrcFiles",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureNoUsersHaveDotRhostsFiles",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureRloginServiceIsDisabled",
+      "schema": "string",
+      "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "remediateEnsureUnnecessaryAccountsAreRemoved",
+      "schema": "string",
+      "writable": true
     }
   ]
 }

--- a/src/modules/mim/securitybaseline.json
+++ b/src/modules/mim/securitybaseline.json
@@ -1229,6 +1229,756 @@
           "type": "mimObject",
           "desired": true,
           "schema": "string"
+        },
+        {
+          "name": "remediateEnsureKernelSupportForCpuNx",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllTelnetdPackagesUninstalled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNodevOptionOnHomePartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNodevOptionOnTmpPartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNodevOptionOnVarTmpPartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNosuidOptionOnTmpPartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNosuidOptionOnVarTmpPartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoexecOptionOnVarTmpPartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoexecOptionOnDevShmPartition",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNodevOptionEnabledForAllRemovableMedia",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoexecOptionEnabledForAllRemovableMedia",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNosuidOptionEnabledForAllRemovableMedia",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoDuplicateUidsExist",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoDuplicateGidsExist",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoDuplicateUserNamesExist",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoDuplicateGroupsExist",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureShadowGroupIsEmpty",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRootGroupExists",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllAccountsHavePasswords",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoLegacyPlusEntriesInEtcPasswd",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoLegacyPlusEntriesInEtcShadow",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoLegacyPlusEntriesInEtcGroup",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDefaultRootAccountGroupIsGidZero",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRootIsOnlyUidZeroAccount",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllUsersHomeDirectoriesExist",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureUsersOwnTheirHomeDirectories",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRestrictedUserHomeDirectories",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePasswordHashingAlgorithm",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureMinDaysBetweenPasswordChanges",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureInactivePasswordLockPeriod",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureMaxDaysBetweenPasswordChanges",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePasswordExpiration",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePasswordExpirationWarning",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSystemAccountsAreNonLogin",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAuthenticationRequiredForSingleUserMode",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDotDoesNotAppearInRootsPath",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRemoteLoginWarningBannerIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureLocalLoginWarningBannerIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSuRestrictedToRootGroup",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDefaultUmaskForAllUsers",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAutomountingDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureKernelCompiledFromApprovedSources",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDefaultDenyFirewallPolicyIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePacketRedirectSendingIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureIcmpRedirectsIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSourceRoutedPacketsIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureIgnoringBogusIcmpBroadcastResponses",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureIgnoringIcmpEchoPingsToMulticast",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureMartianPacketLoggingIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureReversePathSourceValidationIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureTcpSynCookiesAreEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSystemNotActingAsNetworkSniffer",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllWirelessInterfacesAreDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureIpv6ProtocolIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDccpIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSctpIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDisabledSupportForRds",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureTipcIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureZeroconfNetworkingIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePermissionsOnBootloaderConfig",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePasswordReuseIsLimited",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureMountingOfUsbStorageDevicesIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureCoreDumpsAreRestricted",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePasswordCreationRequirements",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureLockoutForFailedPasswordAttempts",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDisabledInstallationOfCramfsFileSystem",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDisabledInstallationOfFreevxfsFileSystem",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDisabledInstallationOfHfsFileSystem",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDisabledInstallationOfHfsplusFileSystem",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureDisabledInstallationOfJffs2FileSystem",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureVirtualMemoryRandomizationIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllBootloadersHavePasswordProtectionEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureLoggingIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSyslogPackageIsInstalled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSystemdJournaldServicePersistsLogMessages",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureALoggingServiceIsSnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureFilePermissionsForAllRsyslogLogFiles",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureLoggerConfigurationFilesAreRestricted",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRsyslogNotAcceptingRemoteMessages",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSyslogRotaterServiceIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureTelnetServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRcprshServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureTftpServiceisDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAtCronIsRestrictedToAuthorizedUsers",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshBestPracticeProtocol",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshBestPracticeIgnoreRhosts",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshLogLevelIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshMaxAuthTriesIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshAccessIsLimited",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshRhostsRsaAuthenticationIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshHostbasedAuthenticationIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshPermitRootLoginIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshPermitEmptyPasswordsIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshIdleTimeoutIntervalIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshLoginGraceTimeIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSshWarningBannerIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureUsersCannotSetSshEnvironmentOptions",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAppropriateCiphersForSsh",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureAvahiDaemonServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureCupsServiceisDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePostfixPackageIsUninstalled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePostfixNetworkListeningIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRpcgssdServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRpcidmapdServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsurePortmapServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNetworkFileSystemServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRpcsvcgssdServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSnmpServerIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRsynServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNisServerIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRshClientNotInstalled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureSmbWithSambaIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureUsersDotFilesArentGroupOrWorldWritable",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoUsersHaveDotForwardFiles",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoUsersHaveDotNetrcFiles",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureNoUsersHaveDotRhostsFiles",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureRloginServiceIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "remediateEnsureUnnecessaryAccountsAreRemoved",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
         }
       ]
     }

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -227,6 +227,134 @@ static const char* g_remediateEnsurePrelinkIsDisabledObject = "remediateEnsurePr
 static const char* g_remediateEnsureTalkClientIsNotInstalledObject = "remediateEnsureTalkClientIsNotInstalled";
 static const char* g_remediateEnsureCronServiceIsEnabledObject = "remediateEnsureCronServiceIsEnabled";
 static const char* g_remediateEnsureAuditdServiceIsRunningObject = "remediateEnsureAuditdServiceIsRunning";
+//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+// 125 remediation checks
+static const char* g_remediateEnsureKernelSupportForCpuNxObject = "remediateEnsureKernelSupportForCpuNx";
+static const char* g_remediateEnsureAllTelnetdPackagesUninstalledObject = "remediateEnsureAllTelnetdPackagesUninstalled";
+static const char* g_remediateEnsureNodevOptionOnHomePartitionObject = "remediateEnsureNodevOptionOnHomePartition";
+static const char* g_remediateEnsureNodevOptionOnTmpPartitionObject = "remediateEnsureNodevOptionOnTmpPartition";
+static const char* g_remediateEnsureNodevOptionOnVarTmpPartitionObject = "remediateEnsureNodevOptionOnVarTmpPartition";
+static const char* g_remediateEnsureNosuidOptionOnTmpPartitionObject = "remediateEnsureNosuidOptionOnTmpPartition";
+static const char* g_remediateEnsureNosuidOptionOnVarTmpPartitionObject = "remediateEnsureNosuidOptionOnVarTmpPartition";
+static const char* g_remediateEnsureNoexecOptionOnVarTmpPartitionObject = "remediateEnsureNoexecOptionOnVarTmpPartition";
+static const char* g_remediateEnsureNoexecOptionOnDevShmPartitionObject = "remediateEnsureNoexecOptionOnDevShmPartition";
+static const char* g_remediateEnsureNodevOptionEnabledForAllRemovableMediaObject = "remediateEnsureNodevOptionEnabledForAllRemovableMedia";
+static const char* g_remediateEnsureNoexecOptionEnabledForAllRemovableMediaObject = "remediateEnsureNoexecOptionEnabledForAllRemovableMedia";
+static const char* g_remediateEnsureNosuidOptionEnabledForAllRemovableMediaObject = "remediateEnsureNosuidOptionEnabledForAllRemovableMedia";
+static const char* g_remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMountsObject = "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
+static const char* g_remediateEnsureAllEtcPasswdGroupsExistInEtcGroupObject = "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup";
+static const char* g_remediateEnsureNoDuplicateUidsExistObject = "remediateEnsureNoDuplicateUidsExist";
+static const char* g_remediateEnsureNoDuplicateGidsExistObject = "remediateEnsureNoDuplicateGidsExist";
+static const char* g_remediateEnsureNoDuplicateUserNamesExistObject = "remediateEnsureNoDuplicateUserNamesExist";
+static const char* g_remediateEnsureNoDuplicateGroupsExistObject = "remediateEnsureNoDuplicateGroupsExist";
+static const char* g_remediateEnsureShadowGroupIsEmptyObject = "remediateEnsureShadowGroupIsEmpty";
+static const char* g_remediateEnsureRootGroupExistsObject = "remediateEnsureRootGroupExists";
+static const char* g_remediateEnsureAllAccountsHavePasswordsObject = "remediateEnsureAllAccountsHavePasswords";
+static const char* g_remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZeroObject = "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
+static const char* g_remediateEnsureNoLegacyPlusEntriesInEtcPasswdObject = "remediateEnsureNoLegacyPlusEntriesInEtcPasswd";
+static const char* g_remediateEnsureNoLegacyPlusEntriesInEtcShadowObject = "remediateEnsureNoLegacyPlusEntriesInEtcShadow";
+static const char* g_remediateEnsureNoLegacyPlusEntriesInEtcGroupObject = "remediateEnsureNoLegacyPlusEntriesInEtcGroup";
+static const char* g_remediateEnsureDefaultRootAccountGroupIsGidZeroObject = "remediateEnsureDefaultRootAccountGroupIsGidZero";
+static const char* g_remediateEnsureRootIsOnlyUidZeroAccountObject = "remediateEnsureRootIsOnlyUidZeroAccount";
+static const char* g_remediateEnsureAllUsersHomeDirectoriesExistObject = "remediateEnsureAllUsersHomeDirectoriesExist";
+static const char* g_remediateEnsureUsersOwnTheirHomeDirectoriesObject = "remediateEnsureUsersOwnTheirHomeDirectories";
+static const char* g_remediateEnsureRestrictedUserHomeDirectoriesObject = "remediateEnsureRestrictedUserHomeDirectories";
+static const char* g_remediateEnsurePasswordHashingAlgorithmObject = "remediateEnsurePasswordHashingAlgorithm";
+static const char* g_remediateEnsureMinDaysBetweenPasswordChangesObject = "remediateEnsureMinDaysBetweenPasswordChanges";
+static const char* g_remediateEnsureInactivePasswordLockPeriodObject = "remediateEnsureInactivePasswordLockPeriod";
+static const char* g_remediateMaxDaysBetweenPasswordChangesObject = "remediateEnsureMaxDaysBetweenPasswordChanges";
+static const char* g_remediateEnsurePasswordExpirationObject = "remediateEnsurePasswordExpiration";
+static const char* g_remediateEnsurePasswordExpirationWarningObject = "remediateEnsurePasswordExpirationWarning";
+static const char* g_remediateEnsureSystemAccountsAreNonLoginObject = "remediateEnsureSystemAccountsAreNonLogin";
+static const char* g_remediateEnsureAuthenticationRequiredForSingleUserModeObject = "remediateEnsureAuthenticationRequiredForSingleUserMode";
+static const char* g_remediateEnsureDotDoesNotAppearInRootsPathObject = "remediateEnsureDotDoesNotAppearInRootsPath";
+static const char* g_remediateEnsureRemoteLoginWarningBannerIsConfiguredObject = "remediateEnsureRemoteLoginWarningBannerIsConfigured";
+static const char* g_remediateEnsureLocalLoginWarningBannerIsConfiguredObject = "remediateEnsureLocalLoginWarningBannerIsConfigured";
+static const char* g_remediateEnsureSuRestrictedToRootGroupObject = "remediateEnsureSuRestrictedToRootGroup";
+static const char* g_remediateEnsureDefaultUmaskForAllUsersObject = "remediateEnsureDefaultUmaskForAllUsers";
+static const char* g_remediateEnsureAutomountingDisabledObject = "remediateEnsureAutomountingDisabled";
+static const char* g_remediateEnsureKernelCompiledFromApprovedSourcesObject = "remediateEnsureKernelCompiledFromApprovedSources";
+static const char* g_remediateEnsureDefaultDenyFirewallPolicyIsSetObject = "remediateEnsureDefaultDenyFirewallPolicyIsSet";
+static const char* g_remediateEnsurePacketRedirectSendingIsDisabledObject = "remediateEnsurePacketRedirectSendingIsDisabled";
+static const char* g_remediateEnsureIcmpRedirectsIsDisabledObject = "remediateEnsureIcmpRedirectsIsDisabled";
+static const char* g_remediateEnsureSourceRoutedPacketsIsDisabledObject = "remediateEnsureSourceRoutedPacketsIsDisabled";
+static const char* g_remediateEnsureAcceptingSourceRoutedPacketsIsDisabledObject = "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled";
+static const char* g_remediateEnsureIgnoringBogusIcmpBroadcastResponsesObject = "remediateEnsureIgnoringBogusIcmpBroadcastResponses";
+static const char* g_remediateEnsureIgnoringIcmpEchoPingsToMulticastObject = "remediateEnsureIgnoringIcmpEchoPingsToMulticast";
+static const char* g_remediateEnsureMartianPacketLoggingIsEnabledObject = "remediateEnsureMartianPacketLoggingIsEnabled";
+static const char* g_remediateEnsureReversePathSourceValidationIsEnabledObject = "remediateEnsureReversePathSourceValidationIsEnabled";
+static const char* g_remediateEnsureTcpSynCookiesAreEnabledObject = "remediateEnsureTcpSynCookiesAreEnabled";
+static const char* g_remediateEnsureSystemNotActingAsNetworkSnifferObject = "remediateEnsureSystemNotActingAsNetworkSniffer";
+static const char* g_remediateEnsureAllWirelessInterfacesAreDisabledObject = "remediateEnsureAllWirelessInterfacesAreDisabled";
+static const char* g_remediateEnsureIpv6ProtocolIsEnabledObject = "remediateEnsureIpv6ProtocolIsEnabled";
+static const char* g_remediateEnsureDccpIsDisabledObject = "remediateEnsureDccpIsDisabled";
+static const char* g_remediateEnsureSctpIsDisabledObject = "remediateEnsureSctpIsDisabled";
+static const char* g_remediateEnsureDisabledSupportForRdsObject = "remediateEnsureDisabledSupportForRds";
+static const char* g_remediateEnsureTipcIsDisabledObject = "remediateEnsureTipcIsDisabled";
+static const char* g_remediateEnsureZeroconfNetworkingIsDisabledObject = "remediateEnsureZeroconfNetworkingIsDisabled";
+static const char* g_remediateEnsurePermissionsOnBootloaderConfigObject = "remediateEnsurePermissionsOnBootloaderConfig";
+static const char* g_remediateEnsurePasswordReuseIsLimitedObject = "remediateEnsurePasswordReuseIsLimited";
+static const char* g_remediateEnsureMountingOfUsbStorageDevicesIsDisabledObject = "remediateEnsureMountingOfUsbStorageDevicesIsDisabled";
+static const char* g_remediateEnsureCoreDumpsAreRestrictedObject = "remediateEnsureCoreDumpsAreRestricted";
+static const char* g_remediateEnsurePasswordCreationRequirementsObject = "remediateEnsurePasswordCreationRequirements";
+static const char* g_remediateEnsureLockoutForFailedPasswordAttemptsObject = "remediateEnsureLockoutForFailedPasswordAttempts";
+static const char* g_remediateEnsureDisabledInstallationOfCramfsFileSystemObject = "remediateEnsureDisabledInstallationOfCramfsFileSystem";
+static const char* g_remediateEnsureDisabledInstallationOfFreevxfsFileSystemObject = "remediateEnsureDisabledInstallationOfFreevxfsFileSystem";
+static const char* g_remediateEnsureDisabledInstallationOfHfsFileSystemObject = "remediateEnsureDisabledInstallationOfHfsFileSystem";
+static const char* g_remediateEnsureDisabledInstallationOfHfsplusFileSystemObject = "remediateEnsureDisabledInstallationOfHfsplusFileSystem";
+static const char* g_remediateEnsureDisabledInstallationOfJffs2FileSystemObject = "remediateEnsureDisabledInstallationOfJffs2FileSystem";
+static const char* g_remediateEnsureVirtualMemoryRandomizationIsEnabledObject = "remediateEnsureVirtualMemoryRandomizationIsEnabled";
+static const char* g_remediateEnsureAllBootloadersHavePasswordProtectionEnabledObject = "remediateEnsureAllBootloadersHavePasswordProtectionEnabled";
+static const char* g_remediateEnsureLoggingIsConfiguredObject = "remediateEnsureLoggingIsConfigured";
+static const char* g_remediateEnsureSyslogPackageIsInstalledObject = "remediateEnsureSyslogPackageIsInstalled";
+static const char* g_remediateEnsureSystemdJournaldServicePersistsLogMessagesObject = "remediateEnsureSystemdJournaldServicePersistsLogMessages";
+static const char* g_remediateEnsureALoggingServiceIsSnabledObject = "remediateEnsureALoggingServiceIsSnabled";
+static const char* g_remediateEnsureFilePermissionsForAllRsyslogLogFilesObject = "remediateEnsureFilePermissionsForAllRsyslogLogFiles";
+static const char* g_remediateEnsureLoggerConfigurationFilesAreRestrictedObject = "remediateEnsureLoggerConfigurationFilesAreRestricted";
+static const char* g_remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroupObject = "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
+static const char* g_remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUserObject = "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
+static const char* g_remediateEnsureRsyslogNotAcceptingRemoteMessagesObject = "remediateEnsureRsyslogNotAcceptingRemoteMessages";
+static const char* g_remediateEnsureSyslogRotaterServiceIsEnabledObject = "remediateEnsureSyslogRotaterServiceIsEnabled";
+static const char* g_remediateEnsureTelnetServiceIsDisabledObject = "remediateEnsureTelnetServiceIsDisabled";
+static const char* g_remediateEnsureRcprshServiceIsDisabledObject = "remediateEnsureRcprshServiceIsDisabled";
+static const char* g_remediateEnsureTftpServiceisDisabledObject = "remediateEnsureTftpServiceisDisabled";
+static const char* g_remediateEnsureAtCronIsRestrictedToAuthorizedUsersObject = "remediateEnsureAtCronIsRestrictedToAuthorizedUsers";
+static const char* g_remediateEnsureSshBestPracticeProtocolObject = "remediateEnsureSshBestPracticeProtocol";
+static const char* g_remediateEnsureSshBestPracticeIgnoreRhostsObject = "remediateEnsureSshBestPracticeIgnoreRhosts";
+static const char* g_remediateEnsureSshLogLevelIsSetObject = "remediateEnsureSshLogLevelIsSet";
+static const char* g_remediateEnsureSshMaxAuthTriesIsSetObject = "remediateEnsureSshMaxAuthTriesIsSet";
+static const char* g_remediateEnsureSshAccessIsLimitedObject = "remediateEnsureSshAccessIsLimited";
+static const char* g_remediateEnsureSshRhostsRsaAuthenticationIsDisabledObject = "remediateEnsureSshRhostsRsaAuthenticationIsDisabled";
+static const char* g_remediateEnsureSshHostbasedAuthenticationIsDisabledObject = "remediateEnsureSshHostbasedAuthenticationIsDisabled";
+static const char* g_remediateEnsureSshPermitRootLoginIsDisabledObject = "remediateEnsureSshPermitRootLoginIsDisabled";
+static const char* g_remediateEnsureSshPermitEmptyPasswordsIsDisabledObject = "remediateEnsureSshPermitEmptyPasswordsIsDisabled";
+static const char* g_remediateEnsureSshIdleTimeoutIntervalIsConfiguredObject = "remediateEnsureSshIdleTimeoutIntervalIsConfigured";
+static const char* g_remediateEnsureSshLoginGraceTimeIsSetObject = "remediateEnsureSshLoginGraceTimeIsSet";
+static const char* g_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed";
+static const char* g_remediateEnsureSshWarningBannerIsEnabledObject = "remediateEnsureSshWarningBannerIsEnabled";
+static const char* g_remediateEnsureUsersCannotSetSshEnvironmentOptionsObject = "remediateEnsureUsersCannotSetSshEnvironmentOptions";
+static const char* g_remediateEnsureAppropriateCiphersForSshObject = "remediateEnsureAppropriateCiphersForSsh";
+static const char* g_remediateEnsureAvahiDaemonServiceIsDisabledObject = "remediateEnsureAvahiDaemonServiceIsDisabled";
+static const char* g_remediateEnsureCupsServiceisDisabledObject = "remediateEnsureCupsServiceisDisabled";
+static const char* g_remediateEnsurePostfixPackageIsUninstalledObject = "remediateEnsurePostfixPackageIsUninstalled";
+static const char* g_remediateEnsurePostfixNetworkListeningIsDisabledObject = "remediateEnsurePostfixNetworkListeningIsDisabled";
+static const char* g_remediateEnsureRpcgssdServiceIsDisabledObject = "remediateEnsureRpcgssdServiceIsDisabled";
+static const char* g_remediateEnsureRpcidmapdServiceIsDisabledObject = "remediateEnsureRpcidmapdServiceIsDisabled";
+static const char* g_remediateEnsurePortmapServiceIsDisabledObject = "remediateEnsurePortmapServiceIsDisabled";
+static const char* g_remediateEnsureNetworkFileSystemServiceIsDisabledObject = "remediateEnsureNetworkFileSystemServiceIsDisabled";
+static const char* g_remediateEnsureRpcsvcgssdServiceIsDisabledObject = "remediateEnsureRpcsvcgssdServiceIsDisabled";
+static const char* g_remediateEnsureSnmpServerIsDisabledObject = "remediateEnsureSnmpServerIsDisabled";
+static const char* g_remediateEnsureRsynServiceIsDisabledObject = "remediateEnsureRsynServiceIsDisabled";
+static const char* g_remediateEnsureNisServerIsDisabledObject = "remediateEnsureNisServerIsDisabled";
+static const char* g_remediateEnsureRshClientNotInstalledObject = "remediateEnsureRshClientNotInstalled";
+static const char* g_remediateEnsureSmbWithSambaIsDisabledObject = "remediateEnsureSmbWithSambaIsDisabled";
+static const char* g_remediateEnsureUsersDotFilesArentGroupOrWorldWritableObject = "remediateEnsureUsersDotFilesArentGroupOrWorldWritable";
+static const char* g_remediateEnsureNoUsersHaveDotForwardFilesObject = "remediateEnsureNoUsersHaveDotForwardFiles";
+static const char* g_remediateEnsureNoUsersHaveDotNetrcFilesObject = "remediateEnsureNoUsersHaveDotNetrcFiles";
+static const char* g_remediateEnsureNoUsersHaveDotRhostsFilesObject = "remediateEnsureNoUsersHaveDotRhostsFiles";
+static const char* g_remediateEnsureRloginServiceIsDisabledObject = "remediateEnsureRloginServiceIsDisabled";
+static const char* g_remediateEnsureUnnecessaryAccountsAreRemovedObject = "remediateEnsureUnnecessaryAccountsAreRemoved";
+//<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 static const char* g_securityBaselineLogFile = "/var/log/osconfig_securitybaseline.log";
 static const char* g_securityBaselineRolledLogFile = "/var/log/osconfig_securitybaseline.bak";
@@ -1646,6 +1774,633 @@ static int RemediateEnsureAuditdServiceIsRunning(void)
         EnableAndStartDaemon(g_auditd, SecurityBaselineGetLog())) ? 0 : ENOENT;
 }
 
+//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+static int RemediateEnsureKernelSupportForCpuNx(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNodevOptionOnHomePartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNodevOptionOnTmpPartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNodevOptionOnVarTmpPartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNosuidOptionOnTmpPartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNosuidOptionOnVarTmpPartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoexecOptionOnVarTmpPartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoexecOptionOnDevShmPartition(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNodevOptionEnabledForAllRemovableMedia(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoexecOptionEnabledForAllRemovableMedia(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNosuidOptionEnabledForAllRemovableMedia(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllTelnetdPackagesUninstalled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllEtcPasswdGroupsExistInEtcGroup(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoDuplicateUidsExist(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoDuplicateGidsExist(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoDuplicateUserNamesExist(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoDuplicateGroupsExist(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureShadowGroupIsEmpty(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRootGroupExists(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllAccountsHavePasswords(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoLegacyPlusEntriesInEtcPasswd(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoLegacyPlusEntriesInEtcShadow(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoLegacyPlusEntriesInEtcGroup(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDefaultRootAccountGroupIsGidZero(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRootIsOnlyUidZeroAccount(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllUsersHomeDirectoriesExist(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureUsersOwnTheirHomeDirectories(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRestrictedUserHomeDirectories(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePasswordHashingAlgorithm(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureMinDaysBetweenPasswordChanges(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureInactivePasswordLockPeriod(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureMaxDaysBetweenPasswordChanges(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePasswordExpiration(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePasswordExpirationWarning(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSystemAccountsAreNonLogin(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAuthenticationRequiredForSingleUserMode(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDotDoesNotAppearInRootsPath(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRemoteLoginWarningBannerIsConfigured(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureLocalLoginWarningBannerIsConfigured(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSuRestrictedToRootGroup(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDefaultUmaskForAllUsers(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAutomountingDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureKernelCompiledFromApprovedSources(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDefaultDenyFirewallPolicyIsSet(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePacketRedirectSendingIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureIcmpRedirectsIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSourceRoutedPacketsIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAcceptingSourceRoutedPacketsIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureIgnoringBogusIcmpBroadcastResponses(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureIgnoringIcmpEchoPingsToMulticast(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureMartianPacketLoggingIsEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureReversePathSourceValidationIsEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureTcpSynCookiesAreEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSystemNotActingAsNetworkSniffer(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllWirelessInterfacesAreDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureIpv6ProtocolIsEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDccpIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSctpIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDisabledSupportForRds(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureTipcIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureZeroconfNetworkingIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePermissionsOnBootloaderConfig(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePasswordReuseIsLimited(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureMountingOfUsbStorageDevicesIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureCoreDumpsAreRestricted(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePasswordCreationRequirements(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureLockoutForFailedPasswordAttempts(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDisabledInstallationOfCramfsFileSystem(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDisabledInstallationOfFreevxfsFileSystem(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDisabledInstallationOfHfsFileSystem(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDisabledInstallationOfHfsplusFileSystem(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureDisabledInstallationOfJffs2FileSystem(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureVirtualMemoryRandomizationIsEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllBootloadersHavePasswordProtectionEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureLoggingIsConfigured(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSyslogPackageIsInstalled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSystemdJournaldServicePersistsLogMessages(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureALoggingServiceIsSnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureFilePermissionsForAllRsyslogLogFiles(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureLoggerConfigurationFilesAreRestricted(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRsyslogNotAcceptingRemoteMessages(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSyslogRotaterServiceIsEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureTelnetServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRcprshServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureTftpServiceisDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAtCronIsRestrictedToAuthorizedUsers(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshBestPracticeProtocol(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshBestPracticeIgnoreRhosts(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshLogLevelIsSet(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshMaxAuthTriesIsSet(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshAccessIsLimited(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshRhostsRsaAuthenticationIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshHostbasedAuthenticationIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshPermitRootLoginIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshPermitEmptyPasswordsIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshIdleTimeoutIntervalIsConfigured(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshLoginGraceTimeIsSet(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureOnlyApprovedMacAlgorithmsAreUsed(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSshWarningBannerIsEnabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureUsersCannotSetSshEnvironmentOptions(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAppropriateCiphersForSsh(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureAvahiDaemonServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureCupsServiceisDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePostfixPackageIsUninstalled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePostfixNetworkListeningIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRpcgssdServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRpcidmapdServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsurePortmapServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNetworkFileSystemServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRpcsvcgssdServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSnmpServerIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRsynServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNisServerIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRshClientNotInstalled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureSmbWithSambaIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureUsersDotFilesArentGroupOrWorldWritable(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoUsersHaveDotForwardFiles(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoUsersHaveDotNetrcFiles(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureNoUsersHaveDotRhostsFiles(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureRloginServiceIsDisabled(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+
+static int RemediateEnsureUnnecessaryAccountsAreRemoved(void)
+{
+    return ENOENT; //TODO: add remediation respecting all existing patterns
+}
+//<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
 AuditRemediate g_remediateChecks[] =
 {
     &RemediateEnsurePermissionsOnEtcIssue,
@@ -1686,7 +2441,134 @@ AuditRemediate g_remediateChecks[] =
     &RemediateEnsurePrelinkIsDisabled,
     &RemediateEnsureTalkClientIsNotInstalled,
     &RemediateEnsureCronServiceIsEnabled,
-    &RemediateEnsureAuditdServiceIsRunning
+    &RemediateEnsureAuditdServiceIsRunning,
+    //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    &RemediateEnsureKernelSupportForCpuNx,
+    &RemediateEnsureNodevOptionOnHomePartition,
+    &RemediateEnsureNodevOptionOnTmpPartition,
+    &RemediateEnsureNodevOptionOnVarTmpPartition,
+    &RemediateEnsureNosuidOptionOnTmpPartition,
+    &RemediateEnsureNosuidOptionOnVarTmpPartition,
+    &RemediateEnsureNoexecOptionOnVarTmpPartition,
+    &RemediateEnsureNoexecOptionOnDevShmPartition,
+    &RemediateEnsureNodevOptionEnabledForAllRemovableMedia,
+    &RemediateEnsureNoexecOptionEnabledForAllRemovableMedia,
+    &RemediateEnsureNosuidOptionEnabledForAllRemovableMedia,
+    &RemediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts,
+    &RemediateEnsureAllTelnetdPackagesUninstalled,
+    &RemediateEnsureAllEtcPasswdGroupsExistInEtcGroup,
+    &RemediateEnsureNoDuplicateUidsExist,
+    &RemediateEnsureNoDuplicateGidsExist,
+    &RemediateEnsureNoDuplicateUserNamesExist,
+    &RemediateEnsureNoDuplicateGroupsExist,
+    &RemediateEnsureShadowGroupIsEmpty,
+    &RemediateEnsureRootGroupExists,
+    &RemediateEnsureAllAccountsHavePasswords,
+    &RemediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero,
+    &RemediateEnsureNoLegacyPlusEntriesInEtcPasswd,
+    &RemediateEnsureNoLegacyPlusEntriesInEtcShadow,
+    &RemediateEnsureNoLegacyPlusEntriesInEtcGroup,
+    &RemediateEnsureDefaultRootAccountGroupIsGidZero,
+    &RemediateEnsureRootIsOnlyUidZeroAccount,
+    &RemediateEnsureAllUsersHomeDirectoriesExist,
+    &RemediateEnsureUsersOwnTheirHomeDirectories,
+    &RemediateEnsureRestrictedUserHomeDirectories,
+    &RemediateEnsurePasswordHashingAlgorithm,
+    &RemediateEnsureMinDaysBetweenPasswordChanges,
+    &RemediateEnsureInactivePasswordLockPeriod,
+    &RemediateEnsureMaxDaysBetweenPasswordChanges,
+    &RemediateEnsurePasswordExpiration,
+    &RemediateEnsurePasswordExpirationWarning,
+    &RemediateEnsureSystemAccountsAreNonLogin,
+    &RemediateEnsureAuthenticationRequiredForSingleUserMode,
+    &RemediateEnsureDotDoesNotAppearInRootsPath,
+    &RemediateEnsureRemoteLoginWarningBannerIsConfigured,
+    &RemediateEnsureLocalLoginWarningBannerIsConfigured,
+    &RemediateEnsureSuRestrictedToRootGroup,
+    &RemediateEnsureDefaultUmaskForAllUsers,
+    &RemediateEnsureAutomountingDisabled,
+    &RemediateEnsureKernelCompiledFromApprovedSources,
+    &RemediateEnsureDefaultDenyFirewallPolicyIsSet,
+    &RemediateEnsurePacketRedirectSendingIsDisabled,
+    &RemediateEnsureIcmpRedirectsIsDisabled,
+    &RemediateEnsureSourceRoutedPacketsIsDisabled,
+    &RemediateEnsureAcceptingSourceRoutedPacketsIsDisabled,
+    &RemediateEnsureIgnoringBogusIcmpBroadcastResponses,
+    &RemediateEnsureIgnoringIcmpEchoPingsToMulticast,
+    &RemediateEnsureMartianPacketLoggingIsEnabled,
+    &RemediateEnsureReversePathSourceValidationIsEnabled,
+    &RemediateEnsureTcpSynCookiesAreEnabled,
+    &RemediateEnsureSystemNotActingAsNetworkSniffer,
+    &RemediateEnsureAllWirelessInterfacesAreDisabled,
+    &RemediateEnsureIpv6ProtocolIsEnabled,
+    &RemediateEnsureDccpIsDisabled,
+    &RemediateEnsureSctpIsDisabled,
+    &RemediateEnsureDisabledSupportForRds,
+    &RemediateEnsureTipcIsDisabled,
+    &RemediateEnsureZeroconfNetworkingIsDisabled,
+    &RemediateEnsurePermissionsOnBootloaderConfig,
+    &RemediateEnsurePasswordReuseIsLimited,
+    &RemediateEnsureMountingOfUsbStorageDevicesIsDisabled,
+    &RemediateEnsureCoreDumpsAreRestricted,
+    &RemediateEnsurePasswordCreationRequirements,
+    &RemediateEnsureLockoutForFailedPasswordAttempts,
+    &RemediateEnsureDisabledInstallationOfCramfsFileSystem,
+    &RemediateEnsureDisabledInstallationOfFreevxfsFileSystem,
+    &RemediateEnsureDisabledInstallationOfHfsFileSystem,
+    &RemediateEnsureDisabledInstallationOfHfsplusFileSystem,
+    &RemediateEnsureDisabledInstallationOfJffs2FileSystem,
+    &RemediateEnsureVirtualMemoryRandomizationIsEnabled,
+    &RemediateEnsureAllBootloadersHavePasswordProtectionEnabled,
+    &RemediateEnsureLoggingIsConfigured,
+    &RemediateEnsureSyslogPackageIsInstalled,
+    &RemediateEnsureSystemdJournaldServicePersistsLogMessages,
+    &RemediateEnsureALoggingServiceIsSnabled,
+    &RemediateEnsureFilePermissionsForAllRsyslogLogFiles,
+    &RemediateEnsureLoggerConfigurationFilesAreRestricted,
+    &RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup,
+    &RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser,
+    &RemediateEnsureRsyslogNotAcceptingRemoteMessages,
+    &RemediateEnsureSyslogRotaterServiceIsEnabled,
+    &RemediateEnsureTelnetServiceIsDisabled,
+    &RemediateEnsureRcprshServiceIsDisabled,
+    &RemediateEnsureTftpServiceisDisabled,
+    &RemediateEnsureAtCronIsRestrictedToAuthorizedUsers,
+    &RemediateEnsureSshBestPracticeProtocol,
+    &RemediateEnsureSshBestPracticeIgnoreRhosts,
+    &RemediateEnsureSshLogLevelIsSet,
+    &RemediateEnsureSshMaxAuthTriesIsSet,
+    &RemediateEnsureSshAccessIsLimited,
+    &RemediateEnsureSshRhostsRsaAuthenticationIsDisabled,
+    &RemediateEnsureSshHostbasedAuthenticationIsDisabled,
+    &RemediateEnsureSshPermitRootLoginIsDisabled,
+    &RemediateEnsureSshPermitEmptyPasswordsIsDisabled,
+    &RemediateEnsureSshIdleTimeoutIntervalIsConfigured,
+    &RemediateEnsureSshLoginGraceTimeIsSet,
+    &RemediateEnsureOnlyApprovedMacAlgorithmsAreUsed,
+    &RemediateEnsureSshWarningBannerIsEnabled,
+    &RemediateEnsureUsersCannotSetSshEnvironmentOptions,
+    &RemediateEnsureAppropriateCiphersForSsh,
+    &RemediateEnsureAvahiDaemonServiceIsDisabled,
+    &RemediateEnsureCupsServiceisDisabled,
+    &RemediateEnsurePostfixPackageIsUninstalled,
+    &RemediateEnsurePostfixNetworkListeningIsDisabled,
+    &RemediateEnsureRpcgssdServiceIsDisabled,
+    &RemediateEnsureRpcidmapdServiceIsDisabled,
+    &RemediateEnsurePortmapServiceIsDisabled,
+    &RemediateEnsureNetworkFileSystemServiceIsDisabled,
+    &RemediateEnsureRpcsvcgssdServiceIsDisabled,
+    &RemediateEnsureSnmpServerIsDisabled,
+    &RemediateEnsureRsynServiceIsDisabled,
+    &RemediateEnsureNisServerIsDisabled,
+    &RemediateEnsureRshClientNotInstalled,
+    &RemediateEnsureSmbWithSambaIsDisabled,
+    &RemediateEnsureUsersDotFilesArentGroupOrWorldWritable,
+    &RemediateEnsureNoUsersHaveDotForwardFiles,
+    &RemediateEnsureNoUsersHaveDotNetrcFiles,
+    &RemediateEnsureNoUsersHaveDotRhostsFiles,
+    &RemediateEnsureRloginServiceIsDisabled,
+    &RemediateEnsureUnnecessaryAccountsAreRemoved
+    //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 };
 
 int RemediateSecurityBaseline(void)
@@ -2705,6 +3587,512 @@ int SecurityBaselineMmiSet(MMI_HANDLE clientSession, const char* componentName, 
         {
             status = RemediateEnsureAuditdServiceIsRunning();
         }
+        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+        else if (0 == strcmp(objectName, g_remediateEnsureKernelSupportForCpuNxObject))
+        {
+            status = RemediateEnsureKernelSupportForCpuNx();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNodevOptionOnHomePartitionObject))
+        {
+            status = RemediateEnsureNodevOptionOnHomePartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNodevOptionOnTmpPartitionObject))
+        {
+            status = RemediateEnsureNodevOptionOnTmpPartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNodevOptionOnVarTmpPartitionObject))
+        {
+            status = RemediateEnsureNodevOptionOnVarTmpPartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNosuidOptionOnTmpPartitionObject))
+        {
+            status = RemediateEnsureNosuidOptionOnTmpPartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNosuidOptionOnVarTmpPartitionObject))
+        {
+            status = RemediateEnsureNosuidOptionOnVarTmpPartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoexecOptionOnVarTmpPartitionObject))
+        {
+            status = RemediateEnsureNoexecOptionOnVarTmpPartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoexecOptionOnDevShmPartitionObject))
+        {
+            status = RemediateEnsureNoexecOptionOnDevShmPartition();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNodevOptionEnabledForAllRemovableMediaObject))
+        {
+            status = RemediateEnsureNodevOptionEnabledForAllRemovableMedia();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoexecOptionEnabledForAllRemovableMediaObject))
+        {
+            status = RemediateEnsureNoexecOptionEnabledForAllRemovableMedia();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNosuidOptionEnabledForAllRemovableMediaObject))
+        {
+            status = RemediateEnsureNosuidOptionEnabledForAllRemovableMedia();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMountsObject))
+        {
+            status = RemediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllTelnetdPackagesUninstalledObject))
+        {
+            status = RemediateEnsureAllTelnetdPackagesUninstalled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllEtcPasswdGroupsExistInEtcGroupObject))
+        {
+            status = RemediateEnsureAllEtcPasswdGroupsExistInEtcGroup();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoDuplicateUidsExistObject))
+        {
+            status = RemediateEnsureNoDuplicateUidsExist();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoDuplicateGidsExistObject))
+        {
+            status = RemediateEnsureNoDuplicateGidsExist();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoDuplicateUserNamesExistObject))
+        {
+            status = RemediateEnsureNoDuplicateUserNamesExist();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoDuplicateGroupsExistObject))
+        {
+            status = RemediateEnsureNoDuplicateGroupsExist();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureShadowGroupIsEmptyObject))
+        {
+            status = RemediateEnsureShadowGroupIsEmpty();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRootGroupExistsObject))
+        {
+            status = RemediateEnsureRootGroupExists();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllAccountsHavePasswordsObject))
+        {
+            status = RemediateEnsureAllAccountsHavePasswords();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZeroObject))
+        {
+            status = RemediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoLegacyPlusEntriesInEtcPasswdObject))
+        {
+            status = RemediateEnsureNoLegacyPlusEntriesInEtcPasswd();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoLegacyPlusEntriesInEtcShadowObject))
+        {
+            status = RemediateEnsureNoLegacyPlusEntriesInEtcShadow();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoLegacyPlusEntriesInEtcGroupObject))
+        {
+            status = RemediateEnsureNoLegacyPlusEntriesInEtcGroup();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDefaultRootAccountGroupIsGidZeroObject))
+        {
+            status = RemediateEnsureDefaultRootAccountGroupIsGidZero();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRootIsOnlyUidZeroAccountObject))
+        {
+            status = RemediateEnsureRootIsOnlyUidZeroAccount();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllUsersHomeDirectoriesExistObject))
+        {
+            status = RemediateEnsureAllUsersHomeDirectoriesExist();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureUsersOwnTheirHomeDirectoriesObject))
+        {
+            status = RemediateEnsureUsersOwnTheirHomeDirectories();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRestrictedUserHomeDirectoriesObject))
+        {
+            status = RemediateEnsureRestrictedUserHomeDirectories();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePasswordHashingAlgorithmObject))
+        {
+            status = RemediateEnsurePasswordHashingAlgorithm();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureMinDaysBetweenPasswordChangesObject))
+        {
+            status = RemediateEnsureMinDaysBetweenPasswordChanges();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureInactivePasswordLockPeriodObject))
+        {
+            status = RemediateEnsureInactivePasswordLockPeriod();
+        }
+        else if (0 == strcmp(objectName, g_remediateMaxDaysBetweenPasswordChangesObject))
+        {
+            status = RemediateEnsureMaxDaysBetweenPasswordChanges();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePasswordExpirationObject))
+        {
+            status = RemediateEnsurePasswordExpiration();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePasswordExpirationWarningObject))
+        {
+            status = RemediateEnsurePasswordExpirationWarning();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSystemAccountsAreNonLoginObject))
+        {
+            status = RemediateEnsureSystemAccountsAreNonLogin();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAuthenticationRequiredForSingleUserModeObject))
+        {
+            status = RemediateEnsureAuthenticationRequiredForSingleUserMode();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDotDoesNotAppearInRootsPathObject))
+        {
+            status = RemediateEnsureDotDoesNotAppearInRootsPath();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRemoteLoginWarningBannerIsConfiguredObject))
+        {
+            status = RemediateEnsureRemoteLoginWarningBannerIsConfigured();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureLocalLoginWarningBannerIsConfiguredObject))
+        {
+            status = RemediateEnsureLocalLoginWarningBannerIsConfigured();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAuditdServiceIsRunningObject))
+        {
+            status = RemediateEnsureAuditdServiceIsRunning();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSuRestrictedToRootGroupObject))
+        {
+            status = RemediateEnsureSuRestrictedToRootGroup();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDefaultUmaskForAllUsersObject))
+        {
+            status = RemediateEnsureDefaultUmaskForAllUsers();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAutomountingDisabledObject))
+        {
+            status = RemediateEnsureAutomountingDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureKernelCompiledFromApprovedSourcesObject))
+        {
+            status = RemediateEnsureKernelCompiledFromApprovedSources();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDefaultDenyFirewallPolicyIsSetObject))
+        {
+            status = RemediateEnsureDefaultDenyFirewallPolicyIsSet();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePacketRedirectSendingIsDisabledObject))
+        {
+            status = RemediateEnsurePacketRedirectSendingIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureIcmpRedirectsIsDisabledObject))
+        {
+            status = RemediateEnsureIcmpRedirectsIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSourceRoutedPacketsIsDisabledObject))
+        {
+            status = RemediateEnsureSourceRoutedPacketsIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAcceptingSourceRoutedPacketsIsDisabledObject))
+        {
+            status = RemediateEnsureAcceptingSourceRoutedPacketsIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureIgnoringBogusIcmpBroadcastResponsesObject))
+        {
+            status = RemediateEnsureIgnoringBogusIcmpBroadcastResponses();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureIgnoringIcmpEchoPingsToMulticastObject))
+        {
+            status = RemediateEnsureIgnoringIcmpEchoPingsToMulticast();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureMartianPacketLoggingIsEnabledObject))
+        {
+            status = RemediateEnsureMartianPacketLoggingIsEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureReversePathSourceValidationIsEnabledObject))
+        {
+            status = RemediateEnsureReversePathSourceValidationIsEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureTcpSynCookiesAreEnabledObject))
+        {
+            status = RemediateEnsureTcpSynCookiesAreEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSystemNotActingAsNetworkSnifferObject))
+        {
+            status = RemediateEnsureSystemNotActingAsNetworkSniffer();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllWirelessInterfacesAreDisabledObject))
+        {
+            status = RemediateEnsureAllWirelessInterfacesAreDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureIpv6ProtocolIsEnabledObject))
+        {
+            status = RemediateEnsureIpv6ProtocolIsEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDccpIsDisabledObject))
+        {
+            status = RemediateEnsureDccpIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSctpIsDisabledObject))
+        {
+            status = RemediateEnsureSctpIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDisabledSupportForRdsObject))
+        {
+            status = RemediateEnsureDisabledSupportForRds();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureTipcIsDisabledObject))
+        {
+            status = RemediateEnsureTipcIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureZeroconfNetworkingIsDisabledObject))
+        {
+            status = RemediateEnsureZeroconfNetworkingIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePermissionsOnBootloaderConfigObject))
+        {
+            status = RemediateEnsurePermissionsOnBootloaderConfig();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePasswordReuseIsLimitedObject))
+        {
+            status = RemediateEnsurePasswordReuseIsLimited();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureMountingOfUsbStorageDevicesIsDisabledObject))
+        {
+            status = RemediateEnsureMountingOfUsbStorageDevicesIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureCoreDumpsAreRestrictedObject))
+        {
+            status = RemediateEnsureCoreDumpsAreRestricted();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePasswordCreationRequirementsObject))
+        {
+            status = RemediateEnsurePasswordCreationRequirements();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureLockoutForFailedPasswordAttemptsObject))
+        {
+            status = RemediateEnsureLockoutForFailedPasswordAttempts();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDisabledInstallationOfCramfsFileSystemObject))
+        {
+            status = RemediateEnsureDisabledInstallationOfCramfsFileSystem();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDisabledInstallationOfFreevxfsFileSystemObject))
+        {
+            status = RemediateEnsureDisabledInstallationOfFreevxfsFileSystem();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDisabledInstallationOfHfsFileSystemObject))
+        {
+            status = RemediateEnsureDisabledInstallationOfHfsFileSystem();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDisabledInstallationOfHfsplusFileSystemObject))
+        {
+            status = RemediateEnsureDisabledInstallationOfHfsplusFileSystem();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureDisabledInstallationOfJffs2FileSystemObject))
+        {
+            status = RemediateEnsureDisabledInstallationOfJffs2FileSystem();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureVirtualMemoryRandomizationIsEnabledObject))
+        {
+            status = RemediateEnsureVirtualMemoryRandomizationIsEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllBootloadersHavePasswordProtectionEnabledObject))
+        {
+            status = RemediateEnsureAllBootloadersHavePasswordProtectionEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureLoggingIsConfiguredObject))
+        {
+            status = RemediateEnsureLoggingIsConfigured();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSyslogPackageIsInstalledObject))
+        {
+            status = RemediateEnsureSyslogPackageIsInstalled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSystemdJournaldServicePersistsLogMessagesObject))
+        {
+            status = RemediateEnsureSystemdJournaldServicePersistsLogMessages();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureALoggingServiceIsSnabledObject))
+        {
+            status = RemediateEnsureALoggingServiceIsSnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureFilePermissionsForAllRsyslogLogFilesObject))
+        {
+            status = RemediateEnsureFilePermissionsForAllRsyslogLogFiles();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureLoggerConfigurationFilesAreRestrictedObject))
+        {
+            status = RemediateEnsureLoggerConfigurationFilesAreRestricted();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroupObject))
+        {
+            status = RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUserObject))
+        {
+            status = RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRsyslogNotAcceptingRemoteMessagesObject))
+        {
+            status = RemediateEnsureRsyslogNotAcceptingRemoteMessages();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSyslogRotaterServiceIsEnabledObject))
+        {
+            status = RemediateEnsureSyslogRotaterServiceIsEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureTelnetServiceIsDisabledObject))
+        {
+            status = RemediateEnsureTelnetServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRcprshServiceIsDisabledObject))
+        {
+            status = RemediateEnsureRcprshServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureTftpServiceisDisabledObject))
+        {
+            status = RemediateEnsureTftpServiceisDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAtCronIsRestrictedToAuthorizedUsersObject))
+        {
+            status = RemediateEnsureAtCronIsRestrictedToAuthorizedUsers();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshBestPracticeProtocolObject))
+        {
+            status = RemediateEnsureSshBestPracticeProtocol();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshBestPracticeIgnoreRhostsObject))
+        {
+            status = RemediateEnsureSshBestPracticeIgnoreRhosts();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshLogLevelIsSetObject))
+        {
+            status = RemediateEnsureSshLogLevelIsSet();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshMaxAuthTriesIsSetObject))
+        {
+            status = RemediateEnsureSshMaxAuthTriesIsSet();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshAccessIsLimitedObject))
+        {
+            status = RemediateEnsureSshAccessIsLimited();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshRhostsRsaAuthenticationIsDisabledObject))
+        {
+            status = RemediateEnsureSshRhostsRsaAuthenticationIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshHostbasedAuthenticationIsDisabledObject))
+        {
+            status = RemediateEnsureSshHostbasedAuthenticationIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshPermitRootLoginIsDisabledObject))
+        {
+            status = RemediateEnsureSshPermitRootLoginIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshPermitEmptyPasswordsIsDisabledObject))
+        {
+            status = RemediateEnsureSshPermitEmptyPasswordsIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshIdleTimeoutIntervalIsConfiguredObject))
+        {
+            status = RemediateEnsureSshIdleTimeoutIntervalIsConfigured();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshLoginGraceTimeIsSetObject))
+        {
+            status = RemediateEnsureSshLoginGraceTimeIsSet();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject))
+        {
+            status = RemediateEnsureOnlyApprovedMacAlgorithmsAreUsed();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSshWarningBannerIsEnabledObject))
+        {
+            status = RemediateEnsureSshWarningBannerIsEnabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureUsersCannotSetSshEnvironmentOptionsObject))
+        {
+            status = RemediateEnsureUsersCannotSetSshEnvironmentOptions();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAppropriateCiphersForSshObject))
+        {
+            status = RemediateEnsureAppropriateCiphersForSsh();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureAvahiDaemonServiceIsDisabledObject))
+        {
+            status = RemediateEnsureAvahiDaemonServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureCupsServiceisDisabledObject))
+        {
+            status = RemediateEnsureCupsServiceisDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePostfixPackageIsUninstalledObject))
+        {
+            status = RemediateEnsurePostfixPackageIsUninstalled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePostfixNetworkListeningIsDisabledObject))
+        {
+            status = RemediateEnsurePostfixNetworkListeningIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRpcgssdServiceIsDisabledObject))
+        {
+            status = RemediateEnsureRpcgssdServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRpcidmapdServiceIsDisabledObject))
+        {
+            status = RemediateEnsureRpcidmapdServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsurePortmapServiceIsDisabledObject))
+        {
+            status = RemediateEnsurePortmapServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNetworkFileSystemServiceIsDisabledObject))
+        {
+            status = RemediateEnsureNetworkFileSystemServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRpcsvcgssdServiceIsDisabledObject))
+        {
+            status = RemediateEnsureRpcsvcgssdServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSnmpServerIsDisabledObject))
+        {
+            status = RemediateEnsureSnmpServerIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRsynServiceIsDisabledObject))
+        {
+            status = RemediateEnsureRsynServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNisServerIsDisabledObject))
+        {
+            status = RemediateEnsureNisServerIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRshClientNotInstalledObject))
+        {
+            status = RemediateEnsureRshClientNotInstalled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureSmbWithSambaIsDisabledObject))
+        {
+            status = RemediateEnsureSmbWithSambaIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureUsersDotFilesArentGroupOrWorldWritableObject))
+        {
+            status = RemediateEnsureUsersDotFilesArentGroupOrWorldWritable();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoUsersHaveDotForwardFilesObject))
+        {
+            status = RemediateEnsureNoUsersHaveDotForwardFiles();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoUsersHaveDotNetrcFilesObject))
+        {
+            status = RemediateEnsureNoUsersHaveDotNetrcFiles();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureNoUsersHaveDotRhostsFilesObject))
+        {
+            status = RemediateEnsureNoUsersHaveDotRhostsFiles();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureRloginServiceIsDisabledObject))
+        {
+            status = RemediateEnsureRloginServiceIsDisabled();
+        }
+        else if (0 == strcmp(objectName, g_remediateEnsureUnnecessaryAccountsAreRemovedObject))
+        {
+            status = RemediateEnsureUnnecessaryAccountsAreRemoved();
+        }
+        //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         else
         {
             OsConfigLogError(SecurityBaselineGetLog(), "MmiSet called for an unsupported object name: %s", objectName);

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -59,7 +59,6 @@ static const char* g_auditEnsurePrelinkIsDisabledObject = "auditEnsurePrelinkIsD
 static const char* g_auditEnsureTalkClientIsNotInstalledObject = "auditEnsureTalkClientIsNotInstalled";
 static const char* g_auditEnsureCronServiceIsEnabledObject = "auditEnsureCronServiceIsEnabled";
 static const char* g_auditEnsureAuditdServiceIsRunningObject = "auditEnsureAuditdServiceIsRunning";
-// Audit-only
 static const char* g_auditEnsureKernelSupportForCpuNxObject = "auditEnsureKernelSupportForCpuNx";
 static const char* g_auditEnsureAllTelnetdPackagesUninstalledObject = "auditEnsureAllTelnetdPackagesUninstalled";
 static const char* g_auditEnsureNodevOptionOnHomePartitionObject = "auditEnsureNodevOptionOnHomePartition";

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -764,7 +764,8 @@ static int AuditEnsureDefaultRootAccountGroupIsGidZero(void)
 
 static int AuditEnsureRootIsOnlyUidZeroAccount(void)
 {
-    return ((0 == CheckRootGroupExists(SecurityBaselineGetLog())) && (0 == CheckRootIsOnlyUidZeroAccount(SecurityBaselineGetLog()))) ? 0 : EACCES;
+    return ((0 == CheckRootGroupExists(SecurityBaselineGetLog())) && 
+        (0 == CheckRootIsOnlyUidZeroAccount(SecurityBaselineGetLog()))) ? 0 : EACCES;
 }
 
 static int AuditEnsureAllUsersHomeDirectoriesExist(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -227,8 +227,7 @@ static const char* g_remediateEnsurePrelinkIsDisabledObject = "remediateEnsurePr
 static const char* g_remediateEnsureTalkClientIsNotInstalledObject = "remediateEnsureTalkClientIsNotInstalled";
 static const char* g_remediateEnsureCronServiceIsEnabledObject = "remediateEnsureCronServiceIsEnabled";
 static const char* g_remediateEnsureAuditdServiceIsRunningObject = "remediateEnsureAuditdServiceIsRunning";
-//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-// 125 remediation checks
+// Remaining 125 remediation checks
 static const char* g_remediateEnsureKernelSupportForCpuNxObject = "remediateEnsureKernelSupportForCpuNx";
 static const char* g_remediateEnsureAllTelnetdPackagesUninstalledObject = "remediateEnsureAllTelnetdPackagesUninstalled";
 static const char* g_remediateEnsureNodevOptionOnHomePartitionObject = "remediateEnsureNodevOptionOnHomePartition";
@@ -354,7 +353,6 @@ static const char* g_remediateEnsureNoUsersHaveDotNetrcFilesObject = "remediateE
 static const char* g_remediateEnsureNoUsersHaveDotRhostsFilesObject = "remediateEnsureNoUsersHaveDotRhostsFiles";
 static const char* g_remediateEnsureRloginServiceIsDisabledObject = "remediateEnsureRloginServiceIsDisabled";
 static const char* g_remediateEnsureUnnecessaryAccountsAreRemovedObject = "remediateEnsureUnnecessaryAccountsAreRemoved";
-//<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 static const char* g_securityBaselineLogFile = "/var/log/osconfig_securitybaseline.log";
 static const char* g_securityBaselineRolledLogFile = "/var/log/osconfig_securitybaseline.bak";
@@ -1774,7 +1772,6 @@ static int RemediateEnsureAuditdServiceIsRunning(void)
         EnableAndStartDaemon(g_auditd, SecurityBaselineGetLog())) ? 0 : ENOENT;
 }
 
-//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 static int RemediateEnsureKernelSupportForCpuNx(void)
 {
     return ENOENT; //TODO: add remediation respecting all existing patterns
@@ -2399,7 +2396,6 @@ static int RemediateEnsureUnnecessaryAccountsAreRemoved(void)
 {
     return ENOENT; //TODO: add remediation respecting all existing patterns
 }
-//<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 AuditRemediate g_remediateChecks[] =
 {
@@ -2442,7 +2438,6 @@ AuditRemediate g_remediateChecks[] =
     &RemediateEnsureTalkClientIsNotInstalled,
     &RemediateEnsureCronServiceIsEnabled,
     &RemediateEnsureAuditdServiceIsRunning,
-    //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     &RemediateEnsureKernelSupportForCpuNx,
     &RemediateEnsureNodevOptionOnHomePartition,
     &RemediateEnsureNodevOptionOnTmpPartition,
@@ -2568,7 +2563,6 @@ AuditRemediate g_remediateChecks[] =
     &RemediateEnsureNoUsersHaveDotRhostsFiles,
     &RemediateEnsureRloginServiceIsDisabled,
     &RemediateEnsureUnnecessaryAccountsAreRemoved
-    //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 };
 
 int RemediateSecurityBaseline(void)
@@ -3587,7 +3581,6 @@ int SecurityBaselineMmiSet(MMI_HANDLE clientSession, const char* componentName, 
         {
             status = RemediateEnsureAuditdServiceIsRunning();
         }
-        //>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         else if (0 == strcmp(objectName, g_remediateEnsureKernelSupportForCpuNxObject))
         {
             status = RemediateEnsureKernelSupportForCpuNx();
@@ -4092,7 +4085,6 @@ int SecurityBaselineMmiSet(MMI_HANDLE clientSession, const char* componentName, 
         {
             status = RemediateEnsureUnnecessaryAccountsAreRemoved();
         }
-        //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         else
         {
             OsConfigLogError(SecurityBaselineGetLog(), "MmiSet called for an unsupported object name: %s", objectName);

--- a/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
+++ b/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
@@ -65,7 +65,6 @@ class SecurityBaselineTest : public ::testing::Test
         const char* m_auditEnsureTalkClientIsNotInstalledObject = "auditEnsureTalkClientIsNotInstalled";
         const char* m_auditEnsureCronServiceIsEnabledObject = "auditEnsureCronServiceIsEnabled";
         const char* m_auditEnsureAuditdServiceIsRunningObject = "auditEnsureAuditdServiceIsRunning";
-        // Audit-only
         const char* m_auditEnsureKernelSupportForCpuNxObject = "auditEnsureKernelSupportForCpuNx";
         const char* m_auditEnsureAllTelnetdPackagesUninstalledObject = "auditEnsureAllTelnetdPackagesUninstalled";
         const char* m_auditEnsureNodevOptionOnHomePartitionObject = "auditEnsureNodevOptionOnHomePartition";
@@ -233,7 +232,6 @@ class SecurityBaselineTest : public ::testing::Test
         const char* m_remediateEnsureTalkClientIsNotInstalledObject = "remediateEnsureTalkClientIsNotInstalled";
         const char* m_remediateEnsureCronServiceIsEnabledObject = "remediateEnsureCronServiceIsEnabled";
         const char* m_remediateEnsureAuditdServiceIsRunningObject = "remediateEnsureAuditdServiceIsRunning";
-        // Remaining 125 remediation checks
         const char* m_remediateEnsureKernelSupportForCpuNxObject = "remediateEnsureKernelSupportForCpuNx";
         const char* m_remediateEnsureAllTelnetdPackagesUninstalledObject = "remediateEnsureAllTelnetdPackagesUninstalled";
         const char* m_remediateEnsureNodevOptionOnHomePartitionObject = "remediateEnsureNodevOptionOnHomePartition";

--- a/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
+++ b/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
@@ -233,6 +233,132 @@ class SecurityBaselineTest : public ::testing::Test
         const char* m_remediateEnsureTalkClientIsNotInstalledObject = "remediateEnsureTalkClientIsNotInstalled";
         const char* m_remediateEnsureCronServiceIsEnabledObject = "remediateEnsureCronServiceIsEnabled";
         const char* m_remediateEnsureAuditdServiceIsRunningObject = "remediateEnsureAuditdServiceIsRunning";
+        // Remaining 125 remediation checks
+        const char* m_remediateEnsureKernelSupportForCpuNxObject = "remediateEnsureKernelSupportForCpuNx";
+        const char* m_remediateEnsureAllTelnetdPackagesUninstalledObject = "remediateEnsureAllTelnetdPackagesUninstalled";
+        const char* m_remediateEnsureNodevOptionOnHomePartitionObject = "remediateEnsureNodevOptionOnHomePartition";
+        const char* m_remediateEnsureNodevOptionOnTmpPartitionObject = "remediateEnsureNodevOptionOnTmpPartition";
+        const char* m_remediateEnsureNodevOptionOnVarTmpPartitionObject = "remediateEnsureNodevOptionOnVarTmpPartition";
+        const char* m_remediateEnsureNosuidOptionOnTmpPartitionObject = "remediateEnsureNosuidOptionOnTmpPartition";
+        const char* m_remediateEnsureNosuidOptionOnVarTmpPartitionObject = "remediateEnsureNosuidOptionOnVarTmpPartition";
+        const char* m_remediateEnsureNoexecOptionOnVarTmpPartitionObject = "remediateEnsureNoexecOptionOnVarTmpPartition";
+        const char* m_remediateEnsureNoexecOptionOnDevShmPartitionObject = "remediateEnsureNoexecOptionOnDevShmPartition";
+        const char* m_remediateEnsureNodevOptionEnabledForAllRemovableMediaObject = "remediateEnsureNodevOptionEnabledForAllRemovableMedia";
+        const char* m_remediateEnsureNoexecOptionEnabledForAllRemovableMediaObject = "remediateEnsureNoexecOptionEnabledForAllRemovableMedia";
+        const char* m_remediateEnsureNosuidOptionEnabledForAllRemovableMediaObject = "remediateEnsureNosuidOptionEnabledForAllRemovableMedia";
+        const char* m_remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMountsObject = "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
+        const char* m_remediateEnsureAllEtcPasswdGroupsExistInEtcGroupObject = "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup";
+        const char* m_remediateEnsureNoDuplicateUidsExistObject = "remediateEnsureNoDuplicateUidsExist";
+        const char* m_remediateEnsureNoDuplicateGidsExistObject = "remediateEnsureNoDuplicateGidsExist";
+        const char* m_remediateEnsureNoDuplicateUserNamesExistObject = "remediateEnsureNoDuplicateUserNamesExist";
+        const char* m_remediateEnsureNoDuplicateGroupsExistObject = "remediateEnsureNoDuplicateGroupsExist";
+        const char* m_remediateEnsureShadowGroupIsEmptyObject = "remediateEnsureShadowGroupIsEmpty";
+        const char* m_remediateEnsureRootGroupExistsObject = "remediateEnsureRootGroupExists";
+        const char* m_remediateEnsureAllAccountsHavePasswordsObject = "remediateEnsureAllAccountsHavePasswords";
+        const char* m_remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZeroObject = "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
+        const char* m_remediateEnsureNoLegacyPlusEntriesInEtcPasswdObject = "remediateEnsureNoLegacyPlusEntriesInEtcPasswd";
+        const char* m_remediateEnsureNoLegacyPlusEntriesInEtcShadowObject = "remediateEnsureNoLegacyPlusEntriesInEtcShadow";
+        const char* m_remediateEnsureNoLegacyPlusEntriesInEtcGroupObject = "remediateEnsureNoLegacyPlusEntriesInEtcGroup";
+        const char* m_remediateEnsureDefaultRootAccountGroupIsGidZeroObject = "remediateEnsureDefaultRootAccountGroupIsGidZero";
+        const char* m_remediateEnsureRootIsOnlyUidZeroAccountObject = "remediateEnsureRootIsOnlyUidZeroAccount";
+        const char* m_remediateEnsureAllUsersHomeDirectoriesExistObject = "remediateEnsureAllUsersHomeDirectoriesExist";
+        const char* m_remediateEnsureUsersOwnTheirHomeDirectoriesObject = "remediateEnsureUsersOwnTheirHomeDirectories";
+        const char* m_remediateEnsureRestrictedUserHomeDirectoriesObject = "remediateEnsureRestrictedUserHomeDirectories";
+        const char* m_remediateEnsurePasswordHashingAlgorithmObject = "remediateEnsurePasswordHashingAlgorithm";
+        const char* m_remediateEnsureMinDaysBetweenPasswordChangesObject = "remediateEnsureMinDaysBetweenPasswordChanges";
+        const char* m_remediateEnsureInactivePasswordLockPeriodObject = "remediateEnsureInactivePasswordLockPeriod";
+        const char* m_remediateMaxDaysBetweenPasswordChangesObject = "remediateEnsureMaxDaysBetweenPasswordChanges";
+        const char* m_remediateEnsurePasswordExpirationObject = "remediateEnsurePasswordExpiration";
+        const char* m_remediateEnsurePasswordExpirationWarningObject = "remediateEnsurePasswordExpirationWarning";
+        const char* m_remediateEnsureSystemAccountsAreNonLoginObject = "remediateEnsureSystemAccountsAreNonLogin";
+        const char* m_remediateEnsureAuthenticationRequiredForSingleUserModeObject = "remediateEnsureAuthenticationRequiredForSingleUserMode";
+        const char* m_remediateEnsureDotDoesNotAppearInRootsPathObject = "remediateEnsureDotDoesNotAppearInRootsPath";
+        const char* m_remediateEnsureRemoteLoginWarningBannerIsConfiguredObject = "remediateEnsureRemoteLoginWarningBannerIsConfigured";
+        const char* m_remediateEnsureLocalLoginWarningBannerIsConfiguredObject = "remediateEnsureLocalLoginWarningBannerIsConfigured";
+        const char* m_remediateEnsureSuRestrictedToRootGroupObject = "remediateEnsureSuRestrictedToRootGroup";
+        const char* m_remediateEnsureDefaultUmaskForAllUsersObject = "remediateEnsureDefaultUmaskForAllUsers";
+        const char* m_remediateEnsureAutomountingDisabledObject = "remediateEnsureAutomountingDisabled";
+        const char* m_remediateEnsureKernelCompiledFromApprovedSourcesObject = "remediateEnsureKernelCompiledFromApprovedSources";
+        const char* m_remediateEnsureDefaultDenyFirewallPolicyIsSetObject = "remediateEnsureDefaultDenyFirewallPolicyIsSet";
+        const char* m_remediateEnsurePacketRedirectSendingIsDisabledObject = "remediateEnsurePacketRedirectSendingIsDisabled";
+        const char* m_remediateEnsureIcmpRedirectsIsDisabledObject = "remediateEnsureIcmpRedirectsIsDisabled";
+        const char* m_remediateEnsureSourceRoutedPacketsIsDisabledObject = "remediateEnsureSourceRoutedPacketsIsDisabled";
+        const char* m_remediateEnsureAcceptingSourceRoutedPacketsIsDisabledObject = "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled";
+        const char* m_remediateEnsureIgnoringBogusIcmpBroadcastResponsesObject = "remediateEnsureIgnoringBogusIcmpBroadcastResponses";
+        const char* m_remediateEnsureIgnoringIcmpEchoPingsToMulticastObject = "remediateEnsureIgnoringIcmpEchoPingsToMulticast";
+        const char* m_remediateEnsureMartianPacketLoggingIsEnabledObject = "remediateEnsureMartianPacketLoggingIsEnabled";
+        const char* m_remediateEnsureReversePathSourceValidationIsEnabledObject = "remediateEnsureReversePathSourceValidationIsEnabled";
+        const char* m_remediateEnsureTcpSynCookiesAreEnabledObject = "remediateEnsureTcpSynCookiesAreEnabled";
+        const char* m_remediateEnsureSystemNotActingAsNetworkSnifferObject = "remediateEnsureSystemNotActingAsNetworkSniffer";
+        const char* m_remediateEnsureAllWirelessInterfacesAreDisabledObject = "remediateEnsureAllWirelessInterfacesAreDisabled";
+        const char* m_remediateEnsureIpv6ProtocolIsEnabledObject = "remediateEnsureIpv6ProtocolIsEnabled";
+        const char* m_remediateEnsureDccpIsDisabledObject = "remediateEnsureDccpIsDisabled";
+        const char* m_remediateEnsureSctpIsDisabledObject = "remediateEnsureSctpIsDisabled";
+        const char* m_remediateEnsureDisabledSupportForRdsObject = "remediateEnsureDisabledSupportForRds";
+        const char* m_remediateEnsureTipcIsDisabledObject = "remediateEnsureTipcIsDisabled";
+        const char* m_remediateEnsureZeroconfNetworkingIsDisabledObject = "remediateEnsureZeroconfNetworkingIsDisabled";
+        const char* m_remediateEnsurePermissionsOnBootloaderConfigObject = "remediateEnsurePermissionsOnBootloaderConfig";
+        const char* m_remediateEnsurePasswordReuseIsLimitedObject = "remediateEnsurePasswordReuseIsLimited";
+        const char* m_remediateEnsureMountingOfUsbStorageDevicesIsDisabledObject = "remediateEnsureMountingOfUsbStorageDevicesIsDisabled";
+        const char* m_remediateEnsureCoreDumpsAreRestrictedObject = "remediateEnsureCoreDumpsAreRestricted";
+        const char* m_remediateEnsurePasswordCreationRequirementsObject = "remediateEnsurePasswordCreationRequirements";
+        const char* m_remediateEnsureLockoutForFailedPasswordAttemptsObject = "remediateEnsureLockoutForFailedPasswordAttempts";
+        const char* m_remediateEnsureDisabledInstallationOfCramfsFileSystemObject = "remediateEnsureDisabledInstallationOfCramfsFileSystem";
+        const char* m_remediateEnsureDisabledInstallationOfFreevxfsFileSystemObject = "remediateEnsureDisabledInstallationOfFreevxfsFileSystem";
+        const char* m_remediateEnsureDisabledInstallationOfHfsFileSystemObject = "remediateEnsureDisabledInstallationOfHfsFileSystem";
+        const char* m_remediateEnsureDisabledInstallationOfHfsplusFileSystemObject = "remediateEnsureDisabledInstallationOfHfsplusFileSystem";
+        const char* m_remediateEnsureDisabledInstallationOfJffs2FileSystemObject = "remediateEnsureDisabledInstallationOfJffs2FileSystem";
+        const char* m_remediateEnsureVirtualMemoryRandomizationIsEnabledObject = "remediateEnsureVirtualMemoryRandomizationIsEnabled";
+        const char* m_remediateEnsureAllBootloadersHavePasswordProtectionEnabledObject = "remediateEnsureAllBootloadersHavePasswordProtectionEnabled";
+        const char* m_remediateEnsureLoggingIsConfiguredObject = "remediateEnsureLoggingIsConfigured";
+        const char* m_remediateEnsureSyslogPackageIsInstalledObject = "remediateEnsureSyslogPackageIsInstalled";
+        const char* m_remediateEnsureSystemdJournaldServicePersistsLogMessagesObject = "remediateEnsureSystemdJournaldServicePersistsLogMessages";
+        const char* m_remediateEnsureALoggingServiceIsSnabledObject = "remediateEnsureALoggingServiceIsSnabled";
+        const char* m_remediateEnsureFilePermissionsForAllRsyslogLogFilesObject = "remediateEnsureFilePermissionsForAllRsyslogLogFiles";
+        const char* m_remediateEnsureLoggerConfigurationFilesAreRestrictedObject = "remediateEnsureLoggerConfigurationFilesAreRestricted";
+        const char* m_remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroupObject = "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
+        const char* m_remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUserObject = "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
+        const char* m_remediateEnsureRsyslogNotAcceptingRemoteMessagesObject = "remediateEnsureRsyslogNotAcceptingRemoteMessages";
+        const char* m_remediateEnsureSyslogRotaterServiceIsEnabledObject = "remediateEnsureSyslogRotaterServiceIsEnabled";
+        const char* m_remediateEnsureTelnetServiceIsDisabledObject = "remediateEnsureTelnetServiceIsDisabled";
+        const char* m_remediateEnsureRcprshServiceIsDisabledObject = "remediateEnsureRcprshServiceIsDisabled";
+        const char* m_remediateEnsureTftpServiceisDisabledObject = "remediateEnsureTftpServiceisDisabled";
+        const char* m_remediateEnsureAtCronIsRestrictedToAuthorizedUsersObject = "remediateEnsureAtCronIsRestrictedToAuthorizedUsers";
+        const char* m_remediateEnsureSshBestPracticeProtocolObject = "remediateEnsureSshBestPracticeProtocol";
+        const char* m_remediateEnsureSshBestPracticeIgnoreRhostsObject = "remediateEnsureSshBestPracticeIgnoreRhosts";
+        const char* m_remediateEnsureSshLogLevelIsSetObject = "remediateEnsureSshLogLevelIsSet";
+        const char* m_remediateEnsureSshMaxAuthTriesIsSetObject = "remediateEnsureSshMaxAuthTriesIsSet";
+        const char* m_remediateEnsureSshAccessIsLimitedObject = "remediateEnsureSshAccessIsLimited";
+        const char* m_remediateEnsureSshRhostsRsaAuthenticationIsDisabledObject = "remediateEnsureSshRhostsRsaAuthenticationIsDisabled";
+        const char* m_remediateEnsureSshHostbasedAuthenticationIsDisabledObject = "remediateEnsureSshHostbasedAuthenticationIsDisabled";
+        const char* m_remediateEnsureSshPermitRootLoginIsDisabledObject = "remediateEnsureSshPermitRootLoginIsDisabled";
+        const char* m_remediateEnsureSshPermitEmptyPasswordsIsDisabledObject = "remediateEnsureSshPermitEmptyPasswordsIsDisabled";
+        const char* m_remediateEnsureSshIdleTimeoutIntervalIsConfiguredObject = "remediateEnsureSshIdleTimeoutIntervalIsConfigured";
+        const char* m_remediateEnsureSshLoginGraceTimeIsSetObject = "remediateEnsureSshLoginGraceTimeIsSet";
+        const char* m_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed";
+        const char* m_remediateEnsureSshWarningBannerIsEnabledObject = "remediateEnsureSshWarningBannerIsEnabled";
+        const char* m_remediateEnsureUsersCannotSetSshEnvironmentOptionsObject = "remediateEnsureUsersCannotSetSshEnvironmentOptions";
+        const char* m_remediateEnsureAppropriateCiphersForSshObject = "remediateEnsureAppropriateCiphersForSsh";
+        const char* m_remediateEnsureAvahiDaemonServiceIsDisabledObject = "remediateEnsureAvahiDaemonServiceIsDisabled";
+        const char* m_remediateEnsureCupsServiceisDisabledObject = "remediateEnsureCupsServiceisDisabled";
+        const char* m_remediateEnsurePostfixPackageIsUninstalledObject = "remediateEnsurePostfixPackageIsUninstalled";
+        const char* m_remediateEnsurePostfixNetworkListeningIsDisabledObject = "remediateEnsurePostfixNetworkListeningIsDisabled";
+        const char* m_remediateEnsureRpcgssdServiceIsDisabledObject = "remediateEnsureRpcgssdServiceIsDisabled";
+        const char* m_remediateEnsureRpcidmapdServiceIsDisabledObject = "remediateEnsureRpcidmapdServiceIsDisabled";
+        const char* m_remediateEnsurePortmapServiceIsDisabledObject = "remediateEnsurePortmapServiceIsDisabled";
+        const char* m_remediateEnsureNetworkFileSystemServiceIsDisabledObject = "remediateEnsureNetworkFileSystemServiceIsDisabled";
+        const char* m_remediateEnsureRpcsvcgssdServiceIsDisabledObject = "remediateEnsureRpcsvcgssdServiceIsDisabled";
+        const char* m_remediateEnsureSnmpServerIsDisabledObject = "remediateEnsureSnmpServerIsDisabled";
+        const char* m_remediateEnsureRsynServiceIsDisabledObject = "remediateEnsureRsynServiceIsDisabled";
+        const char* m_remediateEnsureNisServerIsDisabledObject = "remediateEnsureNisServerIsDisabled";
+        const char* m_remediateEnsureRshClientNotInstalledObject = "remediateEnsureRshClientNotInstalled";
+        const char* m_remediateEnsureSmbWithSambaIsDisabledObject = "remediateEnsureSmbWithSambaIsDisabled";
+        const char* m_remediateEnsureUsersDotFilesArentGroupOrWorldWritableObject = "remediateEnsureUsersDotFilesArentGroupOrWorldWritable";
+        const char* m_remediateEnsureNoUsersHaveDotForwardFilesObject = "remediateEnsureNoUsersHaveDotForwardFiles";
+        const char* m_remediateEnsureNoUsersHaveDotNetrcFilesObject = "remediateEnsureNoUsersHaveDotNetrcFiles";
+        const char* m_remediateEnsureNoUsersHaveDotRhostsFilesObject = "remediateEnsureNoUsersHaveDotRhostsFiles";
+        const char* m_remediateEnsureRloginServiceIsDisabledObject = "remediateEnsureRloginServiceIsDisabled";
+        const char* m_remediateEnsureUnnecessaryAccountsAreRemovedObject = "remediateEnsureUnnecessaryAccountsAreRemoved";
 
         const char* m_pass = "\"PASS\"";
 
@@ -340,7 +466,132 @@ TEST_F(SecurityBaselineTest, MmiSet)
         m_remediateEnsurePrelinkIsDisabledObject,
         m_remediateEnsureTalkClientIsNotInstalledObject,
         m_remediateEnsureCronServiceIsEnabledObject,
-        m_remediateEnsureAuditdServiceIsRunningObject
+        m_remediateEnsureAuditdServiceIsRunningObject,
+        m_remediateEnsureKernelSupportForCpuNxObject,
+        m_remediateEnsureAllTelnetdPackagesUninstalledObject,
+        m_remediateEnsureNodevOptionOnHomePartitionObject,
+        m_remediateEnsureNodevOptionOnTmpPartitionObject,
+        m_remediateEnsureNodevOptionOnVarTmpPartitionObject,
+        m_remediateEnsureNosuidOptionOnTmpPartitionObject,
+        m_remediateEnsureNosuidOptionOnVarTmpPartitionObject,
+        m_remediateEnsureNoexecOptionOnVarTmpPartitionObject,
+        m_remediateEnsureNoexecOptionOnDevShmPartitionObject,
+        m_remediateEnsureNodevOptionEnabledForAllRemovableMediaObject,
+        m_remediateEnsureNoexecOptionEnabledForAllRemovableMediaObject,
+        m_remediateEnsureNosuidOptionEnabledForAllRemovableMediaObject,
+        m_remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMountsObject,
+        m_remediateEnsureAllEtcPasswdGroupsExistInEtcGroupObject,
+        m_remediateEnsureNoDuplicateUidsExistObject,
+        m_remediateEnsureNoDuplicateGidsExistObject,
+        m_remediateEnsureNoDuplicateUserNamesExistObject,
+        m_remediateEnsureNoDuplicateGroupsExistObject,
+        m_remediateEnsureShadowGroupIsEmptyObject,
+        m_remediateEnsureRootGroupExistsObject,
+        m_remediateEnsureAllAccountsHavePasswordsObject,
+        m_remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZeroObject,
+        m_remediateEnsureNoLegacyPlusEntriesInEtcPasswdObject,
+        m_remediateEnsureNoLegacyPlusEntriesInEtcShadowObject,
+        m_remediateEnsureNoLegacyPlusEntriesInEtcGroupObject,
+        m_remediateEnsureDefaultRootAccountGroupIsGidZeroObject,
+        m_remediateEnsureRootIsOnlyUidZeroAccountObject,
+        m_remediateEnsureAllUsersHomeDirectoriesExistObject,
+        m_remediateEnsureUsersOwnTheirHomeDirectoriesObject,
+        m_remediateEnsureRestrictedUserHomeDirectoriesObject,
+        m_remediateEnsurePasswordHashingAlgorithmObject,
+        m_remediateEnsureMinDaysBetweenPasswordChangesObject,
+        m_remediateEnsureInactivePasswordLockPeriodObject,
+        m_remediateMaxDaysBetweenPasswordChangesObject,
+        m_remediateEnsurePasswordExpirationObject,
+        m_remediateEnsurePasswordExpirationWarningObject,
+        m_remediateEnsureSystemAccountsAreNonLoginObject,
+        m_remediateEnsureAuthenticationRequiredForSingleUserModeObject,
+        m_remediateEnsureDotDoesNotAppearInRootsPathObject,
+        m_remediateEnsureRemoteLoginWarningBannerIsConfiguredObject,
+        m_remediateEnsureLocalLoginWarningBannerIsConfiguredObject,
+        m_remediateEnsureSuRestrictedToRootGroupObject,
+        m_remediateEnsureDefaultUmaskForAllUsersObject,
+        m_remediateEnsureAutomountingDisabledObject,
+        m_remediateEnsureKernelCompiledFromApprovedSourcesObject,
+        m_remediateEnsureDefaultDenyFirewallPolicyIsSetObject,
+        m_remediateEnsurePacketRedirectSendingIsDisabledObject,
+        m_remediateEnsureIcmpRedirectsIsDisabledObject,
+        m_remediateEnsureSourceRoutedPacketsIsDisabledObject,
+        m_remediateEnsureAcceptingSourceRoutedPacketsIsDisabledObject,
+        m_remediateEnsureIgnoringBogusIcmpBroadcastResponsesObject,
+        m_remediateEnsureIgnoringIcmpEchoPingsToMulticastObject,
+        m_remediateEnsureMartianPacketLoggingIsEnabledObject,
+        m_remediateEnsureReversePathSourceValidationIsEnabledObject,
+        m_remediateEnsureTcpSynCookiesAreEnabledObject,
+        m_remediateEnsureSystemNotActingAsNetworkSnifferObject,
+        m_remediateEnsureAllWirelessInterfacesAreDisabledObject,
+        m_remediateEnsureIpv6ProtocolIsEnabledObject,
+        m_remediateEnsureDccpIsDisabledObject,
+        m_remediateEnsureSctpIsDisabledObject,
+        m_remediateEnsureDisabledSupportForRdsObject,
+        m_remediateEnsureTipcIsDisabledObject,
+        m_remediateEnsureZeroconfNetworkingIsDisabledObject,
+        m_remediateEnsurePermissionsOnBootloaderConfigObject,
+        m_remediateEnsurePasswordReuseIsLimitedObject,
+        m_remediateEnsureMountingOfUsbStorageDevicesIsDisabledObject,
+        m_remediateEnsureCoreDumpsAreRestrictedObject,
+        m_remediateEnsurePasswordCreationRequirementsObject,
+        m_remediateEnsureLockoutForFailedPasswordAttemptsObject,
+        m_remediateEnsureDisabledInstallationOfCramfsFileSystemObject,
+        m_remediateEnsureDisabledInstallationOfFreevxfsFileSystemObject,
+        m_remediateEnsureDisabledInstallationOfHfsFileSystemObject,
+        m_remediateEnsureDisabledInstallationOfHfsplusFileSystemObject,
+        m_remediateEnsureDisabledInstallationOfJffs2FileSystemObject,
+        m_remediateEnsureVirtualMemoryRandomizationIsEnabledObject,
+        m_remediateEnsureAllBootloadersHavePasswordProtectionEnabledObject,
+        m_remediateEnsureLoggingIsConfiguredObject,
+        m_remediateEnsureSyslogPackageIsInstalledObject,
+        m_remediateEnsureSystemdJournaldServicePersistsLogMessagesObject,
+        m_remediateEnsureALoggingServiceIsSnabledObject,
+        m_remediateEnsureFilePermissionsForAllRsyslogLogFilesObject,
+        m_remediateEnsureLoggerConfigurationFilesAreRestrictedObject,
+        m_remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroupObject,
+        m_remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUserObject,
+        m_remediateEnsureRsyslogNotAcceptingRemoteMessagesObject,
+        m_remediateEnsureSyslogRotaterServiceIsEnabledObject,
+        m_remediateEnsureTelnetServiceIsDisabledObject,
+        m_remediateEnsureRcprshServiceIsDisabledObject,
+        m_remediateEnsureTftpServiceisDisabledObject,
+        m_remediateEnsureAtCronIsRestrictedToAuthorizedUsersObject,
+        m_remediateEnsureSshBestPracticeProtocolObject,
+        m_remediateEnsureSshBestPracticeIgnoreRhostsObject,
+        m_remediateEnsureSshLogLevelIsSetObject,
+        m_remediateEnsureSshMaxAuthTriesIsSetObject,
+        m_remediateEnsureSshAccessIsLimitedObject,
+        m_remediateEnsureSshRhostsRsaAuthenticationIsDisabledObject,
+        m_remediateEnsureSshHostbasedAuthenticationIsDisabledObject,
+        m_remediateEnsureSshPermitRootLoginIsDisabledObject,
+        m_remediateEnsureSshPermitEmptyPasswordsIsDisabledObject,
+        m_remediateEnsureSshIdleTimeoutIntervalIsConfiguredObject,
+        m_remediateEnsureSshLoginGraceTimeIsSetObject,
+        m_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject,
+        m_remediateEnsureSshWarningBannerIsEnabledObject,
+        m_remediateEnsureUsersCannotSetSshEnvironmentOptionsObject,
+        m_remediateEnsureAppropriateCiphersForSshObject,
+        m_remediateEnsureAvahiDaemonServiceIsDisabledObject,
+        m_remediateEnsureCupsServiceisDisabledObject,
+        m_remediateEnsurePostfixPackageIsUninstalledObject,
+        m_remediateEnsurePostfixNetworkListeningIsDisabledObject,
+        m_remediateEnsureRpcgssdServiceIsDisabledObject,
+        m_remediateEnsureRpcidmapdServiceIsDisabledObject,
+        m_remediateEnsurePortmapServiceIsDisabledObject,
+        m_remediateEnsureNetworkFileSystemServiceIsDisabledObject,
+        m_remediateEnsureRpcsvcgssdServiceIsDisabledObject,
+        m_remediateEnsureSnmpServerIsDisabledObject,
+        m_remediateEnsureRsynServiceIsDisabledObject,
+        m_remediateEnsureNisServerIsDisabledObject,
+        m_remediateEnsureRshClientNotInstalledObject,
+        m_remediateEnsureSmbWithSambaIsDisabledObject,
+        m_remediateEnsureUsersDotFilesArentGroupOrWorldWritableObject,
+        m_remediateEnsureNoUsersHaveDotForwardFilesObject,
+        m_remediateEnsureNoUsersHaveDotNetrcFilesObject,
+        m_remediateEnsureNoUsersHaveDotRhostsFilesObject,
+        m_remediateEnsureRloginServiceIsDisabledObject,
+        m_remediateEnsureUnnecessaryAccountsAreRemovedObject
     };
 
     int mimObjectsNumber = ARRAY_SIZE(mimObjects);

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -231,6 +231,631 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureKernelSupportForCpuNx"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllTelnetdPackagesUninstalled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNodevOptionOnHomePartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNodevOptionOnTmpPartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNodevOptionOnVarTmpPartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNosuidOptionOnTmpPartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNosuidOptionOnVarTmpPartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoexecOptionOnVarTmpPartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoexecOptionOnDevShmPartition"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNodevOptionEnabledForAllRemovableMedia"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoexecOptionEnabledForAllRemovableMedia"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNosuidOptionEnabledForAllRemovableMedia"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoDuplicateUidsExist"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoDuplicateGidsExist"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoDuplicateUserNamesExist"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoDuplicateGroupsExist"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureShadowGroupIsEmpty"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRootGroupExists"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllAccountsHavePasswords"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoLegacyPlusEntriesInEtcPasswd"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoLegacyPlusEntriesInEtcShadow"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoLegacyPlusEntriesInEtcGroup"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDefaultRootAccountGroupIsGidZero"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRootIsOnlyUidZeroAccount"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllUsersHomeDirectoriesExist"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureUsersOwnTheirHomeDirectories"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRestrictedUserHomeDirectories"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePasswordHashingAlgorithm"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureMinDaysBetweenPasswordChanges"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureInactivePasswordLockPeriod"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureMaxDaysBetweenPasswordChanges"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePasswordExpiration"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePasswordExpirationWarning"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSystemAccountsAreNonLogin"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAuthenticationRequiredForSingleUserMode"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDotDoesNotAppearInRootsPath"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRemoteLoginWarningBannerIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureLocalLoginWarningBannerIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSuRestrictedToRootGroup"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDefaultUmaskForAllUsers"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAutomountingDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureKernelCompiledFromApprovedSources"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDefaultDenyFirewallPolicyIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePacketRedirectSendingIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureIcmpRedirectsIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSourceRoutedPacketsIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureIgnoringBogusIcmpBroadcastResponses"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureIgnoringIcmpEchoPingsToMulticast"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureMartianPacketLoggingIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureReversePathSourceValidationIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureTcpSynCookiesAreEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSystemNotActingAsNetworkSniffer"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllWirelessInterfacesAreDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureIpv6ProtocolIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDccpIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSctpIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDisabledSupportForRds"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureTipcIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureZeroconfNetworkingIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePermissionsOnBootloaderConfig"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePasswordReuseIsLimited"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureMountingOfUsbStorageDevicesIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureCoreDumpsAreRestricted"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePasswordCreationRequirements"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureLockoutForFailedPasswordAttempts"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDisabledInstallationOfCramfsFileSystem"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDisabledInstallationOfFreevxfsFileSystem"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDisabledInstallationOfHfsFileSystem"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDisabledInstallationOfHfsplusFileSystem"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureDisabledInstallationOfJffs2FileSystem"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureVirtualMemoryRandomizationIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllBootloadersHavePasswordProtectionEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureLoggingIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSyslogPackageIsInstalled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSystemdJournaldServicePersistsLogMessages"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureALoggingServiceIsSnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureFilePermissionsForAllRsyslogLogFiles"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureLoggerConfigurationFilesAreRestricted"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRsyslogNotAcceptingRemoteMessages"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSyslogRotaterServiceIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureTelnetServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRcprshServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureTftpServiceisDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAtCronIsRestrictedToAuthorizedUsers"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshBestPracticeProtocol"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshBestPracticeIgnoreRhosts"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshLogLevelIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshMaxAuthTriesIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshAccessIsLimited"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshRhostsRsaAuthenticationIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshHostbasedAuthenticationIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshPermitRootLoginIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshPermitEmptyPasswordsIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshIdleTimeoutIntervalIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshLoginGraceTimeIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSshWarningBannerIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureUsersCannotSetSshEnvironmentOptions"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAppropriateCiphersForSsh"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAvahiDaemonServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureCupsServiceisDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePostfixPackageIsUninstalled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePostfixNetworkListeningIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRpcgssdServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRpcidmapdServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsurePortmapServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNetworkFileSystemServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRpcsvcgssdServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSnmpServerIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRsynServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNisServerIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRshClientNotInstalled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureSmbWithSambaIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureUsersDotFilesArentGroupOrWorldWritable"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoUsersHaveDotForwardFiles"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoUsersHaveDotNetrcFiles"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureNoUsersHaveDotRhostsFiles"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureRloginServiceIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureUnnecessaryAccountsAreRemoved"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
     "ObjectName": "remediateSecurityBaseline"
   },
   {

--- a/src/platform/ModulesManager.c
+++ b/src/platform/ModulesManager.c
@@ -538,11 +538,11 @@ int MpiSet(MPI_HANDLE handle, const char* component, const char* object, const M
     {
         if (MMI_OK == (status = moduleSession->module->set(moduleSession->handle, component, object, payload, payloadSizeBytes)))
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiSet(%p, %s, %s, %p, %d) succeeded", handle, component, object, payload, payloadSizeBytes, status);
+            OsConfigLogInfo(GetPlatformLog(), "MpiSet(%p, %s, %s, %p, %d) succeeded", moduleSession->handle, component, object, payload, payloadSizeBytes);
         }
         else
         {
-            OsConfigLogError(GetPlatformLog(), "MpiSet(%p, %s, %s, %p, %d) failed with %d", handle, component, object, payload, payloadSizeBytes, status);
+            OsConfigLogError(GetPlatformLog(), "MpiSet(%p, %s, %s, %p, %d) failed with %d", moduleSession->handle, component, object, payload, payloadSizeBytes, status);
         }
     }
 
@@ -694,13 +694,16 @@ int MpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, const int pa
         FREE_MEMORY(json);
     }
 
-    if (MMI_OK == status)
+    if (IsFullLoggingEnabled())
     {
-        OsConfigLogInfo(GetPlatformLog(), "MpiSetDesired(%p, %p, %d) succeeded", handle, payload, payloadSizeBytes);
-    }
-    else
-    {
-        OsConfigLogError(GetPlatformLog(), "MpiSetDesired(%p, %p, %d) failed with %d", handle, payload, payloadSizeBytes, status);
+        if (MMI_OK == status)
+        {
+            OsConfigLogInfo(GetPlatformLog(), "MpiSetDesired(%p, %p, %d) succeeded", handle, payload, payloadSizeBytes);
+        }
+        else
+        {
+            OsConfigLogError(GetPlatformLog(), "MpiSetDesired(%p, %p, %d) failed with %d", handle, payload, payloadSizeBytes, status);
+        }
     }
 
     return status;
@@ -821,11 +824,11 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
     {
         if (MMI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiGetDesired(%p, %p, %d) succeeded", handle, payload, payloadSizeBytes);
+            OsConfigLogInfo(GetPlatformLog(), "MpiGetDesired(%p, %p) succeeded", handle, payload);
         }
         else
         {
-            OsConfigLogError(GetPlatformLog(), "MpiGetDesired(%p, %p, %d) failed with %d", handle, payload, payloadSizeBytes, status);
+            OsConfigLogError(GetPlatformLog(), "MpiGetDesired(%p, %p) failed with %d", handle, payload, status);
         }
     }
 

--- a/src/platform/ModulesManager.c
+++ b/src/platform/ModulesManager.c
@@ -366,7 +366,10 @@ MPI_HANDLE MpiOpen(const char* clientName, const unsigned int maxPayloadSizeByte
     }
     else
     {
-        OsConfigLogInfo(GetPlatformLog(), "MpiOpen: creating session with UUID '%s'", uuid);
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogInfo(GetPlatformLog(), "MpiOpen: creating session with UUID '%s'", uuid);
+        }
 
         if (NULL != (session = (SESSION*)malloc(sizeof(SESSION))))
         {
@@ -451,7 +454,10 @@ void MpiClose(MPI_HANDLE handle)
     }
     else
     {
-        OsConfigLogInfo(GetPlatformLog(), "MpiClose: closing session with UUID '%s'", session->uuid);
+        if (IsFullLoggingEnabled())
+        {
+            OsConfigLogInfo(GetPlatformLog(), "MpiClose: closing session with UUID '%s'", session->uuid);
+        }
 
         // Remove the session from the linked list
         if (session == g_sessions)


### PR DESCRIPTION
## Description

This adds the remaining 125 remediation checks to the SecurityBaseline module, including unit-tests and test recipe functional tests, plus all the management channels supported by OSConfig, including Digital Twins, GitOps and Local Management. The only parts that remain to be added are the implementation for the check functions. A README.md will follow.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.