### PR TITLE
Addressing problem when the SSH banner text is edited in Portal EOL characters are changed to '\\' and 'n' removing the end of lines

### DIFF
--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1338,7 +1338,7 @@ int InitializeSshAuditCheck(const char* name, char* value, void* log)
     }
     else if ((0 == strcmp(name, g_remediateEnsureSshWarningBannerIsEnabledObject)) || (0 == strcmp(name, g_initEnsureSshWarningBannerIsEnabledObject)))
     {
-        if (NULL != strstr(value, "\\\\"))
+        if (NULL != strstr(value, "\\n"))
         {
             OsConfigLogError(log, "########## double backslahes!!! ####");
             CleanDoubleBackslashes(value, log);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1218,7 +1218,7 @@ static char* CleanDoubleBackslashes(char* value, void* log)
     size_t length = 0;
     size_t i = 0;
 
-    if ((NULL == value) || (strlen(old) >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))
+    if ((NULL == value) || (strlen(old) >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))))
     {
         if (NULL == result)
         {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1310,6 +1310,11 @@ int InitializeSshAuditCheck(const char* name, char* value, void* log)
     }
     else if ((0 == strcmp(name, g_remediateEnsureSshWarningBannerIsEnabledObject)) || (0 == strcmp(name, g_initEnsureSshWarningBannerIsEnabledObject)))
     {
+        if (NULL != strstr(value, "\\n"))
+        {
+            OsConfigLogError(log, "########## double backslahes!!! ####");
+        }
+
         FREE_MEMORY(g_desiredSshWarningBannerIsEnabled);
         status = (NULL != (g_desiredSshWarningBannerIsEnabled = DuplicateString(isValidValue ? value : g_sshDefaultSshBannerText))) ? 0 : ENOMEM;
     }

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1230,7 +1230,7 @@ static char* CleanDoubleBackslashes(char* value, void* log)
 
     memset(result, 0, length + 1);
     
-    for (i = 0, j = 0; i < (length - 1), j < length; i++, j++)
+    for (i = 0, j = 0; (i < (length - 1)) && (j < length); i++, j++)
     {
         if ((value[i] == '\\') && (value[i + 1] == 'n'))
         {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1212,6 +1212,37 @@ void SshAuditCleanup(void* log)
     g_auditOnlySession = true;
 }
 
+static char* CleanDoubleBackslashes(char* value, void* log)
+{
+    const char* oldSequence = "\\n";
+    const char* newSequence = "\n";
+    char* cursor = value;
+    char* result = NULL;
+    size_t length = 0;
+    size_t cursorLength = 0;
+    size_t resultLength = 0;
+    size_t i = 0;
+
+    if ((NULL == value) || (strlen(old) >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))
+    {
+        if (NULL == result)
+        {
+            OsConfigLogError(log, "Out of memory");
+        }
+        
+        return result; 
+    }
+
+    for (i = 0; i < length; i++)
+    {
+        OsConfigLogError(log, "### value[%d]: '%c'", i, value[i]);
+    }
+
+    FREE_MEMORY(result); //
+
+    return result;
+}
+
 int InitializeSshAuditCheck(const char* name, char* value, void* log)
 {
     bool isValidValue = ((NULL == value) || (0 == value[0])) ? false : true;
@@ -1313,6 +1344,7 @@ int InitializeSshAuditCheck(const char* name, char* value, void* log)
         if (NULL != strstr(value, "\\n"))
         {
             OsConfigLogError(log, "########## double backslahes!!! ####");
+            CleanDoubleBackslashes(value, log);
         }
 
         FREE_MEMORY(g_desiredSshWarningBannerIsEnabled);
@@ -1478,11 +1510,6 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, void* log
     }
     else if (0 == strcmp(name, g_remediateEnsureSshWarningBannerIsEnabledObject))
     {
-        if (NULL != strstr(value, "\\n"))
-        {
-            OsConfigLogError(log, "########## double backslahes!!! ####");
-        }
-        
         if (0 == (status = InitializeSshAuditCheck(name, value, log)))
         {
             status = SetSshWarningBanner(atoi(g_desiredPermissionsOnEtcSshSshdConfig ? 

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1228,9 +1228,11 @@ static char* CleanDoubleBackslashes(char* value, void* log)
         return result; 
     }
 
+    memcpy(result, value, length);
+    
     for (i = 0; i < length; i++)
     {
-        OsConfigLogError(log, "### value[%d]: '%c'", (int)i, value[i]);
+        OsConfigLogError(log, "### result[%d]: '%c'", (int)i, result[i]);
     }
 
     FREE_MEMORY(result); //

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1214,13 +1214,8 @@ void SshAuditCleanup(void* log)
 
 static char* CleanDoubleBackslashes(char* value, void* log)
 {
-    const char* oldSequence = "\\n";
-    const char* newSequence = "\n";
-    char* cursor = value;
     char* result = NULL;
     size_t length = 0;
-    size_t cursorLength = 0;
-    size_t resultLength = 0;
     size_t i = 0;
 
     if ((NULL == value) || (strlen(old) >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))
@@ -1235,7 +1230,7 @@ static char* CleanDoubleBackslashes(char* value, void* log)
 
     for (i = 0; i < length; i++)
     {
-        OsConfigLogError(log, "### value[%d]: '%c'", i, value[i]);
+        OsConfigLogError(log, "### value[%d]: '%c'", (int)i, value[i]);
     }
 
     FREE_MEMORY(result); //

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1218,7 +1218,7 @@ static char* CleanDoubleBackslashes(char* value, void* log)
     size_t length = 0;
     size_t i = 0;
 
-    if ((NULL == value) || (strlen(old) >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))))
+    if ((NULL == value) || (strlen("\\n") >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))))
     {
         if (NULL == result)
         {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1338,7 +1338,7 @@ int InitializeSshAuditCheck(const char* name, char* value, void* log)
     }
     else if ((0 == strcmp(name, g_remediateEnsureSshWarningBannerIsEnabledObject)) || (0 == strcmp(name, g_initEnsureSshWarningBannerIsEnabledObject)))
     {
-        if (NULL != strstr(value, "\\n"))
+        if (NULL != strstr(value, "\\\\"))
         {
             OsConfigLogError(log, "########## double backslahes!!! ####");
             CleanDoubleBackslashes(value, log);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1216,9 +1216,9 @@ static char* CleanDoubleBackslashes(char* value, void* log)
 {
     char* result = NULL;
     size_t length = 0;
-    size_t i = 0;
+    size_t i = 0, j = 0;
 
-    if ((NULL == value) || (strlen("\\n") >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))))
+    if ((NULL == value) || (2 >= (length = strlen(value))) || (NULL == (result = malloc(length + 1))))
     {
         if (NULL == result)
         {
@@ -1228,11 +1228,21 @@ static char* CleanDoubleBackslashes(char* value, void* log)
         return result; 
     }
 
-    memcpy(result, value, length);
+    memset(result, 0, length + 1);
     
-    for (i = 0; i < length; i++)
+    for (i = 0, j = 0; i < (length - 1), j < length; i++, j++)
     {
-        OsConfigLogError(log, "### result[%d]: '%c'", (int)i, result[i]);
+        if ((value[i] == '\\') && (value[i + 1] == 'n'))
+        {
+            result[j] = '\n';
+            i += 1;
+        }
+        else
+        {
+            result[j] = value[i];
+        }
+        
+        OsConfigLogError(log, "### result[%d]: '%c'", (int)j, result[j]);
     }
 
     FREE_MEMORY(result); //

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1473,6 +1473,11 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, void* log
     }
     else if (0 == strcmp(name, g_remediateEnsureSshWarningBannerIsEnabledObject))
     {
+        if (NULL != strstr(value, "\\n"))
+        {
+            OsConfigLogError(log, "########## double backslahes!!! ####");
+        }
+        
         if (0 == (status = InitializeSshAuditCheck(name, value, log)))
         {
             status = SetSshWarningBanner(atoi(g_desiredPermissionsOnEtcSshSshdConfig ? 


### PR DESCRIPTION
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.