### PR TITLE
Added Ubuntu 22.04 Jammy amd64/arm64 to packaging workflows

### DIFF
--- a/.github/actions/footprint-check/action.yml
+++ b/.github/actions/footprint-check/action.yml
@@ -28,6 +28,7 @@ runs:
         case $distroName in
           ("ubuntu18.04") distroName="ubuntu-18.04";;
           ("ubuntu20.04") distroName="ubuntu-20.04";;
+          ("ubuntu22.04") distroName="ubuntu-22.04";;
           ("debian9")     distroName="debian-9";;
         esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, debian-10, debian-11]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
         arch: [arm, arm64, amd64]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
         arch: [arm, arm64, amd64]
+        exclude:
+          - target: { os: ubuntu, version: 22.04, dist: jammy }
+            arch: arm
+          - target: { os: ubuntu, version: 22.04, dist: jammy }
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,8 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
         arch: [arm, arm64, amd64]
         exclude:
-          - target: { os: ubuntu, version: 22.04, dist: jammy }
-            arch: arm
-          - target: { os: ubuntu, version: 22.04, dist: jammy }
-            arch: arm64
+          - target: { os: ubuntu-22.04, arch: arm }
+          - target: { os: ubuntu-22.04, version: arm64 }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
         arch: [arm, arm64, amd64]
         exclude:
-          - target: { os: ubuntu-22.04, arch: arm }
-          - target: { os: ubuntu-22.04, version: arm64 }
+          - os: ubuntu-22.04
+            arch: arm 
+          - os: ubuntu-22.04
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ubuntu-18.04, ubuntu-20.04, debian-10, debian-11]
+        target: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
         arch: [amd64]
     secrets:
       client_id: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -40,6 +40,11 @@ jobs:
             { os: debian, version: 11, dist: bullseye },
           ]
         arch: [arm, arm64, amd64]
+        exclude:
+          - target: { os: ubuntu, version: 22.04, dist: jammy }
+            arch: arm
+          - target: { os: ubuntu, version: 22.04, dist: jammy }
+            arch: arm64
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}

--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -3,6 +3,7 @@ name: Publish (insiders-fast)
 on:
   schedule:
     - cron: '0 8 * * *' # Every day at 8am UTC (12am PST)
+  workflow_dispatch:
 
 jobs:
   changes:

--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -34,6 +34,7 @@ jobs:
           [
             { os: ubuntu, version: 18.04, dist: bionic },
             { os: ubuntu, version: 20.04, dist: focal },
+            { os: ubuntu, version: 22.04, dist: jammy },
             { os: debian, version: 10, dist: buster },
             { os: debian, version: 11, dist: bullseye },
           ]

--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -43,8 +43,6 @@ jobs:
         exclude:
           - target: { os: ubuntu, version: 22.04, dist: jammy }
             arch: arm
-          - target: { os: ubuntu, version: 22.04, dist: jammy }
-            arch: arm64
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}

--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ubuntu-18.04, ubuntu-20.04, debian-10, debian-11]
+        target: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
         arch: [amd64]
     with:
       target: ${{ matrix.target }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -46,6 +46,11 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
+          name: ubuntu-22.04-signed
+          path: packages
+
+      - uses: actions/download-artifact@v3
+        with:
           name: debian-10-signed
           path: packages
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -23,8 +23,6 @@ jobs:
         exclude:
           - target: { os: ubuntu, version: 22.04, dist: jammy }
             arch: arm
-          - target: { os: ubuntu, version: 22.04, dist: jammy }
-            arch: arm64
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -15,6 +15,7 @@ jobs:
           [
             { os: ubuntu, version: 18.04, dist: bionic },
             { os: ubuntu, version: 20.04, dist: focal },
+            { os: ubuntu, version: 22.04, dist: jammy },
             { os: debian, version: 10, dist: buster },
             { os: debian, version: 11, dist: bullseye },
           ]

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -19,6 +19,11 @@ jobs:
             { os: debian, version: 11, dist: bullseye },
           ]
         arch: [arm, arm64, amd64]
+        exclude:
+          - target: { os: ubuntu, version: 22.04, dist: jammy }
+            arch: arm
+          - target: { os: ubuntu, version: 22.04, dist: jammy }
+            arch: arm64
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}


### PR DESCRIPTION
## Description

* Added Ubuntu 22.04 Jammy (amd64/arm64) to packaging workflows. Will now get published in `insiders-fast` and `prod` channels on packages.microsoft.com

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.