### PR TITLE
Making the SecurityBaseline module to accept initialization for the SSH policy audit checks

### DIFF
--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -233,6 +233,198 @@ void MI_CALL OsConfigResource_DeleteInstance(
     MI_Context_PostResult(context, MI_RESULT_NOT_SUPPORTED);
 }
 
+// Later we need to add a new member to the resource class, a string called InitObjectName. For now we'll deduct this here for just the SSH policy objects:
+static char* GetInitObjectNameFromDesiredObjectName(void)
+{
+    const char* initEnsurePermissionsOnEtcSshSshdConfigObject = "initEnsurePermissionsOnEtcSshSshdConfig";
+    const char* initEnsureSshBestPracticeProtocolObject = "initEnsureSshBestPracticeProtocol";
+    const char* initEnsureSshBestPracticeIgnoreRhostsObject = "initEnsureSshBestPracticeIgnoreRhosts";
+    const char* initEnsureSshLogLevelIsSetObject = "initEnsureSshLogLevelIsSet";
+    const char* initEnsureSshMaxAuthTriesIsSetObject = "initEnsureSshMaxAuthTriesIsSet";
+    const char* initEnsureAllowUsersIsConfiguredObject = "initEnsureAllowUsersIsConfigured";
+    const char* initEnsureDenyUsersIsConfiguredObject = "initEnsureDenyUsersIsConfigured";
+    const char* initEnsureAllowGroupsIsConfiguredObject = "initEnsureAllowGroupsIsConfigured";
+    const char* initEnsureDenyGroupsConfiguredObject = "initEnsureDenyGroupsConfigured";
+    const char* initEnsureSshHostbasedAuthenticationIsDisabledObject = "initEnsureSshHostbasedAuthenticationIsDisabled";
+    const char* initEnsureSshPermitRootLoginIsDisabledObject = "initEnsureSshPermitRootLoginIsDisabled";
+    const char* initEnsureSshPermitEmptyPasswordsIsDisabledObject = "initEnsureSshPermitEmptyPasswordsIsDisabled";
+    const char* initEnsureSshClientIntervalCountMaxIsConfiguredObject = "initEnsureSshClientIntervalCountMaxIsConfigured";
+    const char* initEnsureSshClientAliveIntervalIsConfiguredObject = "initEnsureSshClientAliveIntervalIsConfigured";
+    const char* initEnsureSshLoginGraceTimeIsSetObject = "initEnsureSshLoginGraceTimeIsSet";
+    const char* initEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "initEnsureOnlyApprovedMacAlgorithmsAreUsed";
+    const char* initEnsureSshWarningBannerIsEnabledObject = "initEnsureSshWarningBannerIsEnabled";
+    const char* initEnsureUsersCannotSetSshEnvironmentOptionsObject = "initEnsureUsersCannotSetSshEnvironmentOptions";
+    const char* initEnsureAppropriateCiphersForSshObject = "initEnsureAppropriateCiphersForSsh";
+    
+    char* result = NULL;
+
+    if (NULL == g_desiredObjectName)
+    {
+        return result;
+    }
+
+    if (0 == strcmp(g_desiredObjectName, g_remediateEnsurePermissionsOnEtcSshSshdConfigObject))
+    {
+        result = DuplicateString(initEnsurePermissionsOnEtcSshSshdConfigObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshBestPracticeProtocolObject))
+    {
+        result = DuplicateString(initEnsureSshBestPracticeProtocolObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshBestPracticeIgnoreRhostsObject))
+    {
+        result = DuplicateString(initEnsureSshBestPracticeIgnoreRhostsObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshLogLevelIsSetObject))
+    {
+        result = DuplicateString(g_initEnsureSshLogLevelIsSetObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshMaxAuthTriesIsSetObject))
+    {
+        result = DuplicateString(g_initEnsureSshMaxAuthTriesIsSetObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAllowUsersIsConfiguredObject))
+    {
+        result = DuplicateString(g_initEnsureAllowUsersIsConfiguredObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAllowUsersIsConfiguredObject))
+    {
+        result = DuplicateString(g_initEnsureAllowUsersIsConfiguredObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAllowGroupsIsConfiguredObject))
+    {
+        result = DuplicateString(g_initEnsureAllowGroupsIsConfiguredObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureDenyGroupsConfiguredObject))
+    {
+        result = DuplicateString(g_initEnsureDenyGroupsConfiguredObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshHostbasedAuthenticationIsDisabledObject))
+    {
+        result = DuplicateString(g_initEnsureSshHostbasedAuthenticationIsDisabledObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshPermitRootLoginIsDisabledObject))
+    {
+        result = DuplicateString(g_initEnsureSshPermitRootLoginIsDisabledObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshPermitEmptyPasswordsIsDisabledObject))
+    {
+        result = DuplicateString(g_initEnsureSshPermitEmptyPasswordsIsDisabledObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshClientIntervalCountMaxIsConfiguredObject))
+    {
+        result = DuplicateString(g_initEnsureSshClientIntervalCountMaxIsConfiguredObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshClientAliveIntervalIsConfiguredObject))
+    {
+        result = DuplicateString(g_initEnsureSshClientAliveIntervalIsConfiguredObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshLoginGraceTimeIsSetObject))
+    {
+        result = DuplicateString(g_initEnsureSshLoginGraceTimeIsSetObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject))
+    {
+        result = DuplicateString(g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshWarningBannerIsEnabledObject))
+    {
+        result = DuplicateString(g_initEnsureSshWarningBannerIsEnabledObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureUsersCannotSetSshEnvironmentOptionsObject))
+    {
+        result = DuplicateString(g_initEnsureUsersCannotSetSshEnvironmentOptionsObject);
+    }
+    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAppropriateCiphersForSshObject))
+    {
+        result = DuplicateString(g_initEnsureAppropriateCiphersForSshObject);
+    }
+
+    return result;
+}
+
+static MI_Result SetDesiredObjectValueToDevice(const char* who, char* objectName, MI_Context* context)
+{
+    char* payloadString = NULL;
+    int payloadSize = 0;
+
+    JSON_Value* jsonValue = NULL;
+    char* serializedValue = NULL;
+
+    MI_Result miResult = MI_RESULT_OK;
+    int mpiResult = MPI_OK;
+
+    if (NULL == g_mpiHandle)
+    {
+        LogError(context, miResult, GetLog(), "[%s] SetDesiredObjectValueToDevice(%s, %s) called outside of a valid MPI session", who, g_componentName, g_desiredObjectName);
+        return ENOENT;
+    }
+    else if ((NULL == objectName) || (NULL == g_desiredObjectValue)))
+    {
+        LogError(context, miResult, GetLog(), "[%s] SetDesiredObjectValueToDevice called with an invalid object name and/or desired object value", who);
+        return EINVAL;
+    }
+
+    if (NULL == (jsonValue = json_value_init_string(g_desiredObjectValue)))
+    {
+        miResult = MI_RESULT_FAILED;
+        mpiResult = ENOMEM;
+        LogError(context, miResult, GetLog(), "[%s] json_value_init_string('%s') failed", who, g_desiredObjectValue);
+    }
+    else if (NULL == (serializedValue = json_serialize_to_string(jsonValue)))
+    {
+        miResult = MI_RESULT_FAILED;
+        mpiResult = ENOMEM;
+        LogError(context, miResult, GetLog(), "[%s] json_serialize_to_string('%s') failed", who, g_desiredObjectValue);
+    }
+    else
+    {
+        payloadSize = (int)strlen(serializedValue);
+        if (NULL != (payloadString = malloc(payloadSize + 1)))
+        {
+            memset(payloadString, 0, payloadSize + 1);
+            memcpy(payloadString, serializedValue, payloadSize);
+
+            if (MPI_OK == (mpiResult = CallMpiSet(g_componentName, initObjectName, payloadString, payloadSize, GetLog())))
+            {
+                LogInfo(context, GetLog(), "[%s] CallMpiSet(%s, %s, '%.*s', %d) ok",
+                    who, g_componentName, g_desiredObjectName, payloadSize, payloadString, payloadSize);
+            }
+            else
+            {
+                miResult = MI_RESULT_FAILED;
+                LogError(context, miResult, GetLog(), "[%s] CallMpiSet(%s, %s, '%.*s', %d) failed with %d, miResult %d",
+                    who, g_componentName, g_desiredObjectName, payloadSize, payloadString, payloadSize, mpiResult, miResult);
+            }
+
+            FREE_MEMORY(payloadString);
+        }
+        else
+        {
+            miResult = MI_RESULT_FAILED;
+            mpiResult = ENOMEM;
+            LogError(context, miResult, GetLog(), "[%s] Failed to allocate %d bytes", who, payloadSize);
+        }
+    }
+
+    if (NULL != serializedValue)
+    {
+        json_free_serialized_string(serializedValue);
+    }
+
+    if (NULL != jsonValue)
+    {
+        json_value_free(jsonValue);
+    }
+
+    if (MPI_OK != mpiResult)
+    {
+        g_reportedMpiResult = mpiResult;
+    }
+
+    return miResult;
+}
+
 static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* context)
 {
     JSON_Value* jsonValue = NULL;
@@ -240,6 +432,7 @@ static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* c
     char* objectValue = NULL;
     int objectValueLength = 0;
     char* payloadString = NULL;
+    char* initObjectName = NULL;
     int mpiResult = MPI_OK;
     MI_Result miResult = MI_RESULT_OK;
 
@@ -250,7 +443,18 @@ static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* c
 
     if (NULL != g_mpiHandle)
     {
-        if (MPI_OK == (mpiResult = CallMpiGet(g_componentName, g_reportedObjectName, &objectValue, &objectValueLength, GetLog())))
+        if (NULL == (initObjectName = GetInitObjectNameFromDesiredObjectName()))
+        {
+            miResult = MI_RESULT_FAILED;
+            mpiResult = ENOMEM;
+            LogError(context, miResult, GetLog(), "[%s] Unsupported desired object name (%s)", who, g_desiredObjectName);
+        }
+        else if (MI_RESULT_OK != (miResult = SetDesiredObjectValueToDevice(who, initObjectName, context)))
+        {
+            mpiResult = ENOENT;
+            LogError(context, miResult, GetLog(), "[%s] Failed to initialize object (%s, %s) to '%s'", who, g_componentName, initObjectName, g_desiredObjectValue);
+        }
+        else if (MPI_OK == (mpiResult = CallMpiGet(g_componentName, g_reportedObjectName, &objectValue, &objectValueLength, GetLog())))
         {
             if (NULL == objectValue)
             {
@@ -992,62 +1196,7 @@ void MI_CALL OsConfigResource_Invoke_SetTargetResource(
 
     if (NULL != g_mpiHandle)
     {
-        if (NULL == (jsonValue = json_value_init_string(g_desiredObjectValue)))
-        {
-            miResult = MI_RESULT_FAILED;
-            mpiResult = ENOMEM;
-            LogError(context, miResult, GetLog(), "[OsConfigResource.Set] json_value_init_string('%s') failed", g_desiredObjectValue);
-        }
-        else if (NULL == (serializedValue = json_serialize_to_string(jsonValue)))
-        {
-            miResult = MI_RESULT_FAILED;
-            mpiResult = ENOMEM;
-            LogError(context, miResult, GetLog(), "[OsConfigResource.Set] json_serialize_to_string('%s') failed", g_desiredObjectValue);
-        }
-        else
-        {
-            payloadSize = (int)strlen(serializedValue);
-            if (NULL != (payloadString = malloc(payloadSize + 1)))
-            {
-                memset(payloadString, 0, payloadSize + 1);
-                memcpy(payloadString, serializedValue, payloadSize);
-
-                if (MPI_OK == (mpiResult = CallMpiSet(g_componentName, g_desiredObjectName, payloadString, payloadSize, GetLog())))
-                {
-                    LogInfo(context, GetLog(), "[OsConfigResource.Set] CallMpiSet(%s, %s, '%.*s', %d) ok",
-                        g_componentName, g_desiredObjectName, payloadSize, payloadString, payloadSize);
-                }
-                else
-                {
-                    miResult = MI_RESULT_FAILED;
-                    LogError(context, miResult, GetLog(), "[OsConfigResource.Set] CallMpiSet(%s, %s, '%.*s', %d) failed with %d, miResult %d",
-                        g_componentName, g_desiredObjectName, payloadSize, payloadString, payloadSize, mpiResult, miResult);
-                }
-
-                FREE_MEMORY(payloadString);
-            }
-            else
-            {
-                miResult = MI_RESULT_FAILED;
-                mpiResult = ENOMEM;
-                LogError(context, miResult, GetLog(), "[OsConfigResource.Set] Failed to allocate %d bytes", payloadSize);
-            }
-        }
-
-        if (NULL != serializedValue)
-        {
-            json_free_serialized_string(serializedValue);
-        }
-
-        if (NULL != jsonValue)
-        {
-            json_value_free(jsonValue);
-        }
-
-        if (MPI_OK != mpiResult)
-        {
-            g_reportedMpiResult = mpiResult;
-        }
+        miResult = SetDesiredObjectValueToDevice("OsConfigResource.Set", g_desiredObjectName, context);
     }
     else
     {
@@ -1060,12 +1209,8 @@ void MI_CALL OsConfigResource_Invoke_SetTargetResource(
         {
             miResult = MI_RESULT_FAILED;
             LogError(context, miResult, GetLog(), "[OsConfigResource.Set] ProcessSshAuditCheck(%s, '%s') failed with %d", g_desiredObjectName, g_desiredObjectValue, mpiResult);
-            g_reportedMpiResult = mpiResult;
         }
     }
-
-    // Set results to report back
-    g_reportedMpiResult = 0;
 
 Exit:
     if (MI_RESULT_OK != miResult)
@@ -1073,7 +1218,7 @@ Exit:
         g_reportedMpiResult = miResult;
     }
 
-    if (MI_RESULT_OK != (miResult =OsConfigResource_SetTargetResource_Destruct(&set_result_object)))
+    if (MI_RESULT_OK != (miResult = OsConfigResource_SetTargetResource_Destruct(&set_result_object)))
     {
         LogError(context, miResult, GetLog(), "[OsConfigResource.Set] SetTargetResource_Destruct failed");
     }

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -251,7 +251,7 @@ static char* GetInitObjectNameFromDesiredObjectName(MI_Context* context)
         }
         else
         {
-            LogError(context, miResult, GetLog(), "GetInitObjectNameFromDesiredObjectName failed to allocate memory");
+            LogError(context, MI_RESULT_FAILED, GetLog(), "GetInitObjectNameFromDesiredObjectName failed to allocate memory");
         }
     }
 
@@ -994,7 +994,8 @@ void MI_CALL OsConfigResource_Invoke_SetTargetResource(
     MI_UNREFERENCED_PARAMETER(instanceName);
 
     MI_Result miResult = MI_RESULT_OK;
-    
+    int mpiResult = MPI_OK;
+
     OsConfigResource_SetTargetResource set_result_object = {0};
 
     if ((NULL == in) || (MI_FALSE == in->InputResource.exists) || (NULL == in->InputResource.value))

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -233,111 +233,26 @@ void MI_CALL OsConfigResource_DeleteInstance(
     MI_Context_PostResult(context, MI_RESULT_NOT_SUPPORTED);
 }
 
-// Later we need to add a new member to the resource class, a string called InitObjectName. For now we'll deduct this here for just the SSH policy objects:
-static char* GetInitObjectNameFromDesiredObjectName(void)
+// Converts from "remediateFoo" to "initFoo" (there may or may be not such an initFoo object, depends on the MIM)
+static char* GetInitObjectNameFromDesiredObjectName(MI_Context* context)
 {
-    const char* initEnsurePermissionsOnEtcSshSshdConfigObject = "initEnsurePermissionsOnEtcSshSshdConfig";
-    const char* initEnsureSshBestPracticeProtocolObject = "initEnsureSshBestPracticeProtocol";
-    const char* initEnsureSshBestPracticeIgnoreRhostsObject = "initEnsureSshBestPracticeIgnoreRhosts";
-    const char* initEnsureSshLogLevelIsSetObject = "initEnsureSshLogLevelIsSet";
-    const char* initEnsureSshMaxAuthTriesIsSetObject = "initEnsureSshMaxAuthTriesIsSet";
-    const char* initEnsureAllowUsersIsConfiguredObject = "initEnsureAllowUsersIsConfigured";
-    const char* initEnsureDenyUsersIsConfiguredObject = "initEnsureDenyUsersIsConfigured";
-    const char* initEnsureAllowGroupsIsConfiguredObject = "initEnsureAllowGroupsIsConfigured";
-    const char* initEnsureDenyGroupsConfiguredObject = "initEnsureDenyGroupsConfigured";
-    const char* initEnsureSshHostbasedAuthenticationIsDisabledObject = "initEnsureSshHostbasedAuthenticationIsDisabled";
-    const char* initEnsureSshPermitRootLoginIsDisabledObject = "initEnsureSshPermitRootLoginIsDisabled";
-    const char* initEnsureSshPermitEmptyPasswordsIsDisabledObject = "initEnsureSshPermitEmptyPasswordsIsDisabled";
-    const char* initEnsureSshClientIntervalCountMaxIsConfiguredObject = "initEnsureSshClientIntervalCountMaxIsConfigured";
-    const char* initEnsureSshClientAliveIntervalIsConfiguredObject = "initEnsureSshClientAliveIntervalIsConfigured";
-    const char* initEnsureSshLoginGraceTimeIsSetObject = "initEnsureSshLoginGraceTimeIsSet";
-    const char* initEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "initEnsureOnlyApprovedMacAlgorithmsAreUsed";
-    const char* initEnsureSshWarningBannerIsEnabledObject = "initEnsureSshWarningBannerIsEnabled";
-    const char* initEnsureUsersCannotSetSshEnvironmentOptionsObject = "initEnsureUsersCannotSetSshEnvironmentOptions";
-    const char* initEnsureAppropriateCiphersForSshObject = "initEnsureAppropriateCiphersForSsh";
-    
+    const char* remediate = "remediate";
+    const char* init = "init";
     char* result = NULL;
+    size_t resultLength = 0;
 
-    if (NULL == g_desiredObjectName)
+    if (NULL != g_desiredObjectName)
     {
-        return result;
-    }
-
-    if (0 == strcmp(g_desiredObjectName, g_remediateEnsurePermissionsOnEtcSshSshdConfigObject))
-    {
-        result = DuplicateString(initEnsurePermissionsOnEtcSshSshdConfigObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshBestPracticeProtocolObject))
-    {
-        result = DuplicateString(initEnsureSshBestPracticeProtocolObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshBestPracticeIgnoreRhostsObject))
-    {
-        result = DuplicateString(initEnsureSshBestPracticeIgnoreRhostsObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshLogLevelIsSetObject))
-    {
-        result = DuplicateString(g_initEnsureSshLogLevelIsSetObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshMaxAuthTriesIsSetObject))
-    {
-        result = DuplicateString(g_initEnsureSshMaxAuthTriesIsSetObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAllowUsersIsConfiguredObject))
-    {
-        result = DuplicateString(g_initEnsureAllowUsersIsConfiguredObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAllowUsersIsConfiguredObject))
-    {
-        result = DuplicateString(g_initEnsureAllowUsersIsConfiguredObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAllowGroupsIsConfiguredObject))
-    {
-        result = DuplicateString(g_initEnsureAllowGroupsIsConfiguredObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureDenyGroupsConfiguredObject))
-    {
-        result = DuplicateString(g_initEnsureDenyGroupsConfiguredObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshHostbasedAuthenticationIsDisabledObject))
-    {
-        result = DuplicateString(g_initEnsureSshHostbasedAuthenticationIsDisabledObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshPermitRootLoginIsDisabledObject))
-    {
-        result = DuplicateString(g_initEnsureSshPermitRootLoginIsDisabledObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshPermitEmptyPasswordsIsDisabledObject))
-    {
-        result = DuplicateString(g_initEnsureSshPermitEmptyPasswordsIsDisabledObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshClientIntervalCountMaxIsConfiguredObject))
-    {
-        result = DuplicateString(g_initEnsureSshClientIntervalCountMaxIsConfiguredObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshClientAliveIntervalIsConfiguredObject))
-    {
-        result = DuplicateString(g_initEnsureSshClientAliveIntervalIsConfiguredObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshLoginGraceTimeIsSetObject))
-    {
-        result = DuplicateString(g_initEnsureSshLoginGraceTimeIsSetObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject))
-    {
-        result = DuplicateString(g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureSshWarningBannerIsEnabledObject))
-    {
-        result = DuplicateString(g_initEnsureSshWarningBannerIsEnabledObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureUsersCannotSetSshEnvironmentOptionsObject))
-    {
-        result = DuplicateString(g_initEnsureUsersCannotSetSshEnvironmentOptionsObject);
-    }
-    else if (0 == strcmp(g_desiredObjectName, g_remediateEnsureAppropriateCiphersForSshObject))
-    {
-        result = DuplicateString(g_initEnsureAppropriateCiphersForSshObject);
+        resultLength = strlen(g_desiredObjectName) + strlen(init) - strlen(remediate) + 1;
+        if (NULL != (result = malloc(resultLength)))
+        {
+            memset(result, 0, resultLength);
+            snprintf(result, resultLength, "%s%s", init, (char*)(g_desiredObjectName - strlen(remediate)));
+        }
+        else
+        {
+            LogError(context, miResult, GetLog(), "GetInitObjectNameFromDesiredObjectName failed to allocate memory");
+        }
     }
 
     return result;
@@ -385,16 +300,16 @@ static MI_Result SetDesiredObjectValueToDevice(const char* who, char* objectName
             memset(payloadString, 0, payloadSize + 1);
             memcpy(payloadString, serializedValue, payloadSize);
 
-            if (MPI_OK == (mpiResult = CallMpiSet(g_componentName, initObjectName, payloadString, payloadSize, GetLog())))
+            if (MPI_OK == (mpiResult = CallMpiSet(g_componentName, objectName, payloadString, payloadSize, GetLog())))
             {
                 LogInfo(context, GetLog(), "[%s] CallMpiSet(%s, %s, '%.*s', %d) ok",
-                    who, g_componentName, g_desiredObjectName, payloadSize, payloadString, payloadSize);
+                    who, g_componentName, objectName, payloadSize, payloadString, payloadSize);
             }
             else
             {
                 miResult = MI_RESULT_FAILED;
                 LogError(context, miResult, GetLog(), "[%s] CallMpiSet(%s, %s, '%.*s', %d) failed with %d, miResult %d",
-                    who, g_componentName, g_desiredObjectName, payloadSize, payloadString, payloadSize, mpiResult, miResult);
+                    who, g_componentName, objectName, payloadSize, payloadString, payloadSize, mpiResult, miResult);
             }
 
             FREE_MEMORY(payloadString);
@@ -443,18 +358,13 @@ static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* c
 
     if (NULL != g_mpiHandle)
     {
-        if (NULL == (initObjectName = GetInitObjectNameFromDesiredObjectName()))
+        // If this reported object has a corresponding init object, initalize it with the desired object value
+        if (NULL != (initObjectName = GetInitObjectNameFromDesiredObjectName()))
         {
-            miResult = MI_RESULT_FAILED;
-            mpiResult = ENOMEM;
-            LogError(context, miResult, GetLog(), "[%s] Unsupported desired object name (%s)", who, g_desiredObjectName);
+            SetDesiredObjectValueToDevice(who, initObjectName, context);
         }
-        else if (MI_RESULT_OK != (miResult = SetDesiredObjectValueToDevice(who, initObjectName, context)))
-        {
-            mpiResult = ENOENT;
-            LogError(context, miResult, GetLog(), "[%s] Failed to initialize object (%s, %s) to '%s'", who, g_componentName, initObjectName, g_desiredObjectValue);
-        }
-        else if (MPI_OK == (mpiResult = CallMpiGet(g_componentName, g_reportedObjectName, &objectValue, &objectValueLength, GetLog())))
+        
+        if (MPI_OK == (mpiResult = CallMpiGet(g_componentName, g_reportedObjectName, &objectValue, &objectValueLength, GetLog())))
         {
             if (NULL == objectValue)
             {
@@ -518,6 +428,8 @@ static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* c
             miResult = MI_RESULT_FAILED;
             LogError(context, miResult, GetLog(), "[%s] CallMpiGet(%s, %s) failed with %d", who, g_componentName, g_reportedObjectName, mpiResult);
         }
+
+        FREE_MEMORY(initObjectName);
     }
     else
     {
@@ -1081,14 +993,7 @@ void MI_CALL OsConfigResource_Invoke_SetTargetResource(
     MI_UNREFERENCED_PARAMETER(self);
     MI_UNREFERENCED_PARAMETER(instanceName);
 
-    char* payloadString = NULL;
-    int payloadSize = 0;
-    
-    JSON_Value* jsonValue = NULL;
-    char* serializedValue = NULL;
-    
     MI_Result miResult = MI_RESULT_OK;
-    int mpiResult = MPI_OK;
     
     OsConfigResource_SetTargetResource set_result_object = {0};
 

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -234,7 +234,7 @@ void MI_CALL OsConfigResource_DeleteInstance(
 }
 
 // Converts from "remediateFoo" to "initFoo" (there may or may be not such an initFoo object, depends on the MIM)
-static char* GetInitObjectNameFromDesiredObjectName(MI_Context* context)
+static char* GetInitObjectNameFromDesiredObjectName(const char* who, MI_Context* context)
 {
     const char* remediate = "remediate";
     const char* init = "init";
@@ -251,7 +251,7 @@ static char* GetInitObjectNameFromDesiredObjectName(MI_Context* context)
         }
         else
         {
-            LogError(context, MI_RESULT_FAILED, GetLog(), "GetInitObjectNameFromDesiredObjectName failed to allocate memory");
+            LogError(context, MI_RESULT_FAILED, GetLog(), "[%s] GetInitObjectNameFromDesiredObjectName failed to allocate memory", who);
         }
     }
 
@@ -274,7 +274,7 @@ static MI_Result SetDesiredObjectValueToDevice(const char* who, char* objectName
         LogError(context, miResult, GetLog(), "[%s] SetDesiredObjectValueToDevice(%s, %s) called outside of a valid MPI session", who, g_componentName, g_desiredObjectName);
         return ENOENT;
     }
-    else if ((NULL == objectName) || (NULL == g_desiredObjectValue)))
+    else if ((NULL == objectName) || (NULL == g_desiredObjectValue))
     {
         LogError(context, miResult, GetLog(), "[%s] SetDesiredObjectValueToDevice called with an invalid object name and/or desired object value", who);
         return EINVAL;
@@ -359,7 +359,7 @@ static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* c
     if (NULL != g_mpiHandle)
     {
         // If this reported object has a corresponding init object, initalize it with the desired object value
-        if (NULL != (initObjectName = GetInitObjectNameFromDesiredObjectName()))
+        if (NULL != (initObjectName = GetInitObjectNameFromDesiredObjectName(who, context)))
         {
             SetDesiredObjectValueToDevice(who, initObjectName, context);
         }

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -260,7 +260,7 @@ static char* GetInitObjectNameFromReportedObjectName(const char* who, MI_Context
         }
         else
         {
-            LogError(context, MI_RESULT_FAILED, GetLog(), "[%s] GetInitObjectNameFromReportedObjectName: invalid reported object name %s", who, );
+            LogError(context, MI_RESULT_FAILED, GetLog(), "[%s] GetInitObjectNameFromReportedObjectName: invalid reported object name %s", who, g_reportedObjectName);
         }
     }
 

--- a/src/modules/mim/securitybaseline.json
+++ b/src/modules/mim/securitybaseline.json
@@ -2015,6 +2015,120 @@
           "type": "mimObject",
           "desired": true,
           "schema": "string"
+        },
+        {
+          "name": "initEnsurePermissionsOnEtcSshSshdConfig",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshBestPracticeProtocol",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshBestPracticeIgnoreRhosts",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshLogLevelIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshMaxAuthTriesIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureAllowUsersIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureDenyUsersIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureAllowGroupsIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureDenyGroupsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshHostbasedAuthenticationIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshPermitRootLoginIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshPermitEmptyPasswordsIsDisabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshClientIntervalCountMaxIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshClientAliveIntervalIsConfigured",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshLoginGraceTimeIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureOnlyApprovedMacAlgorithmsAreUsed",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureSshWarningBannerIsEnabled",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureUsersCannotSetSshEnvironmentOptions",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
+        },
+        {
+          "name": "initEnsureAppropriateCiphersForSsh",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
         }
       ]
     }

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -361,6 +361,27 @@ static const char* g_remediateEnsureNoUsersHaveDotRhostsFilesObject = "remediate
 static const char* g_remediateEnsureRloginServiceIsDisabledObject = "remediateEnsureRloginServiceIsDisabled";
 static const char* g_remediateEnsureUnnecessaryAccountsAreRemovedObject = "remediateEnsureUnnecessaryAccountsAreRemoved";
 
+// Initialization for audit before remediation
+static const char* g_initEnsurePermissionsOnEtcSshSshdConfigObject = "initEnsurePermissionsOnEtcSshSshdConfig";
+static const char* g_initEnsureSshBestPracticeProtocolObject = "initEnsureSshBestPracticeProtocol";
+static const char* g_initEnsureSshBestPracticeIgnoreRhostsObject = "initEnsureSshBestPracticeIgnoreRhosts";
+static const char* g_initEnsureSshLogLevelIsSetObject = "initEnsureSshLogLevelIsSet";
+static const char* g_initEnsureSshMaxAuthTriesIsSetObject = "initEnsureSshMaxAuthTriesIsSet";
+static const char* g_initEnsureAllowUsersIsConfiguredObject = "initEnsureAllowUsersIsConfigured";
+static const char* g_initEnsureDenyUsersIsConfiguredObject = "initEnsureDenyUsersIsConfigured";
+static const char* g_initEnsureAllowGroupsIsConfiguredObject = "initEnsureAllowGroupsIsConfigured";
+static const char* g_initEnsureDenyGroupsConfiguredObject = "initEnsureDenyGroupsConfigured";
+static const char* g_initEnsureSshHostbasedAuthenticationIsDisabledObject = "initEnsureSshHostbasedAuthenticationIsDisabled";
+static const char* g_initEnsureSshPermitRootLoginIsDisabledObject = "initEnsureSshPermitRootLoginIsDisabled";
+static const char* g_initEnsureSshPermitEmptyPasswordsIsDisabledObject = "initEnsureSshPermitEmptyPasswordsIsDisabled";
+static const char* g_initEnsureSshClientIntervalCountMaxIsConfiguredObject = "initEnsureSshClientIntervalCountMaxIsConfigured";
+static const char* g_initEnsureSshClientAliveIntervalIsConfiguredObject = "initEnsureSshClientAliveIntervalIsConfigured";
+static const char* g_initEnsureSshLoginGraceTimeIsSetObject = "initEnsureSshLoginGraceTimeIsSet";
+static const char* g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "initEnsureOnlyApprovedMacAlgorithmsAreUsed";
+static const char* g_initEnsureSshWarningBannerIsEnabledObject = "initEnsureSshWarningBannerIsEnabled";
+static const char* g_initEnsureUsersCannotSetSshEnvironmentOptionsObject = "initEnsureUsersCannotSetSshEnvironmentOptions";
+static const char* g_initEnsureAppropriateCiphersForSshObject = "initEnsureAppropriateCiphersForSsh";
+
 static const char* g_securityBaselineLogFile = "/var/log/osconfig_securitybaseline.log";
 static const char* g_securityBaselineRolledLogFile = "/var/log/osconfig_securitybaseline.bak";
 
@@ -2869,6 +2890,106 @@ static int RemediateEnsureUnnecessaryAccountsAreRemoved(char* value)
     return RemoveUserAccounts(names, ARRAY_SIZE(names), SecurityBaselineGetLog());
 }
 
+static int InitEnsurePermissionsOnEtcSshSshdConfig(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsurePermissionsOnEtcSshSshdConfigObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshBestPracticeProtocol(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshBestPracticeProtocolObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshBestPracticeIgnoreRhosts(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshBestPracticeIgnoreRhostsObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshLogLevelIsSet(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshLogLevelIsSetObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshMaxAuthTriesIsSet(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshMaxAuthTriesIsSetObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureAllowUsersIsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureAllowUsersIsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureDenyUsersIsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureDenyUsersIsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureAllowGroupsIsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureAllowGroupsIsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureDenyGroupsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureDenyGroupsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshHostbasedAuthenticationIsDisabled(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsurePermissionsOnEtcSshSshdConfigObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshPermitRootLoginIsDisabled(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshPermitRootLoginIsDisabledObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshPermitEmptyPasswordsIsDisabled(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshPermitEmptyPasswordsIsDisabledObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshClientIntervalCountMaxIsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshClientIntervalCountMaxIsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshClientIntervalCountMaxIsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshClientIntervalCountMaxIsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshClientAliveIntervalIsConfigured(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshClientAliveIntervalIsConfiguredObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshLoginGraceTimeIsSet(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshLoginGraceTimeIsSetObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureOnlyApprovedMacAlgorithmsAreUsed(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureSshWarningBannerIsEnabled(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureSshWarningBannerIsEnabledObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureUsersCannotSetSshEnvironmentOptions(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureUsersCannotSetSshEnvironmentOptionsObject, value, SecurityBaselineGetLog());
+}
+
+static int InitEnsureAppropriateCiphersForSsh(char* value)
+{
+    return InitializeSshAuditCheck(g_initEnsureAppropriateCiphersForSshObject, value, SecurityBaselineGetLog());
+}
+
 RemediationCall g_remediateChecks[] =
 {
     &RemediateEnsurePermissionsOnEtcIssue,
@@ -4603,6 +4724,83 @@ int SecurityBaselineMmiSet(MMI_HANDLE clientSession, const char* componentName, 
         else if (0 == strcmp(objectName, g_remediateEnsureUnnecessaryAccountsAreRemovedObject))
         {
             status = RemediateEnsureUnnecessaryAccountsAreRemoved(jsonString);
+        }
+        // Initialization for audit before remediation
+        else if (0 == strcmp(objectName, g_initEnsurePermissionsOnEtcSshSshdConfigObject))
+        {
+            status = InitEnsurePermissionsOnEtcSshSshdConfig(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshBestPracticeProtocolObject))
+        {
+            status = InitEnsureSshBestPracticeProtocol(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshBestPracticeIgnoreRhostsObject))
+        {
+            status = InitEnsureSshBestPracticeIgnoreRhosts(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshLogLevelIsSetObject))
+        {
+            status = InitEnsureSshLogLevelIsSet(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshMaxAuthTriesIsSetObject))
+        {
+            status = InitEnsureSshMaxAuthTriesIsSet(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureAllowUsersIsConfiguredObject))
+        {
+            status = InitEnsureAllowUsersIsConfigured(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureDenyUsersIsConfiguredObject))
+        {
+            status = InitEnsureDenyUsersIsConfigured(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureAllowGroupsIsConfiguredObject))
+        {
+            status = InitEnsureAllowGroupsIsConfigured(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureDenyGroupsConfiguredObject))
+        {
+            status = InitEnsureDenyGroupsConfigured(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshHostbasedAuthenticationIsDisabledObject))
+        {
+            status = InitEnsureSshHostbasedAuthenticationIsDisabled(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshPermitRootLoginIsDisabledObject))
+        {
+            status = InitEnsureSshPermitRootLoginIsDisabled(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshPermitEmptyPasswordsIsDisabledObject))
+        {
+            status = InitEnsureSshPermitEmptyPasswordsIsDisabled(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshClientIntervalCountMaxIsConfiguredObject))
+        {
+            status = InitEnsureSshClientIntervalCountMaxIsConfigured(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshClientAliveIntervalIsConfiguredObject))
+        {
+            status = InitEnsureSshClientAliveIntervalIsConfigured(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshLoginGraceTimeIsSetObject))
+        {
+            status = InitEnsureSshLoginGraceTimeIsSet(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject))
+        {
+            status = InitEnsureOnlyApprovedMacAlgorithmsAreUsed(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureSshWarningBannerIsEnabledObject))
+        {
+            status = InitEnsureSshWarningBannerIsEnabled(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureUsersCannotSetSshEnvironmentOptionsObject))
+        {
+            status = InitEnsureUsersCannotSetSshEnvironmentOptions(jsonString);
+        }
+        else if (0 == strcmp(objectName, g_initEnsureAppropriateCiphersForSshObject))
+        {
+            status = InitEnsureAppropriateCiphersForSsh(jsonString);
         }
         else
         {

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -2955,11 +2955,6 @@ static int InitEnsureSshClientIntervalCountMaxIsConfigured(char* value)
     return InitializeSshAuditCheck(g_initEnsureSshClientIntervalCountMaxIsConfiguredObject, value, SecurityBaselineGetLog());
 }
 
-static int InitEnsureSshClientIntervalCountMaxIsConfigured(char* value)
-{
-    return InitializeSshAuditCheck(g_initEnsureSshClientIntervalCountMaxIsConfiguredObject, value, SecurityBaselineGetLog());
-}
-
 static int InitEnsureSshClientAliveIntervalIsConfigured(char* value)
 {
     return InitializeSshAuditCheck(g_initEnsureSshClientAliveIntervalIsConfiguredObject, value, SecurityBaselineGetLog());

--- a/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
+++ b/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
@@ -637,7 +637,7 @@ TEST_F(SecurityBaselineTest, MmiSet)
         m_remediateEnsureNoUsersHaveDotNetrcFilesObject,
         m_remediateEnsureNoUsersHaveDotRhostsFilesObject,
         m_remediateEnsureRloginServiceIsDisabledObject,
-        m_remediateEnsureUnnecessaryAccountsAreRemovedObject,
+        m_remediateEnsureUnnecessaryAccountsAreRemovedObject
     };
 
     int mimObjectsNumber = ARRAY_SIZE(mimObjects);

--- a/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
+++ b/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
@@ -362,6 +362,27 @@ class SecurityBaselineTest : public ::testing::Test
         const char* m_remediateEnsureRloginServiceIsDisabledObject = "remediateEnsureRloginServiceIsDisabled";
         const char* m_remediateEnsureUnnecessaryAccountsAreRemovedObject = "remediateEnsureUnnecessaryAccountsAreRemoved";
 
+        // Initialization for audit before remediation
+        static const char* g_initEnsurePermissionsOnEtcSshSshdConfigObject = "initEnsurePermissionsOnEtcSshSshdConfig";
+        static const char* g_initEnsureSshBestPracticeProtocolObject = "initEnsureSshBestPracticeProtocol";
+        static const char* g_initEnsureSshBestPracticeIgnoreRhostsObject = "initEnsureSshBestPracticeIgnoreRhosts";
+        static const char* g_initEnsureSshLogLevelIsSetObject = "initEnsureSshLogLevelIsSet";
+        static const char* g_initEnsureSshMaxAuthTriesIsSetObject = "initEnsureSshMaxAuthTriesIsSet";
+        static const char* g_initEnsureAllowUsersIsConfiguredObject = "initEnsureAllowUsersIsConfigured";
+        static const char* g_initEnsureDenyUsersIsConfiguredObject = "initEnsureDenyUsersIsConfigured";
+        static const char* g_initEnsureAllowGroupsIsConfiguredObject = "initEnsureAllowGroupsIsConfigured";
+        static const char* g_initEnsureDenyGroupsConfiguredObject = "initEnsureDenyGroupsConfigured";
+        static const char* g_initEnsureSshHostbasedAuthenticationIsDisabledObject = "initEnsureSshHostbasedAuthenticationIsDisabled";
+        static const char* g_initEnsureSshPermitRootLoginIsDisabledObject = "initEnsureSshPermitRootLoginIsDisabled";
+        static const char* g_initEnsureSshPermitEmptyPasswordsIsDisabledObject = "initEnsureSshPermitEmptyPasswordsIsDisabled";
+        static const char* g_initEnsureSshClientIntervalCountMaxIsConfiguredObject = "initEnsureSshClientIntervalCountMaxIsConfigured";
+        static const char* g_initEnsureSshClientAliveIntervalIsConfiguredObject = "initEnsureSshClientAliveIntervalIsConfigured";
+        static const char* g_initEnsureSshLoginGraceTimeIsSetObject = "initEnsureSshLoginGraceTimeIsSet";
+        static const char* g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "initEnsureOnlyApprovedMacAlgorithmsAreUsed";
+        static const char* g_initEnsureSshWarningBannerIsEnabledObject = "initEnsureSshWarningBannerIsEnabled";
+        static const char* g_initEnsureUsersCannotSetSshEnvironmentOptionsObject = "initEnsureUsersCannotSetSshEnvironmentOptions";
+        static const char* g_initEnsureAppropriateCiphersForSshObject = "initEnsureAppropriateCiphersForSsh";
+
         const char* m_pass = "\"PASS\"";
 
         const char* m_clientName = "SecurityBaselineTest";
@@ -429,6 +450,27 @@ TEST_F(SecurityBaselineTest, MmiSet)
     const char* payload = "PASS";
 
     const char* mimObjects[] = {
+        // Initialziation
+        g_initEnsurePermissionsOnEtcSshSshdConfigObject,
+        g_initEnsureSshBestPracticeProtocolObject,
+        g_initEnsureSshBestPracticeIgnoreRhostsObject,
+        g_initEnsureSshLogLevelIsSetObject,
+        g_initEnsureSshMaxAuthTriesIsSetObject,
+        g_initEnsureAllowUsersIsConfiguredObject,
+        g_initEnsureDenyUsersIsConfiguredObject,
+        g_initEnsureAllowGroupsIsConfiguredObject,
+        g_initEnsureDenyGroupsConfiguredObject,
+        g_initEnsureSshHostbasedAuthenticationIsDisabledObject,
+        g_initEnsureSshPermitRootLoginIsDisabledObject,
+        g_initEnsureSshPermitEmptyPasswordsIsDisabledObject,
+        g_initEnsureSshClientIntervalCountMaxIsConfiguredObject,
+        g_initEnsureSshClientAliveIntervalIsConfiguredObject,
+        g_initEnsureSshLoginGraceTimeIsSetObject,
+        g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject,
+        g_initEnsureSshWarningBannerIsEnabledObject,
+        g_initEnsureUsersCannotSetSshEnvironmentOptionsObject,
+        g_initEnsureAppropriateCiphersForSshObject
+        // Actual remediation
         m_remediateSecurityBaselineObject,
         m_remediateEnsurePermissionsOnEtcIssueObject,
         m_remediateEnsurePermissionsOnEtcIssueNetObject,
@@ -595,7 +637,7 @@ TEST_F(SecurityBaselineTest, MmiSet)
         m_remediateEnsureNoUsersHaveDotNetrcFilesObject,
         m_remediateEnsureNoUsersHaveDotRhostsFilesObject,
         m_remediateEnsureRloginServiceIsDisabledObject,
-        m_remediateEnsureUnnecessaryAccountsAreRemovedObject
+        m_remediateEnsureUnnecessaryAccountsAreRemovedObject,
     };
 
     int mimObjectsNumber = ARRAY_SIZE(mimObjects);

--- a/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
+++ b/src/modules/securitybaseline/tests/SecurityBaselineTests.cpp
@@ -363,25 +363,25 @@ class SecurityBaselineTest : public ::testing::Test
         const char* m_remediateEnsureUnnecessaryAccountsAreRemovedObject = "remediateEnsureUnnecessaryAccountsAreRemoved";
 
         // Initialization for audit before remediation
-        static const char* g_initEnsurePermissionsOnEtcSshSshdConfigObject = "initEnsurePermissionsOnEtcSshSshdConfig";
-        static const char* g_initEnsureSshBestPracticeProtocolObject = "initEnsureSshBestPracticeProtocol";
-        static const char* g_initEnsureSshBestPracticeIgnoreRhostsObject = "initEnsureSshBestPracticeIgnoreRhosts";
-        static const char* g_initEnsureSshLogLevelIsSetObject = "initEnsureSshLogLevelIsSet";
-        static const char* g_initEnsureSshMaxAuthTriesIsSetObject = "initEnsureSshMaxAuthTriesIsSet";
-        static const char* g_initEnsureAllowUsersIsConfiguredObject = "initEnsureAllowUsersIsConfigured";
-        static const char* g_initEnsureDenyUsersIsConfiguredObject = "initEnsureDenyUsersIsConfigured";
-        static const char* g_initEnsureAllowGroupsIsConfiguredObject = "initEnsureAllowGroupsIsConfigured";
-        static const char* g_initEnsureDenyGroupsConfiguredObject = "initEnsureDenyGroupsConfigured";
-        static const char* g_initEnsureSshHostbasedAuthenticationIsDisabledObject = "initEnsureSshHostbasedAuthenticationIsDisabled";
-        static const char* g_initEnsureSshPermitRootLoginIsDisabledObject = "initEnsureSshPermitRootLoginIsDisabled";
-        static const char* g_initEnsureSshPermitEmptyPasswordsIsDisabledObject = "initEnsureSshPermitEmptyPasswordsIsDisabled";
-        static const char* g_initEnsureSshClientIntervalCountMaxIsConfiguredObject = "initEnsureSshClientIntervalCountMaxIsConfigured";
-        static const char* g_initEnsureSshClientAliveIntervalIsConfiguredObject = "initEnsureSshClientAliveIntervalIsConfigured";
-        static const char* g_initEnsureSshLoginGraceTimeIsSetObject = "initEnsureSshLoginGraceTimeIsSet";
-        static const char* g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "initEnsureOnlyApprovedMacAlgorithmsAreUsed";
-        static const char* g_initEnsureSshWarningBannerIsEnabledObject = "initEnsureSshWarningBannerIsEnabled";
-        static const char* g_initEnsureUsersCannotSetSshEnvironmentOptionsObject = "initEnsureUsersCannotSetSshEnvironmentOptions";
-        static const char* g_initEnsureAppropriateCiphersForSshObject = "initEnsureAppropriateCiphersForSsh";
+        const char* m_initEnsurePermissionsOnEtcSshSshdConfigObject = "initEnsurePermissionsOnEtcSshSshdConfig";
+        const char* m_initEnsureSshBestPracticeProtocolObject = "initEnsureSshBestPracticeProtocol";
+        const char* m_initEnsureSshBestPracticeIgnoreRhostsObject = "initEnsureSshBestPracticeIgnoreRhosts";
+        const char* m_initEnsureSshLogLevelIsSetObject = "initEnsureSshLogLevelIsSet";
+        const char* m_initEnsureSshMaxAuthTriesIsSetObject = "initEnsureSshMaxAuthTriesIsSet";
+        const char* m_initEnsureAllowUsersIsConfiguredObject = "initEnsureAllowUsersIsConfigured";
+        const char* m_initEnsureDenyUsersIsConfiguredObject = "initEnsureDenyUsersIsConfigured";
+        const char* m_initEnsureAllowGroupsIsConfiguredObject = "initEnsureAllowGroupsIsConfigured";
+        const char* m_initEnsureDenyGroupsConfiguredObject = "initEnsureDenyGroupsConfigured";
+        const char* m_initEnsureSshHostbasedAuthenticationIsDisabledObject = "initEnsureSshHostbasedAuthenticationIsDisabled";
+        const char* m_initEnsureSshPermitRootLoginIsDisabledObject = "initEnsureSshPermitRootLoginIsDisabled";
+        const char* m_initEnsureSshPermitEmptyPasswordsIsDisabledObject = "initEnsureSshPermitEmptyPasswordsIsDisabled";
+        const char* m_initEnsureSshClientIntervalCountMaxIsConfiguredObject = "initEnsureSshClientIntervalCountMaxIsConfigured";
+        const char* m_initEnsureSshClientAliveIntervalIsConfiguredObject = "initEnsureSshClientAliveIntervalIsConfigured";
+        const char* m_initEnsureSshLoginGraceTimeIsSetObject = "initEnsureSshLoginGraceTimeIsSet";
+        const char* m_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject = "initEnsureOnlyApprovedMacAlgorithmsAreUsed";
+        const char* m_initEnsureSshWarningBannerIsEnabledObject = "initEnsureSshWarningBannerIsEnabled";
+        const char* m_initEnsureUsersCannotSetSshEnvironmentOptionsObject = "initEnsureUsersCannotSetSshEnvironmentOptions";
+        const char* m_initEnsureAppropriateCiphersForSshObject = "initEnsureAppropriateCiphersForSsh";
 
         const char* m_pass = "\"PASS\"";
 
@@ -450,26 +450,26 @@ TEST_F(SecurityBaselineTest, MmiSet)
     const char* payload = "PASS";
 
     const char* mimObjects[] = {
-        // Initialziation
-        g_initEnsurePermissionsOnEtcSshSshdConfigObject,
-        g_initEnsureSshBestPracticeProtocolObject,
-        g_initEnsureSshBestPracticeIgnoreRhostsObject,
-        g_initEnsureSshLogLevelIsSetObject,
-        g_initEnsureSshMaxAuthTriesIsSetObject,
-        g_initEnsureAllowUsersIsConfiguredObject,
-        g_initEnsureDenyUsersIsConfiguredObject,
-        g_initEnsureAllowGroupsIsConfiguredObject,
-        g_initEnsureDenyGroupsConfiguredObject,
-        g_initEnsureSshHostbasedAuthenticationIsDisabledObject,
-        g_initEnsureSshPermitRootLoginIsDisabledObject,
-        g_initEnsureSshPermitEmptyPasswordsIsDisabledObject,
-        g_initEnsureSshClientIntervalCountMaxIsConfiguredObject,
-        g_initEnsureSshClientAliveIntervalIsConfiguredObject,
-        g_initEnsureSshLoginGraceTimeIsSetObject,
-        g_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject,
-        g_initEnsureSshWarningBannerIsEnabledObject,
-        g_initEnsureUsersCannotSetSshEnvironmentOptionsObject,
-        g_initEnsureAppropriateCiphersForSshObject
+        // Initialization
+        m_initEnsurePermissionsOnEtcSshSshdConfigObject,
+        m_initEnsureSshBestPracticeProtocolObject,
+        m_initEnsureSshBestPracticeIgnoreRhostsObject,
+        m_initEnsureSshLogLevelIsSetObject,
+        m_initEnsureSshMaxAuthTriesIsSetObject,
+        m_initEnsureAllowUsersIsConfiguredObject,
+        m_initEnsureDenyUsersIsConfiguredObject,
+        m_initEnsureAllowGroupsIsConfiguredObject,
+        m_initEnsureDenyGroupsConfiguredObject,
+        m_initEnsureSshHostbasedAuthenticationIsDisabledObject,
+        m_initEnsureSshPermitRootLoginIsDisabledObject,
+        m_initEnsureSshPermitEmptyPasswordsIsDisabledObject,
+        m_initEnsureSshClientIntervalCountMaxIsConfiguredObject,
+        m_initEnsureSshClientAliveIntervalIsConfiguredObject,
+        m_initEnsureSshLoginGraceTimeIsSetObject,
+        m_initEnsureOnlyApprovedMacAlgorithmsAreUsedObject,
+        m_initEnsureSshWarningBannerIsEnabledObject,
+        m_initEnsureUsersCannotSetSshEnvironmentOptionsObject,
+        m_initEnsureAppropriateCiphersForSshObject,
         // Actual remediation
         m_remediateSecurityBaselineObject,
         m_remediateEnsurePermissionsOnEtcIssueObject,

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -17,6 +17,96 @@
   },
   {
     "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshBestPracticeProtocol"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshLogLevelIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshMaxAuthTriesIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAllowUsersIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureDenyUsersIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAllowGroupsIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureDenyGroupsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshLoginGraceTimeIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshWarningBannerIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAppropriateCiphersForSsh"
+  },
+  {
+    "ObjectType": "Desired",
     "ComponentName": "DoesNotExist",
     "ObjectName": "remediateEnsurePermissionsOnEtcCronWeekly",
     "ExpectedResult": 22


### PR DESCRIPTION
## Description

Adding to the SecurityBaseline 19 new desired MIM objects for initialization of the SSH audit checks so they can accept new values from Azure Policy assignment at run time.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.