### PR TITLE
Add explicit token permissions for publishing reports

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -6,6 +6,11 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
 jobs:
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-report.yml
+++ b/.github/workflows/e2e-report.yml
@@ -6,6 +6,11 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add explicit token permissions for workflows that publish test reports. 

> Starting February 1, 2024 the default permission for the GITHUB_TOKEN will change from Read/Write to Read-only for all our Open Source GitHub orgs.
>
> https://aka.ms/github-token-perms-changes
