### PR TITLE
Downgrade upload-artifact from v4 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,10 @@ jobs:
           path: ./build/gtest-output
           output: ${{ matrix.os }}-${{ matrix.arch }}.xml
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: unit-test
-          overwrite: true
           path: |
             ${{ matrix.os }}-${{ matrix.arch }}.log
             ${{ matrix.os }}-${{ matrix.arch }}.xml


### PR DESCRIPTION
Downgrade upload-artifact to v3 to allow multiple uploads to a single `unit-test` artifact (used for generating the test report).

> https://github.com/actions/upload-artifact/issues/478