### PR TITLE
Add --id-only flag to PMC upload command

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -61,7 +61,13 @@ jobs:
         with:
           command: --id-only package upload ./packages
 
+      # Associates the uploaded package with the target repo
       - name: Update repo
         uses: ./.github/actions/pmc
         with:
           command: repo package update --add-packages '${{ steps.upload.outputs.result }}' ${{ steps.target.outputs.id }}
+
+      - name: Publish package
+        uses: ./.github/actions/pmc
+        with:
+          command: repo publish ${{ steps.target.outputs.id }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -59,9 +59,9 @@ jobs:
         id: upload
         uses: ./.github/actions/pmc
         with:
-          command: package upload ./packages
+          command: --id-only package upload ./packages
 
       - name: Update repo
         uses: ./.github/actions/pmc
         with:
-          command: repo package update --add-packages ${{ steps.upload.outputs.result }} ${{ steps.target.outputs.id }}
+          command: repo package update --add-packages '${{ steps.upload.outputs.result }}' ${{ steps.target.outputs.id }}


### PR DESCRIPTION
Fixes error in the publishing workflow during the update step. The PMC CLI expects a list of IDs during the final update step when packages are associated with the repo. Packages are then published separately in the final step. 