### PR TITLE
Add Rust sample module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/rust:1": {}
 	},
 	"postCreateCommand": "git submodule update --init",
 	"customizations": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           cmd: |
             mkdir build && cd build
-            cmake ../src -DCMAKE_build-type=${{ env.BUILD_TYPE }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_ADAPTERS=ON -G Ninja
+            cmake ../src -DCMAKE_build-type=${{ env.BUILD_TYPE }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=OFF -DBUILD_ADAPTERS=ON -G Ninja
 
       - name: Build azure-osconfig
         uses: ./.github/actions/container-exec

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ node_modules
 .terraform/
 .terraform.lock.hcl
 *.tfstate*
+
+# Rust
+target/
+Cargo.lock

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,6 +99,17 @@ if (BUILD_TESTS)
     set (GTEST_OUTPUT_DIR ${CMAKE_BINARY_DIR}/gtest-output)
 endif()
 
+if (BUILD_SAMPLES)
+    include(FetchContent)
+
+    FetchContent_Declare(
+        Corrosion
+        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+        GIT_TAG v0.4
+    )
+    FetchContent_MakeAvailable(Corrosion)
+endif()
+
 add_subdirectory(common)
 if (BUILD_ADAPTERS)
     add_subdirectory(adapters)

--- a/src/common/rust/osc/Cargo.toml
+++ b/src/common/rust/osc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "osc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+env_logger = "0.10.0"
+errno = "0.3.5"
+libc = "0.2.149"
+log = "0.4.20"
+osc_codegen = { path = "../osc_codegen" }
+serde = { version = "1.0.189", features = ["derive"] }
+serde_json = "1.0.107"
+serde_repr = "0.1.16"
+thiserror = "1.0.49"

--- a/src/common/rust/osc/src/lib.rs
+++ b/src/common/rust/osc/src/lib.rs
@@ -1,0 +1,6 @@
+// Depend on osc_codegen and re-export everything in it.
+// This allows users to just depend on osc and automatically get the macro functionality.
+pub use osc_codegen::osc_module;
+
+pub mod log;
+pub mod module;

--- a/src/common/rust/osc/src/log.rs
+++ b/src/common/rust/osc/src/log.rs
@@ -1,0 +1,34 @@
+use std::io::Write;
+
+use env_logger::{Builder, Env};
+
+// These are required by the code generated via the `osc_codegen` macros.
+pub use log::{debug, error, info, trace, warn};
+
+/// Initializes the logger to provide standard formatting for the [`log`] crate using [`env_logger`].
+///
+/// Format: `[<timestamp>] [<short file>:<line number>] [<log level>] <message>`
+///
+/// WARNING: this function should only be called *once* as early in the program execution as possible.
+pub fn init() {
+    let env = Env::default();
+
+    Builder::from_env(env)
+        .format(|buf, record| {
+            let timestamp = buf.timestamp();
+            let file = record.module_path().unwrap_or("unknown");
+            let line_number = record.line().unwrap_or(0);
+            let level = record.level();
+
+            writeln!(
+                buf,
+                "[{}] [{}:{}] [{}] {}",
+                timestamp,
+                file,
+                line_number,
+                level,
+                record.args()
+            )
+        })
+        .init();
+}

--- a/src/common/rust/osc/src/module/bind.rs
+++ b/src/common/rust/osc/src/module/bind.rs
@@ -1,0 +1,9 @@
+use std::ffi::{c_char, c_void};
+
+pub use libc;
+
+pub const OK: i32 = 0;
+pub const ERROR: i32 = -1;
+
+pub type Handle = *mut c_void;
+pub type JsonString = *mut c_char;

--- a/src/common/rust/osc/src/module/mod.rs
+++ b/src/common/rust/osc/src/module/mod.rs
@@ -1,0 +1,278 @@
+use std::{
+    cmp::Ordering,
+    error::Error,
+    fmt::{self, Display},
+};
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+pub mod bind;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Meta {
+    pub name: String,
+    pub description: Option<String>,
+    pub manufacturer: Option<String>,
+    #[serde(flatten)]
+    pub version: Version,
+    pub components: Vec<String>,
+    pub user_account: UserAccount,
+    pub lifetime: Lifetime,
+}
+
+impl Display for Meta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = serde_json::to_string(&self).unwrap();
+        write!(f, "{}", str)
+    }
+}
+
+#[derive(Default, Debug, Eq, Serialize, Deserialize, PartialEq)]
+pub struct Version {
+    #[serde(rename = "VersionMajor", default)]
+    pub major: u32,
+    #[serde(rename = "VersionMinor", default)]
+    pub minor: u32,
+    #[serde(rename = "VersionPatch", default)]
+    pub patch: u32,
+    #[serde(rename = "VersionTweak", default)]
+    pub tweak: u32,
+}
+
+impl Ord for Version {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.major.cmp(&other.major) {
+            Ordering::Equal => match self.minor.cmp(&other.minor) {
+                Ordering::Equal => match self.patch.cmp(&other.patch) {
+                    Ordering::Equal => self.tweak.cmp(&other.tweak),
+                    ordering => ordering,
+                },
+                ordering => ordering,
+            },
+            ordering => ordering,
+        }
+    }
+}
+
+impl PartialOrd for Version {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl From<&str> for Version {
+    fn from(version: &str) -> Self {
+        let mut split = version.split('.');
+
+        let major = split.next().unwrap_or("0").parse().unwrap_or(0);
+        let minor = split.next().unwrap_or("0").parse().unwrap_or(0);
+        let patch = split.next().unwrap_or("0").parse().unwrap_or(0);
+        let tweak = split.next().unwrap_or("0").parse().unwrap_or(0);
+
+        Self {
+            major,
+            minor,
+            patch,
+            tweak,
+        }
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "v{}.{}.{}.{}",
+            self.major, self.minor, self.patch, self.tweak
+        )
+    }
+}
+
+/// The lifetime of a module determines how long the module will be kept loaded. Short lifetime
+/// modules will be loaded/unloaded for each request. Long lifetime modules will be kept loaded
+/// until the platform is restarted.
+#[derive(Debug, PartialEq, Serialize_repr, Deserialize_repr)]
+#[serde(rename_all = "lowercase")]
+#[repr(u8)]
+pub enum Lifetime {
+    Short = 1,
+    Long = 2,
+}
+
+/// The UID of the user account that the module will be run with. Root (0) is default.
+/// UIDs can be found in `/etc/passwd`.
+///
+/// _Note: UIDs can change/be moved._
+#[derive(Debug, PartialEq)]
+pub enum UserAccount {
+    Root,
+    User(u32),
+}
+
+impl From<i32> for UserAccount {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Root,
+            value => Self::User(value as u32),
+        }
+    }
+}
+
+impl Serialize for UserAccount {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        match self {
+            Self::Root => serializer.serialize_i32(0),
+            Self::User(uid) => serializer.serialize_u32(*uid),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for UserAccount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        Ok(i32::deserialize(deserializer)?.into())
+    }
+}
+
+pub struct Value(serde_json::Value);
+
+/// Error type for errors that occur during property resolution.
+///
+/// Property errors are represented by a human-readable error message
+/// which can be displayed in log traces.
+pub struct PropertyError {
+    message: String,
+}
+
+impl PropertyError {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl fmt::Display for PropertyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// The result of resolving the value of a field of type `T`
+pub type PropertyResult<T> = Result<T, PropertyError>;
+
+/// Custom error handling trait to enable error types other than [`PropertyError`]
+/// to be specified as a return value for property resolvers.
+pub trait IntoPropertyError {
+    /// Performs the custom conversion into a [`PropertyError`].
+    fn into_prop_error(self) -> PropertyError;
+}
+
+impl<T> IntoPropertyError for T
+where
+    T: Error,
+{
+    fn into_prop_error(self) -> PropertyError {
+        PropertyError::new(self.to_string())
+    }
+}
+
+/// Custom trait for converting custom result types into [`PropertyResult`].
+pub trait IntoPropertyResult<T> {
+    #[doc(hidden)]
+    fn into_result(self) -> PropertyResult<T>;
+}
+
+impl<T> IntoPropertyResult<T> for T
+where
+    T: Serialize,
+{
+    fn into_result(self) -> PropertyResult<T> {
+        Ok(self)
+    }
+}
+
+impl<T, E> IntoPropertyResult<T> for Result<T, E>
+where
+    T: IntoPropertyResult<T>,
+    E: IntoPropertyError,
+{
+    fn into_result(self) -> PropertyResult<T> {
+        self.map_err(E::into_prop_error)
+    }
+}
+
+/// Custom trait for converting custom result types into payload strings.
+pub trait IntoPayload {
+    fn into_payload(self) -> PropertyResult<String>;
+}
+
+impl<T> IntoPayload for PropertyResult<T>
+where
+    T: Serialize,
+{
+    fn into_payload(self) -> PropertyResult<String> {
+        match self {
+            Ok(value) => Ok(serde_json::to_string(&value).unwrap()),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+/// Custom trait for converting payloads into custom argument types.
+pub trait IntoPropertyArgument<T> {
+    #[doc(hidden)]
+    fn into_arg(self) -> T;
+}
+
+impl<T> IntoPropertyArgument<T> for String
+where
+    T: DeserializeOwned,
+{
+    fn into_arg(self) -> T {
+        serde_json::from_str::<T>(&self).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version() {
+        let version = Version::from("1.2.3.4");
+
+        assert_eq!(version.major, 1);
+        assert_eq!(version.minor, 2);
+        assert_eq!(version.patch, 3);
+        assert_eq!(version.tweak, 4);
+    }
+
+    fn test_version_cmp(a: &str, b: &str, ordering: Ordering) {
+        let a = Version::from(a);
+        let b = Version::from(b);
+
+        assert_eq!(a.cmp(&b), ordering);
+    }
+
+    #[test]
+    fn test_version_cmp_major() {
+        test_version_cmp("1.0.0.0", "1.0.0.0", Ordering::Equal);
+        test_version_cmp("0.1.0.0", "0.1.0.0", Ordering::Equal);
+        test_version_cmp("0.0.1.0", "0.0.1.0", Ordering::Equal);
+        test_version_cmp("0.0.0.1", "0.0.0.1", Ordering::Equal);
+
+        test_version_cmp("1.0.0.0", "1.0.0.1", Ordering::Less);
+        test_version_cmp("1.0.0.0", "1.0.1.0", Ordering::Less);
+        test_version_cmp("1.0.0.0", "1.1.0.0", Ordering::Less);
+
+        test_version_cmp("1.0.0.1", "1.0.0.0", Ordering::Greater);
+        test_version_cmp("1.0.1.0", "1.0.0.0", Ordering::Greater);
+        test_version_cmp("1.1.0.0", "1.0.0.0", Ordering::Greater);
+    }
+}

--- a/src/common/rust/osc_codegen/Cargo.toml
+++ b/src/common/rust/osc_codegen/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "osc_codegen"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-error = "1.0.4"
+proc-macro2 = "1.0.69"
+quote = "1.0.33"
+syn = { version = "2.0.38", features = ["full"] }

--- a/src/common/rust/osc_codegen/src/common/diagnostic.rs
+++ b/src/common/rust/osc_codegen/src/common/diagnostic.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+use proc_macro2::Span;
+use proc_macro_error::{Diagnostic, Level};
+
+pub(crate) enum Scope {
+    ModuleAttr,
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::ModuleAttr => "module",
+        };
+        write!(f, "OSConfig {name}")
+    }
+}
+
+impl Scope {
+    pub(crate) fn custom<S: AsRef<str>>(&self, span: Span, msg: S) -> Diagnostic {
+        Diagnostic::spanned(span, Level::Error, format!("{self} {}", msg.as_ref()))
+    }
+
+    pub(crate) fn emit_custom<S: AsRef<str>>(&self, span: Span, msg: S) {
+        self.custom(span, msg).emit()
+    }
+
+    pub(crate) fn custom_error<S: AsRef<str>>(&self, span: Span, msg: S) -> syn::Error {
+        syn::Error::new(span, format!("{self} {}", msg.as_ref()))
+    }
+}

--- a/src/common/rust/osc_codegen/src/common/mod.rs
+++ b/src/common/rust/osc_codegen/src/common/mod.rs
@@ -1,0 +1,24 @@
+//! Common functions, definitions and extensions for code generation, used by this crate.
+
+pub(crate) mod diagnostic;
+pub(crate) mod parse;
+mod span_container;
+
+pub(crate) use self::span_container::SpanContainer;
+
+/// Filters the provided [`syn::Attribute`] to contain only ones with the
+/// specified `name`.
+pub(crate) fn filter_attrs<'a>(
+    name: &'a str,
+    attrs: &'a [syn::Attribute],
+) -> impl Iterator<Item = &'a syn::Attribute> + 'a {
+    attrs
+        .iter()
+        .filter(move |attr| path_eq_single(&attr.path(), name))
+}
+
+/// Checks whether the specified [`syn::Path`] equals to one-segment string
+/// `value`.
+pub(crate) fn path_eq_single(path: &syn::Path, value: &str) -> bool {
+    path.segments.len() == 1 && path.segments[0].ident == value
+}

--- a/src/common/rust/osc_codegen/src/common/parse/attr.rs
+++ b/src/common/rust/osc_codegen/src/common/parse/attr.rs
@@ -1,0 +1,101 @@
+//! Common functions, definitions and extensions for parsing and modifying Rust attributes, used by
+//! this crate.
+
+use proc_macro2::{Span, TokenStream};
+use syn::parse_quote;
+
+use crate::common::path_eq_single;
+
+/// Prepends the given `attrs` collection with a new [`syn::Attribute`] generated from the given
+/// `attr_path` and `attr_args`.
+///
+/// This function is generally used for uniting `proc_macro_attribute` with its body attributes.
+pub(crate) fn unite(
+    (attr_path, attr_args): (&str, &TokenStream),
+    attrs: &[syn::Attribute],
+) -> Vec<syn::Attribute> {
+    let mut full_attrs = Vec::with_capacity(attrs.len() + 1);
+    let attr_path = syn::Ident::new(attr_path, Span::call_site());
+    full_attrs.push(parse_quote! { #[#attr_path(#attr_args)] });
+    full_attrs.extend_from_slice(attrs);
+    full_attrs
+}
+
+/// Strips all `attr_path` attributes from the given `attrs` collection.
+///
+/// This function is generally used for removing duplicate attributes during `proc_macro_attribute`
+/// expansion, so avoid unnecessary expansion duplication.
+pub(crate) fn strip(attr_path: &str, attrs: Vec<syn::Attribute>) -> Vec<syn::Attribute> {
+    attrs
+        .into_iter()
+        .filter(|attr| !path_eq_single(&attr.path(), attr_path))
+        .collect()
+}
+
+/// Common errors of parsing Rust attributes, appeared in this crate.
+pub(crate) mod err {
+    use proc_macro2::Span;
+    use syn::spanned::Spanned;
+
+    /// Creates "duplicated argument" [`syn::Error`] for the given `name` pointing to the given
+    /// `span`.
+    #[must_use]
+    pub(crate) fn dup_arg<S: AsSpan>(span: S) -> syn::Error {
+        syn::Error::new(span.as_span(), "duplicated attribute argument found")
+    }
+
+    /// Creates "unknown argument" [`syn::Error`] for the given `name` pointing to the given `span`.
+    #[must_use]
+    pub(crate) fn unknown_arg<S: AsSpan>(span: S, name: &str) -> syn::Error {
+        syn::Error::new(
+            span.as_span(),
+            format!("unknown `{name}` attribute argument"),
+        )
+    }
+
+    /// Helper coercion for [`Span`] and [`Spanned`] types to use in function arguments.
+    pub(crate) trait AsSpan {
+        /// Returns the coerced [`Span`].
+        #[must_use]
+        fn as_span(&self) -> Span;
+    }
+
+    impl AsSpan for Span {
+        #[inline]
+        fn as_span(&self) -> Self {
+            *self
+        }
+    }
+
+    impl<T: Spanned> AsSpan for &T {
+        #[inline]
+        fn as_span(&self) -> Span {
+            self.span()
+        }
+    }
+}
+
+/// Handy extension of [`Option`] methods, used in this crate.
+pub(crate) trait OptionExt {
+    type Inner;
+
+    /// Transforms the `Option<T>` into a `Result<(), E>`, mapping `None` to `Ok(())` and `Some(v)`
+    /// to `Err(err(v))`.
+    fn none_or_else<E, F>(self, err: F) -> Result<(), E>
+    where
+        F: FnOnce(Self::Inner) -> E;
+}
+
+impl<T> OptionExt for Option<T> {
+    type Inner = T;
+
+    fn none_or_else<E, F>(self, err: F) -> Result<(), E>
+    where
+        F: FnOnce(T) -> E,
+    {
+        match self {
+            Some(v) => Err(err(v)),
+            None => Ok(()),
+        }
+    }
+}

--- a/src/common/rust/osc_codegen/src/common/parse/mod.rs
+++ b/src/common/rust/osc_codegen/src/common/parse/mod.rs
@@ -1,0 +1,127 @@
+//! Common functions, definitions and extensions for parsing, normalizing and modifying Rust syntax,
+//! used by this crate.
+
+pub(crate) mod attr;
+
+use std::borrow::Cow;
+
+use syn::{
+    ext::IdentExt as _,
+    parse::{Parse, ParseBuffer},
+    token::Token,
+};
+
+/// Extension of [`ParseBuffer`] providing common function widely used by this crate for parsing.
+pub(crate) trait ParseBufferExt {
+    /// Tries to parse `T` as the next token.
+    ///
+    /// Doesn't move [`ParseStream`]'s cursor if there is no `T`.
+    fn try_parse<T: Default + Parse + Token>(&self) -> syn::Result<Option<T>>;
+
+    /// Checks whether next token is `T`.
+    ///
+    /// Doesn't move [`ParseStream`]'s cursor.
+    #[must_use]
+    fn is_next<T: Default + Token>(&self) -> bool;
+
+    /// Parses next token as [`syn::Ident`] _allowing_ Rust keywords, while default [`Parse`]
+    /// implementation for [`syn::Ident`] disallows keywords.
+    ///
+    /// Always moves [`ParseStream`]'s cursor.
+    fn parse_any_ident(&self) -> syn::Result<syn::Ident>;
+}
+
+impl<'a> ParseBufferExt for ParseBuffer<'a> {
+    fn try_parse<T: Default + Parse + Token>(&self) -> syn::Result<Option<T>> {
+        Ok(if self.is_next::<T>() {
+            Some(self.parse()?)
+        } else {
+            None
+        })
+    }
+
+    fn is_next<T: Default + Token>(&self) -> bool {
+        self.lookahead1().peek(|_| T::default())
+    }
+
+    fn parse_any_ident(&self) -> syn::Result<syn::Ident> {
+        self.call(syn::Ident::parse_any)
+    }
+}
+
+/// Extension of [`syn::Type`] providing common function widely used by this crate for parsing.
+pub(crate) trait TypeExt {
+    /// Retrieves the innermost non-parenthesized [`syn::Type`] from the given
+    /// one (unwraps nested [`syn::TypeParen`]s asap).
+    #[must_use]
+    fn unparenthesized(&self) -> &Self;
+
+    /// Returns the topmost [`syn::Ident`] of this [`syn::TypePath`], if any.
+    #[must_use]
+    fn topmost_ident(&self) -> Option<&syn::Ident>;
+}
+
+impl TypeExt for syn::Type {
+    fn unparenthesized(&self) -> &Self {
+        match self {
+            Self::Paren(ty) => ty.elem.unparenthesized(),
+            Self::Group(ty) => ty.elem.unparenthesized(),
+            ty => ty,
+        }
+    }
+
+    fn topmost_ident(&self) -> Option<&syn::Ident> {
+        match self.unparenthesized() {
+            syn::Type::Path(p) => Some(&p.path),
+            syn::Type::Reference(r) => match (*r.elem).unparenthesized() {
+                syn::Type::Path(p) => Some(&p.path),
+                syn::Type::TraitObject(o) => match o.bounds.iter().next().unwrap() {
+                    syn::TypeParamBound::Trait(b) => Some(&b.path),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }?
+        .segments
+        .last()
+        .map(|s| &s.ident)
+    }
+}
+
+/// Convert string to camel case.
+#[doc(hidden)]
+pub fn to_camel_case(s: &'_ str) -> Cow<'_, str> {
+    let mut dest = Cow::Borrowed(s);
+
+    // handle '_' to be more friendly with the
+    // _var convention for unused variables
+    let s_iter = if let Some(stripped) = s.strip_prefix('_') {
+        stripped
+    } else {
+        s
+    }
+    .split('_')
+    .enumerate();
+
+    for (i, part) in s_iter {
+        if i > 0 && part.len() == 1 {
+            dest += Cow::Owned(part.to_uppercase());
+        } else if i > 0 && part.len() > 1 {
+            let first = part
+                .chars()
+                .next()
+                .unwrap()
+                .to_uppercase()
+                .collect::<String>();
+            let second = &part[1..];
+
+            dest += Cow::Owned(first);
+            dest += second;
+        } else if i == 0 {
+            dest = Cow::Borrowed(part);
+        }
+    }
+
+    dest
+}

--- a/src/common/rust/osc_codegen/src/common/span_container.rs
+++ b/src/common/rust/osc_codegen/src/common/span_container.rs
@@ -1,0 +1,71 @@
+use std::{
+    hash::{Hash, Hasher},
+    ops,
+};
+
+use proc_macro2::{Span, TokenStream};
+use quote::ToTokens;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SpanContainer<T> {
+    _expr: Option<Span>,
+    ident: Span,
+    val: T,
+}
+
+impl<T: ToTokens> ToTokens for SpanContainer<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.val.to_tokens(tokens)
+    }
+}
+
+impl<T> SpanContainer<T> {
+    pub(crate) fn new(ident: Span, _expr: Option<Span>, val: T) -> Self {
+        Self { _expr, ident, val }
+    }
+
+    pub(crate) fn span_ident(&self) -> Span {
+        self.ident
+    }
+
+    pub(crate) fn into_inner(self) -> T {
+        self.val
+    }
+}
+
+impl<T> AsRef<T> for SpanContainer<T> {
+    fn as_ref(&self) -> &T {
+        &self.val
+    }
+}
+
+impl<T> ops::Deref for SpanContainer<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl<T: PartialEq> PartialEq for SpanContainer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.val == other.val
+    }
+}
+
+impl<T: Eq> Eq for SpanContainer<T> {}
+
+impl<T: PartialEq> PartialEq<T> for SpanContainer<T> {
+    fn eq(&self, other: &T) -> bool {
+        &self.val == other
+    }
+}
+
+impl<T: Hash> Hash for SpanContainer<T> {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.val.hash(state)
+    }
+}

--- a/src/common/rust/osc_codegen/src/lib.rs
+++ b/src/common/rust/osc_codegen/src/lib.rs
@@ -1,0 +1,80 @@
+// NOTICE: Unfortunately this macro MUST be defined here, in the crate's root module, because Rust
+//         doesn't allow to export `macro_rules!` macros from a `proc-macro` crate type currently,
+//         and so we cannot move the definition into a sub-module and use the `#[macro_export]`
+//         attribute.
+/// Attempts to merge an [`Option`]ed `$field` of a `$self` struct with the same `$field` of
+/// `$another` struct. If both are [`Some`], then throws a duplication error with a [`Span`] related
+/// to the `$another` struct (a later one).
+///
+/// The type of [`Span`] may be explicitly specified as one of the [`SpanContainer`] methods.
+/// By default, [`SpanContainer::span_ident`] is used.
+///
+/// [`Span`]: proc_macro2::Span
+/// [`SpanContainer`]: crate::common::SpanContainer
+/// [`SpanContainer::span_ident`]: crate::common::SpanContainer::span_ident
+macro_rules! try_merge_opt {
+    ($field:ident: $self:ident, $another:ident => $span:ident) => {{
+        if let Some(v) = $self.$field {
+            $another
+                .$field
+                .replace(v)
+                .none_or_else(|dup| crate::common::parse::attr::err::dup_arg(&dup.$span()))?;
+        }
+        $another.$field
+    }};
+
+    ($field:ident: $self:ident, $another:ident) => {
+        try_merge_opt!($field: $self, $another => span_ident)
+    };
+}
+
+use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+
+mod common;
+mod osc_module;
+
+/// `#[osc_module]` macro for generating an [OSConfig module][1] implementation.
+///
+/// It enables you to write property resolvers for a single-component module by
+/// declaring a regular Rust `impl` block for a struct. Under the hood, the macro
+/// implements the module interface and handles all FFI type conversions.
+///
+/// Desired and reported properties are declared as methods on the impl block of
+/// the struct. fields definited on the struct can be used for storing state
+/// between method calls, and can be accessed from prooperty resolvers.
+///
+/// ```rust
+/// use osc::osc_module;
+///
+/// struct Hostname {
+///     name: String
+/// }
+///
+/// #[osc_module(
+///    name = "Hostname",
+///    description = "Provides functionality to observe and configure network hostname",
+///    manufacturer = "Microsoft",
+///    version = "1.0"
+/// )]
+/// impl Hostname {
+///     #[osc(reported)]
+///     fn name(&self) -> String {
+///         self.name.clone()
+///     }
+///
+///     #[osc(desired)]
+///     fn desired_name(&mut self, name: String) {
+///         self.name = name;
+///     }
+/// }
+///  ```
+///
+/// [1]: https://github.com/Azure/azure-osconfig/blob/main/docs/modules.md
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn osc_module(args: TokenStream, input: TokenStream) -> TokenStream {
+    osc_module::attr::expand(args.into(), input.into())
+        .unwrap()
+        .into()
+}

--- a/src/common/rust/osc_codegen/src/osc_module/attr/lifetime.rs
+++ b/src/common/rust/osc_codegen/src/osc_module/attr/lifetime.rs
@@ -1,0 +1,40 @@
+use quote::ToTokens;
+use syn::parse::{Parse, ParseStream};
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Lifetime {
+    Short,
+    Long
+}
+
+impl Parse for Lifetime {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let lifetime = input.parse::<syn::LitStr>()?;
+        let value = lifetime.value();
+
+        match value.as_str() {
+            "short" => Ok(Lifetime::Short),
+            "long" => Ok(Lifetime::Long),
+            _ => Err(syn::Error::new(lifetime.span(), "Invalid lifetime"))
+        }
+    }
+}
+
+impl Default for Lifetime {
+    fn default() -> Self {
+        Lifetime::Long
+    }
+}
+
+impl ToTokens for Lifetime {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let lifetime = match self {
+            Lifetime::Short => quote::format_ident!("Short"),
+            Lifetime::Long => quote::format_ident!("Long"),
+        };
+
+        tokens.extend(quote::quote! {
+            ::osc::module::Lifetime::#lifetime
+        });
+    }
+}

--- a/src/common/rust/osc_codegen/src/osc_module/attr/mod.rs
+++ b/src/common/rust/osc_codegen/src/osc_module/attr/mod.rs
@@ -1,0 +1,217 @@
+//! Code generation for `#[osc_module]` macro.
+
+use std::mem;
+
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{ext::IdentExt as _, parse_quote, spanned::Spanned};
+
+use crate::common::{
+    diagnostic,
+    parse::{self, to_camel_case, TypeExt as _},
+    path_eq_single, SpanContainer,
+};
+
+use super::{property, Attr, Definition};
+
+mod lifetime;
+mod user_account;
+mod version;
+
+pub(crate) use lifetime::Lifetime;
+pub(crate) use user_account::UserAccount;
+pub(crate) use version::Version;
+
+/// [`diagnostic::Scope`] of errors for `#[osc_module]` macro.
+const ERR: diagnostic::Scope = diagnostic::Scope::ModuleAttr;
+
+/// Expands `#[osc_module]` macro into generated code.
+pub fn expand(attr_args: TokenStream, body: TokenStream) -> syn::Result<TokenStream> {
+    if let Ok(mut ast) = syn::parse2::<syn::ItemImpl>(body) {
+        if ast.trait_.is_none() {
+            let impl_attrs = parse::attr::unite(("osc_module", &attr_args), &ast.attrs);
+            ast.attrs = parse::attr::strip("osc_module", ast.attrs);
+            return expand_on_impl(Attr::from_attrs("osc_module", &impl_attrs)?, ast);
+        }
+    }
+
+    Err(syn::Error::new(
+        Span::call_site(),
+        "#[osc_module] attribute is applicable to non-trait `impl` blocks only",
+    ))
+}
+
+/// Expands `#[osc_module]` macro placed on an implementation block.
+fn expand_on_impl(attr: Attr, mut ast: syn::ItemImpl) -> syn::Result<TokenStream>
+where
+    Definition: ToTokens,
+{
+    let type_span = ast.self_ty.span();
+    let type_ident = ast.self_ty.topmost_ident().ok_or_else(|| {
+        ERR.custom_error(type_span, "could not determine ident for the `impl` type")
+    })?;
+
+    let name = attr
+        .name
+        .clone()
+        .map(SpanContainer::into_inner)
+        .unwrap_or_else(|| type_ident.unraw().to_string());
+
+    proc_macro_error::abort_if_dirty();
+
+    let props: Vec<_> = ast
+        .items
+        .iter_mut()
+        .filter_map(|item| {
+            if let syn::ImplItem::Fn(f) = item {
+                parse_property(f)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    proc_macro_error::abort_if_dirty();
+
+    if !property::all_different(&props) {
+        ERR.emit_custom(
+            type_span,
+            "must have a different name for each reported field",
+        );
+    }
+
+    proc_macro_error::abort_if_dirty();
+
+    let generated_code = Definition {
+        name,
+        ty: ast.self_ty.unparenthesized().clone(),
+        description: attr.description.map(SpanContainer::into_inner),
+        manufacturer: attr.manufacturer.map(SpanContainer::into_inner),
+        version: attr
+            .version
+            .map(SpanContainer::into_inner)
+            .unwrap_or_default(),
+        lifetime: attr
+            .lifetime
+            .map(SpanContainer::into_inner)
+            .unwrap_or_default(),
+        user_account: attr
+            .user_account
+            .map(SpanContainer::into_inner)
+            .unwrap_or_default(),
+        props,
+    };
+
+    Ok(quote! {
+        #ast
+        #generated_code
+    })
+}
+
+/// Parses a [`property::Definition`] from the given Rust [`syn::ImplItemMethod`].
+///
+/// Returns [`None`] if parsing fails, or the method field is ignored.
+#[must_use]
+fn parse_property(method: &mut syn::ImplItemFn) -> Option<property::Definition> {
+    let method_attrs = method.attrs.clone();
+
+    // If the method does not have `#[osc]` attribute, ignore it.
+    if !method_attrs
+        .iter()
+        .any(|attr| path_eq_single(&attr.path(), "osc"))
+    {
+        return None;
+    }
+
+    // Remove repeated attributes from the method, to omit incorrect expansion.
+    method.attrs = mem::take(&mut method.attrs)
+        .into_iter()
+        .filter(|attr| !path_eq_single(&attr.path(), "osc"))
+        .collect();
+
+    let attr = property::Attr::from_attrs("osc", &method_attrs).ok()?;
+
+    let method_ident = &method.sig.ident;
+
+    let name = attr
+        .name
+        .as_ref()
+        .map(|m| m.as_ref().value())
+        .unwrap_or(method_ident.unraw().to_string());
+
+    let name = to_camel_case(&name).into_owned();
+
+    let arguments: Vec<_> = {
+        if let Some(arg) = method.sig.inputs.first() {
+            match arg {
+                syn::FnArg::Receiver(rcv) => {
+                    if rcv.reference.is_none() {
+                        return err_invalid_method_receiver(rcv);
+                    }
+                }
+                syn::FnArg::Typed(arg) => {
+                    if let syn::Pat::Ident(a) = &*arg.pat {
+                        if a.ident == "self" {
+                            return err_invalid_method_receiver(arg);
+                        }
+                    }
+                }
+            }
+        }
+
+        method
+            .sig
+            .inputs
+            .iter_mut()
+            .filter_map(|arg| match arg {
+                syn::FnArg::Receiver(_) => None,
+                syn::FnArg::Typed(arg) => Some(arg.ty.as_ref().clone()),
+            })
+            .collect()
+    };
+
+    let access = attr.access.map(SpanContainer::into_inner)?;
+
+    match access {
+        property::AccessType::Read => {
+            if !arguments.is_empty() {
+                ERR.emit_custom(
+                    method.sig.inputs.span(),
+                    "reported method should not have any arguments",
+                );
+            }
+        }
+        property::AccessType::Write => {
+            if arguments.is_empty() {
+                ERR.emit_custom(
+                    method.sig.inputs.span(),
+                    "desired method should have one argument",
+                );
+            }
+        }
+    }
+
+    let ty = match &method.sig.output {
+        syn::ReturnType::Default => parse_quote! { () },
+        syn::ReturnType::Type(_, ty) => ty.unparenthesized().clone(),
+    };
+
+    Some(property::Definition {
+        name,
+        ty,
+        ident: method_ident.clone(),
+        arguments: Some(arguments),
+        has_receiver: method.sig.receiver().is_some(),
+        access,
+    })
+}
+
+/// Emits "invalid method receiver" [`syn::Error`] pointing to the given `span`.
+#[must_use]
+fn err_invalid_method_receiver<T, S: Spanned>(span: &S) -> Option<T> {
+    ERR.emit_custom(
+        span.span(),
+        "method should have a shared reference receiver `&self`, or no receiver at all",
+    );
+    None
+}

--- a/src/common/rust/osc_codegen/src/osc_module/attr/user_account.rs
+++ b/src/common/rust/osc_codegen/src/osc_module/attr/user_account.rs
@@ -1,0 +1,27 @@
+use quote::ToTokens;
+use syn::parse::{Parse, ParseStream};
+
+#[derive(Debug)]
+pub struct UserAccount(i32);
+
+impl Parse for UserAccount {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let user_account = input.parse::<syn::LitInt>()?;
+        let value = user_account.base10_parse::<i32>()?;
+
+        Ok(UserAccount(value))
+    }
+}
+
+impl Default for UserAccount {
+    fn default() -> Self {
+        UserAccount(0)
+    }
+}
+
+impl ToTokens for UserAccount {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let user_account = self.0;
+        tokens.extend(quote::quote! { ::osc::module::UserAccount::from(#user_account) });
+    }
+}

--- a/src/common/rust/osc_codegen/src/osc_module/attr/version.rs
+++ b/src/common/rust/osc_codegen/src/osc_module/attr/version.rs
@@ -1,0 +1,57 @@
+use quote::ToTokens;
+use syn::parse::{Parse, ParseStream};
+
+#[derive(Default, Debug, Eq, PartialEq)]
+pub(crate) struct Version {
+    pub(crate) major: u32,
+    pub(crate) minor: u32,
+    pub(crate) patch: u32,
+    pub(crate) tweak: u32,
+}
+
+impl Parse for Version {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let version = input.parse::<syn::LitStr>()?;
+        let span = version.span();
+
+        let version = version.value();
+        let mut version = version.split('.');
+
+        if version.clone().count() > 4 {
+            return Err(syn::Error::new(
+                span,
+                "Version string must be in the format of 'major.minor.patch.tweak'",
+            ));
+        }
+
+        let major = version.next().unwrap_or("0").parse().unwrap_or(0);
+        let minor = version.next().unwrap_or("0").parse().unwrap_or(0);
+        let patch = version.next().unwrap_or("0").parse().unwrap_or(0);
+        let tweak = version.next().unwrap_or("0").parse().unwrap_or(0);
+
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            tweak,
+        })
+    }
+}
+
+impl ToTokens for Version {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let major = self.major;
+        let minor = self.minor;
+        let patch = self.patch;
+        let tweak = self.tweak;
+
+        tokens.extend(quote::quote! {
+            ::osc::module::Version {
+                major: #major,
+                minor: #minor,
+                patch: #patch,
+                tweak: #tweak,
+            }
+        });
+    }
+}

--- a/src/common/rust/osc_codegen/src/osc_module/mod.rs
+++ b/src/common/rust/osc_codegen/src/osc_module/mod.rs
@@ -1,0 +1,467 @@
+//! Code generation for [OSConfig modules][1].
+//!
+//! [1]: https://github.com/Azure/azure-osconfig/blob/main/docs/modules.md
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    token,
+};
+
+use crate::common::{
+    filter_attrs,
+    parse::{
+        attr::{err, OptionExt as _},
+        ParseBufferExt as _,
+    },
+    SpanContainer,
+};
+
+pub mod attr;
+mod property;
+
+use self::attr::{Lifetime, UserAccount, Version};
+
+/// Available arguments behind `#[osc]` (or `#[osc_module]`) attribute
+/// when generating code for an [OSConfig module][1].
+///
+/// [1]: https://github.com/Azure/azure-osconfig/blob/main/docs/modules.md
+#[derive(Debug, Default)]
+pub(crate) struct Attr {
+    /// Name of the module.
+    pub(crate) name: Option<SpanContainer<String>>,
+
+    /// Description of the module.
+    pub(crate) description: Option<SpanContainer<String>>,
+
+    /// Manufacturer of the module.
+    pub(crate) manufacturer: Option<SpanContainer<String>>,
+
+    /// Version of the module.
+    pub(crate) version: Option<SpanContainer<Version>>,
+
+    /// Lifetime of the module.
+    pub(crate) lifetime: Option<SpanContainer<Lifetime>>,
+
+    /// User account of the module.
+    pub(crate) user_account: Option<SpanContainer<UserAccount>>,
+}
+
+impl Parse for Attr {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut out = Self::default();
+        while !input.is_empty() {
+            let ident = input.parse_any_ident()?;
+            match ident.to_string().as_str() {
+                "name" => {
+                    input.parse::<token::Eq>()?;
+                    let name = input.parse::<syn::LitStr>()?;
+                    out.name
+                        .replace(SpanContainer::new(
+                            ident.span(),
+                            Some(name.span()),
+                            name.value(),
+                        ))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                "desc" | "description" => {
+                    input.parse::<token::Eq>()?;
+                    let desc = input.parse::<syn::LitStr>()?;
+                    out.description
+                        .replace(SpanContainer::new(
+                            ident.span(),
+                            Some(desc.span()),
+                            desc.value(),
+                        ))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                "manufacturer" => {
+                    input.parse::<token::Eq>()?;
+                    let manufacturer = input.parse::<syn::LitStr>()?;
+                    out.manufacturer
+                        .replace(SpanContainer::new(
+                            ident.span(),
+                            Some(manufacturer.span()),
+                            manufacturer.value(),
+                        ))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                "version" => {
+                    input.parse::<token::Eq>()?;
+                    let version = input.parse::<Version>()?;
+                    out.version
+                        .replace(SpanContainer::new(ident.span(), None, version))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                "lifetime" => {
+                    input.parse::<token::Eq>()?;
+                    let lifetime = input.parse::<Lifetime>()?;
+                    out.lifetime
+                        .replace(SpanContainer::new(ident.span(), None, lifetime))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                "user" | "user_account" => {
+                    input.parse::<token::Eq>()?;
+                    let user_account = input.parse::<UserAccount>()?;
+                    out.user_account
+                        .replace(SpanContainer::new(ident.span(), None, user_account))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                name => {
+                    return Err(err::unknown_arg(&ident, name));
+                }
+            }
+            input.try_parse::<token::Comma>()?;
+        }
+        Ok(out)
+    }
+}
+
+impl Attr {
+    /// Tries to merge two [`Attr`]s into a single one, reporting about
+    /// duplicates, if any.
+    fn try_merge(self, mut another: Self) -> syn::Result<Self> {
+        Ok(Self {
+            name: try_merge_opt!(name: self, another),
+            description: try_merge_opt!(description: self, another),
+            manufacturer: try_merge_opt!(manufacturer: self, another),
+            version: try_merge_opt!(version: self, another),
+            lifetime: try_merge_opt!(lifetime: self, another),
+            user_account: try_merge_opt!(user_account: self, another),
+        })
+    }
+
+    /// Parses [`Attr`] from the given multiple `name`d [`syn::Attribute`]s
+    /// placed on a struct or impl block definition.
+    pub(crate) fn from_attrs(name: &str, attrs: &[syn::Attribute]) -> syn::Result<Self> {
+        filter_attrs(name, attrs)
+            .map(|attr| attr.parse_args())
+            .try_fold(Self::default(), |prev, curr| prev.try_merge(curr?))
+    }
+}
+
+/// Definition of a module for code generation.
+pub(crate) struct Definition {
+    /// Name of this module.
+    pub(crate) name: String,
+
+    /// Rust type that this module is represented with.
+    pub(crate) ty: syn::Type,
+
+    /// Description of this module to use in the module metadata.
+    pub(crate) description: Option<String>,
+
+    /// The manufacturer of this module to use in the module metadata.
+    pub(crate) manufacturer: Option<String>,
+
+    /// The version of this module to use in the module metadata.
+    pub(crate) version: Version,
+
+    /// The lifetime of this module to use in the module metadata.
+    pub(crate) lifetime: Lifetime,
+
+    /// The user account of this module to use in the module metadata.
+    pub(crate) user_account: UserAccount,
+
+    /// The properties of this module.
+    pub(crate) props: Vec<property::Definition>,
+}
+
+impl Definition {
+    fn impl_meta_tokens(&self) -> TokenStream {
+        let name = &self.name;
+
+        let description = self
+            .description
+            .as_ref()
+            .map(|s| quote! { Some(#s.to_string()) })
+            .unwrap_or_else(|| quote! { None });
+
+        let manufacturer = self
+            .manufacturer
+            .as_ref()
+            .map(|s| quote! { Some(#s.to_string()) })
+            .unwrap_or_else(|| quote! { None });
+
+        let (lifetime, user_account, version) = (&self.lifetime, &self.user_account, &self.version);
+
+        quote! {
+            ::osc::module::Meta {
+                name: #name.to_string(),
+                description: #description,
+                manufacturer: #manufacturer,
+                version: #version,
+                components: vec![#name.to_string()],
+                lifetime: #lifetime,
+                user_account: #user_account,
+            }
+        }
+    }
+
+    fn impl_osc_module_meta_tokens(&self) -> TokenStream {
+        let meta = self.impl_meta_tokens();
+
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn MmiGetInfo(
+                client: *const ::std::ffi::c_char,
+                payload: *mut ::osc::module::bind::JsonString,
+                payload_size: *mut ::std::ffi::c_int,
+            ) -> ::std::ffi::c_int {
+                if client.is_null() {
+                    ::osc::log::error!("invalid 'null' client name");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if payload.is_null() {
+                    ::osc::log::error!("invalid 'null' payload");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if payload_size.is_null() {
+                    ::osc::log::error!("invalid 'null' payload size");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                unsafe {
+                    *payload = ::std::ptr::null_mut();
+                    *payload_size = 0;
+                }
+
+                let meta = #meta;
+
+                let json = meta.to_string();
+                let json = ::std::ffi::CString::new(json.as_str()).unwrap();
+                let size = json.as_bytes().len() as ::std::ffi::c_int;
+
+                unsafe {
+                    *payload = json.into_raw();
+                    *payload_size = size as ::std::ffi::c_int;
+                };
+
+                ::osc::module::bind::OK
+            }
+        }
+    }
+
+    fn impl_osc_module_open_tokens(&self) -> TokenStream {
+        let ty = &self.ty;
+
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn MmiOpen(
+                client: *const ::std::ffi::c_char,
+                max_size: ::std::ffi::c_uint
+            ) -> *mut ::std::ffi::c_void {
+                ::osc::log::init();
+
+                if client.is_null() {
+                    ::osc::log::error!("invalid 'null' client name");
+                    return std::ptr::null_mut();
+                }
+
+                let instance = Box::new(#ty::default());
+                Box::into_raw(instance) as *mut ::std::ffi::c_void
+            }
+        }
+    }
+
+    fn impl_osc_module_close_tokens(&self) -> TokenStream {
+        let ty = &self.ty;
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn MmiClose(handle: ::osc::module::bind::Handle) {
+                if !handle.is_null() {
+                    let _ = unsafe { Box::from_raw(handle as *mut #ty) };
+                }
+            }
+        }
+    }
+
+    fn impl_osc_module_set_tokens(&self) -> TokenStream {
+        let (name, ty) = (&self.name, &self.ty);
+
+        let desired = self
+            .props
+            .iter()
+            .filter(|prop| prop.is_write())
+            .map(|prop| prop.method_resolve_desired_prop_tokens(ty));
+
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn MmiSet(
+                handle: ::osc::module::bind::Handle,
+                component: *const ::std::ffi::c_char,
+                property: *const ::std::ffi::c_char,
+                payload: ::osc::module::bind::JsonString,
+                payload_size: ::std::ffi::c_int,
+            ) -> ::std::ffi::c_int {
+                if handle.is_null() {
+                    ::osc::log::error!("invalid 'null' handle");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if component.is_null() {
+                    ::osc::log::error!("invalid 'null' component");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if property.is_null() {
+                    ::osc::log::error!("invalid 'null' property");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                let component = unsafe { std::ffi::CStr::from_ptr(component) };
+                let component = component.to_str().unwrap();
+
+                if #name != component {
+                    ::osc::log::error!("invalid component name: {}", component);
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                let property = unsafe { std::ffi::CStr::from_ptr(property) };
+                let property = property.to_str().unwrap();
+
+                let payload = unsafe { std::slice::from_raw_parts(payload as *const u8, payload_size as usize) };
+                let payload = String::from_utf8_lossy(payload).to_string();
+
+                let instance: &mut #ty = unsafe { &mut *(handle as *mut #ty) };
+
+                let result = match property {
+                    #(#desired)*
+                    _ => {
+                        ::osc::module::PropertyResult::Err(
+                            ::osc::module::PropertyError::new(
+                                format!("invalid property name: {}.{}", component, property)
+                            )
+                        )
+                    }
+                };
+
+                match result {
+                    Ok(_) => ::osc::module::bind::OK,
+                    Err(err) => {
+                        ::osc::log::error!("{}", err);
+                        ::osc::module::bind::ERROR
+                    }
+                }
+            }
+        }
+    }
+
+    fn impl_osc_module_get_tokens(&self) -> TokenStream {
+        let (name, ty) = (&self.name, &self.ty);
+
+        let reported = self
+            .props
+            .iter()
+            .filter(|prop| prop.is_read())
+            .map(|prop| prop.method_resolve_reported_prop_tokens(ty));
+
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn MmiGet(
+                handle: ::osc::module::bind::Handle,
+                component: *const ::std::ffi::c_char,
+                property: *const ::std::ffi::c_char,
+                payload: *mut ::osc::module::bind::JsonString,
+                payload_size: *mut ::std::ffi::c_int,
+            ) -> ::std::ffi::c_int {
+                if handle.is_null() {
+                    ::osc::log::error!("invalid 'null' handle");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if component.is_null() {
+                    ::osc::log::error!("invalid 'null' component");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if property.is_null() {
+                    ::osc::log::error!("invalid 'null' property");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if payload.is_null() {
+                    ::osc::log::error!("invalid 'null' payload");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                if payload_size.is_null() {
+                    ::osc::log::error!("invalid 'null' payload size");
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                unsafe {
+                    *payload = std::ptr::null_mut();
+                    *payload_size = 0;
+                }
+
+                let component = unsafe { ::std::ffi::CStr::from_ptr(component) };
+                let component = component.to_str().unwrap();
+
+                if #name != component {
+                    ::osc::log::error!("invalid component name: {}", component);
+                    return ::osc::module::bind::libc::EINVAL;
+                }
+
+                let property = unsafe { ::std::ffi::CStr::from_ptr(property) };
+                let property = property.to_str().unwrap();
+
+                let instance: &#ty = unsafe { &*(handle as *const #ty) };
+
+                let res = match property {
+                    #(#reported)*
+                    _ => {
+                        ::osc::module::PropertyResult::Err(
+                            ::osc::module::PropertyError::new(
+                                format!("invalid property name: {}.{}", component, property)
+                            )
+                        )
+                    }
+                };
+
+                match res {
+                    Ok(val) => {
+                        let json = ::std::ffi::CString::new(val).unwrap();
+                        let size = json.as_bytes().len() as ::std::ffi::c_int;
+
+                        unsafe {
+                            *payload = json.into_raw();
+                            *payload_size = size as ::std::ffi::c_int;
+                        };
+
+                        ::osc::module::bind::OK
+                    }
+                    Err(err) => {
+                        ::osc::log::error!("{}", err);
+                        -1
+                    }
+                }
+            }
+        }
+    }
+
+    fn impl_osc_module_free_tokens(&self) -> TokenStream {
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn MmiFree(ptr: *mut ::std::ffi::c_char) {
+                if !ptr.is_null() {
+                    let _ = unsafe { Box::from_raw(ptr as *mut ::std::ffi::c_char) };
+                }
+            }
+        }
+    }
+}
+
+impl ToTokens for Definition {
+    fn to_tokens(&self, into: &mut TokenStream) {
+        self.impl_osc_module_meta_tokens().to_tokens(into);
+        self.impl_osc_module_open_tokens().to_tokens(into);
+        self.impl_osc_module_close_tokens().to_tokens(into);
+        self.impl_osc_module_set_tokens().to_tokens(into);
+        self.impl_osc_module_get_tokens().to_tokens(into);
+        self.impl_osc_module_free_tokens().to_tokens(into);
+    }
+}

--- a/src/common/rust/osc_codegen/src/osc_module/property.rs
+++ b/src/common/rust/osc_codegen/src/osc_module/property.rs
@@ -1,0 +1,185 @@
+//! Common functions, definitions and extensions for parsing and code generation
+//! of module properties
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    spanned::Spanned as _,
+    token,
+};
+
+use crate::common::{
+    filter_attrs,
+    parse::{
+        attr::{err, OptionExt as _},
+        ParseBufferExt as _,
+    },
+    SpanContainer,
+};
+
+/// Available metadata (arguments) behind `#[osc]` attribute placed on a
+/// property definition.
+#[derive(Default)]
+pub struct Attr {
+    /// Explicitly specified name of this property.
+    ///
+    /// If [`None`], then `camelCased` Rust method name is used by default.
+    pub(crate) name: Option<SpanContainer<syn::LitStr>>,
+
+    /// The access type of this property.
+    pub(crate) access: Option<SpanContainer<AccessType>>,
+}
+
+#[derive(PartialEq)]
+pub enum AccessType {
+    Read,
+    Write,
+}
+
+impl Parse for Attr {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut out = Self::default();
+        while !input.is_empty() {
+            let ident = input.parse::<syn::Ident>()?;
+            match ident.to_string().as_str() {
+                "name" => {
+                    input.parse::<token::Eq>()?;
+                    let name = input.parse::<syn::LitStr>()?;
+                    out.name
+                        .replace(SpanContainer::new(ident.span(), Some(name.span()), name))
+                        .none_or_else(|_| err::dup_arg(&ident))?
+                }
+                "reported" | "read" => out
+                    .access
+                    .replace(SpanContainer::new(ident.span(), None, AccessType::Read))
+                    .none_or_else(|_| err::dup_arg(&ident))?,
+
+                "desired" | "write" => out
+                    .access
+                    .replace(SpanContainer::new(ident.span(), None, AccessType::Write))
+                    .none_or_else(|_| err::dup_arg(&ident))?,
+                name => {
+                    return Err(err::unknown_arg(&ident, name));
+                }
+            }
+            input.try_parse::<token::Comma>()?;
+        }
+        Ok(out)
+    }
+}
+
+impl Attr {
+    /// Tries to merge two [`Attr`]s into a single one, reporting about
+    /// duplicates, if any.
+    fn try_merge(self, mut another: Self) -> syn::Result<Self> {
+        Ok(Self {
+            name: try_merge_opt!(name: self, another),
+            access: try_merge_opt!(access: self, another),
+        })
+    }
+
+    /// Parses [`Attr`] from the given multiple `name`d [`syn::Attribute`]s
+    /// placed on a property definition.
+    pub fn from_attrs(name: &str, attrs: &[syn::Attribute]) -> syn::Result<Self> {
+        let attr = filter_attrs(name, attrs)
+            .map(|attr| attr.parse_args())
+            .try_fold(Self::default(), |prev, curr| prev.try_merge(curr?))?;
+
+        if let None = &attr.access {
+            return Err(syn::Error::new(
+                name.span(),
+                "missing `reported` or `desired` attribute argument",
+            ));
+        }
+
+        Ok(attr)
+    }
+}
+
+/// Representation of an property for code generation.
+pub struct Definition {
+    /// Rust type that this property is represented by (method return
+    /// type).
+    pub ty: syn::Type,
+
+    /// Name of this property in the schema.
+    pub name: String,
+
+    /// Ident of the Rust method (or struct field) representing this
+    /// property.
+    pub ident: syn::Ident,
+
+    /// Rust [`syn::Type`]s required to call the method representing this
+    /// property.
+    pub arguments: Option<Vec<syn::Type>>,
+
+    /// Indicator whether the Rust method representing this property
+    /// has a [`syn::Receiver`].
+    pub has_receiver: bool,
+
+    /// The access type of this property (read or write).
+    pub access: AccessType,
+}
+
+impl Definition {
+    #[must_use]
+    pub fn method_resolve_reported_prop_tokens(&self, ty_name: &syn::Type) -> TokenStream {
+        let (name, ident) = (&self.name, &self.ident);
+
+        let rcv = self.has_receiver.then(|| {
+            quote! { &instance }
+        });
+
+        quote! {
+             #name => {
+                ::osc::module::IntoPayload::into_payload(
+                    ::osc::module::IntoPropertyResult::into_result(
+                        #ty_name::#ident(#rcv)
+                    )
+                )
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn method_resolve_desired_prop_tokens(&self, ty_name: &syn::Type) -> TokenStream {
+        let (name, ident) = (&self.name, &self.ident);
+
+        let args = self.arguments.as_ref().unwrap().iter().map(|arg| {
+            quote! {
+                ::osc::module::IntoPropertyArgument::<#arg>::into_arg(payload)
+            }
+        });
+
+        let rcv = self.has_receiver.then(|| {
+            quote! { instance, }
+        });
+
+        quote! {
+             #name => {
+                ::osc::module::IntoPropertyResult::into_result(
+                    #ty_name::#ident(#rcv #( #args ),*)
+                )
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn is_read(&self) -> bool {
+        self.access == AccessType::Read
+    }
+
+    #[must_use]
+    pub fn is_write(&self) -> bool {
+        self.access == AccessType::Write
+    }
+}
+
+/// Checks whether all properties have different names
+#[must_use]
+pub fn all_different(props: &[Definition]) -> bool {
+    let mut names: Vec<_> = props.iter().map(|def| &def.name).collect();
+    names.dedup();
+    names.len() == props.len()
+}

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -63,5 +63,5 @@ if (BUILD_MODULETEST)
 endif()
 
 if (BUILD_SAMPLES)
-    add_subdirectory(samples/cpp)
+    add_subdirectory(samples)
 endif()

--- a/src/modules/samples/rust/CMakeLists.txt
+++ b/src/modules/samples/rust/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-add_subdirectory(cpp)
-add_subdirectory(rust)
+corrosion_import_crate(MANIFEST_PATH "Cargo.toml")

--- a/src/modules/samples/rust/Cargo.toml
+++ b/src/modules/samples/rust/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "rust_sample"
+crate-type = ["cdylib"]
+
+[dependencies]
+osc = { path = "../../../common/rust/osc" }
+serde = { version = "1.0.189", features = ["derive"] }

--- a/src/modules/samples/rust/src/lib.rs
+++ b/src/modules/samples/rust/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved..
+// Licensed under the MIT License.
+
+use osc::osc_module;
+use serde::{Serialize, Deserialize};
+
+#[derive(Default)]
+struct Sample {
+    x: i32,
+}
+
+#[osc_module]
+impl Sample {
+    #[osc(reported)]
+    fn simple(&self) -> i32 {
+       self.x
+    }
+
+    #[osc(desired)]
+    fn desired_simple(&mut self, x: i32) {
+        self.x = x;
+    }
+
+    #[osc(reported)]
+    fn complex() -> Vec<Complex> {
+        vec![
+            Complex {
+                x: 42,
+                y: "hello".to_string(),
+            },
+            Complex {
+                x: 43,
+                y: "world".to_string(),
+            },
+        ]
+    }
+
+    #[osc(desired)]
+    fn desired_complex(x: Vec<Complex>) {
+        println!("desired_complex: {:?}", x);
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Complex {
+    x: i32,
+    y: String,
+}


### PR DESCRIPTION
Adds support for building modules in Rust:

- `#[osc_module]` macro for implementing the MMI and [Foreign Function Interface (FFI)](https://doc.rust-lang.org/nomicon/ffi.html) type conversions
  - Shared logging implementation for using `log::*` macros in modules with our existing log format
  - Module info types (`Lifetime`, `Version`, `UserAccount`)
- Integration into CMake builds (via [corrosion](https://github.com/corrosion-rs/corrosion))