### PR TITLE
Temporarily removing Ubuntu 22.04 from the E2E tests due to AIS unavailability

### DIFF
--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Configure AIS
         run: |
-          sudo aziotctl config mp --connection-string "${{ steps.device.outputs.connection_string}}"
+          sudo aziotctl config mp --connection-string "${{ steps.device.outputs.connection_string }}"
           sudo aziotctl config apply -c '/etc/aziot/config.toml'
 
       - name: Install package
@@ -94,14 +94,19 @@ jobs:
           sudo systemctl restart osconfig
           sleep 90s
 
+      - name: Get IoT Hub connection string
+        id: iothub
+        run: |
+          echo connection_string=$(echo ${{ secrets.iothub_connection_string }} | base64 -d) >> $GITHUB_OUTPUT
+
       - name: Run tests
         working-directory: ./src/tests/e2etest
         env:
-          IOTHUB_CONNECTION_STRING: ${{ secrets.iothub_connection_string }}
+          IOTHUB_CONNECTION_STRING: ${{ steps.iothub.outputs.connection_string }}
           DEVICE_ID: ${{ steps.device.outputs.id }}
           DOTNET_CLI_HOME: /tmp
         run: |
-          sudo -E dotnet test \
+          dotnet test \
             --logger "trx;LogFileName=${{ github.workspace }}/${{ inputs.target }}-results.trx" \
             --logger "console;verbosity=detailed"
 

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -30,7 +30,7 @@ jobs:
   package:
     uses: ./.github/workflows/package-build.yml
     with:
-      os: ${{ inputs.target }}
+      target: ${{ inputs.target }}
       arch: ${{ inputs.arch }}
       artifact: ${{ inputs.target }}
       test: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: latest
           terraform_wrapper: false
@@ -38,7 +38,7 @@ jobs:
           terraform apply -auto-approve
 
           echo iothub_name=$(terraform output -raw iothub_name) >> $GITHUB_OUTPUT
-          echo connection_string=$(terraform output -raw connection_string) >> $GITHUB_OUTPUT
+          echo connection_string=$(terraform output -raw connection_string | base64 -w 0) >> $GITHUB_OUTPUT
 
   test:
     name: Test
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, debian-10, debian-11]
+        target: [ubuntu-18.04, ubuntu-20.04, debian-10, debian-11]
         arch: [amd64]
     secrets:
       client_id: ${{ secrets.CLIENT_ID }}

--- a/devops/e2e/cloudtest/ubuntu-18_04.json
+++ b/devops/e2e/cloudtest/ubuntu-18_04.json
@@ -9,7 +9,7 @@
         {
             "name": "linux-add-repository",
             "parameters": {
-                "repository": "https://packages.microsoft.com/ubuntu/20.04/prod"
+                "repository": "https://packages.microsoft.com/ubuntu/18.04/multiarch/prod"
             }
         },
         {

--- a/devops/e2e/cloudtest/ubuntu-22_04.json
+++ b/devops/e2e/cloudtest/ubuntu-22_04.json
@@ -9,7 +9,7 @@
         {
             "name": "linux-add-repository",
             "parameters": {
-                "repository": "https://packages.microsoft.com/ubuntu/20.04/prod"
+                "repository": "https://packages.microsoft.com/ubuntu/22.04/prod"
             }
         },
         {


### PR DESCRIPTION
- Fix E2E tests (pass connection string secret between jobs)
- Temporarily remove Ubuntu 22.04 E2E test job
- Add Ubuntu 22.04 cloudtest managed image definition

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.