### PR TITLE
Adding use of backup for original SSH server configuration and more stabilization for the SSH server security policy

### DIFF
--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -242,7 +242,8 @@ static int IsSshConfigIncludeSupported(void* log)
             // SSH servers implementing OpenSSH version 8.2 or newer support Include
             // See https://www.openssh.com/txt/release-8.2, quote: "add an Include sshd_config keyword that allows including additional configuration files"
 
-            if ((versionMajor >= 8) && (versionMinor >= 2))
+            //if ((versionMajor >= 8) && (versionMinor >= 2))
+            if ((versionMajor >= 10) && (versionMinor >= 10))
             {
                 OsConfigLogInfo(log, "IsSshConfigIncludeSupported: the %s service reports OpenSSH version %d.%d and appears to support Include", g_sshServerService, versionMajor, versionMinor);
                 result = 0;

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -238,22 +238,21 @@ static int IsSshConfigIncludeSupported(void* log)
                 versionMinor = atoi(versionMinorString);
             }
 
-            if ((versionMajor <= 0) || (versionMinor <= 0))
+            // SSH servers implementing OpenSSH version 8.2 or newer support Include
+            // See https://www.openssh.com/txt/release-8.2, quote: "add an Include sshd_config keyword that allows including additional configuration files"
+
+            if ((versionMajor >= 8) && (versionMinor >= 2))
             {
-                OsConfigLogInfo(log, "IsSshConfigIncludeSupported: unexpected response to '%s' ('%s'), assuming Include is not supported", command, textCursor);
-                result = ENOENT;
+                OsConfigLogInfo(log, "IsSshConfigIncludeSupported: the %s service reports OpenSSH version %d.%d and appears to support Include", g_sshServerService, versionMajor, versionMinor);
+                result = 0;
             }
-            else if ((versionMajor < 8) || (versionMinor < 2))
+            else
             {
                 OsConfigLogInfo(log, "IsSshConfigIncludeSupported: the %s service reports OpenSSH version %d.%d and appears to not support Include", g_sshServerService, versionMajor, versionMinor);
                 result = ENOENT;
             }
             else
-            {
-                // SSH servers implementing OpenSSH version 8.2 or newer support Include
-                OsConfigLogInfo(log, "IsSshConfigIncludeSupported: the %s service reports OpenSSH version %d.%d and appears to support Include", g_sshServerService, versionMajor, versionMinor);
-                result = 0;
-            }
+            
         }
         else
         {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -252,8 +252,6 @@ static int IsSshConfigIncludeSupported(void* log)
                 OsConfigLogInfo(log, "IsSshConfigIncludeSupported: the %s service reports OpenSSH version %d.%d and appears to not support Include", g_sshServerService, versionMajor, versionMinor);
                 result = ENOENT;
             }
-            else
-            
         }
         else
         {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -692,6 +692,13 @@ int CheckSshProtocol(char** reason, void* log)
                 OsConfigCaptureSuccessReason(reason, "%s'%s' is found uncommented in %s", protocol, g_osconfigRemediationConf);
                 status = 0;
             }
+            else
+            {
+                OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_osconfigRemediationConf);
+                OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s",
+                    "%s, also '%s' is not found uncommented with '#' in %s", protocol, g_osconfigRemediationConf);
+                status = ENOENT;
+            }
 
             FREE_MEMORY(inclusion);
         }
@@ -703,17 +710,16 @@ int CheckSshProtocol(char** reason, void* log)
                 OsConfigCaptureSuccessReason(reason, "%s'%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
                 status = 0;
             }
+            else
+            {
+                OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
+                OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s",
+                    "%s, also '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
+                status = ENOENT;
+            }
         }
     }
     
-    if (0 != status)
-    {
-        OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
-        OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s",
-            "%s, also '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
-        status = ENOENT;
-    }
-
     FREE_MEMORY(protocol);
 
     OsConfigLogInfo(log, "CheckSshProtocol: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1020,7 +1020,7 @@ static int SaveRemediationToConfFile(void* log)
     return status;
 }
 
-static char* BackupSshdConfig(const char* configuration)
+static int BackupSshdConfig(const char* configuration)
 {
     size_t configurationSize = 0;
     int status = 0;


### PR DESCRIPTION
## Description

A backup of original configuration allows us to add in the case when the server does not support the Include keyword repeated remediations without piling them on top of each other. 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.