### PR TITLE
Fixing the package publication channel based on package type instead of distro

### DIFF
--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -54,6 +54,6 @@ jobs:
       dist: ${{ matrix.target.dist }}
       # ESRP debian based repos (deb) have channels/rings on repos.
       # ESRP yum based repos (rpm) have no channels
-      channel: ${{ matrix.target.dist == 'azurelinux' && '' || 'insiders-fast' }}
+      channel: ${{ matrix.target.package-type == 'DEB' && 'insiders-fast' || '' }}
       package-type: ${{ matrix.target.package-type }}
     secrets: inherit


### PR DESCRIPTION
## Description

* Fixing the package publication channel behavior to use package type instead of distro. RPM based distros do not require channels.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.