### PR TITLE
Remove unused workflow steps

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -78,14 +78,6 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Docker login (azurecr.io)
-        if: false
-        uses: docker/login-action@v2
-        with:
-          registry: osconfig.azurecr.io
-          username: ${{ secrets.ACR_CLIENT_ID }}
-          password: ${{ secrets.ACR_CLIENT_SECRET }}
-
       - name: Docker login (ghcr.io)
         uses: docker/login-action@v2
         with:
@@ -107,17 +99,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ${{ steps.image.outputs.path }}
+          # Only push the image when a pull request is merged to main
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Push image to ACR
-        # Only push the image when a pull request is merged to main
-        # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        if: false
-        run: |
-          docker buildx imagetools create \
-            --tag osconfig.azurecr.io/${{ steps.image.outputs.name }}:latest \
-            --tag osconfig.azurecr.io/${{ steps.image.outputs.name }}:${{ github.run_number }} \
-            --tag osconfig.azurecr.io/${{ steps.image.outputs.name }}:${{ github.sha }} \
-            ghcr.io/${{ steps.image.outputs.name }}:latest


### PR DESCRIPTION
Remove unused workflow steps for pushing containers to an ACR. This method for storing/managing out build containers was temporarily disabled, then fully replaced by GHCR.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.