### PR TITLE
Add Ubuntu 22.04 and Debian 12 build containers

### DIFF
--- a/devops/docker/debian-12-amd64/Dockerfile
+++ b/devops/docker/debian-12-amd64/Dockerfile
@@ -1,0 +1,35 @@
+FROM mcr.microsoft.com/mirror/docker/library/debian:bullseye
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -y update && apt-get -y install software-properties-common
+RUN apt -y update && apt-get -y install \
+    git \
+    cmake \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    uuid-dev \
+    rapidjson-dev \
+    ninja-build \
+    python3-jsonschema \
+    wget \
+    gcovr \
+    jq \
+    bc \
+    file
+
+WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
+
+# GTest
+RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
+RUN cd googletest && cmake . -G Ninja && cmake --build . --target install && rm -rf /git/googletest
+
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive
+RUN cd rapidjson && cmake . -G Ninja && cmake --build . --target install && rm -rf /git/rapidjson

--- a/devops/docker/debian-12-arm64/Dockerfile
+++ b/devops/docker/debian-12-arm64/Dockerfile
@@ -1,0 +1,38 @@
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM arm64v8/debian:bullseye
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -y update && apt-get -y install software-properties-common
+RUN apt -y update && apt-get -y install \
+    git \
+    cmake \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    uuid-dev \
+    rapidjson-dev \
+    ninja-build \
+    python3-jsonschema \
+    wget \
+    gcovr \
+    jq \
+    bc \
+    file
+
+WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
+
+# GTest
+RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
+RUN cd googletest && cmake . -G Ninja && cmake --build . --target install && rm -rf /git/googletest
+
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive
+RUN cd rapidjson && cmake . -G Ninja && cmake --build . --target install && rm -rf /git/rapidjson

--- a/devops/docker/ubuntu-22.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-22.04-amd64/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -y update && apt-get -y install software-properties-common
+RUN apt -y update && apt-get -y install \
+    apt-transport-https \
+    git \
+    cmake \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    uuid-dev \
+    libgtest-dev \
+    libgmock-dev \
+    rapidjson-dev \
+    ninja-build \
+    python3-jsonschema \
+    wget \
+    gcovr\
+    jq \
+    bc
+
+WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake

--- a/devops/docker/ubuntu-22.04-arm64/Dockerfile
+++ b/devops/docker/ubuntu-22.04-arm64/Dockerfile
@@ -1,0 +1,35 @@
+FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
+FROM arm64v8/ubuntu:20.04
+
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -y update && apt-get -y install software-properties-common
+RUN apt -y update && apt-get -y install \
+    apt-transport-https \
+    git \
+    cmake \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    uuid-dev \
+    libgtest-dev \
+    libgmock-dev \
+    rapidjson-dev \
+    ninja-build \
+    python3-jsonschema \
+    wget \
+    jq \
+    bc
+
+WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
+
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive
+RUN cd rapidjson && cmake . -G Ninja && cmake --build . --target install && rm -rf /git/rapidjson


### PR DESCRIPTION
Add Ubuntu 22.04 (`jammy`) and Debian 12 (`bookworm`) build containers (amd64 and arm64). 

_Workflow changes will follow after the containers are published to `ghcr.io`._