### PR TITLE
Preparing the Universal NRP to accept custom parameter values for audit and remediation and reporting reasons for passed SSH audits

### DIFF
--- a/src/adapters/mc/OsConfig.schema.mof
+++ b/src/adapters/mc/OsConfig.schema.mof
@@ -13,7 +13,7 @@ class ReasonClass
     string Code;
 };
 
-[ClassVersion("1.0.0")]
+[ClassVersion("2.0.0")]
 class OsConfigResource : OMI_BaseResource
 {
   [key] 
@@ -27,6 +27,9 @@ class OsConfigResource : OMI_BaseResource
 
   [read, Description ("Reported MIM Setting value (for audit)")]
   string ReportedObjectValue;
+
+  [write, Description ("Expected MIM Setting value (for audit)")]
+  string ExpectedObjectValue;
 
   [write, Description ("Desired MIM Object (for remediation)")]
   string DesiredObjectName;

--- a/src/adapters/mc/OsConfig.schema.mof
+++ b/src/adapters/mc/OsConfig.schema.mof
@@ -19,59 +19,59 @@ class OsConfigResource : OMI_BaseResource
   [key] 
   string  PayloadKey;
 
-  [write, Description ("MIM Component (for audit and remediation)")]
+  [write, Description("MIM Component (for audit and remediation)")]
   string ComponentName;
 
-  [write, Description ("Reported MIM Object (for audit)")]
+  [write, Description("Reported MIM Object (for audit)")]
   string ReportedObjectName;
 
-  [read, Description ("Reported MIM Setting value (for audit)")]
+  [read, Description("Reported MIM Setting value (for audit)")]
   string ReportedObjectValue;
 
-  [write, Description ("Expected MIM Setting value (for audit)")]
+  [write, Description("Expected MIM Setting value (for audit)")]
   string ExpectedObjectValue;
 
-  [write, Description ("Desired MIM Object (for remediation)")]
+  [write, Description("Desired MIM Object (for remediation)")]
   string DesiredObjectName;
 
-  [write, Description ("Desired MIM Setting value (for remediation)")]
+  [write, Description("Desired MIM Setting value (for remediation)")]
   string DesiredObjectValue;
 
-  [read, Description ("Reported MPI result (for audit and remediation)")]
+  [read, Description("Reported MPI result (for audit and remediation)")]
   uint32 ReportedMpiResult;
 
   [read, EmbeddedInstance("ReasonClass")] 
   string Reasons[];
 
-  [static, Description ("Get resource state based on input configuration.")]
+  [static, Description("Get resource state based on input configuration.")]
   uint32 GetTargetResource(
-    [in, EmbeddedInstance ("OsConfigResource"), Description ("Desired configuration to be applied.")]
+    [in, EmbeddedInstance("OsConfigResource"), Description("Desired configuration to be applied.")]
     string InputResource,
-    [in, Description ("Flags passed to the providers. Reserved for future use.")] 
+    [in, Description("Flags passed to the providers. Reserved for future use.")] 
     uint32 Flags,
-    [out, EmbeddedInstance ("OsConfigResource"), Description ("The current configuration state.")]
+    [out, EmbeddedInstance("OsConfigResource"), Description("The current configuration state.")]
     string OutputResource
   );
     
-  [static, Description ("Test resource state based on input configuration.")]
+  [static, Description("Test resource state based on input configuration.")]
   uint32 TestTargetResource(
-    [in, EmbeddedInstance("OsConfigResource"), Description ("Desired configuration to be applied.")]
+    [in, EmbeddedInstance("OsConfigResource"), Description("Desired configuration to be applied.")]
     string InputResource,
-    [in, Description ("Flags passed to the providers. Reserved for future use.")]
+    [in, Description("Flags passed to the providers. Reserved for future use.")]
     uint32 Flags,
-    [out, Description ("True if identical. False otherwise.")]
+    [out, Description("True if identical. False otherwise.")]
     boolean Result,
-    [out, Description ("Context information that the provider can use to optimize the set. This is optional.")]
+    [out, Description("Context information that the provider can use to optimize the set. This is optional.")]
     uint64 ProviderContext
   );
 
-  [static, Description ("Set desired configuration based on input configuration.")]
+  [static, Description("Set desired configuration based on input configuration.")]
   uint32 SetTargetResource(
-    [in, EmbeddedInstance ("OsConfigResource"), Description ("Desired configuration to be applied.")]
+    [in, EmbeddedInstance("OsConfigResource"), Description("Desired configuration to be applied.")]
     string InputResource,
-    [in, Description ("Context information that the provider can use to optimize the set. This is optional.")]
+    [in, Description("Context information that the provider can use to optimize the set. This is optional.")]
     uint64 ProviderContext,
-    [in, Description ("Flags passed to the providers. Reserved for future use.")]
+    [in, Description("Flags passed to the providers. Reserved for future use.")]
     uint32 Flags
   );
 };

--- a/src/adapters/mc/OsConfigPolicy.mof
+++ b/src/adapters/mc/OsConfigPolicy.mof
@@ -1,10 +1,11 @@
 instance of OsConfigResource as $OsConfigResource0ref
 {
-    ResourceID = "Ensure nodev option set on /home partition";
-    PayloadKey = "EnsureNodevOptionOnHomePartition";
+    ResourceID = "Ensure permissions on /etc/ssh/sshd_config are configured";
+    PayloadKey = "EnsurePermissionsOnEtcSshSshdConfig";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNodevOptionOnHomePartition";
-    DesiredObjectName = "remediateEnsureNodevOptionOnHomePartition";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcSshSshdConfig";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcSshSshdConfig";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -14,11 +15,12 @@ instance of OsConfigResource as $OsConfigResource0ref
 
 instance of OsConfigResource as $OsConfigResource1ref
 {
-    ResourceID = "Ensure nodev option set on /tmp partition";
-    PayloadKey = "EnsureNodevOptionOnTmpPartition";
+    ResourceID = "Ensure SSH is configured to meet best practices (protocol 2)";
+    PayloadKey = "EnsureSshBestPracticeProtocol";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNodevOptionOnTmpPartition";
-    DesiredObjectName = "remediateEnsureNodevOptionOnTmpPartition";
+    ReportedObjectName = "auditEnsureSshBestPracticeProtocol";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureSshBestPracticeProtocol";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -28,11 +30,12 @@ instance of OsConfigResource as $OsConfigResource1ref
 
 instance of OsConfigResource as $OsConfigResource2ref
 {
-    ResourceID = "Ensure nodev option set on /var/tmp partition";
-    PayloadKey = "EnsureNodevOptionOnVarTmpPartition";
+    ResourceID = "Ensure SSH is configured to ignore rhosts";
+    PayloadKey = "EnsureSshBestPracticeIgnoreRhosts";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNodevOptionOnVarTmpPartition";
-    DesiredObjectName = "remediateEnsureNodevOptionOnVarTmpPartition";
+    ReportedObjectName = "auditEnsureSshBestPracticeIgnoreRhosts";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureSshBestPracticeIgnoreRhosts";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -42,11 +45,12 @@ instance of OsConfigResource as $OsConfigResource2ref
 
 instance of OsConfigResource as $OsConfigResource3ref
 {
-    ResourceID = "Ensure nosuid option set on /tmp partition";
-    PayloadKey = "EnsureNosuidOptionOnTmpPartition";
+    ResourceID = "Ensure SSH LogLevel is set to INFO";
+    PayloadKey = "EnsureSshLogLevelIsSet";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNosuidOptionOnTmpPartition";
-    DesiredObjectName = "remediateEnsureNosuidOptionOnTmpPartition";
+    ReportedObjectName = "auditEnsureSshLogLevelIsSet";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureSshLogLevelIsSet";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -56,11 +60,12 @@ instance of OsConfigResource as $OsConfigResource3ref
 
 instance of OsConfigResource as $OsConfigResource4ref
 {
-    ResourceID = "Ensure nosuid option set on /var/tmp partition";
-    PayloadKey = "EnsureNosuidOptionOnVarTmpPartition";
+    ResourceID = "Ensure SSH MaxAuthTries is configured";
+    PayloadKey = "EnsureSshMaxAuthTriesIsSet";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNosuidOptionOnVarTmpPartition";
-    DesiredObjectName = "remediateEnsureNosuidOptionOnVarTmpPartition";
+    ReportedObjectName = "auditEnsureSshMaxAuthTriesIsSet";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureSshMaxAuthTriesIsSet";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -70,11 +75,12 @@ instance of OsConfigResource as $OsConfigResource4ref
 
 instance of OsConfigResource as $OsConfigResource5ref
 {
-    ResourceID = "Ensure noexec option set on /var/tmp partition";
-    PayloadKey = "EnsureNoexecOptionOnVarTmpPartition";
+    ResourceID = "Ensure allowed users for SSH access are configured";
+    PayloadKey = "EnsureAllowUsersIsConfigured";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoexecOptionOnVarTmpPartition";
-    DesiredObjectName = "remediateEnsureNoexecOptionOnVarTmpPartition";
+    ReportedObjectName = "auditEnsureAllowUsersIsConfigured";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureAllowUsersIsConfigured";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -84,11 +90,12 @@ instance of OsConfigResource as $OsConfigResource5ref
 
 instance of OsConfigResource as $OsConfigResource6ref
 {
-    ResourceID = "Ensure noexec option set on /dev/shm partition";
-    PayloadKey = "EnsureNoexecOptionOnDevShmPartition";
+    ResourceID = "Ensure denied users for SSH are configured";
+    PayloadKey = "EnsureDenyUsersIsConfigured";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoexecOptionOnDevShmPartition";
-    DesiredObjectName = "remediateEnsureNoexecOptionOnDevShmPartition";
+    ReportedObjectName = "auditEnsureDenyUsersIsConfigured";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureDenyUsersIsConfigured";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -98,11 +105,12 @@ instance of OsConfigResource as $OsConfigResource6ref
 
 instance of OsConfigResource as $OsConfigResource7ref
 {
-    ResourceID = "Ensure automounting is disabled";
-    PayloadKey = "EnsureAutomountingDisabled";
+    ResourceID = "Ensure allowed groups for SSH are configured";
+    PayloadKey = "EnsureAllowGroupsIsConfigured";
     ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAutomountingDisabled";
-    DesiredObjectName = "remediateEnsureAutomountingDisabled";
+    ReportedObjectName = "auditEnsureAllowGroupsIsConfigured";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateEnsureAllowGroupsIsConfigured";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -112,1563 +120,10 @@ instance of OsConfigResource as $OsConfigResource7ref
 
 instance of OsConfigResource as $OsConfigResource8ref
 {
-    ResourceID = "Ensure mounting of USB storage devices is disabled";
-    PayloadKey = "EnsureMountingOfUsbStorageDevicesIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureMountingOfUsbStorageDevicesIsDisabled";
-    DesiredObjectName = "remediateEnsureMountingOfUsbStorageDevicesIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource9ref
-{
-    ResourceID = "Ensure core dumps are restricted";
-    PayloadKey = "EnsureCoreDumpsAreRestricted";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureCoreDumpsAreRestricted";
-    DesiredObjectName = "remediateEnsureCoreDumpsAreRestricted";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource10ref
-{
-    ResourceID = "Ensure prelink is disabled";
-    PayloadKey = "EnsurePrelinkIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePrelinkIsDisabled";
-    DesiredObjectName = "remediateEnsurePrelinkIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource11ref
-{
-    ResourceID = "Ensure permissions on /etc/motd are configured";
-    PayloadKey = "EnsurePermissionsOnEtcMotd";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcMotd";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcMotd";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource12ref
-{
-    ResourceID = "Ensure permissions on /etc/issue are configured";
-    PayloadKey = "EnsurePermissionsOnEtcIssue";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcIssue";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcIssue";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource13ref
-{
-    ResourceID = "Ensure permissions on /etc/issue.net are configured";
-    PayloadKey = "EnsurePermissionsOnEtcIssueNet";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcIssueNet";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcIssueNet";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource14ref
-{
-    ResourceID = "Ensure the nodev option is enabled for all removable media";
-    PayloadKey = "EnsureNodevOptionEnabledForAllRemovableMedia";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNodevOptionEnabledForAllRemovableMedia";
-    DesiredObjectName = "remediateEnsureNodevOptionEnabledForAllRemovableMedia";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource15ref
-{
-    ResourceID = "Ensure the noexec option is enabled for all removable media";
-    PayloadKey = "EnsureNoexecOptionEnabledForAllRemovableMedia";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoexecOptionEnabledForAllRemovableMedia";
-    DesiredObjectName = "remediateEnsureNoexecOptionEnabledForAllRemovableMedia";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource16ref
-{
-    ResourceID = "Ensure the nosuid option is enabled for all removable media";
-    PayloadKey = "EnsureNosuidOptionEnabledForAllRemovableMedia";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNosuidOptionEnabledForAllRemovableMedia";
-    DesiredObjectName = "remediateEnsureNosuidOptionEnabledForAllRemovableMedia";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource17ref
-{
-    ResourceID = "Ensure talk client is not installed";
-    PayloadKey = "EnsureTalkClientIsNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureTalkClientIsNotInstalled";
-    DesiredObjectName = "remediateEnsureTalkClientIsNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource18ref
-{
-    ResourceID = "Ensure permissions on /etc/hosts.allow are configured";
-    PayloadKey = "EnsurePermissionsOnEtcHostsAllow";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcHostsAllow";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcHostsAllow";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource19ref
-{
-    ResourceID = "Ensure permissions on /etc/hosts.deny are configured";
-    PayloadKey = "EnsurePermissionsOnEtcHostsDeny";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcHostsDeny";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcHostsDeny";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource20ref
-{
-    ResourceID = "Ensure default deny firewall policy is set";
-    PayloadKey = "EnsureDefaultDenyFirewallPolicyIsSet";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDefaultDenyFirewallPolicyIsSet";
-    DesiredObjectName = "remediateEnsureDefaultDenyFirewallPolicyIsSet";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource21ref
-{
-    ResourceID = "Ensure the nodev/nosuid option is enabled for all NFS mounts";
-    PayloadKey = "EnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
-    DesiredObjectName = "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource22ref
-{
-    ResourceID = "Ensure permissions on /etc/ssh/sshd_config are configured";
-    PayloadKey = "EnsurePermissionsOnEtcSshSshdConfig";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcSshSshdConfig";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcSshSshdConfig";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource23ref
-{
-    ResourceID = "Ensure password creation requirements are configured";
-    PayloadKey = "EnsurePasswordCreationRequirements";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePasswordCreationRequirements";
-    DesiredObjectName = "remediateEnsurePasswordCreationRequirements";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource24ref
-{
-    ResourceID = "Ensure lockout for failed password attempts is configured";
-    PayloadKey = "EnsureLockoutForFailedPasswordAttempts";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureLockoutForFailedPasswordAttempts";
-    DesiredObjectName = "remediateEnsureLockoutForFailedPasswordAttempts";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource25ref
-{
-    ResourceID = "Ensure the cramfs file system is disabled";
-    PayloadKey = "EnsureDisabledInstallationOfCramfsFileSystem";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDisabledInstallationOfCramfsFileSystem";
-    DesiredObjectName = "remediateEnsureDisabledInstallationOfCramfsFileSystem";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource26ref
-{
-    ResourceID = "Ensure the freevxfs file system is disabled";
-    PayloadKey = "EnsureDisabledInstallationOfFreevxfsFileSystem";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDisabledInstallationOfFreevxfsFileSystem";
-    DesiredObjectName = "remediateEnsureDisabledInstallationOfFreevxfsFileSystem";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource27ref
-{
-    ResourceID = "Ensure all users' home directories exist";
-    PayloadKey = "EnsureAllUsersHomeDirectoriesExist";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllUsersHomeDirectoriesExist";
-    DesiredObjectName = "remediateEnsureAllUsersHomeDirectoriesExist";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource28ref
-{
-    ResourceID = "Ensure users own their home directories";
-    PayloadKey = "EnsureUsersOwnTheirHomeDirectories";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureUsersOwnTheirHomeDirectories";
-    DesiredObjectName = "remediateEnsureUsersOwnTheirHomeDirectories";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource29ref
-{
-    ResourceID = "Ensure users' dot files aren't group or world writable";
-    PayloadKey = "EnsureUsersDotFilesArentGroupOrWorldWritable";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureUsersDotFilesArentGroupOrWorldWritable";
-    DesiredObjectName = "remediateEnsureUsersDotFilesArentGroupOrWorldWritable";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource30ref
-{
-    ResourceID = "Ensure no users have .forward files";
-    PayloadKey = "EnsureNoUsersHaveDotForwardFiles";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoUsersHaveDotForwardFiles";
-    DesiredObjectName = "remediateEnsureNoUsersHaveDotForwardFiles";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource31ref
-{
-    ResourceID = "Ensure no users have .netrc files";
-    PayloadKey = "EnsureNoUsersHaveDotNetrcFiles";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoUsersHaveDotNetrcFiles";
-    DesiredObjectName = "remediateEnsureNoUsersHaveDotNetrcFiles";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource32ref
-{
-    ResourceID = "Ensure no users have .rhosts files";
-    PayloadKey = "EnsureNoUsersHaveDotRhostsFiles";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoUsersHaveDotRhostsFiles";
-    DesiredObjectName = "remediateEnsureNoUsersHaveDotRhostsFiles";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource33ref
-{
-    ResourceID = "Ensure all groups in /etc/passwd exist in /etc/group";
-    PayloadKey = "EnsureAllEtcPasswdGroupsExistInEtcGroup";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllEtcPasswdGroupsExistInEtcGroup";
-    DesiredObjectName = "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource34ref
-{
-    ResourceID = "Ensure no duplicate UIDs exist";
-    PayloadKey = "EnsureNoDuplicateUidsExist";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoDuplicateUidsExist";
-    DesiredObjectName = "remediateEnsureNoDuplicateUidsExist";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource35ref
-{
-    ResourceID = "Ensure no duplicate GIDs exist";
-    PayloadKey = "EnsureNoDuplicateGidsExist";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoDuplicateGidsExist";
-    DesiredObjectName = "remediateEnsureNoDuplicateGidsExist";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource36ref
-{
-    ResourceID = "Ensure no duplicate user names exist";
-    PayloadKey = "EnsureNoDuplicateUserNamesExist";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoDuplicateUserNamesExist";
-    DesiredObjectName = "remediateEnsureNoDuplicateUserNamesExist";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource37ref
-{
-    ResourceID = "Ensure no duplicate groups exist";
-    PayloadKey = "EnsureNoDuplicateGroupsExist";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoDuplicateGroupsExist";
-    DesiredObjectName = "remediateEnsureNoDuplicateGroupsExist";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource38ref
-{
-    ResourceID = "Ensure shadow group is empty";
-    PayloadKey = "EnsureShadowGroupIsEmpty";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureShadowGroupIsEmpty";
-    DesiredObjectName = "remediateEnsureShadowGroupIsEmpty";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource39ref
-{
-    ResourceID = "Ensure the hfs file system is disabled";
-    PayloadKey = "EnsureDisabledInstallationOfHfsFileSystem";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDisabledInstallationOfHfsFileSystem";
-    DesiredObjectName = "remediateEnsureDisabledInstallationOfHfsFileSystem";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource40ref
-{
-    ResourceID = "Ensure the hfsplus file systems is disabled";
-    PayloadKey = "EnsureDisabledInstallationOfHfsplusFileSystem";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDisabledInstallationOfHfsplusFileSystem";
-    DesiredObjectName = "remediateEnsureDisabledInstallationOfHfsplusFileSystem";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource41ref
-{
-    ResourceID = "Ensure the jffs2 file systems is disabled";
-    PayloadKey = "EnsureDisabledInstallationOfJffs2FileSystem";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDisabledInstallationOfJffs2FileSystem";
-    DesiredObjectName = "remediateEnsureDisabledInstallationOfJffs2FileSystem";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource42ref
-{
-    ResourceID = "Ensure the kernel is compiled from approved sources";
-    PayloadKey = "EnsureKernelCompiledFromApprovedSources";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureKernelCompiledFromApprovedSources";
-    DesiredObjectName = "remediateEnsureKernelCompiledFromApprovedSources";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource43ref
-{
-    ResourceID = "Ensure file permissions on /etc/shadow are configured";
-    PayloadKey = "EnsurePermissionsOnEtcShadow";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcShadow";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcShadow";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource44ref
-{
-    ResourceID = "Ensure file permissions on /etc/shadow- are configured";
-    PayloadKey = "EnsurePermissionsOnEtcShadowDash";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcShadowDash";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcShadowDash";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource45ref
-{
-    ResourceID = "Ensure file permissions on /etc/gshadow are configured";
-    PayloadKey = "EnsurePermissionsOnEtcGShadow";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcGShadow";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcGShadow";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource46ref
-{
-    ResourceID = "Ensure file permissions on /etc/gshadow- are configured";
-    PayloadKey = "EnsurePermissionsOnEtcGShadowDash";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcGShadowDash";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcGShadowDash";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource47ref
-{
-    ResourceID = "Ensure file permissions on /etc/passwd are configured";
-    PayloadKey = "EnsurePermissionsOnEtcPasswd";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcPasswd";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcPasswd";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource48ref
-{
-    ResourceID = "Ensure file permissions on /etc/group are configured";
-    PayloadKey = "EnsurePermissionsOnEtcGroup";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcGroup";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcGroup";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource49ref
-{
-    ResourceID = "Ensure file permissions on /etc/passwd- are configured";
-    PayloadKey = "EnsurePermissionsOnEtcPasswdDash";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcPasswdDash";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcPasswdDash";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource50ref
-{
-    ResourceID = "Ensure file permissions on /etc/group- are configured";
-    PayloadKey = "EnsurePermissionsOnEtcGroupDash";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcGroupDash";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcGroupDash";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource51ref
-{
-    ResourceID = "Ensure that access to the root account via su is restricted to the 'root' group";
-    PayloadKey = "EnsureSuRestrictedToRootGroup";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSuRestrictedToRootGroup";
-    DesiredObjectName = "remediateEnsureSuRestrictedToRootGroup";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource52ref
-{
-    ResourceID = "Ensure the 'root' group exists, and contain all members who can su to root";
-    PayloadKey = "EnsureRootGroupExists";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRootGroupExists";
-    DesiredObjectName = "remediateEnsureRootGroupExists";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource53ref
-{
-    ResourceID = "Ensure that all user accounts that can login have a password set";
-    PayloadKey = "EnsureAllAccountsHavePasswords";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllAccountsHavePasswords";
-    DesiredObjectName = "remediateEnsureAllAccountsHavePasswords";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource54ref
-{
-    ResourceID = "Ensure that all user accounts other than root have unique UIDs greater than zero (0)";
-    PayloadKey = "EnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
-    DesiredObjectName = "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource55ref
-{
-    ResourceID = "Ensure that randomized placement of virtual memory regions is enabled";
-    PayloadKey = "EnsureVirtualMemoryRandomizationIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureVirtualMemoryRandomizationIsEnabled";
-    DesiredObjectName = "remediateEnsureVirtualMemoryRandomizationIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource56ref
-{
-    ResourceID = "Ensure that kernel support for the XD/NX processor feature is enabled";
-    PayloadKey = "EnsureKernelSupportForCpuNx";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureKernelSupportForCpuNx";
-    DesiredObjectName = "remediateEnsureKernelSupportForCpuNx";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource57ref
-{
-    ResourceID = "Ensure '.' does not appear in root's $PATH";
-    PayloadKey = "EnsureDotDoesNotAppearInRootsPath";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDotDoesNotAppearInRootsPath";
-    DesiredObjectName = "remediateEnsureDotDoesNotAppearInRootsPath";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource58ref
-{
-    ResourceID = "Ensure access to user home directories is restricted";
-    PayloadKey = "EnsureRestrictedUserHomeDirectories";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRestrictedUserHomeDirectories";
-    DesiredObjectName = "remediateEnsureRestrictedUserHomeDirectories";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource59ref
-{
-    ResourceID = "Ensure the default umask for all users is configured";
-    PayloadKey = "EnsureDefaultUmaskForAllUsers";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDefaultUmaskForAllUsers";
-    DesiredObjectName = "remediateEnsureDefaultUmaskForAllUsers";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource60ref
-{
-    ResourceID = "Ensure all bootloaders have password protection enabled";
-    PayloadKey = "EnsureAllBootloadersHavePasswordProtectionEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllBootloadersHavePasswordProtectionEnabled";
-    DesiredObjectName = "remediateEnsureAllBootloadersHavePasswordProtectionEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource61ref
-{
-    ResourceID = "Ensure permissions on bootloader config are configured";
-    PayloadKey = "EnsurePermissionsOnBootloaderConfig";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnBootloaderConfig";
-    DesiredObjectName = "remediateEnsurePermissionsOnBootloaderConfig";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource62ref
-{
-    ResourceID = "Ensure authentication is required for single user mode";
-    PayloadKey = "EnsureAuthenticationRequiredForSingleUserMode";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAuthenticationRequiredForSingleUserMode";
-    DesiredObjectName = "remediateEnsureAuthenticationRequiredForSingleUserMode";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource63ref
-{
-    ResourceID = "Ensure packet redirect sending is disabled";
-    PayloadKey = "EnsurePacketRedirectSendingIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePacketRedirectSendingIsDisabled";
-    DesiredObjectName = "remediateEnsurePacketRedirectSendingIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource64ref
-{
-    ResourceID = "Ensure sending ICMP redirects is disabled for all interfaces";
-    PayloadKey = "EnsureIcmpRedirectsIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIcmpRedirectsIsDisabled";
-    DesiredObjectName = "remediateEnsureIcmpRedirectsIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource65ref
-{
-    ResourceID = "Ensure accepting source routed packets is disabled for all interfaces";
-    PayloadKey = "EnsureSourceRoutedPacketsIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSourceRoutedPacketsIsDisabled";
-    DesiredObjectName = "remediateEnsureSourceRoutedPacketsIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource66ref
-{
-    ResourceID = "Ensure the default setting for accepting source routed packets is disabled for network interfaces";
-    PayloadKey = "EnsureAcceptingSourceRoutedPacketsIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAcceptingSourceRoutedPacketsIsDisabled";
-    DesiredObjectName = "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource67ref
-{
-    ResourceID = "Ensure ignoring bogus ICMP responses to broadcasts is enabled";
-    PayloadKey = "EnsureIgnoringBogusIcmpBroadcastResponses";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIgnoringBogusIcmpBroadcastResponses";
-    DesiredObjectName = "remediateEnsureIgnoringBogusIcmpBroadcastResponses";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource68ref
-{
-    ResourceID = "Ensure ignoring ICMP echo requests (pings) sent to broadcast/multicast addresses is enabled";
-    PayloadKey = "EnsureIgnoringIcmpEchoPingsToMulticast";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIgnoringIcmpEchoPingsToMulticast";
-    DesiredObjectName = "remediateEnsureIgnoringIcmpEchoPingsToMulticast";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource69ref
-{
-    ResourceID = "Ensure logging of martian packets (those with impossible addresses) is enabled for all interfaces";
-    PayloadKey = "EnsureMartianPacketLoggingIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureMartianPacketLoggingIsEnabled";
-    DesiredObjectName = "remediateEnsureMartianPacketLoggingIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource70ref
-{
-    ResourceID = "Ensure performing source validation by reverse path is enabled for all interfaces";
-    PayloadKey = "EnsureReversePathSourceValidationIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureReversePathSourceValidationIsEnabled";
-    DesiredObjectName = "remediateEnsureReversePathSourceValidationIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource71ref
-{
-    ResourceID = "Ensure TCP SYN cookies are enabled";
-    PayloadKey = "EnsureTcpSynCookiesAreEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureTcpSynCookiesAreEnabled";
-    DesiredObjectName = "remediateEnsureTcpSynCookiesAreEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource72ref
-{
-    ResourceID = "Ensure the system does not act as a network sniffer";
-    PayloadKey = "EnsureSystemNotActingAsNetworkSniffer";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSystemNotActingAsNetworkSniffer";
-    DesiredObjectName = "remediateEnsureSystemNotActingAsNetworkSniffer";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource73ref
-{
-    ResourceID = "Ensure all wireless interfaces are disabled";
-    PayloadKey = "EnsureAllWirelessInterfacesAreDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllWirelessInterfacesAreDisabled";
-    DesiredObjectName = "remediateEnsureAllWirelessInterfacesAreDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource74ref
-{
-    ResourceID = "Ensure the IPv6 protocol is enabled";
-    PayloadKey = "EnsureIpv6ProtocolIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIpv6ProtocolIsEnabled";
-    DesiredObjectName = "remediateEnsureIpv6ProtocolIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource75ref
-{
-    ResourceID = "Ensure DCCP is disabled";
-    PayloadKey = "EnsureDccpIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDccpIsDisabled";
-    DesiredObjectName = "remediateEnsureDccpIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource76ref
-{
-    ResourceID = "Ensure SCTP is disabled";
-    PayloadKey = "EnsureSctpIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSctpIsDisabled";
-    DesiredObjectName = "remediateEnsureSctpIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource77ref
-{
-    ResourceID = "Ensure support for RDS is disabled";
-    PayloadKey = "EnsureDisabledSupportForRds";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDisabledSupportForRds";
-    DesiredObjectName = "remediateEnsureDisabledSupportForRds";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource78ref
-{
-    ResourceID = "Ensure TIPC is disabled";
-    PayloadKey = "EnsureTipcIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureTipcIsDisabled";
-    DesiredObjectName = "remediateEnsureTipcIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource79ref
-{
-    ResourceID = "Ensure logging is configured";
-    PayloadKey = "EnsureLoggingIsConfigured";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureLoggingIsConfigured";
-    DesiredObjectName = "remediateEnsureLoggingIsConfigured";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource80ref
-{
-    ResourceID = "Ensure the syslog package is installed";
-    PayloadKey = "EnsureSyslogPackageIsInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSyslogPackageIsInstalled";
-    DesiredObjectName = "remediateEnsureSyslogPackageIsInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource81ref
-{
-    ResourceID = "Ensure the systemd-journald service persists log messages";
-    PayloadKey = "EnsureSystemdJournaldServicePersistsLogMessages";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSystemdJournaldServicePersistsLogMessages";
-    DesiredObjectName = "remediateEnsureSystemdJournaldServicePersistsLogMessages";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource82ref
-{
-    ResourceID = "Ensure a logging service is enabled";
-    PayloadKey = "EnsureALoggingServiceIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureALoggingServiceIsEnabled";
-    DesiredObjectName = "remediateEnsureALoggingServiceIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource83ref
-{
-    ResourceID = "Ensure file permissions for all rsyslog log files are configured";
-    PayloadKey = "EnsureFilePermissionsForAllRsyslogLogFiles";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureFilePermissionsForAllRsyslogLogFiles";
-    DesiredObjectName = "remediateEnsureFilePermissionsForAllRsyslogLogFiles";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource84ref
-{
-    ResourceID = "Ensure logger configuration files are restricted";
-    PayloadKey = "EnsureLoggerConfigurationFilesAreRestricted";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureLoggerConfigurationFilesAreRestricted";
-    DesiredObjectName = "remediateEnsureLoggerConfigurationFilesAreRestricted";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource85ref
-{
-    ResourceID = "Ensure that all rsyslog log files are owned by the 'adm' group";
-    PayloadKey = "EnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
-    DesiredObjectName = "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource86ref
-{
-    ResourceID = "Ensure all rsyslog log files are owned by the syslog user";
-    PayloadKey = "EnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
-    DesiredObjectName = "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource87ref
-{
-    ResourceID = "Ensure rsyslog does not accept remote messages";
-    PayloadKey = "EnsureRsyslogNotAcceptingRemoteMessages";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRsyslogNotAcceptingRemoteMessages";
-    DesiredObjectName = "remediateRsyslogNotAcceptingRemoteMessages";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource88ref
-{
-    ResourceID = "Ensure the logrotate (syslog rotater) service is enabled";
-    PayloadKey = "EnsureSyslogRotaterServiceIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSyslogRotaterServiceIsEnabled";
-    DesiredObjectName = "remediateEnsureSyslogRotaterServiceIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource89ref
-{
-    ResourceID = "Ensure the rlogin service is disabled";
-    PayloadKey = "EnsureRloginServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRloginServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureRloginServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource90ref
-{
-    ResourceID = "Ensure inetd is not installed";
-    PayloadKey = "EnsureInetdNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureInetdNotInstalled";
-    DesiredObjectName = "remediateEnsureInetdNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource91ref
-{
-    ResourceID = "Ensure xinetd is not installed";
-    PayloadKey = "EnsureXinetdNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureXinetdNotInstalled";
-    DesiredObjectName = "remediateEnsureXinetdNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource92ref
-{
-    ResourceID = "Ensure the telnet service is disabled";
-    PayloadKey = "EnsureTelnetServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureTelnetServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureTelnetServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource93ref
-{
-    ResourceID = "Ensure all telnetd packages are uninstalled";
-    PayloadKey = "EnsureAllTelnetdPackagesUninstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllTelnetdPackagesUninstalled";
-    DesiredObjectName = "remediateEnsureAllTelnetdPackagesUninstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource94ref
-{
-    ResourceID = "Ensure the rcp/rsh service is disabled";
-    PayloadKey = "EnsureRcprshServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRcprshServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureRcprshServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource95ref
-{
-    ResourceID = "Ensure the rsh-server package is uninstalled";
-    PayloadKey = "EnsureRshServerNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRshServerNotInstalled";
-    DesiredObjectName = "remediateEnsureRshServerNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource96ref
-{
-    ResourceID = "Ensure the ypbind service is disabled and the nis package is not installed";
-    PayloadKey = "EnsureNisNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNisNotInstalled";
-    DesiredObjectName = "remediateEnsureNisNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource97ref
-{
-    ResourceID = "Ensure the tftp service is disabled";
-    PayloadKey = "EnsureTftpServiceisDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureTftpServiceisDisabled";
-    DesiredObjectName = "remediateEnsureTftpServiceisDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource98ref
-{
-    ResourceID = "Ensure the tftpd package is not installed";
-    PayloadKey = "EnsureTftpdNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureTftpdNotInstalled";
-    DesiredObjectName = "remediateEnsureTftpdNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource99ref
-{
-    ResourceID = "Ensure the readahead-fedora package is not installed";
-    PayloadKey = "EnsureReadaheadFedoraNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureReadaheadFedoraNotInstalled";
-    DesiredObjectName = "remediateEnsureReadaheadFedoraNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource100ref
-{
-    ResourceID = "Ensure the bluetooth package is not installed";
-    PayloadKey = "EnsureBluetoothHiddNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureBluetoothHiddNotInstalled";
-    DesiredObjectName = "remediateEnsureBluetoothHiddNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource101ref
-{
-    ResourceID = "Ensure the isdnutils-base package is not installed";
-    PayloadKey = "EnsureIsdnUtilsBaseNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIsdnUtilsBaseNotInstalled";
-    DesiredObjectName = "remediateEnsureIsdnUtilsBaseNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource102ref
-{
-    ResourceID = "Ensure the kdump-tools package is not installed";
-    PayloadKey = "EnsureIsdnUtilsKdumpToolsNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIsdnUtilsKdumpToolsNotInstalled";
-    DesiredObjectName = "remediateEnsureIsdnUtilsKdumpToolsNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource103ref
-{
-    ResourceID = "Ensure zeroconf networking is disabled";
-    PayloadKey = "EnsureZeroconfNetworkingIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureZeroconfNetworkingIsDisabled";
-    DesiredObjectName = "remediateEnsureZeroconfNetworkingIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource104ref
-{
-    ResourceID = "Ensure the cron service is enabled";
-    PayloadKey = "EnsureCronServiceIsEnabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureCronServiceIsEnabled";
-    DesiredObjectName = "remediateEnsureCronServiceIsEnabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource105ref
-{
-    ResourceID = "Ensure File permissions on /etc/anacrontab are configured";
-    PayloadKey = "EnsurePermissionsOnEtcAnacronTab";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcAnacronTab";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcAnacronTab";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource106ref
-{
-    ResourceID = "Ensure permissions on /etc/cron.d are configured";
-    PayloadKey = "EnsurePermissionsOnEtcCronD";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcCronD";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronD";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource107ref
-{
-    ResourceID = "Ensure permissions on  /etc/cron.daily are configured";
-    PayloadKey = "EnsurePermissionsOnEtcCronDaily";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcCronDaily";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronDaily";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource108ref
-{
-    ResourceID = "Ensure permissions on  /etc/cron.hourly are configured";
-    PayloadKey = "EnsurePermissionsOnEtcCronHourly";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcCronHourly";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronHourly";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource109ref
-{
-    ResourceID = "Ensure permissions on  /etc/cron.monthly are configured";
-    PayloadKey = "EnsurePermissionsOnEtcCronMonthly";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcCronMonthly";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronMonthly";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource110ref
-{
-    ResourceID = "Ensure permissions on  /etc/cron.weekly are configured";
-    PayloadKey = "EnsurePermissionsOnEtcCronWeekly";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePermissionsOnEtcCronWeekly";
-    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronWeekly";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource111ref
-{
-    ResourceID = "Ensure at/cron is restricted to authorized users";
-    PayloadKey = "EnsureAtCronIsRestrictedToAuthorizedUsers";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAtCronIsRestrictedToAuthorizedUsers";
-    DesiredObjectName = "remediateEnsureAtCronIsRestrictedToAuthorizedUsers";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource112ref
-{
-    ResourceID = "Ensure SSH is configured to meet best practices (protocol 2)";
-    PayloadKey = "EnsureSshBestPracticeProtocol";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSshBestPracticeProtocol";
-    DesiredObjectName = "remediateEnsureSshBestPracticeProtocol";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource113ref
-{
-    ResourceID = "Ensure SSH is configured to ignore rhosts";
-    PayloadKey = "EnsureSshBestPracticeIgnoreRhosts";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSshBestPracticeIgnoreRhosts";
-    DesiredObjectName = "remediateEnsureSshBestPracticeIgnoreRhosts";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource114ref
-{
-    ResourceID = "Ensure SSH LogLevel is set to INFO";
-    PayloadKey = "EnsureSshLogLevelIsSet";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSshLogLevelIsSet";
-    DesiredObjectName = "remediateEnsureSshLogLevelIsSet";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource115ref
-{
-    ResourceID = "Ensure SSH MaxAuthTries is configured";
-    PayloadKey = "EnsureSshMaxAuthTriesIsSet";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSshMaxAuthTriesIsSet";
-    DesiredObjectName = "remediateEnsureSshMaxAuthTriesIsSet";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource116ref
-{
-    ResourceID = "Ensure allowed users for SSH access are configured";
-    PayloadKey = "EnsureAllowUsersIsConfigured";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllowUsersIsConfigured";
-    DesiredObjectName = "remediateEnsureAllowUsersIsConfigured";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource117ref
-{
-    ResourceID = "Ensure denied users for SSH are configured";
-    PayloadKey = "EnsureDenyUsersIsConfigured";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDenyUsersIsConfigured";
-    DesiredObjectName = "remediateEnsureDenyUsersIsConfigured";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource118ref
-{
-    ResourceID = "Ensure allowed groups for SSH are configured";
-    PayloadKey = "EnsureAllowGroupsIsConfigured";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAllowGroupsIsConfigured";
-    DesiredObjectName = "remediateEnsureAllowGroupsIsConfigured";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource119ref
-{
     ResourceID = "Ensure denied groups for SSH are configured";
     PayloadKey = "EnsureDenyGroupsConfigured";
     ComponentName = "SecurityBaseline";
+    ExpectedObjectValue = "PASS";
     ReportedObjectName = "auditEnsureDenyGroupsConfigured";
     DesiredObjectName = "remediateEnsureDenyGroupsConfigured";
     DesiredObjectValue = "PASS";
@@ -1678,12 +133,13 @@ instance of OsConfigResource as $OsConfigResource119ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource120ref
+instance of OsConfigResource as $OsConfigResource9ref
 {
     ResourceID = "Ensure SSH host-based authenticationis disabled";
     PayloadKey = "EnsureSshHostbasedAuthenticationIsDisabled";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshHostbasedAuthenticationIsDisabled";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshHostbasedAuthenticationIsDisabled";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1692,12 +148,13 @@ instance of OsConfigResource as $OsConfigResource120ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource121ref
+instance of OsConfigResource as $OsConfigResource10ref
 {
     ResourceID = "Ensure root login via SSH is disabled";
     PayloadKey = "EnsureSshPermitRootLoginIsDisabled";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshPermitRootLoginIsDisabled";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshPermitRootLoginIsDisabled";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1706,12 +163,13 @@ instance of OsConfigResource as $OsConfigResource121ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource122ref
+instance of OsConfigResource as $OsConfigResource11ref
 {
     ResourceID = "Ensure that remote connection from accounts with empty passwords is disabled";
     PayloadKey = "EnsureSshPermitEmptyPasswordsIsDisabled";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshPermitEmptyPasswordsIsDisabled";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshPermitEmptyPasswordsIsDisabled";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1720,12 +178,13 @@ instance of OsConfigResource as $OsConfigResource122ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource123ref
+instance of OsConfigResource as $OsConfigResource12ref
 {
     ResourceID = "Ensure the SSH Client Interval Count Maximum is configured";
     PayloadKey = "EnsureSshClientIntervalCountMaxIsConfigured";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshClientIntervalCountMaxIsConfigured";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshClientIntervalCountMaxIsConfigured";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1734,12 +193,13 @@ instance of OsConfigResource as $OsConfigResource123ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource124ref
+instance of OsConfigResource as $OsConfigResource13ref
 {
     ResourceID = "Ensure the SSH Client Alive interval Interval is configured";
     PayloadKey = "EnsureSshClientAliveIntervalIsConfigured";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshClientAliveIntervalIsConfigured";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshClientAliveIntervalIsConfigured";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1748,12 +208,13 @@ instance of OsConfigResource as $OsConfigResource124ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource125ref
+instance of OsConfigResource as $OsConfigResource14ref
 {
     ResourceID = "Ensure the SSH LoginGraceTime is configured";
     PayloadKey = "EnsureSshLoginGraceTimeIsSet";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshLoginGraceTimeIsSet";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshLoginGraceTimeIsSet";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1762,12 +223,13 @@ instance of OsConfigResource as $OsConfigResource125ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource126ref
+instance of OsConfigResource as $OsConfigResource15ref
 {
     ResourceID = "Ensure that only approved MAC algorithms are used";
     PayloadKey = "EnsureOnlyApprovedMacAlgorithmsAreUsed";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureOnlyApprovedMacAlgorithmsAreUsed";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1776,40 +238,13 @@ instance of OsConfigResource as $OsConfigResource126ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource127ref
-{
-    ResourceID = "Ensure the remote login warning banner is properly configured";
-    PayloadKey = "EnsureRemoteLoginWarningBannerIsConfigured";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRemoteLoginWarningBannerIsConfigured";
-    DesiredObjectName = "remediateEnsureRemoteLoginWarningBannerIsConfigured";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource128ref
-{
-    ResourceID = "Ensure the local login warning banner is properly configured";
-    PayloadKey = "EnsureLocalLoginWarningBannerIsConfigured";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureLocalLoginWarningBannerIsConfigured";
-    DesiredObjectName = "remediateEnsureLocalLoginWarningBannerIsConfigured";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource129ref
+instance of OsConfigResource as $OsConfigResource16ref
 {
     ResourceID = "Ensure the SSH warning banner is enabled";
     PayloadKey = "EnsureSshWarningBannerIsEnabled";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureSshWarningBannerIsEnabled";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureSshWarningBannerIsEnabled";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1818,12 +253,13 @@ instance of OsConfigResource as $OsConfigResource129ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource130ref
+instance of OsConfigResource as $OsConfigResource17ref
 {
     ResourceID = "Ensure that users cannot set environment options for SSH";
     PayloadKey = "EnsureUsersCannotSetSshEnvironmentOptions";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureUsersCannotSetSshEnvironmentOptions";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureUsersCannotSetSshEnvironmentOptions";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
@@ -1832,503 +268,14 @@ instance of OsConfigResource as $OsConfigResource130ref
     SourceInfo = "::4::5::OsConfigResource";
 };
 
-instance of OsConfigResource as $OsConfigResource131ref
+instance of OsConfigResource as $OsConfigResource118ref
 {
     ResourceID = "Ensure that appropriate ciphers are used for SSH";
     PayloadKey = "EnsureAppropriateCiphersForSsh";
     ComponentName = "SecurityBaseline";
     ReportedObjectName = "auditEnsureAppropriateCiphersForSsh";
+    ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureAppropriateCiphersForSsh";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource132ref
-{
-    ResourceID = "Ensure the avahi-daemon service is disabled";
-    PayloadKey = "EnsureAvahiDaemonServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAvahiDaemonServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureAvahiDaemonServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource133ref
-{
-    ResourceID = "Ensure the cups service is disabled";
-    PayloadKey = "EnsureCupsServiceisDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureCupsServiceisDisabled";
-    DesiredObjectName = "remediateEnsureCupsServiceisDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource134ref
-{
-    ResourceID = "Ensure the isc-dhcp-server package is not installed";
-    PayloadKey = "EnsureIscDhcpdServerNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureIscDhcpdServerNotInstalled";
-    DesiredObjectName = "remediateEnsureIscDhcpdServerNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource135ref
-{
-    ResourceID = "Ensure the sendmail package is not installed";
-    PayloadKey = "EnsureSendmailNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSendmailNotInstalled";
-    DesiredObjectName = "remediateEnsureSendmailNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource136ref
-{
-    ResourceID = "Ensure the postfix package is not installed";
-    PayloadKey = "EnsurePostfixPackageIsUninstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePostfixPackageIsUninstalled";
-    DesiredObjectName = "remediateEnsurePostfixPackageIsUninstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource137ref
-{
-    ResourceID = "Ensure that postfix network listening is disabled";
-    PayloadKey = "EnsurePostfixNetworkListeningIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePostfixNetworkListeningIsDisabled";
-    DesiredObjectName = "remediateEnsurePostfixNetworkListeningIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource138ref
-{
-    ResourceID = "Ensure the sldapd package is not installed";
-    PayloadKey = "EnsureSldapdNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSldapdNotInstalled";
-    DesiredObjectName = "remediateEnsureSldapdNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource139ref
-{
-    ResourceID = "Ensure the rpcgssd service is disabled";
-    PayloadKey = "EnsureRpcgssdServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRpcgssdServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureRpcgssdServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource140ref
-{
-    ResourceID = "Ensure the rpcidmapd service is disabled";
-    PayloadKey = "EnsureRpcidmapdServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRpcidmapdServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureRpcidmapdServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource141ref
-{
-    ResourceID = "Ensure the portmap service is disabled";
-    PayloadKey = "EnsurePortmapServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePortmapServiceIsDisabled";
-    DesiredObjectName = "remediateEnsurePortmapServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource142ref
-{
-    ResourceID = "Ensure the Network File System (NFS) service is disabled";
-    PayloadKey = "EnsureNetworkFileSystemServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNetworkFileSystemServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureNetworkFileSystemServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource143ref
-{
-    ResourceID = "Ensure the rpcsvcgssd service is disabled";
-    PayloadKey = "EnsureRpcsvcgssdServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRpcsvcgssdServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureRpcsvcgssdServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource144ref
-{
-    ResourceID = "Ensure the bind9 package is not installed";
-    PayloadKey = "EnsureBind9NotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureBind9NotInstalled";
-    DesiredObjectName = "remediateEnsureBind9NotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource145ref
-{
-    ResourceID = "Ensure the dovecot-core package is not installed";
-    PayloadKey = "EnsureDovecotCoreNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDovecotCoreNotInstalled";
-    DesiredObjectName = "remediateEnsureDovecotCoreNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource146ref
-{
-    ResourceID = "Ensure no legacy + entries exist in /etc/passwd";
-    PayloadKey = "EnsureNoLegacyPlusEntriesInEtcPasswd";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoLegacyPlusEntriesInEtcPasswd";
-    DesiredObjectName = "remediateEnsureNoLegacyPlusEntriesInEtcPasswd";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource147ref
-{
-    ResourceID = "Ensure no legacy + entries exist in /etc/shadow";
-    PayloadKey = "EnsureNoLegacyPlusEntriesInEtcShadow";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoLegacyPlusEntriesInEtcShadow";
-    DesiredObjectName = "remediateEnsureNoLegacyPlusEntriesInEtcShadow";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource148ref
-{
-    ResourceID = "Ensure no legacy + entries exist in /etc/group";
-    PayloadKey = "EnsureNoLegacyPlusEntriesInEtcGroup";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNoLegacyPlusEntriesInEtcGroup";
-    DesiredObjectName = "remediateEnsureNoLegacyPlusEntriesInEtcGroup";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource149ref
-{
-    ResourceID = "Ensure password expiration is configured";
-    PayloadKey = "EnsurePasswordExpiration";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePasswordExpiration";
-    DesiredObjectName = "remediateEnsurePasswordExpiration";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource150ref
-{
-    ResourceID = "Ensure password expiration warning days is configured";
-    PayloadKey = "EnsurePasswordExpirationWarning";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePasswordExpirationWarning";
-    DesiredObjectName = "remediateEnsurePasswordExpirationWarning";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource151ref
-{
-    ResourceID = "Ensure password reuse is limited";
-    PayloadKey = "EnsurePasswordReuseIsLimited";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePasswordReuseIsLimited";
-    DesiredObjectName = "remediateEnsurePasswordReuseIsLimited";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource152ref
-{
-    ResourceID = "Ensure the password hashing algorithm is SHA-512";
-    PayloadKey = "EnsurePasswordHashingAlgorithm";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsurePasswordHashingAlgorithm";
-    DesiredObjectName = "remediateEnsurePasswordHashingAlgorithm";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource153ref
-{
-    ResourceID = "Ensure the minimum days between password changes is configured";
-    PayloadKey = "EnsureMinDaysBetweenPasswordChanges";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureMinDaysBetweenPasswordChanges";
-    DesiredObjectName = "remediateEnsureMinDaysBetweenPasswordChanges";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource154ref
-{
-    ResourceID = "Ensure the maximum days between password changes is configured";
-    PayloadKey = "EnsureMaxDaysBetweenPasswordChanges";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureMaxDaysBetweenPasswordChanges";
-    DesiredObjectName = "remediateEnsureMaxDaysBetweenPasswordChanges";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource155ref
-{
-    ResourceID = "Ensure the inactive password lock period is configured";
-    PayloadKey = "EnsureInactivePasswordLockPeriod";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureInactivePasswordLockPeriod";
-    DesiredObjectName = "remediateEnsureInactivePasswordLockPeriod";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource156ref
-{
-    ResourceID = "Ensure all system accounts are non-login";
-    PayloadKey = "EnsureSystemAccountsAreNonLogin";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSystemAccountsAreNonLogin";
-    DesiredObjectName = "remediateEnsureSystemAccountsAreNonLogin";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource157ref
-{
-    ResourceID = "Ensure default group for the root account is GID 0";
-    PayloadKey = "EnsureDefaultRootAccountGroupIsGidZero";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureDefaultRootAccountGroupIsGidZero";
-    DesiredObjectName = "remediateEnsureDefaultRootAccountGroupIsGidZero";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource158ref
-{
-    ResourceID = "Ensure root is the only UID 0 account";
-    PayloadKey = "EnsureRootIsOnlyUidZeroAccount";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRootIsOnlyUidZeroAccount";
-    DesiredObjectName = "remediateEnsureRootIsOnlyUidZeroAccount";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource159ref
-{
-    ResourceID = "Ensure unnecessary accounts are removed";
-    PayloadKey = "EnsureUnnecessaryAccountsAreRemoved";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureUnnecessaryAccountsAreRemoved";
-    DesiredObjectName = "remediateEnsureUnnecessaryAccountsAreRemoved";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource160ref
-{
-    ResourceID = "Ensure the auditd package is installed";
-    PayloadKey = "EnsureAuditdInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAuditdInstalled";
-    DesiredObjectName = "remediateEnsureAuditdInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource161ref
-{
-    ResourceID = "Ensure the auditd service is running";
-    PayloadKey = "EnsureAuditdServiceIsRunning";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureAuditdServiceIsRunning";
-    DesiredObjectName = "remediateEnsureAuditdServiceIsRunning";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource162ref
-{
-    ResourceID = "Ensure the SNMP Server is not enabled";
-    PayloadKey = "EnsureSnmpServerIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSnmpServerIsDisabled";
-    DesiredObjectName = "remediateEnsureSnmpServerIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource163ref
-{
-    ResourceID = "Ensure the rsync service is not enabled";
-    PayloadKey = "EnsureRsynServiceIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRsynServiceIsDisabled";
-    DesiredObjectName = "remediateEnsureRsynServiceIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource164ref
-{
-    ResourceID = "Ensure the NIS server is not enabled";
-    PayloadKey = "EnsureNisServerIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureNisServerIsDisabled";
-    DesiredObjectName = "remediateEnsureNisServerIsDisabled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource165ref
-{
-    ResourceID = "Ensure the rsh client is not installed";
-    PayloadKey = "EnsureRshClientNotInstalled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureRshClientNotInstalled";
-    DesiredObjectName = "remediateEnsureRshClientNotInstalled";
-    DesiredObjectValue = "PASS";
-    ModuleName = "GuestConfiguration";
-    ModuleVersion = "1.0.0";
-    ConfigurationName = "OsConfigSecurityBaseline";
-    SourceInfo = "::4::5::OsConfigResource";
-};
-
-instance of OsConfigResource as $OsConfigResource166ref
-{
-    ResourceID = "Ensure SMB V1 with Samba is disabled";
-    PayloadKey = "EnsureSmbWithSambaIsDisabled";
-    ComponentName = "SecurityBaseline";
-    ReportedObjectName = "auditEnsureSmbWithSambaIsDisabled";
-    DesiredObjectName = "remediateEnsureSmbWithSambaIsDisabled";
     DesiredObjectValue = "PASS";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
@@ -2338,9 +285,9 @@ instance of OsConfigResource as $OsConfigResource166ref
 
 instance of OMI_ConfigurationDocument
 {
-    Version="2.0.0";
+    Version="3.0.0";
     CompatibleVersionAdditionalProperties= {"Omi_BaseResource:ConfigurationName"};
     Author="Microsoft";
-    GenerationDate="11/10/2023 09:07:00 AM PST";
-    Name="OsConfigSecurityBaseline";
+    GenerationDate="11/13/2023 01:26:00 AM PST";
+    Name="OsConfigSshServerSecurity";
 };

--- a/src/adapters/mc/OsConfigPolicyFull.mof
+++ b/src/adapters/mc/OsConfigPolicyFull.mof
@@ -1,0 +1,2346 @@
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "Ensure nodev option set on /home partition";
+    PayloadKey = "EnsureNodevOptionOnHomePartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNodevOptionOnHomePartition";
+    DesiredObjectName = "remediateEnsureNodevOptionOnHomePartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource1ref
+{
+    ResourceID = "Ensure nodev option set on /tmp partition";
+    PayloadKey = "EnsureNodevOptionOnTmpPartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNodevOptionOnTmpPartition";
+    DesiredObjectName = "remediateEnsureNodevOptionOnTmpPartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource2ref
+{
+    ResourceID = "Ensure nodev option set on /var/tmp partition";
+    PayloadKey = "EnsureNodevOptionOnVarTmpPartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNodevOptionOnVarTmpPartition";
+    DesiredObjectName = "remediateEnsureNodevOptionOnVarTmpPartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource3ref
+{
+    ResourceID = "Ensure nosuid option set on /tmp partition";
+    PayloadKey = "EnsureNosuidOptionOnTmpPartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNosuidOptionOnTmpPartition";
+    DesiredObjectName = "remediateEnsureNosuidOptionOnTmpPartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource4ref
+{
+    ResourceID = "Ensure nosuid option set on /var/tmp partition";
+    PayloadKey = "EnsureNosuidOptionOnVarTmpPartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNosuidOptionOnVarTmpPartition";
+    DesiredObjectName = "remediateEnsureNosuidOptionOnVarTmpPartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource5ref
+{
+    ResourceID = "Ensure noexec option set on /var/tmp partition";
+    PayloadKey = "EnsureNoexecOptionOnVarTmpPartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoexecOptionOnVarTmpPartition";
+    DesiredObjectName = "remediateEnsureNoexecOptionOnVarTmpPartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource6ref
+{
+    ResourceID = "Ensure noexec option set on /dev/shm partition";
+    PayloadKey = "EnsureNoexecOptionOnDevShmPartition";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoexecOptionOnDevShmPartition";
+    DesiredObjectName = "remediateEnsureNoexecOptionOnDevShmPartition";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource7ref
+{
+    ResourceID = "Ensure automounting is disabled";
+    PayloadKey = "EnsureAutomountingDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAutomountingDisabled";
+    DesiredObjectName = "remediateEnsureAutomountingDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource8ref
+{
+    ResourceID = "Ensure mounting of USB storage devices is disabled";
+    PayloadKey = "EnsureMountingOfUsbStorageDevicesIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureMountingOfUsbStorageDevicesIsDisabled";
+    DesiredObjectName = "remediateEnsureMountingOfUsbStorageDevicesIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource9ref
+{
+    ResourceID = "Ensure core dumps are restricted";
+    PayloadKey = "EnsureCoreDumpsAreRestricted";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureCoreDumpsAreRestricted";
+    DesiredObjectName = "remediateEnsureCoreDumpsAreRestricted";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource10ref
+{
+    ResourceID = "Ensure prelink is disabled";
+    PayloadKey = "EnsurePrelinkIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePrelinkIsDisabled";
+    DesiredObjectName = "remediateEnsurePrelinkIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource11ref
+{
+    ResourceID = "Ensure permissions on /etc/motd are configured";
+    PayloadKey = "EnsurePermissionsOnEtcMotd";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcMotd";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcMotd";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource12ref
+{
+    ResourceID = "Ensure permissions on /etc/issue are configured";
+    PayloadKey = "EnsurePermissionsOnEtcIssue";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcIssue";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcIssue";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource13ref
+{
+    ResourceID = "Ensure permissions on /etc/issue.net are configured";
+    PayloadKey = "EnsurePermissionsOnEtcIssueNet";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcIssueNet";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcIssueNet";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource14ref
+{
+    ResourceID = "Ensure the nodev option is enabled for all removable media";
+    PayloadKey = "EnsureNodevOptionEnabledForAllRemovableMedia";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNodevOptionEnabledForAllRemovableMedia";
+    DesiredObjectName = "remediateEnsureNodevOptionEnabledForAllRemovableMedia";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource15ref
+{
+    ResourceID = "Ensure the noexec option is enabled for all removable media";
+    PayloadKey = "EnsureNoexecOptionEnabledForAllRemovableMedia";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoexecOptionEnabledForAllRemovableMedia";
+    DesiredObjectName = "remediateEnsureNoexecOptionEnabledForAllRemovableMedia";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource16ref
+{
+    ResourceID = "Ensure the nosuid option is enabled for all removable media";
+    PayloadKey = "EnsureNosuidOptionEnabledForAllRemovableMedia";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNosuidOptionEnabledForAllRemovableMedia";
+    DesiredObjectName = "remediateEnsureNosuidOptionEnabledForAllRemovableMedia";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource17ref
+{
+    ResourceID = "Ensure talk client is not installed";
+    PayloadKey = "EnsureTalkClientIsNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureTalkClientIsNotInstalled";
+    DesiredObjectName = "remediateEnsureTalkClientIsNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource18ref
+{
+    ResourceID = "Ensure permissions on /etc/hosts.allow are configured";
+    PayloadKey = "EnsurePermissionsOnEtcHostsAllow";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcHostsAllow";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcHostsAllow";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource19ref
+{
+    ResourceID = "Ensure permissions on /etc/hosts.deny are configured";
+    PayloadKey = "EnsurePermissionsOnEtcHostsDeny";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcHostsDeny";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcHostsDeny";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource20ref
+{
+    ResourceID = "Ensure default deny firewall policy is set";
+    PayloadKey = "EnsureDefaultDenyFirewallPolicyIsSet";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDefaultDenyFirewallPolicyIsSet";
+    DesiredObjectName = "remediateEnsureDefaultDenyFirewallPolicyIsSet";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource21ref
+{
+    ResourceID = "Ensure the nodev/nosuid option is enabled for all NFS mounts";
+    PayloadKey = "EnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
+    DesiredObjectName = "remediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource22ref
+{
+    ResourceID = "Ensure permissions on /etc/ssh/sshd_config are configured";
+    PayloadKey = "EnsurePermissionsOnEtcSshSshdConfig";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcSshSshdConfig";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcSshSshdConfig";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource23ref
+{
+    ResourceID = "Ensure password creation requirements are configured";
+    PayloadKey = "EnsurePasswordCreationRequirements";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePasswordCreationRequirements";
+    DesiredObjectName = "remediateEnsurePasswordCreationRequirements";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource24ref
+{
+    ResourceID = "Ensure lockout for failed password attempts is configured";
+    PayloadKey = "EnsureLockoutForFailedPasswordAttempts";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureLockoutForFailedPasswordAttempts";
+    DesiredObjectName = "remediateEnsureLockoutForFailedPasswordAttempts";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource25ref
+{
+    ResourceID = "Ensure the cramfs file system is disabled";
+    PayloadKey = "EnsureDisabledInstallationOfCramfsFileSystem";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDisabledInstallationOfCramfsFileSystem";
+    DesiredObjectName = "remediateEnsureDisabledInstallationOfCramfsFileSystem";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource26ref
+{
+    ResourceID = "Ensure the freevxfs file system is disabled";
+    PayloadKey = "EnsureDisabledInstallationOfFreevxfsFileSystem";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDisabledInstallationOfFreevxfsFileSystem";
+    DesiredObjectName = "remediateEnsureDisabledInstallationOfFreevxfsFileSystem";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource27ref
+{
+    ResourceID = "Ensure all users' home directories exist";
+    PayloadKey = "EnsureAllUsersHomeDirectoriesExist";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllUsersHomeDirectoriesExist";
+    DesiredObjectName = "remediateEnsureAllUsersHomeDirectoriesExist";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource28ref
+{
+    ResourceID = "Ensure users own their home directories";
+    PayloadKey = "EnsureUsersOwnTheirHomeDirectories";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureUsersOwnTheirHomeDirectories";
+    DesiredObjectName = "remediateEnsureUsersOwnTheirHomeDirectories";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource29ref
+{
+    ResourceID = "Ensure users' dot files aren't group or world writable";
+    PayloadKey = "EnsureUsersDotFilesArentGroupOrWorldWritable";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureUsersDotFilesArentGroupOrWorldWritable";
+    DesiredObjectName = "remediateEnsureUsersDotFilesArentGroupOrWorldWritable";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource30ref
+{
+    ResourceID = "Ensure no users have .forward files";
+    PayloadKey = "EnsureNoUsersHaveDotForwardFiles";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoUsersHaveDotForwardFiles";
+    DesiredObjectName = "remediateEnsureNoUsersHaveDotForwardFiles";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource31ref
+{
+    ResourceID = "Ensure no users have .netrc files";
+    PayloadKey = "EnsureNoUsersHaveDotNetrcFiles";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoUsersHaveDotNetrcFiles";
+    DesiredObjectName = "remediateEnsureNoUsersHaveDotNetrcFiles";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource32ref
+{
+    ResourceID = "Ensure no users have .rhosts files";
+    PayloadKey = "EnsureNoUsersHaveDotRhostsFiles";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoUsersHaveDotRhostsFiles";
+    DesiredObjectName = "remediateEnsureNoUsersHaveDotRhostsFiles";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource33ref
+{
+    ResourceID = "Ensure all groups in /etc/passwd exist in /etc/group";
+    PayloadKey = "EnsureAllEtcPasswdGroupsExistInEtcGroup";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllEtcPasswdGroupsExistInEtcGroup";
+    DesiredObjectName = "remediateEnsureAllEtcPasswdGroupsExistInEtcGroup";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource34ref
+{
+    ResourceID = "Ensure no duplicate UIDs exist";
+    PayloadKey = "EnsureNoDuplicateUidsExist";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoDuplicateUidsExist";
+    DesiredObjectName = "remediateEnsureNoDuplicateUidsExist";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource35ref
+{
+    ResourceID = "Ensure no duplicate GIDs exist";
+    PayloadKey = "EnsureNoDuplicateGidsExist";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoDuplicateGidsExist";
+    DesiredObjectName = "remediateEnsureNoDuplicateGidsExist";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource36ref
+{
+    ResourceID = "Ensure no duplicate user names exist";
+    PayloadKey = "EnsureNoDuplicateUserNamesExist";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoDuplicateUserNamesExist";
+    DesiredObjectName = "remediateEnsureNoDuplicateUserNamesExist";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource37ref
+{
+    ResourceID = "Ensure no duplicate groups exist";
+    PayloadKey = "EnsureNoDuplicateGroupsExist";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoDuplicateGroupsExist";
+    DesiredObjectName = "remediateEnsureNoDuplicateGroupsExist";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource38ref
+{
+    ResourceID = "Ensure shadow group is empty";
+    PayloadKey = "EnsureShadowGroupIsEmpty";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureShadowGroupIsEmpty";
+    DesiredObjectName = "remediateEnsureShadowGroupIsEmpty";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource39ref
+{
+    ResourceID = "Ensure the hfs file system is disabled";
+    PayloadKey = "EnsureDisabledInstallationOfHfsFileSystem";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDisabledInstallationOfHfsFileSystem";
+    DesiredObjectName = "remediateEnsureDisabledInstallationOfHfsFileSystem";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource40ref
+{
+    ResourceID = "Ensure the hfsplus file systems is disabled";
+    PayloadKey = "EnsureDisabledInstallationOfHfsplusFileSystem";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDisabledInstallationOfHfsplusFileSystem";
+    DesiredObjectName = "remediateEnsureDisabledInstallationOfHfsplusFileSystem";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource41ref
+{
+    ResourceID = "Ensure the jffs2 file systems is disabled";
+    PayloadKey = "EnsureDisabledInstallationOfJffs2FileSystem";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDisabledInstallationOfJffs2FileSystem";
+    DesiredObjectName = "remediateEnsureDisabledInstallationOfJffs2FileSystem";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource42ref
+{
+    ResourceID = "Ensure the kernel is compiled from approved sources";
+    PayloadKey = "EnsureKernelCompiledFromApprovedSources";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureKernelCompiledFromApprovedSources";
+    DesiredObjectName = "remediateEnsureKernelCompiledFromApprovedSources";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource43ref
+{
+    ResourceID = "Ensure file permissions on /etc/shadow are configured";
+    PayloadKey = "EnsurePermissionsOnEtcShadow";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcShadow";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcShadow";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource44ref
+{
+    ResourceID = "Ensure file permissions on /etc/shadow- are configured";
+    PayloadKey = "EnsurePermissionsOnEtcShadowDash";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcShadowDash";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcShadowDash";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource45ref
+{
+    ResourceID = "Ensure file permissions on /etc/gshadow are configured";
+    PayloadKey = "EnsurePermissionsOnEtcGShadow";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcGShadow";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcGShadow";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource46ref
+{
+    ResourceID = "Ensure file permissions on /etc/gshadow- are configured";
+    PayloadKey = "EnsurePermissionsOnEtcGShadowDash";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcGShadowDash";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcGShadowDash";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource47ref
+{
+    ResourceID = "Ensure file permissions on /etc/passwd are configured";
+    PayloadKey = "EnsurePermissionsOnEtcPasswd";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcPasswd";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcPasswd";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource48ref
+{
+    ResourceID = "Ensure file permissions on /etc/group are configured";
+    PayloadKey = "EnsurePermissionsOnEtcGroup";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcGroup";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcGroup";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource49ref
+{
+    ResourceID = "Ensure file permissions on /etc/passwd- are configured";
+    PayloadKey = "EnsurePermissionsOnEtcPasswdDash";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcPasswdDash";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcPasswdDash";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource50ref
+{
+    ResourceID = "Ensure file permissions on /etc/group- are configured";
+    PayloadKey = "EnsurePermissionsOnEtcGroupDash";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcGroupDash";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcGroupDash";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource51ref
+{
+    ResourceID = "Ensure that access to the root account via su is restricted to the 'root' group";
+    PayloadKey = "EnsureSuRestrictedToRootGroup";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSuRestrictedToRootGroup";
+    DesiredObjectName = "remediateEnsureSuRestrictedToRootGroup";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource52ref
+{
+    ResourceID = "Ensure the 'root' group exists, and contain all members who can su to root";
+    PayloadKey = "EnsureRootGroupExists";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRootGroupExists";
+    DesiredObjectName = "remediateEnsureRootGroupExists";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource53ref
+{
+    ResourceID = "Ensure that all user accounts that can login have a password set";
+    PayloadKey = "EnsureAllAccountsHavePasswords";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllAccountsHavePasswords";
+    DesiredObjectName = "remediateEnsureAllAccountsHavePasswords";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource54ref
+{
+    ResourceID = "Ensure that all user accounts other than root have unique UIDs greater than zero (0)";
+    PayloadKey = "EnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
+    DesiredObjectName = "remediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource55ref
+{
+    ResourceID = "Ensure that randomized placement of virtual memory regions is enabled";
+    PayloadKey = "EnsureVirtualMemoryRandomizationIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureVirtualMemoryRandomizationIsEnabled";
+    DesiredObjectName = "remediateEnsureVirtualMemoryRandomizationIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource56ref
+{
+    ResourceID = "Ensure that kernel support for the XD/NX processor feature is enabled";
+    PayloadKey = "EnsureKernelSupportForCpuNx";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureKernelSupportForCpuNx";
+    DesiredObjectName = "remediateEnsureKernelSupportForCpuNx";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource57ref
+{
+    ResourceID = "Ensure '.' does not appear in root's $PATH";
+    PayloadKey = "EnsureDotDoesNotAppearInRootsPath";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDotDoesNotAppearInRootsPath";
+    DesiredObjectName = "remediateEnsureDotDoesNotAppearInRootsPath";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource58ref
+{
+    ResourceID = "Ensure access to user home directories is restricted";
+    PayloadKey = "EnsureRestrictedUserHomeDirectories";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRestrictedUserHomeDirectories";
+    DesiredObjectName = "remediateEnsureRestrictedUserHomeDirectories";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource59ref
+{
+    ResourceID = "Ensure the default umask for all users is configured";
+    PayloadKey = "EnsureDefaultUmaskForAllUsers";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDefaultUmaskForAllUsers";
+    DesiredObjectName = "remediateEnsureDefaultUmaskForAllUsers";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource60ref
+{
+    ResourceID = "Ensure all bootloaders have password protection enabled";
+    PayloadKey = "EnsureAllBootloadersHavePasswordProtectionEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllBootloadersHavePasswordProtectionEnabled";
+    DesiredObjectName = "remediateEnsureAllBootloadersHavePasswordProtectionEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource61ref
+{
+    ResourceID = "Ensure permissions on bootloader config are configured";
+    PayloadKey = "EnsurePermissionsOnBootloaderConfig";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnBootloaderConfig";
+    DesiredObjectName = "remediateEnsurePermissionsOnBootloaderConfig";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource62ref
+{
+    ResourceID = "Ensure authentication is required for single user mode";
+    PayloadKey = "EnsureAuthenticationRequiredForSingleUserMode";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAuthenticationRequiredForSingleUserMode";
+    DesiredObjectName = "remediateEnsureAuthenticationRequiredForSingleUserMode";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource63ref
+{
+    ResourceID = "Ensure packet redirect sending is disabled";
+    PayloadKey = "EnsurePacketRedirectSendingIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePacketRedirectSendingIsDisabled";
+    DesiredObjectName = "remediateEnsurePacketRedirectSendingIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource64ref
+{
+    ResourceID = "Ensure sending ICMP redirects is disabled for all interfaces";
+    PayloadKey = "EnsureIcmpRedirectsIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIcmpRedirectsIsDisabled";
+    DesiredObjectName = "remediateEnsureIcmpRedirectsIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource65ref
+{
+    ResourceID = "Ensure accepting source routed packets is disabled for all interfaces";
+    PayloadKey = "EnsureSourceRoutedPacketsIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSourceRoutedPacketsIsDisabled";
+    DesiredObjectName = "remediateEnsureSourceRoutedPacketsIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource66ref
+{
+    ResourceID = "Ensure the default setting for accepting source routed packets is disabled for network interfaces";
+    PayloadKey = "EnsureAcceptingSourceRoutedPacketsIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAcceptingSourceRoutedPacketsIsDisabled";
+    DesiredObjectName = "remediateEnsureAcceptingSourceRoutedPacketsIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource67ref
+{
+    ResourceID = "Ensure ignoring bogus ICMP responses to broadcasts is enabled";
+    PayloadKey = "EnsureIgnoringBogusIcmpBroadcastResponses";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIgnoringBogusIcmpBroadcastResponses";
+    DesiredObjectName = "remediateEnsureIgnoringBogusIcmpBroadcastResponses";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource68ref
+{
+    ResourceID = "Ensure ignoring ICMP echo requests (pings) sent to broadcast/multicast addresses is enabled";
+    PayloadKey = "EnsureIgnoringIcmpEchoPingsToMulticast";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIgnoringIcmpEchoPingsToMulticast";
+    DesiredObjectName = "remediateEnsureIgnoringIcmpEchoPingsToMulticast";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource69ref
+{
+    ResourceID = "Ensure logging of martian packets (those with impossible addresses) is enabled for all interfaces";
+    PayloadKey = "EnsureMartianPacketLoggingIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureMartianPacketLoggingIsEnabled";
+    DesiredObjectName = "remediateEnsureMartianPacketLoggingIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource70ref
+{
+    ResourceID = "Ensure performing source validation by reverse path is enabled for all interfaces";
+    PayloadKey = "EnsureReversePathSourceValidationIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureReversePathSourceValidationIsEnabled";
+    DesiredObjectName = "remediateEnsureReversePathSourceValidationIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource71ref
+{
+    ResourceID = "Ensure TCP SYN cookies are enabled";
+    PayloadKey = "EnsureTcpSynCookiesAreEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureTcpSynCookiesAreEnabled";
+    DesiredObjectName = "remediateEnsureTcpSynCookiesAreEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource72ref
+{
+    ResourceID = "Ensure the system does not act as a network sniffer";
+    PayloadKey = "EnsureSystemNotActingAsNetworkSniffer";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSystemNotActingAsNetworkSniffer";
+    DesiredObjectName = "remediateEnsureSystemNotActingAsNetworkSniffer";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource73ref
+{
+    ResourceID = "Ensure all wireless interfaces are disabled";
+    PayloadKey = "EnsureAllWirelessInterfacesAreDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllWirelessInterfacesAreDisabled";
+    DesiredObjectName = "remediateEnsureAllWirelessInterfacesAreDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource74ref
+{
+    ResourceID = "Ensure the IPv6 protocol is enabled";
+    PayloadKey = "EnsureIpv6ProtocolIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIpv6ProtocolIsEnabled";
+    DesiredObjectName = "remediateEnsureIpv6ProtocolIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource75ref
+{
+    ResourceID = "Ensure DCCP is disabled";
+    PayloadKey = "EnsureDccpIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDccpIsDisabled";
+    DesiredObjectName = "remediateEnsureDccpIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource76ref
+{
+    ResourceID = "Ensure SCTP is disabled";
+    PayloadKey = "EnsureSctpIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSctpIsDisabled";
+    DesiredObjectName = "remediateEnsureSctpIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource77ref
+{
+    ResourceID = "Ensure support for RDS is disabled";
+    PayloadKey = "EnsureDisabledSupportForRds";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDisabledSupportForRds";
+    DesiredObjectName = "remediateEnsureDisabledSupportForRds";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource78ref
+{
+    ResourceID = "Ensure TIPC is disabled";
+    PayloadKey = "EnsureTipcIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureTipcIsDisabled";
+    DesiredObjectName = "remediateEnsureTipcIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource79ref
+{
+    ResourceID = "Ensure logging is configured";
+    PayloadKey = "EnsureLoggingIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureLoggingIsConfigured";
+    DesiredObjectName = "remediateEnsureLoggingIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource80ref
+{
+    ResourceID = "Ensure the syslog package is installed";
+    PayloadKey = "EnsureSyslogPackageIsInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSyslogPackageIsInstalled";
+    DesiredObjectName = "remediateEnsureSyslogPackageIsInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource81ref
+{
+    ResourceID = "Ensure the systemd-journald service persists log messages";
+    PayloadKey = "EnsureSystemdJournaldServicePersistsLogMessages";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSystemdJournaldServicePersistsLogMessages";
+    DesiredObjectName = "remediateEnsureSystemdJournaldServicePersistsLogMessages";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource82ref
+{
+    ResourceID = "Ensure a logging service is enabled";
+    PayloadKey = "EnsureALoggingServiceIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureALoggingServiceIsEnabled";
+    DesiredObjectName = "remediateEnsureALoggingServiceIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource83ref
+{
+    ResourceID = "Ensure file permissions for all rsyslog log files are configured";
+    PayloadKey = "EnsureFilePermissionsForAllRsyslogLogFiles";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureFilePermissionsForAllRsyslogLogFiles";
+    DesiredObjectName = "remediateEnsureFilePermissionsForAllRsyslogLogFiles";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource84ref
+{
+    ResourceID = "Ensure logger configuration files are restricted";
+    PayloadKey = "EnsureLoggerConfigurationFilesAreRestricted";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureLoggerConfigurationFilesAreRestricted";
+    DesiredObjectName = "remediateEnsureLoggerConfigurationFilesAreRestricted";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource85ref
+{
+    ResourceID = "Ensure that all rsyslog log files are owned by the 'adm' group";
+    PayloadKey = "EnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
+    DesiredObjectName = "remediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource86ref
+{
+    ResourceID = "Ensure all rsyslog log files are owned by the syslog user";
+    PayloadKey = "EnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
+    DesiredObjectName = "remediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource87ref
+{
+    ResourceID = "Ensure rsyslog does not accept remote messages";
+    PayloadKey = "EnsureRsyslogNotAcceptingRemoteMessages";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRsyslogNotAcceptingRemoteMessages";
+    DesiredObjectName = "remediateRsyslogNotAcceptingRemoteMessages";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource88ref
+{
+    ResourceID = "Ensure the logrotate (syslog rotater) service is enabled";
+    PayloadKey = "EnsureSyslogRotaterServiceIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSyslogRotaterServiceIsEnabled";
+    DesiredObjectName = "remediateEnsureSyslogRotaterServiceIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource89ref
+{
+    ResourceID = "Ensure the rlogin service is disabled";
+    PayloadKey = "EnsureRloginServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRloginServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureRloginServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource90ref
+{
+    ResourceID = "Ensure inetd is not installed";
+    PayloadKey = "EnsureInetdNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureInetdNotInstalled";
+    DesiredObjectName = "remediateEnsureInetdNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource91ref
+{
+    ResourceID = "Ensure xinetd is not installed";
+    PayloadKey = "EnsureXinetdNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureXinetdNotInstalled";
+    DesiredObjectName = "remediateEnsureXinetdNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource92ref
+{
+    ResourceID = "Ensure the telnet service is disabled";
+    PayloadKey = "EnsureTelnetServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureTelnetServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureTelnetServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource93ref
+{
+    ResourceID = "Ensure all telnetd packages are uninstalled";
+    PayloadKey = "EnsureAllTelnetdPackagesUninstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllTelnetdPackagesUninstalled";
+    DesiredObjectName = "remediateEnsureAllTelnetdPackagesUninstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource94ref
+{
+    ResourceID = "Ensure the rcp/rsh service is disabled";
+    PayloadKey = "EnsureRcprshServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRcprshServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureRcprshServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource95ref
+{
+    ResourceID = "Ensure the rsh-server package is uninstalled";
+    PayloadKey = "EnsureRshServerNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRshServerNotInstalled";
+    DesiredObjectName = "remediateEnsureRshServerNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource96ref
+{
+    ResourceID = "Ensure the ypbind service is disabled and the nis package is not installed";
+    PayloadKey = "EnsureNisNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNisNotInstalled";
+    DesiredObjectName = "remediateEnsureNisNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource97ref
+{
+    ResourceID = "Ensure the tftp service is disabled";
+    PayloadKey = "EnsureTftpServiceisDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureTftpServiceisDisabled";
+    DesiredObjectName = "remediateEnsureTftpServiceisDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource98ref
+{
+    ResourceID = "Ensure the tftpd package is not installed";
+    PayloadKey = "EnsureTftpdNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureTftpdNotInstalled";
+    DesiredObjectName = "remediateEnsureTftpdNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource99ref
+{
+    ResourceID = "Ensure the readahead-fedora package is not installed";
+    PayloadKey = "EnsureReadaheadFedoraNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureReadaheadFedoraNotInstalled";
+    DesiredObjectName = "remediateEnsureReadaheadFedoraNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource100ref
+{
+    ResourceID = "Ensure the bluetooth package is not installed";
+    PayloadKey = "EnsureBluetoothHiddNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureBluetoothHiddNotInstalled";
+    DesiredObjectName = "remediateEnsureBluetoothHiddNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource101ref
+{
+    ResourceID = "Ensure the isdnutils-base package is not installed";
+    PayloadKey = "EnsureIsdnUtilsBaseNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIsdnUtilsBaseNotInstalled";
+    DesiredObjectName = "remediateEnsureIsdnUtilsBaseNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource102ref
+{
+    ResourceID = "Ensure the kdump-tools package is not installed";
+    PayloadKey = "EnsureIsdnUtilsKdumpToolsNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIsdnUtilsKdumpToolsNotInstalled";
+    DesiredObjectName = "remediateEnsureIsdnUtilsKdumpToolsNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource103ref
+{
+    ResourceID = "Ensure zeroconf networking is disabled";
+    PayloadKey = "EnsureZeroconfNetworkingIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureZeroconfNetworkingIsDisabled";
+    DesiredObjectName = "remediateEnsureZeroconfNetworkingIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource104ref
+{
+    ResourceID = "Ensure the cron service is enabled";
+    PayloadKey = "EnsureCronServiceIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureCronServiceIsEnabled";
+    DesiredObjectName = "remediateEnsureCronServiceIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource105ref
+{
+    ResourceID = "Ensure File permissions on /etc/anacrontab are configured";
+    PayloadKey = "EnsurePermissionsOnEtcAnacronTab";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcAnacronTab";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcAnacronTab";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource106ref
+{
+    ResourceID = "Ensure permissions on /etc/cron.d are configured";
+    PayloadKey = "EnsurePermissionsOnEtcCronD";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcCronD";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronD";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource107ref
+{
+    ResourceID = "Ensure permissions on  /etc/cron.daily are configured";
+    PayloadKey = "EnsurePermissionsOnEtcCronDaily";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcCronDaily";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronDaily";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource108ref
+{
+    ResourceID = "Ensure permissions on  /etc/cron.hourly are configured";
+    PayloadKey = "EnsurePermissionsOnEtcCronHourly";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcCronHourly";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronHourly";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource109ref
+{
+    ResourceID = "Ensure permissions on  /etc/cron.monthly are configured";
+    PayloadKey = "EnsurePermissionsOnEtcCronMonthly";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcCronMonthly";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronMonthly";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource110ref
+{
+    ResourceID = "Ensure permissions on  /etc/cron.weekly are configured";
+    PayloadKey = "EnsurePermissionsOnEtcCronWeekly";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePermissionsOnEtcCronWeekly";
+    DesiredObjectName = "remediateEnsurePermissionsOnEtcCronWeekly";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource111ref
+{
+    ResourceID = "Ensure at/cron is restricted to authorized users";
+    PayloadKey = "EnsureAtCronIsRestrictedToAuthorizedUsers";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAtCronIsRestrictedToAuthorizedUsers";
+    DesiredObjectName = "remediateEnsureAtCronIsRestrictedToAuthorizedUsers";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource112ref
+{
+    ResourceID = "Ensure SSH is configured to meet best practices (protocol 2)";
+    PayloadKey = "EnsureSshBestPracticeProtocol";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshBestPracticeProtocol";
+    DesiredObjectName = "remediateEnsureSshBestPracticeProtocol";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource113ref
+{
+    ResourceID = "Ensure SSH is configured to ignore rhosts";
+    PayloadKey = "EnsureSshBestPracticeIgnoreRhosts";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshBestPracticeIgnoreRhosts";
+    DesiredObjectName = "remediateEnsureSshBestPracticeIgnoreRhosts";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource114ref
+{
+    ResourceID = "Ensure SSH LogLevel is set to INFO";
+    PayloadKey = "EnsureSshLogLevelIsSet";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshLogLevelIsSet";
+    DesiredObjectName = "remediateEnsureSshLogLevelIsSet";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource115ref
+{
+    ResourceID = "Ensure SSH MaxAuthTries is configured";
+    PayloadKey = "EnsureSshMaxAuthTriesIsSet";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshMaxAuthTriesIsSet";
+    DesiredObjectName = "remediateEnsureSshMaxAuthTriesIsSet";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource116ref
+{
+    ResourceID = "Ensure allowed users for SSH access are configured";
+    PayloadKey = "EnsureAllowUsersIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllowUsersIsConfigured";
+    DesiredObjectName = "remediateEnsureAllowUsersIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource117ref
+{
+    ResourceID = "Ensure denied users for SSH are configured";
+    PayloadKey = "EnsureDenyUsersIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDenyUsersIsConfigured";
+    DesiredObjectName = "remediateEnsureDenyUsersIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource118ref
+{
+    ResourceID = "Ensure allowed groups for SSH are configured";
+    PayloadKey = "EnsureAllowGroupsIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAllowGroupsIsConfigured";
+    DesiredObjectName = "remediateEnsureAllowGroupsIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource119ref
+{
+    ResourceID = "Ensure denied groups for SSH are configured";
+    PayloadKey = "EnsureDenyGroupsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDenyGroupsConfigured";
+    DesiredObjectName = "remediateEnsureDenyGroupsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource120ref
+{
+    ResourceID = "Ensure SSH host-based authenticationis disabled";
+    PayloadKey = "EnsureSshHostbasedAuthenticationIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshHostbasedAuthenticationIsDisabled";
+    DesiredObjectName = "remediateEnsureSshHostbasedAuthenticationIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource121ref
+{
+    ResourceID = "Ensure root login via SSH is disabled";
+    PayloadKey = "EnsureSshPermitRootLoginIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshPermitRootLoginIsDisabled";
+    DesiredObjectName = "remediateEnsureSshPermitRootLoginIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource122ref
+{
+    ResourceID = "Ensure that remote connection from accounts with empty passwords is disabled";
+    PayloadKey = "EnsureSshPermitEmptyPasswordsIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshPermitEmptyPasswordsIsDisabled";
+    DesiredObjectName = "remediateEnsureSshPermitEmptyPasswordsIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource123ref
+{
+    ResourceID = "Ensure the SSH Client Interval Count Maximum is configured";
+    PayloadKey = "EnsureSshClientIntervalCountMaxIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshClientIntervalCountMaxIsConfigured";
+    DesiredObjectName = "remediateEnsureSshClientIntervalCountMaxIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource124ref
+{
+    ResourceID = "Ensure the SSH Client Alive interval Interval is configured";
+    PayloadKey = "EnsureSshClientAliveIntervalIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshClientAliveIntervalIsConfigured";
+    DesiredObjectName = "remediateEnsureSshClientAliveIntervalIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource125ref
+{
+    ResourceID = "Ensure the SSH LoginGraceTime is configured";
+    PayloadKey = "EnsureSshLoginGraceTimeIsSet";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshLoginGraceTimeIsSet";
+    DesiredObjectName = "remediateEnsureSshLoginGraceTimeIsSet";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource126ref
+{
+    ResourceID = "Ensure that only approved MAC algorithms are used";
+    PayloadKey = "EnsureOnlyApprovedMacAlgorithmsAreUsed";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureOnlyApprovedMacAlgorithmsAreUsed";
+    DesiredObjectName = "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource127ref
+{
+    ResourceID = "Ensure the remote login warning banner is properly configured";
+    PayloadKey = "EnsureRemoteLoginWarningBannerIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRemoteLoginWarningBannerIsConfigured";
+    DesiredObjectName = "remediateEnsureRemoteLoginWarningBannerIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource128ref
+{
+    ResourceID = "Ensure the local login warning banner is properly configured";
+    PayloadKey = "EnsureLocalLoginWarningBannerIsConfigured";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureLocalLoginWarningBannerIsConfigured";
+    DesiredObjectName = "remediateEnsureLocalLoginWarningBannerIsConfigured";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource129ref
+{
+    ResourceID = "Ensure the SSH warning banner is enabled";
+    PayloadKey = "EnsureSshWarningBannerIsEnabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSshWarningBannerIsEnabled";
+    DesiredObjectName = "remediateEnsureSshWarningBannerIsEnabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource130ref
+{
+    ResourceID = "Ensure that users cannot set environment options for SSH";
+    PayloadKey = "EnsureUsersCannotSetSshEnvironmentOptions";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureUsersCannotSetSshEnvironmentOptions";
+    DesiredObjectName = "remediateEnsureUsersCannotSetSshEnvironmentOptions";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource131ref
+{
+    ResourceID = "Ensure that appropriate ciphers are used for SSH";
+    PayloadKey = "EnsureAppropriateCiphersForSsh";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAppropriateCiphersForSsh";
+    DesiredObjectName = "remediateEnsureAppropriateCiphersForSsh";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource132ref
+{
+    ResourceID = "Ensure the avahi-daemon service is disabled";
+    PayloadKey = "EnsureAvahiDaemonServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAvahiDaemonServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureAvahiDaemonServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource133ref
+{
+    ResourceID = "Ensure the cups service is disabled";
+    PayloadKey = "EnsureCupsServiceisDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureCupsServiceisDisabled";
+    DesiredObjectName = "remediateEnsureCupsServiceisDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource134ref
+{
+    ResourceID = "Ensure the isc-dhcp-server package is not installed";
+    PayloadKey = "EnsureIscDhcpdServerNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureIscDhcpdServerNotInstalled";
+    DesiredObjectName = "remediateEnsureIscDhcpdServerNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource135ref
+{
+    ResourceID = "Ensure the sendmail package is not installed";
+    PayloadKey = "EnsureSendmailNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSendmailNotInstalled";
+    DesiredObjectName = "remediateEnsureSendmailNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource136ref
+{
+    ResourceID = "Ensure the postfix package is not installed";
+    PayloadKey = "EnsurePostfixPackageIsUninstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePostfixPackageIsUninstalled";
+    DesiredObjectName = "remediateEnsurePostfixPackageIsUninstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource137ref
+{
+    ResourceID = "Ensure that postfix network listening is disabled";
+    PayloadKey = "EnsurePostfixNetworkListeningIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePostfixNetworkListeningIsDisabled";
+    DesiredObjectName = "remediateEnsurePostfixNetworkListeningIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource138ref
+{
+    ResourceID = "Ensure the sldapd package is not installed";
+    PayloadKey = "EnsureSldapdNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSldapdNotInstalled";
+    DesiredObjectName = "remediateEnsureSldapdNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource139ref
+{
+    ResourceID = "Ensure the rpcgssd service is disabled";
+    PayloadKey = "EnsureRpcgssdServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRpcgssdServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureRpcgssdServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource140ref
+{
+    ResourceID = "Ensure the rpcidmapd service is disabled";
+    PayloadKey = "EnsureRpcidmapdServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRpcidmapdServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureRpcidmapdServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource141ref
+{
+    ResourceID = "Ensure the portmap service is disabled";
+    PayloadKey = "EnsurePortmapServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePortmapServiceIsDisabled";
+    DesiredObjectName = "remediateEnsurePortmapServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource142ref
+{
+    ResourceID = "Ensure the Network File System (NFS) service is disabled";
+    PayloadKey = "EnsureNetworkFileSystemServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNetworkFileSystemServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureNetworkFileSystemServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource143ref
+{
+    ResourceID = "Ensure the rpcsvcgssd service is disabled";
+    PayloadKey = "EnsureRpcsvcgssdServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRpcsvcgssdServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureRpcsvcgssdServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource144ref
+{
+    ResourceID = "Ensure the bind9 package is not installed";
+    PayloadKey = "EnsureBind9NotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureBind9NotInstalled";
+    DesiredObjectName = "remediateEnsureBind9NotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource145ref
+{
+    ResourceID = "Ensure the dovecot-core package is not installed";
+    PayloadKey = "EnsureDovecotCoreNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDovecotCoreNotInstalled";
+    DesiredObjectName = "remediateEnsureDovecotCoreNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource146ref
+{
+    ResourceID = "Ensure no legacy + entries exist in /etc/passwd";
+    PayloadKey = "EnsureNoLegacyPlusEntriesInEtcPasswd";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoLegacyPlusEntriesInEtcPasswd";
+    DesiredObjectName = "remediateEnsureNoLegacyPlusEntriesInEtcPasswd";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource147ref
+{
+    ResourceID = "Ensure no legacy + entries exist in /etc/shadow";
+    PayloadKey = "EnsureNoLegacyPlusEntriesInEtcShadow";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoLegacyPlusEntriesInEtcShadow";
+    DesiredObjectName = "remediateEnsureNoLegacyPlusEntriesInEtcShadow";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource148ref
+{
+    ResourceID = "Ensure no legacy + entries exist in /etc/group";
+    PayloadKey = "EnsureNoLegacyPlusEntriesInEtcGroup";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNoLegacyPlusEntriesInEtcGroup";
+    DesiredObjectName = "remediateEnsureNoLegacyPlusEntriesInEtcGroup";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource149ref
+{
+    ResourceID = "Ensure password expiration is configured";
+    PayloadKey = "EnsurePasswordExpiration";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePasswordExpiration";
+    DesiredObjectName = "remediateEnsurePasswordExpiration";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource150ref
+{
+    ResourceID = "Ensure password expiration warning days is configured";
+    PayloadKey = "EnsurePasswordExpirationWarning";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePasswordExpirationWarning";
+    DesiredObjectName = "remediateEnsurePasswordExpirationWarning";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource151ref
+{
+    ResourceID = "Ensure password reuse is limited";
+    PayloadKey = "EnsurePasswordReuseIsLimited";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePasswordReuseIsLimited";
+    DesiredObjectName = "remediateEnsurePasswordReuseIsLimited";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource152ref
+{
+    ResourceID = "Ensure the password hashing algorithm is SHA-512";
+    PayloadKey = "EnsurePasswordHashingAlgorithm";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsurePasswordHashingAlgorithm";
+    DesiredObjectName = "remediateEnsurePasswordHashingAlgorithm";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource153ref
+{
+    ResourceID = "Ensure the minimum days between password changes is configured";
+    PayloadKey = "EnsureMinDaysBetweenPasswordChanges";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureMinDaysBetweenPasswordChanges";
+    DesiredObjectName = "remediateEnsureMinDaysBetweenPasswordChanges";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource154ref
+{
+    ResourceID = "Ensure the maximum days between password changes is configured";
+    PayloadKey = "EnsureMaxDaysBetweenPasswordChanges";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureMaxDaysBetweenPasswordChanges";
+    DesiredObjectName = "remediateEnsureMaxDaysBetweenPasswordChanges";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource155ref
+{
+    ResourceID = "Ensure the inactive password lock period is configured";
+    PayloadKey = "EnsureInactivePasswordLockPeriod";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureInactivePasswordLockPeriod";
+    DesiredObjectName = "remediateEnsureInactivePasswordLockPeriod";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource156ref
+{
+    ResourceID = "Ensure all system accounts are non-login";
+    PayloadKey = "EnsureSystemAccountsAreNonLogin";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSystemAccountsAreNonLogin";
+    DesiredObjectName = "remediateEnsureSystemAccountsAreNonLogin";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource157ref
+{
+    ResourceID = "Ensure default group for the root account is GID 0";
+    PayloadKey = "EnsureDefaultRootAccountGroupIsGidZero";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureDefaultRootAccountGroupIsGidZero";
+    DesiredObjectName = "remediateEnsureDefaultRootAccountGroupIsGidZero";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource158ref
+{
+    ResourceID = "Ensure root is the only UID 0 account";
+    PayloadKey = "EnsureRootIsOnlyUidZeroAccount";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRootIsOnlyUidZeroAccount";
+    DesiredObjectName = "remediateEnsureRootIsOnlyUidZeroAccount";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource159ref
+{
+    ResourceID = "Ensure unnecessary accounts are removed";
+    PayloadKey = "EnsureUnnecessaryAccountsAreRemoved";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureUnnecessaryAccountsAreRemoved";
+    DesiredObjectName = "remediateEnsureUnnecessaryAccountsAreRemoved";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource160ref
+{
+    ResourceID = "Ensure the auditd package is installed";
+    PayloadKey = "EnsureAuditdInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAuditdInstalled";
+    DesiredObjectName = "remediateEnsureAuditdInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource161ref
+{
+    ResourceID = "Ensure the auditd service is running";
+    PayloadKey = "EnsureAuditdServiceIsRunning";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureAuditdServiceIsRunning";
+    DesiredObjectName = "remediateEnsureAuditdServiceIsRunning";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource162ref
+{
+    ResourceID = "Ensure the SNMP Server is not enabled";
+    PayloadKey = "EnsureSnmpServerIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSnmpServerIsDisabled";
+    DesiredObjectName = "remediateEnsureSnmpServerIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource163ref
+{
+    ResourceID = "Ensure the rsync service is not enabled";
+    PayloadKey = "EnsureRsynServiceIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRsynServiceIsDisabled";
+    DesiredObjectName = "remediateEnsureRsynServiceIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource164ref
+{
+    ResourceID = "Ensure the NIS server is not enabled";
+    PayloadKey = "EnsureNisServerIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureNisServerIsDisabled";
+    DesiredObjectName = "remediateEnsureNisServerIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource165ref
+{
+    ResourceID = "Ensure the rsh client is not installed";
+    PayloadKey = "EnsureRshClientNotInstalled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureRshClientNotInstalled";
+    DesiredObjectName = "remediateEnsureRshClientNotInstalled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OsConfigResource as $OsConfigResource166ref
+{
+    ResourceID = "Ensure SMB V1 with Samba is disabled";
+    PayloadKey = "EnsureSmbWithSambaIsDisabled";
+    ComponentName = "SecurityBaseline";
+    ReportedObjectName = "auditEnsureSmbWithSambaIsDisabled";
+    DesiredObjectName = "remediateEnsureSmbWithSambaIsDisabled";
+    DesiredObjectValue = "PASS";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "OsConfigSecurityBaseline";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+
+instance of OMI_ConfigurationDocument
+{
+    Version="2.0.0";
+    CompatibleVersionAdditionalProperties= {"Omi_BaseResource:ConfigurationName"};
+    Author="Microsoft";
+    GenerationDate="11/10/2023 09:07:00 AM PST";
+    Name="OsConfigSecurityBaseline";
+};

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -432,7 +432,7 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
     // Read the desired MIM object value from the input resource values
     if ((in->InputResource.value->DesiredObjectValue.exists == MI_TRUE) && (in->InputResource.value->DesiredObjectValue.value != NULL))
     {
-        FREE_MEMORY(g_DesiredObjectValue);
+        FREE_MEMORY(g_desiredObjectValue);
 
         if (NULL == (g_DesiredObjectValue = DuplicateString(in->InputResource.value->DesiredObjectValue.value)))
         {
@@ -521,7 +521,7 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
     if ((in->InputResource.value->ExpectedObjectValue.exists == MI_TRUE) && (NULL != in->InputResource.value->ExpectedObjectValue.value))
     {
         memset(&miValue, 0, sizeof(miValue));
-        miValue.string = (MI_Char*)(g_ExpectedObjectValue);
+        miValue.string = (MI_Char*)(g_expectedObjectValue);
         if (MI_RESULT_OK != (miResult = MI_Instance_SetElement(resultResourceObject, MI_T("ExpectedObjectValue"), &miValue, MI_STRING, 0)))
         {
             LogError(context, miResult, GetLog(), "[OsConfigResource.Get] MI_Instance_SetElement(ExpectedObjectValue) to string value '%s' failed with miResult %d", miValue.string, miResult);

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -434,7 +434,7 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
     {
         FREE_MEMORY(g_desiredObjectValue);
 
-        if (NULL == (g_DesiredObjectValue = DuplicateString(in->InputResource.value->DesiredObjectValue.value)))
+        if (NULL == (g_desiredObjectValue = DuplicateString(in->InputResource.value->DesiredObjectValue.value)))
         {
             LogError(context, miResult, GetLog(), "[OsConfigResource.Get] DuplicateString(%s) failed", in->InputResource.value->DesiredObjectValue.value);
             g_DesiredObjectValue = DuplicateString(g_failValue);

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -437,7 +437,7 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
         if (NULL == (g_desiredObjectValue = DuplicateString(in->InputResource.value->DesiredObjectValue.value)))
         {
             LogError(context, miResult, GetLog(), "[OsConfigResource.Get] DuplicateString(%s) failed", in->InputResource.value->DesiredObjectValue.value);
-            g_DesiredObjectValue = DuplicateString(g_failValue);
+            g_desiredObjectValue = DuplicateString(g_failValue);
         }
     }
 

--- a/src/adapters/mc/OsConfigResource.h
+++ b/src/adapters/mc/OsConfigResource.h
@@ -41,6 +41,7 @@ typedef struct _OsConfigResource /* extends OMI_BaseResource */
     MI_ConstStringField ComponentName;
     MI_ConstStringField ReportedObjectName;
     MI_ConstStringField ReportedObjectValue;
+    MI_ConstStringField ExpectedObjectValue;
     MI_ConstStringField DesiredObjectName;
     MI_ConstStringField DesiredObjectValue;
     MI_ConstUint32Field ReportedMpiResult;
@@ -496,13 +497,45 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ReportedObjectValue(
         10);
 }
 
-MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectName(
+MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ExpectedObjectValue(
     OsConfigResource* self,
     const MI_Char* str)
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
         11,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_ExpectedObjectValue(
+    OsConfigResource* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        11,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ExpectedObjectValue(
+    OsConfigResource* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        11);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectName(
+    OsConfigResource* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        12,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -514,7 +547,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_DesiredObjectName(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        11,
+        12,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -525,7 +558,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_DesiredObjectName(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        11);
+        12);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectValue(
@@ -534,7 +567,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        12,
+        13,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -546,7 +579,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_DesiredObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        12,
+        13,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -557,7 +590,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_DesiredObjectValue(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        12);
+        13);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ReportedMpiResult(
@@ -586,7 +619,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_Reasons(
     arr.size = size;
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        14,
+        15,
         (MI_Value*)&arr,
         MI_INSTANCEA,
         0);
@@ -602,7 +635,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_Reasons(
     arr.size = size;
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        14,
+        15,
         (MI_Value*)&arr,
         MI_INSTANCEA,
         MI_FLAG_BORROW);
@@ -613,7 +646,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_Reasons(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        14);
+        15);
 }
 
 /*
@@ -1139,5 +1172,6 @@ MI_EXTERN_C void MI_CALL OsConfigResource_Invoke_SetTargetResource(
     const MI_Char* methodName,
     const OsConfigResource* instanceName,
     const OsConfigResource_SetTargetResource* in);
+
 
 #endif /* _OsConfigResource_h */

--- a/src/adapters/mc/schema.c
+++ b/src/adapters/mc/schema.c
@@ -1708,6 +1708,49 @@ static MI_CONST MI_PropertyDecl OsConfigResource_ReportedObjectValue_prop =
     NULL,
 };
 
+static MI_CONST MI_Boolean OsConfigResource_ExpectedObjectValue_Write_qual_value = 1;
+
+static MI_CONST MI_Qualifier OsConfigResource_ExpectedObjectValue_Write_qual =
+{
+    MI_T("Write"),
+    MI_BOOLEAN,
+    MI_FLAG_ENABLEOVERRIDE|MI_FLAG_TOSUBCLASS,
+    &OsConfigResource_ExpectedObjectValue_Write_qual_value
+};
+
+static MI_CONST MI_Char* OsConfigResource_ExpectedObjectValue_Description_qual_value = MI_T("15");
+
+static MI_CONST MI_Qualifier OsConfigResource_ExpectedObjectValue_Description_qual =
+{
+    MI_T("Description"),
+    MI_STRING,
+    MI_FLAG_ENABLEOVERRIDE|MI_FLAG_TOSUBCLASS|MI_FLAG_TRANSLATABLE,
+    &OsConfigResource_ExpectedObjectValue_Description_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST OsConfigResource_ExpectedObjectValue_quals[] =
+{
+    &OsConfigResource_ExpectedObjectValue_Write_qual,
+    &OsConfigResource_ExpectedObjectValue_Description_qual,
+};
+
+/* property OsConfigResource.ExpectedObjectValue */
+static MI_CONST MI_PropertyDecl OsConfigResource_ExpectedObjectValue_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00656513, /* code */
+    MI_T("ExpectedObjectValue"), /* name */
+    OsConfigResource_ExpectedObjectValue_quals, /* qualifiers */
+    MI_COUNT(OsConfigResource_ExpectedObjectValue_quals), /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(OsConfigResource, ExpectedObjectValue), /* offset */
+    MI_T("OsConfigResource"), /* origin */
+    MI_T("OsConfigResource"), /* propagator */
+    NULL,
+};
+
 static MI_CONST MI_Boolean OsConfigResource_DesiredObjectName_Write_qual_value = 1;
 
 static MI_CONST MI_Qualifier OsConfigResource_DesiredObjectName_Write_qual =
@@ -1718,7 +1761,7 @@ static MI_CONST MI_Qualifier OsConfigResource_DesiredObjectName_Write_qual =
     &OsConfigResource_DesiredObjectName_Write_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_DesiredObjectName_Description_qual_value = MI_T("15");
+static MI_CONST MI_Char* OsConfigResource_DesiredObjectName_Description_qual_value = MI_T("16");
 
 static MI_CONST MI_Qualifier OsConfigResource_DesiredObjectName_Description_qual =
 {
@@ -1761,7 +1804,7 @@ static MI_CONST MI_Qualifier OsConfigResource_DesiredObjectValue_Write_qual =
     &OsConfigResource_DesiredObjectValue_Write_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_DesiredObjectValue_Description_qual_value = MI_T("16");
+static MI_CONST MI_Char* OsConfigResource_DesiredObjectValue_Description_qual_value = MI_T("17");
 
 static MI_CONST MI_Qualifier OsConfigResource_DesiredObjectValue_Description_qual =
 {
@@ -1804,7 +1847,7 @@ static MI_CONST MI_Qualifier OsConfigResource_ReportedMpiResult_Read_qual =
     &OsConfigResource_ReportedMpiResult_Read_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_ReportedMpiResult_Description_qual_value = MI_T("17");
+static MI_CONST MI_Char* OsConfigResource_ReportedMpiResult_Description_qual_value = MI_T("18");
 
 static MI_CONST MI_Qualifier OsConfigResource_ReportedMpiResult_Description_qual =
 {
@@ -1893,6 +1936,7 @@ static MI_PropertyDecl MI_CONST* MI_CONST OsConfigResource_props[] =
     &OsConfigResource_ComponentName_prop,
     &OsConfigResource_ReportedObjectName_prop,
     &OsConfigResource_ReportedObjectValue_prop,
+    &OsConfigResource_ExpectedObjectValue_prop,
     &OsConfigResource_DesiredObjectName_prop,
     &OsConfigResource_DesiredObjectValue_prop,
     &OsConfigResource_ReportedMpiResult_prop,
@@ -1909,7 +1953,7 @@ static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_Static_qual =
     &OsConfigResource_GetTargetResource_Static_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_GetTargetResource_Description_qual_value = MI_T("18");
+static MI_CONST MI_Char* OsConfigResource_GetTargetResource_Description_qual_value = MI_T("19");
 
 static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_Description_qual =
 {
@@ -1945,7 +1989,7 @@ static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_InputResource_Em
     &OsConfigResource_GetTargetResource_InputResource_EmbeddedInstance_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_GetTargetResource_InputResource_Description_qual_value = MI_T("19");
+static MI_CONST MI_Char* OsConfigResource_GetTargetResource_InputResource_Description_qual_value = MI_T("20");
 
 static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_InputResource_Description_qual =
 {
@@ -1986,7 +2030,7 @@ static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_Flags_In_qual =
     &OsConfigResource_GetTargetResource_Flags_In_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_GetTargetResource_Flags_Description_qual_value = MI_T("20");
+static MI_CONST MI_Char* OsConfigResource_GetTargetResource_Flags_Description_qual_value = MI_T("21");
 
 static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_Flags_Description_qual =
 {
@@ -2036,7 +2080,7 @@ static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_OutputResource_E
     &OsConfigResource_GetTargetResource_OutputResource_EmbeddedInstance_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_GetTargetResource_OutputResource_Description_qual_value = MI_T("21");
+static MI_CONST MI_Char* OsConfigResource_GetTargetResource_OutputResource_Description_qual_value = MI_T("22");
 
 static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_OutputResource_Description_qual =
 {
@@ -2077,7 +2121,7 @@ static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_MIReturn_Static_
     &OsConfigResource_GetTargetResource_MIReturn_Static_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_GetTargetResource_MIReturn_Description_qual_value = MI_T("18");
+static MI_CONST MI_Char* OsConfigResource_GetTargetResource_MIReturn_Description_qual_value = MI_T("19");
 
 static MI_CONST MI_Qualifier OsConfigResource_GetTargetResource_MIReturn_Description_qual =
 {
@@ -2143,7 +2187,7 @@ static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_Static_qual =
     &OsConfigResource_TestTargetResource_Static_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_TestTargetResource_Description_qual_value = MI_T("22");
+static MI_CONST MI_Char* OsConfigResource_TestTargetResource_Description_qual_value = MI_T("23");
 
 static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_Description_qual =
 {
@@ -2179,7 +2223,7 @@ static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_InputResource_E
     &OsConfigResource_TestTargetResource_InputResource_EmbeddedInstance_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_TestTargetResource_InputResource_Description_qual_value = MI_T("19");
+static MI_CONST MI_Char* OsConfigResource_TestTargetResource_InputResource_Description_qual_value = MI_T("20");
 
 static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_InputResource_Description_qual =
 {
@@ -2220,7 +2264,7 @@ static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_Flags_In_qual =
     &OsConfigResource_TestTargetResource_Flags_In_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_TestTargetResource_Flags_Description_qual_value = MI_T("20");
+static MI_CONST MI_Char* OsConfigResource_TestTargetResource_Flags_Description_qual_value = MI_T("21");
 
 static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_Flags_Description_qual =
 {
@@ -2260,7 +2304,7 @@ static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_Result_Out_qual
     &OsConfigResource_TestTargetResource_Result_Out_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_TestTargetResource_Result_Description_qual_value = MI_T("23");
+static MI_CONST MI_Char* OsConfigResource_TestTargetResource_Result_Description_qual_value = MI_T("24");
 
 static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_Result_Description_qual =
 {
@@ -2300,7 +2344,7 @@ static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_ProviderContext
     &OsConfigResource_TestTargetResource_ProviderContext_Out_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_TestTargetResource_ProviderContext_Description_qual_value = MI_T("24");
+static MI_CONST MI_Char* OsConfigResource_TestTargetResource_ProviderContext_Description_qual_value = MI_T("25");
 
 static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_ProviderContext_Description_qual =
 {
@@ -2340,7 +2384,7 @@ static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_MIReturn_Static
     &OsConfigResource_TestTargetResource_MIReturn_Static_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_TestTargetResource_MIReturn_Description_qual_value = MI_T("22");
+static MI_CONST MI_Char* OsConfigResource_TestTargetResource_MIReturn_Description_qual_value = MI_T("23");
 
 static MI_CONST MI_Qualifier OsConfigResource_TestTargetResource_MIReturn_Description_qual =
 {
@@ -2407,7 +2451,7 @@ static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_Static_qual =
     &OsConfigResource_SetTargetResource_Static_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_SetTargetResource_Description_qual_value = MI_T("25");
+static MI_CONST MI_Char* OsConfigResource_SetTargetResource_Description_qual_value = MI_T("26");
 
 static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_Description_qual =
 {
@@ -2443,7 +2487,7 @@ static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_InputResource_Em
     &OsConfigResource_SetTargetResource_InputResource_EmbeddedInstance_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_SetTargetResource_InputResource_Description_qual_value = MI_T("19");
+static MI_CONST MI_Char* OsConfigResource_SetTargetResource_InputResource_Description_qual_value = MI_T("20");
 
 static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_InputResource_Description_qual =
 {
@@ -2484,7 +2528,7 @@ static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_ProviderContext_
     &OsConfigResource_SetTargetResource_ProviderContext_In_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_SetTargetResource_ProviderContext_Description_qual_value = MI_T("24");
+static MI_CONST MI_Char* OsConfigResource_SetTargetResource_ProviderContext_Description_qual_value = MI_T("25");
 
 static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_ProviderContext_Description_qual =
 {
@@ -2524,7 +2568,7 @@ static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_Flags_In_qual =
     &OsConfigResource_SetTargetResource_Flags_In_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_SetTargetResource_Flags_Description_qual_value = MI_T("20");
+static MI_CONST MI_Char* OsConfigResource_SetTargetResource_Flags_Description_qual_value = MI_T("21");
 
 static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_Flags_Description_qual =
 {
@@ -2564,7 +2608,7 @@ static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_MIReturn_Static_
     &OsConfigResource_SetTargetResource_MIReturn_Static_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_SetTargetResource_MIReturn_Description_qual_value = MI_T("25");
+static MI_CONST MI_Char* OsConfigResource_SetTargetResource_MIReturn_Description_qual_value = MI_T("26");
 
 static MI_CONST MI_Qualifier OsConfigResource_SetTargetResource_MIReturn_Description_qual =
 {
@@ -2655,7 +2699,7 @@ static MI_CONST MI_Qualifier OsConfigResource_Description_qual =
     &OsConfigResource_Description_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_ClassVersion_qual_value = MI_T("1.0.0");
+static MI_CONST MI_Char* OsConfigResource_ClassVersion_qual_value = MI_T("2.0.0");
 
 static MI_CONST MI_Qualifier OsConfigResource_ClassVersion_qual =
 {

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -97,6 +97,8 @@ int FindTextInFolder(const char* directory, const char* text, void* log);
 int CheckLineNotFoundOrCommentedOut(const char* fileName, char commentMark, const char* text, void* log);
 int FindTextInCommandOutput(const char* command, const char* text, char** reason, void* log);
 
+int CheckLockoutForFailedPasswordAttempts(const char* fileName, void* log);
+
 char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, void* log);
 int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, void* log);
 

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -97,15 +97,6 @@ int FindTextInFolder(const char* directory, const char* text, void* log);
 int CheckLineNotFoundOrCommentedOut(const char* fileName, char commentMark, const char* text, void* log);
 int FindTextInCommandOutput(const char* command, const char* text, char** reason, void* log);
 
-int CheckLockoutForFailedPasswordAttempts(const char* fileName, void* log);
-int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int numberOfMacs, char** reason, void* log);
-int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCiphers, char** reason, void* log);
-int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** actualValue, char** reason, void* log);
-int CheckSshClientAliveInterval(char** reason, void* log);
-int CheckSshLoginGraceTime(char** reason, void* log);
-int SetSshOption(const char* option, const char* value, void* log);
-int SetSshWarningBanner(unsigned int desiredBannerFileAccess, const char* bannerText, void* log);
-
 char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, void* log);
 int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, void* log);
 

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -34,6 +34,8 @@
     }\
 }\
 
+#define PLAIN_STATUS_FROM_ERRNO(a) ((0 == a) ? "passed" : "failed")
+
 // Linefeed (LF) ASCII character
 #ifndef EOL
 #define EOL 10

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -283,6 +283,12 @@ static int CheckAccess(bool directory, const char* name, int desiredOwnerId, int
                     }
                     
                     result = 0;
+
+                    if (reason)
+                    {
+                        FREE_MEMORY(*reason);
+                        *reason = FormatAllocateString("PASSAccess to '%s' matches required %d", name, desiredMode)
+                    }
                 }
             }
         }
@@ -295,6 +301,12 @@ static int CheckAccess(bool directory, const char* name, int desiredOwnerId, int
     {
         OsConfigLogInfo(log, "CheckAccess: '%s' not found, nothing to check", name);
         result = 0;
+
+        if (reason)
+        {
+            FREE_MEMORY(*reason);
+            *reason = FormatAllocateString("PASS'%s' not found, nothing to check", name)
+        }
     }
 
     return result;

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -287,7 +287,8 @@ static int CheckAccess(bool directory, const char* name, int desiredOwnerId, int
                     if (reason)
                     {
                         FREE_MEMORY(*reason);
-                        *reason = FormatAllocateString("PASSAccess to '%s' matches required %d", name, desiredMode);
+                        *reason = FormatAllocateString("%sAccess to '%s' matches required access (%d) and ownership (UID: %d, GID: %u)", 
+                            SECURITY_AUDIT_PASS, name, desiredMode, desiredOwnerId, desiredGroupId);
                     }
                 }
             }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -287,7 +287,7 @@ static int CheckAccess(bool directory, const char* name, int desiredOwnerId, int
                     if (reason)
                     {
                         FREE_MEMORY(*reason);
-                        *reason = FormatAllocateString("PASSAccess to '%s' matches required %d", name, desiredMode)
+                        *reason = FormatAllocateString("PASSAccess to '%s' matches required %d", name, desiredMode);
                     }
                 }
             }
@@ -305,7 +305,7 @@ static int CheckAccess(bool directory, const char* name, int desiredOwnerId, int
         if (reason)
         {
             FREE_MEMORY(*reason);
-            *reason = FormatAllocateString("PASS'%s' not found, nothing to check", name)
+            *reason = FormatAllocateString("PASS'%s' not found, nothing to check", name);
         }
     }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -306,7 +306,7 @@ static int CheckAccess(bool directory, const char* name, int desiredOwnerId, int
         if (reason)
         {
             FREE_MEMORY(*reason);
-            *reason = FormatAllocateString("PASS'%s' not found, nothing to check", name);
+            *reason = FormatAllocateString("%s'%s' not found, nothing to check", SECURITY_AUDIT_PASS, name);
         }
     }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1196,7 +1196,7 @@ int CheckLockoutForFailedPasswordAttempts(const char* fileName, void* log)
         }
     }
 
-    OsConfigLogInfo(log, "CheckLockoutForFailedPasswordAttempts: %s (%d)", status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "CheckLockoutForFailedPasswordAttempts: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }

--- a/src/common/commonutils/Internal.h
+++ b/src/common/commonutils/Internal.h
@@ -28,6 +28,8 @@
 #include <Logging.h>
 #include <CommonUtils.h>
 
+#define SECURITY_AUDIT_PASS "PASS"
+
 #if ((__GLIBC__ == 2) && (__GLIBC_MINOR__ < 30))
 #include <sys/syscall.h>
 #define gettid() syscall(SYS_gettid)

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -138,6 +138,12 @@ int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int number
         }
     }
 
+    if ((0 == status) && reason)
+    {
+        FREE_MEMORY(*reason);
+        *reason = FormatAllocateString("PASSThe SSH Server response contains all approved MAC algorithms '%s'", macsValue);
+    }
+
     FREE_MEMORY(macsValue);
 
     OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: %s (%d)", status ? "failed" : "passed", status);
@@ -228,6 +234,12 @@ int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCip
         }
     }
 
+    if ((0 == status) && reason)
+    {
+        FREE_MEMORY(*reason);
+        *reason = FormatAllocateString("PASSThe SSH Server response contains only the approved ciphers '%s'", ciphersValue);
+    }
+
     FREE_MEMORY(ciphersValue);
 
     OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh: %s (%d)", status ? "failed" : "passed", status);
@@ -266,6 +278,12 @@ int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** ac
         if (NULL != actualValue)
         {
             *actualValue = DuplicateString(value);
+        }
+
+        if ((0 == status) && reason)
+        {
+            FREE_MEMORY(*reason);
+            *reason = FormatAllocateString("PASS'%s' is set to '%s' in SSH Server response", option, value);
         }
 
         FREE_MEMORY(value);
@@ -312,6 +330,11 @@ int CheckSshClientAliveInterval(char** reason, void* log)
             "%s, also 'clientaliveinterval' is not set to a greater than zero value in SSH Server response (but to %d)", actualValue);
         status = ENOENT;
     }
+    else if (reason)
+    {
+        FREE_MEMORY(*reason);
+        *reason = FormatAllocateString("PASS'clientaliveinterval' is set to %d (greater than zero) in SSH Server response", actualValue);
+    }
 
     OsConfigLogInfo(log, "CheckSshClientAliveInterval: %s (%d)", status ? "failed" : "passed", status);
 
@@ -330,6 +353,11 @@ int CheckSshLoginGraceTime(char** reason, void* log)
         OsConfigCaptureReason(reason, "'logingracetime' is not set to a value of 60 or less in SSH Server response (but to %d)",
             "%s, also 'logingracetime' is not set to a value of 60 or less in SSH Server response (but to %d)", actualValue);
         status = ENOENT;
+    }
+    else if (reason)
+    {
+        FREE_MEMORY(*reason);
+        *reason = FormatAllocateString("PASS'logingracetime' is set to %d (that is 60 or less) in SSH Server response", actualValue);
     }
 
     OsConfigLogInfo(log, "CheckSshLoginGraceTime: %s (%d)", status ? "failed" : "passed", status);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -141,7 +141,7 @@ int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int number
     if ((0 == status) && reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASSThe SSH Server response contains all approved MAC algorithms '%s'", macsValue);
+        *reason = FormatAllocateString("PASSThe SSH Server response contains all approved MAC algorithms: '%s'", macsValue);
     }
 
     FREE_MEMORY(macsValue);
@@ -237,7 +237,7 @@ int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCip
     if ((0 == status) && reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASSThe SSH Server response contains only the approved ciphers '%s'", ciphersValue);
+        *reason = FormatAllocateString("PASSThe SSH Server response contains only the approved ciphers: '%s'", ciphersValue);
     }
 
     FREE_MEMORY(ciphersValue);
@@ -283,7 +283,7 @@ int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** ac
         if ((0 == status) && reason)
         {
             FREE_MEMORY(*reason);
-            *reason = FormatAllocateString("PASS'%s' is set to '%s' in SSH Server response", option, value);
+            *reason = FormatAllocateString("PASS'%s' is set to '%s' in the SSH Server response", option, value);
         }
 
         FREE_MEMORY(value);
@@ -333,7 +333,7 @@ int CheckSshClientAliveInterval(char** reason, void* log)
     else if (reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASS'clientaliveinterval' is set to %d (greater than zero) in SSH Server response", actualValue);
+        *reason = FormatAllocateString("PASS'clientaliveinterval' is set to %d (greater than zero) in the SSH Server response", actualValue);
     }
 
     OsConfigLogInfo(log, "CheckSshClientAliveInterval: %s (%d)", status ? "failed" : "passed", status);
@@ -357,7 +357,7 @@ int CheckSshLoginGraceTime(char** reason, void* log)
     else if (reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASS'logingracetime' is set to %d (that is 60 or less) in SSH Server response", actualValue);
+        *reason = FormatAllocateString("PASS'logingracetime' is set to %d (60 or less) in the SSH Server response", actualValue);
     }
 
     OsConfigLogInfo(log, "CheckSshLoginGraceTime: %s (%d)", status ? "failed" : "passed", status);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "Internal.h"
+#include "SshUtils.h"
 
 static const char* g_sshServerService = "sshd";
 static const char* g_sshServerConfiguration = "/etc/ssh/sshd_config";
@@ -300,10 +301,11 @@ static int CheckSshOptionIsSetToInteger(const char* option, int* expectedValue, 
 
 int CheckSshClientAliveInterval(char** reason, void* log)
 {
+    const char* clientAliveInterval = "clientaliveinterval";
     int actualValue = 0;
-    int status = CheckSshOptionIsSetToInteger("clientaliveinterval", NULL, &actualValue, reason, log);
+    int status = 0; 
     
-    if ((0 == IsSshServerActive(log)) && (actualValue <= 0))
+    if ((0 == (status = CheckSshOptionIsSetToInteger(clientAliveInterval, NULL, &actualValue, reason, log))) && (actualValue <= 0))
     {
         OsConfigLogError(log, "CheckSshClientAliveInterval: 'clientaliveinterval' is not set to a greater than zero value in SSH Server response (but to %d)", actualValue);
         OsConfigCaptureReason(reason, "'clientaliveinterval' is not set to a greater than zero value in SSH Server response (but to %d)",
@@ -318,10 +320,11 @@ int CheckSshClientAliveInterval(char** reason, void* log)
 
 int CheckSshLoginGraceTime(char** reason, void* log)
 {
+    const char* loginGraceTime = "logingracetime";
     int actualValue = 0;
-    int status = CheckSshOptionIsSetToInteger("logingracetime", NULL, &actualValue, reason, log);
+    int status = 0; 
 
-    if ((0 == IsSshServerActive(log)) && (actualValue > 60))
+    if ((0 == (status = CheckSshOptionIsSetToInteger(loginGraceTime, NULL, &actualValue, reason, log))) && (actualValue > 60))
     {
         OsConfigLogError(log, "CheckSshLoginGraceTime: 'logingracetime' is not set to 60 or less in SSH Server response (but to %d)", actualValue);
         OsConfigCaptureReason(reason, "'logingracetime' is not set to a value of 60 or less in SSH Server response (but to %d)",

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -141,7 +141,8 @@ int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int number
     if ((0 == status) && reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASSThe SSH Server response contains all approved MAC algorithms: '%s'", macsValue);
+        *reason = FormatAllocateString("%sThe %s service reports that '%s' is set to '%s' (all approved MAC algorithms)", 
+            SECURITY_AUDIT_PASS, g_sshServerService, sshMacs, macsValue);
     }
 
     FREE_MEMORY(macsValue);
@@ -237,7 +238,8 @@ int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCip
     if ((0 == status) && reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASSThe SSH Server response contains only the approved ciphers: '%s'", ciphersValue);
+        *reason = FormatAllocateString("%sThe %s service reports that '%s' is set to '%s' (only approved ciphers)",
+            SECURITY_AUDIT_PASS, g_sshServerService, sshCiphers, ciphersValue);
     }
 
     FREE_MEMORY(ciphersValue);
@@ -283,7 +285,7 @@ int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** ac
         if ((0 == status) && reason)
         {
             FREE_MEMORY(*reason);
-            *reason = FormatAllocateString("PASS'%s' is set to '%s' in the SSH Server response", option, value);
+            *reason = FormatAllocateString("%sThe %s service reports that '%s' is set to '%s'", SECURITY_AUDIT_PASS, g_sshServerService, option, value);
         }
 
         FREE_MEMORY(value);
@@ -333,7 +335,8 @@ int CheckSshClientAliveInterval(char** reason, void* log)
     else if (reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASS'clientaliveinterval' is set to %d (greater than zero) in the SSH Server response", actualValue);
+        *reason = FormatAllocateString("%sThe %s service reports that '%s' is set to '%d' (that is greater than zero)", 
+            SECURITY_AUDIT_PASS, g_sshServerService, clientAliveInterval, actualValue);
     }
 
     OsConfigLogInfo(log, "CheckSshClientAliveInterval: %s (%d)", status ? "failed" : "passed", status);
@@ -357,7 +360,8 @@ int CheckSshLoginGraceTime(char** reason, void* log)
     else if (reason)
     {
         FREE_MEMORY(*reason);
-        *reason = FormatAllocateString("PASS'logingracetime' is set to %d (60 or less) in the SSH Server response", actualValue);
+        *reason = FormatAllocateString("%sThe %s service reports that '%s' is set to '%d' (that is 60 or less)", 
+            SECURITY_AUDIT_PASS, g_sshServerService, loginGraceTime, actualValue);
     }
 
     OsConfigLogInfo(log, "CheckSshLoginGraceTime: %s (%d)", status ? "failed" : "passed", status);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -147,7 +147,7 @@ int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int number
 
     FREE_MEMORY(macsValue);
 
-    OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: %s (%d)", status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }
@@ -244,7 +244,7 @@ int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCip
 
     FREE_MEMORY(ciphersValue);
 
-    OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh: %s (%d)", status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }
@@ -297,7 +297,7 @@ int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** ac
         status = ENOENT;
     }
 
-    OsConfigLogInfo(log, "CheckSshOptionIsSet: %s (%d)", status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "CheckSshOptionIsSet: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }
@@ -339,7 +339,7 @@ int CheckSshClientAliveInterval(char** reason, void* log)
             SECURITY_AUDIT_PASS, g_sshServerService, clientAliveInterval, actualValue);
     }
 
-    OsConfigLogInfo(log, "CheckSshClientAliveInterval: %s (%d)", status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "CheckSshClientAliveInterval: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }
@@ -364,7 +364,7 @@ int CheckSshLoginGraceTime(char** reason, void* log)
             SECURITY_AUDIT_PASS, g_sshServerService, loginGraceTime, actualValue);
     }
 
-    OsConfigLogInfo(log, "CheckSshLoginGraceTime: %s (%d)", status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "CheckSshLoginGraceTime: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }
@@ -420,7 +420,7 @@ int SetSshOption(const char* option, const char* value, void* log)
     FREE_MEMORY(commandResult);
     FREE_MEMORY(command);
 
-    OsConfigLogInfo(log, "SetSshOption('%s' to '%s'): %s (%d)", option, value, status ? "failed" : "passed", status);
+    OsConfigLogInfo(log, "SetSshOption('%s' to '%s'): %s (%d)", option, value, PLAIN_STATUS_FROM_ERRNO(status), status);
 
     return status;
 }

--- a/src/common/commonutils/SshUtils.h
+++ b/src/common/commonutils/SshUtils.h
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMMONUTILS_H
+#define COMMONUTILS_H
+
+// Include CommonUtils.h in the target source before including this header
+
+#define OPEN_SSH_SSHD "sshd"
+#define OPEN_SSH_ETC_SSH_SSHD_CONFIG "/etc/ssh/sshd_config"
+#define OPEN_SSH_SSHD_T "sshd -T"
+#define OPEN_SSH_CONFIG_PROTOCOL "Protocol"
+#define OPEN_SSH_CONFIG_IGNORE_HOSTS "IgnoreRhosts"
+#define OPEN_SSH_CONFIG_LOG_LEVEL "LogLevel"
+#define OPEN_SSH_CONFIG_MAX_AUTH_TRIES "MaxAuthTries"
+#define OPEN_SSH_CONFIG_ALLOW_USERS "AllowUsers"
+#define OPEN_SSH_CONFIG_DENY_USERS "DenyUsers"
+#define OPEN_SSH_CONFIG_ALLOW_GROUPS "AllowGroups"
+#define OPEN_SSH_CONFIG_DENY_GROUPS "DenyGroups"
+#define OPEN_SSH_CONFIG_HOST_BASED_AUTH "HostBasedAuthentication"
+#define OPEN_SSH_CONFIG_PERMIT_ROOT_LOGIN "PermitRootLogin"
+#define OPEN_SSH_CONFIG_PERMIT_EMPTY_PASSWORDS "PermitEmptyPasswords"
+#define OPEN_SSH_CONFIG_CLIENT_ALIVE_COUNT_MAX "ClientAliveCountMax"
+#define OPEN_SSH_CONFIG_CLIENT_ALIVE_INTERVAL "ClientAliveInterval"
+#define OPEN_SSH_CONFIG_LOGIN_GRACE_TIME "LoginGraceTime"
+#define OPEN_SSH_CONFIG_MACS "MACs" 
+#define OPEN_SSH_CONFIG_PERMIT_USER_ENVIRONMENT "PermitUserEnvironment"
+#define OPEN_SSH_CONFIG_CIPHERS "Ciphers"
+#define OPEN_SSH_CONFIG_BANNER "Banner"
+
+#define OPEN_SSH_CONFIG_ROOT "root"
+#define OPEN_SSH_CONFIG_ALL_USERS "*@*"
+#define OPEN_SSH_CONFIG_ALL_GROUPS "*"
+#define OPEN_SSH_CONFIG_PROTOCOL_2 "Protocol 2"
+#define OPEN_SSH_CONFIG_DEFAULT_MAC_VALUES "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
+#define OPEN_SSH_CONFIG_DEFAULT_CIPHERS "aes128-ctr,aes192-ctr,aes256-ctr"
+
+#define OPEN_SSH_CONFIG_BANNER_TEXT \
+"#######################################################################\n\n"\
+"Authorized access only!\n\n"\
+"If you are not authorized to access or use this system, disconnect now!\n\n"\
+"#######################################################################\n"
+
+#define OPEN_SSHD_T_IGNORE_HOSTS "ignorerhosts"
+#define OPEN_SSHD_T_LOG_LEVEL "loglevel"
+#define OPEN_SSHD_T_INFO "INFO"
+#define OPEN_SSHD_T_MAX_AUTH_TRIES "maxauthtries"
+#define OPEN_SSHD_T_ALLOW_USERS "allowusers"
+#define OPEN_SSHD_T_DENY_USERS "denyusers"
+#define OPEN_SSHD_T_ALLOW_GROUPS "allowgroups"
+#define OPEN_SSHD_T_DENY_GROUPS "denygroups"
+#define OPEN_SSHD_T_HOST_BASED_AUTH "hostbasedauthentication"
+#define OPEN_SSHD_T_PERMIT_ROOT_LOGIN "permitrootlogin"
+#define OPEN_SSHD_T_PERMIT_EMPTY_PASSWORDS "permitemptypasswords"
+#define OPEN_SSHD_T_CLIENT_ALIVE_COUNT_MAX "clientalivecountmax"
+#define OPEN_SSHD_T_LOGIN_GRACE_TIME "logingracetime"
+#define OPEN_SSHD_T_CLIENT_ALIVE_INTERVAL "clientaliveinterval"
+#define OPEN_SSHD_T_MACS "macs"
+#define OPEN_SSHD_T_PERMIT_USER_ENVIRONMENT "permituserenvironment"
+#define OPEN_SSHD_T_CIPHERS "ciphers"
+#define OPEN_SSHD_T_BANNER "banner"
+
+#define OPEN_SSHD_T_YES "yes"
+#define OPEN_SSHD_T_NO "no"
+#define OPEN_SSHD_T_DEFAULT_BANNER_FILE "/etc/azsec/banner.txt"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int CheckLockoutForFailedPasswordAttempts(const char* fileName, void* log);
+int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int numberOfMacs, char** reason, void* log);
+int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCiphers, char** reason, void* log);
+int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** actualValue, char** reason, void* log);
+int CheckSshClientAliveInterval(char** reason, void* log);
+int CheckSshLoginGraceTime(char** reason, void* log);
+int SetSshOption(const char* option, const char* value, void* log);
+int SetSshWarningBanner(unsigned int desiredBannerFileAccess, const char* bannerText, void* log);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // COMMONUTILS_H

--- a/src/common/commonutils/SshUtils.h
+++ b/src/common/commonutils/SshUtils.h
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#ifndef COMMONUTILS_H
-#define COMMONUTILS_H
+#ifndef SSHUTILS_H
+#define SSHUTILS_H
 
 // Include CommonUtils.h in the target source before including this header
 
@@ -23,4 +23,4 @@ int SetSshWarningBanner(unsigned int desiredBannerFileAccess, const char* banner
 }
 #endif
 
-#endif // COMMONUTILS_H
+#endif // SSHUTILS_H

--- a/src/common/commonutils/SshUtils.h
+++ b/src/common/commonutils/SshUtils.h
@@ -6,64 +6,6 @@
 
 // Include CommonUtils.h in the target source before including this header
 
-#define OPEN_SSH_SSHD "sshd"
-#define OPEN_SSH_ETC_SSH_SSHD_CONFIG "/etc/ssh/sshd_config"
-#define OPEN_SSH_SSHD_T "sshd -T"
-#define OPEN_SSH_CONFIG_PROTOCOL "Protocol"
-#define OPEN_SSH_CONFIG_IGNORE_HOSTS "IgnoreRhosts"
-#define OPEN_SSH_CONFIG_LOG_LEVEL "LogLevel"
-#define OPEN_SSH_CONFIG_MAX_AUTH_TRIES "MaxAuthTries"
-#define OPEN_SSH_CONFIG_ALLOW_USERS "AllowUsers"
-#define OPEN_SSH_CONFIG_DENY_USERS "DenyUsers"
-#define OPEN_SSH_CONFIG_ALLOW_GROUPS "AllowGroups"
-#define OPEN_SSH_CONFIG_DENY_GROUPS "DenyGroups"
-#define OPEN_SSH_CONFIG_HOST_BASED_AUTH "HostBasedAuthentication"
-#define OPEN_SSH_CONFIG_PERMIT_ROOT_LOGIN "PermitRootLogin"
-#define OPEN_SSH_CONFIG_PERMIT_EMPTY_PASSWORDS "PermitEmptyPasswords"
-#define OPEN_SSH_CONFIG_CLIENT_ALIVE_COUNT_MAX "ClientAliveCountMax"
-#define OPEN_SSH_CONFIG_CLIENT_ALIVE_INTERVAL "ClientAliveInterval"
-#define OPEN_SSH_CONFIG_LOGIN_GRACE_TIME "LoginGraceTime"
-#define OPEN_SSH_CONFIG_MACS "MACs" 
-#define OPEN_SSH_CONFIG_PERMIT_USER_ENVIRONMENT "PermitUserEnvironment"
-#define OPEN_SSH_CONFIG_CIPHERS "Ciphers"
-#define OPEN_SSH_CONFIG_BANNER "Banner"
-
-#define OPEN_SSH_CONFIG_ROOT "root"
-#define OPEN_SSH_CONFIG_ALL_USERS "*@*"
-#define OPEN_SSH_CONFIG_ALL_GROUPS "*"
-#define OPEN_SSH_CONFIG_PROTOCOL_2 "Protocol 2"
-#define OPEN_SSH_CONFIG_DEFAULT_MAC_VALUES "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
-#define OPEN_SSH_CONFIG_DEFAULT_CIPHERS "aes128-ctr,aes192-ctr,aes256-ctr"
-
-#define OPEN_SSH_CONFIG_BANNER_TEXT \
-"#######################################################################\n\n"\
-"Authorized access only!\n\n"\
-"If you are not authorized to access or use this system, disconnect now!\n\n"\
-"#######################################################################\n"
-
-#define OPEN_SSHD_T_IGNORE_HOSTS "ignorerhosts"
-#define OPEN_SSHD_T_LOG_LEVEL "loglevel"
-#define OPEN_SSHD_T_INFO "INFO"
-#define OPEN_SSHD_T_MAX_AUTH_TRIES "maxauthtries"
-#define OPEN_SSHD_T_ALLOW_USERS "allowusers"
-#define OPEN_SSHD_T_DENY_USERS "denyusers"
-#define OPEN_SSHD_T_ALLOW_GROUPS "allowgroups"
-#define OPEN_SSHD_T_DENY_GROUPS "denygroups"
-#define OPEN_SSHD_T_HOST_BASED_AUTH "hostbasedauthentication"
-#define OPEN_SSHD_T_PERMIT_ROOT_LOGIN "permitrootlogin"
-#define OPEN_SSHD_T_PERMIT_EMPTY_PASSWORDS "permitemptypasswords"
-#define OPEN_SSHD_T_CLIENT_ALIVE_COUNT_MAX "clientalivecountmax"
-#define OPEN_SSHD_T_LOGIN_GRACE_TIME "logingracetime"
-#define OPEN_SSHD_T_CLIENT_ALIVE_INTERVAL "clientaliveinterval"
-#define OPEN_SSHD_T_MACS "macs"
-#define OPEN_SSHD_T_PERMIT_USER_ENVIRONMENT "permituserenvironment"
-#define OPEN_SSHD_T_CIPHERS "ciphers"
-#define OPEN_SSHD_T_BANNER "banner"
-
-#define OPEN_SSHD_T_YES "yes"
-#define OPEN_SSHD_T_NO "no"
-#define OPEN_SSHD_T_DEFAULT_BANNER_FILE "/etc/azsec/banner.txt"
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/common/commonutils/SshUtils.h
+++ b/src/common/commonutils/SshUtils.h
@@ -11,7 +11,6 @@ extern "C"
 {
 #endif
 
-int CheckLockoutForFailedPasswordAttempts(const char* fileName, void* log);
 int CheckOnlyApprovedMacAlgorithmsAreUsed(const char** macs, unsigned int numberOfMacs, char** reason, void* log);
 int CheckAppropriateCiphersForSsh(const char** ciphers, unsigned int numberOfCiphers, char** reason, void* log);
 int CheckSshOptionIsSet(const char* option, const char* expectedValue, char** actualValue, char** reason, void* log);

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <CommonUtils.h>
 #include <UserUtils.h>
+#include <SshUtils.h>
 
 using namespace std;
 

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1624,7 +1624,7 @@ static char* AuditEnsureSmbWithSambaIsDisabled(void)
     return (CheckPackageInstalled("samba", SecurityBaselineGetLog()) || 
         ((EEXIST == CheckLineNotFoundOrCommentedOut(etcSambaConf, '#', minProtocol, SecurityBaselineGetLog())) &&
         (EEXIST == CheckLineNotFoundOrCommentedOut(etcSambaConf, ';', minProtocol, SecurityBaselineGetLog())))) ? DuplicateString(g_pass) : 
-        FormatAllocateString("Package 'samba' is not installed or '%s' is not found in %s", minProtocol);
+        FormatAllocateString("Package 'samba' is not installed or '%s' is not found in %s", minProtocol, etcSambaConf);
 }
 
 static char* AuditEnsureUsersDotFilesArentGroupOrWorldWritable(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1500,8 +1500,8 @@ static char* AuditEnsureSshWarningBannerIsEnabled(void)
 
 static char* AuditEnsureUsersCannotSetSshEnvironmentOptions(void)
 {
-    return CheckLineNotFoundOrCommentedOut(g_etcSshSshdConfig, '#', "PermitUserEnvironment yes", SecurityBaselineGetLog()) ? 
-        FormatAllocateString("'PermitUserEnvironment yes' is not found uncommented with '#' in %s", g_etcSshSshdConfig) : DuplicateString(g_pass);
+    char* reason = NULL;
+    return CheckSshOptionIsSet("permituserenvironment", "yes", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
 }
 
 static char* AuditEnsureAppropriateCiphersForSsh(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -10,6 +10,7 @@
 #include <parson.h>
 #include <CommonUtils.h>
 #include <UserUtils.h>
+#include <SshUtils.h>
 #include <Logging.h>
 #include <Mmi.h>
 

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1404,26 +1404,30 @@ static char* AuditEnsureAtCronIsRestrictedToAuthorizedUsers(void)
 static char* AuditEnsureSshBestPracticeProtocol(void)
 {
     return ((EEXIST == CheckFileExists(g_etcSshSshdConfig, SecurityBaselineGetLog())) ||
-        (EEXIST == CheckLineNotFoundOrCommentedOut(g_etcSshSshdConfig, '#', "Protocol 2", SecurityBaselineGetLog()))) ? DuplicateString(g_pass) : 
+        (EEXIST == CheckLineNotFoundOrCommentedOut(g_etcSshSshdConfig, '#', "Protocol 2", SecurityBaselineGetLog()))) ? 
+        FormatAllocateString("PASS'Protocol 2' is uncommented in %s", g_etcSshSshdConfig) : 
         FormatAllocateString("'Protocol 2' is not found uncommented with '#' in %s", g_etcSshSshdConfig);
 }
 
 static char* AuditEnsureSshBestPracticeIgnoreRhosts(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("ignorerhosts", "yes", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("ignorerhosts", "yes", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshLogLevelIsSet(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("loglevel", "INFO", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("loglevel", "INFO", NULL, &reason, SecurityBaselineGetLog()); 
+    return reason;
 }
 
 static char* AuditEnsureSshMaxAuthTriesIsSet(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("maxauthtries", "6", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("maxauthtries", "6", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureAllowUsersIsConfigured(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1502,7 +1502,7 @@ static char* AuditEnsureSshWarningBannerIsEnabled(void)
 static char* AuditEnsureUsersCannotSetSshEnvironmentOptions(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("permituserenvironment", "yes", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    return CheckSshOptionIsSet("permituserenvironment", "no", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
 }
 
 static char* AuditEnsureAppropriateCiphersForSsh(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -514,7 +514,8 @@ static char* AuditEnsurePermissionsOnEtcHostsDeny(void)
 static char* AuditEnsurePermissionsOnEtcSshSshdConfig(void)
 {
     char* reason = NULL;
-    return CheckFileAccess(g_etcSshSshdConfig, 0, 0, 600, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckFileAccess(g_etcSshSshdConfig, 0, 0, 600, &reason, SecurityBaselineGetLog());
+    return reason;
 };
 
 static char* AuditEnsurePermissionsOnEtcShadow(void)
@@ -1405,7 +1406,7 @@ static char* AuditEnsureSshBestPracticeProtocol(void)
 {
     return ((EEXIST == CheckFileExists(g_etcSshSshdConfig, SecurityBaselineGetLog())) ||
         (EEXIST == CheckLineNotFoundOrCommentedOut(g_etcSshSshdConfig, '#', "Protocol 2", SecurityBaselineGetLog()))) ? 
-        FormatAllocateString("PASS'Protocol 2' is uncommented in %s", g_etcSshSshdConfig) : 
+        FormatAllocateString("PASS'Protocol 2' is found uncommented in %s", g_etcSshSshdConfig) : 
         FormatAllocateString("'Protocol 2' is not found uncommented with '#' in %s", g_etcSshSshdConfig);
 }
 
@@ -1433,87 +1434,101 @@ static char* AuditEnsureSshMaxAuthTriesIsSet(void)
 static char* AuditEnsureAllowUsersIsConfigured(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("allowusers", NULL, NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("allowusers", NULL, NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureDenyUsersIsConfigured(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("denyusers", NULL, NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("denyusers", NULL, NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureAllowGroupsIsConfigured(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("allowgroups", NULL, NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("allowgroups", NULL, NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureDenyGroupsConfigured(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("denygroups", NULL, NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("denygroups", NULL, NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshHostbasedAuthenticationIsDisabled(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("hostbasedauthentication", "no", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("hostbasedauthentication", "no", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshPermitRootLoginIsDisabled(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("permitrootlogin", "no", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("permitrootlogin", "no", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshPermitEmptyPasswordsIsDisabled(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("permitemptypasswords", "no", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("permitemptypasswords", "no", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshClientIntervalCountMaxIsConfigured(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("clientalivecountmax", "0", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("clientalivecountmax", "0", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshClientAliveIntervalIsConfigured(void)
 {
     char* reason = NULL;
-    return CheckSshClientAliveInterval(&reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshClientAliveInterval(&reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshLoginGraceTimeIsSet(void)
 {
     char* reason = NULL;
-    return CheckSshLoginGraceTime(&reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshLoginGraceTime(&reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureOnlyApprovedMacAlgorithmsAreUsed(void)
 {
     const char* macs[] = {"hmac-sha2-256", "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512", "hmac-sha2-512-etm@openssh.com"};
     char* reason = NULL;
-    return CheckOnlyApprovedMacAlgorithmsAreUsed(macs, ARRAY_SIZE(macs), &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckOnlyApprovedMacAlgorithmsAreUsed(macs, ARRAY_SIZE(macs), &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureSshWarningBannerIsEnabled(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("banner", "/etc/azsec/banner.txt", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("banner", "/etc/azsec/banner.txt", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureUsersCannotSetSshEnvironmentOptions(void)
 {
     char* reason = NULL;
-    return CheckSshOptionIsSet("permituserenvironment", "no", NULL, &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckSshOptionIsSet("permituserenvironment", "no", NULL, &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureAppropriateCiphersForSsh(void)
 {
     const char* ciphers[] = {"aes128-ctr", "aes192-ctr", "aes256-ctr"};
     char* reason = NULL;
-    return CheckAppropriateCiphersForSsh(ciphers, ARRAY_SIZE(ciphers), &reason, SecurityBaselineGetLog()) ? reason : DuplicateString(g_pass);
+    CheckAppropriateCiphersForSsh(ciphers, ARRAY_SIZE(ciphers), &reason, SecurityBaselineGetLog());
+    return reason;
 }
 
 static char* AuditEnsureAvahiDaemonServiceIsDisabled(void)

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -895,8 +895,7 @@
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsurePermissionsOnEtcSshSshdConfig",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsurePermissionsOnEtcSshSshdConfig"
   },
   {
     "ObjectType": "Reported",
@@ -1639,104 +1638,87 @@
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshBestPracticeProtocol",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshBestPracticeProtocol"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshBestPracticeIgnoreRhosts",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshBestPracticeIgnoreRhosts"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshLogLevelIsSet",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshLogLevelIsSet"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshMaxAuthTriesIsSet",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshMaxAuthTriesIsSet"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAllowUsersIsConfigured",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureAllowUsersIsConfigured"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureDenyUsersIsConfigured",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureDenyUsersIsConfigured"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAllowGroupsIsConfigured",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureAllowGroupsIsConfigured"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureDenyGroupsConfigured",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureDenyGroupsConfigured"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshHostbasedAuthenticationIsDisabled",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshHostbasedAuthenticationIsDisabled"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshPermitRootLoginIsDisabled",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshPermitRootLoginIsDisabled"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshPermitEmptyPasswordsIsDisabled",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshPermitEmptyPasswordsIsDisabled"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshClientIntervalCountMaxIsConfigured",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshClientIntervalCountMaxIsConfigured"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshLoginGraceTimeIsSet",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshLoginGraceTimeIsSet"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureOnlyApprovedMacAlgorithmsAreUsed",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureOnlyApprovedMacAlgorithmsAreUsed"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureSshWarningBannerIsEnabled",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureSshWarningBannerIsEnabled"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureUsersCannotSetSshEnvironmentOptions",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureUsersCannotSetSshEnvironmentOptions"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAppropriateCiphersForSsh",
-    "Payload": "PASS"
+    "ObjectName": "auditEnsureAppropriateCiphersForSsh"
   },
   {
     "ObjectType": "Reported",


### PR DESCRIPTION
The SecurityBaseline MIM has reported and desired simple MIM objects (containing one string MIM setting each) for each audit and respectively remediation check. For the desired objects, that string will be used to specify desired values at run time for audit and remediation. For the reported objects, the original requirement was for them to return something simple, stating audit passed of failed, thus the "PASS" and "FAIL". Since then the reported strings have been repurposed to hold reason phrases for failed audits (and when the NRP sees they are not "PASS", considers that audit failed with the stated reason). In this PR the reported strings for the passed audits are expanded with the reason following the "PASS" prefix (which is not included in the reported reason).

The Universal NRP original design for checking audit was to compare the reported value against the desired value.  That blocks the desired values for exact match to reported. To support  parameter customization, a new class paremeter is added, the expected value, which holds the value to be compared with the first characters of the reported value, freeing the desired value to hold anything necessary.

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.