### PR TITLE
Making the SecurityBaseline test recipe to remediate and audit real SSH server configuration values

### DIFF
--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -18,97 +18,122 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig"
+    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig",
+    "Payload": "600"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPortIsConfigured"
+    "ObjectName": "initEnsureSshPortIsConfigured",
+    "Payload": "22"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshBestPracticeProtocol"
+    "ObjectName": "initEnsureSshBestPracticeProtocol",
+    "Payload": "2"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts"
+    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts",
+    "Payload": "yes"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshLogLevelIsSet"
+    "ObjectName": "initEnsureSshLogLevelIsSet",
+    "Payload": "INFO"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshMaxAuthTriesIsSet"
+    "ObjectName": "initEnsureSshMaxAuthTriesIsSet",
+    "Payload": "6"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAllowUsersIsConfigured"
+    "ObjectName": "initEnsureAllowUsersIsConfigured",
+    "Payload": "*@*"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureDenyUsersIsConfigured"
+    "ObjectName": "initEnsureDenyUsersIsConfigured",
+    "Payload": "root"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAllowGroupsIsConfigured"
+    "ObjectName": "initEnsureAllowGroupsIsConfigured",
+    "Payload": "*"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureDenyGroupsConfigured"
+    "ObjectName": "initEnsureDenyGroupsConfigured",
+    "Payload": "root"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled"
+    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled",
+    "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled"
+    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled",
+    "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled"
+    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled",
+    "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured"
+    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured",
+    "Payload": "0"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshLoginGraceTimeIsSet"
+    "ObjectName": "initEnsureSshClientAliveIntervalIsConfigured",
+    "Payload": "3600"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed"
+    "ObjectName": "initEnsureSshLoginGraceTimeIsSet",
+    "Payload": "60"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshWarningBannerIsEnabled"
+    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed",
+    "Payload": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions"
+    "ObjectName": "initEnsureSshWarningBannerIsEnabled",
+    "Payload": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAppropriateCiphersForSsh"
+    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions",
+    "Payload": "no"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAppropriateCiphersForSsh",
+    "Payload": "aes128-ctr,aes192-ctr,aes256-ctr"
   },
   {
     "ObjectType": "Desired",
@@ -212,101 +237,126 @@
     "Action": "LoadModule",
     "Module": "securitybaseline.so"
   },
-  {
+{
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig"
+    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig",
+    "Payload": "600"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPortIsConfigured"
+    "ObjectName": "initEnsureSshPortIsConfigured",
+    "Payload": "22"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshBestPracticeProtocol"
+    "ObjectName": "initEnsureSshBestPracticeProtocol",
+    "Payload": "2"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts"
+    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts",
+    "Payload": "yes"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshLogLevelIsSet"
+    "ObjectName": "initEnsureSshLogLevelIsSet",
+    "Payload": "INFO"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshMaxAuthTriesIsSet"
+    "ObjectName": "initEnsureSshMaxAuthTriesIsSet",
+    "Payload": "6"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAllowUsersIsConfigured"
+    "ObjectName": "initEnsureAllowUsersIsConfigured",
+    "Payload": "*@*"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureDenyUsersIsConfigured"
+    "ObjectName": "initEnsureDenyUsersIsConfigured",
+    "Payload": "root"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAllowGroupsIsConfigured"
+    "ObjectName": "initEnsureAllowGroupsIsConfigured",
+    "Payload": "*"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureDenyGroupsConfigured"
+    "ObjectName": "initEnsureDenyGroupsConfigured",
+    "Payload": "root"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled"
+    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled",
+    "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled"
+    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled",
+    "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled"
+    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled",
+    "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured"
+    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured",
+    "Payload": "0"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshLoginGraceTimeIsSet"
+    "ObjectName": "initEnsureSshClientAliveIntervalIsConfigured",
+    "Payload": "3600"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed"
+    "ObjectName": "initEnsureSshLoginGraceTimeIsSet",
+    "Payload": "60"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshWarningBannerIsEnabled"
+    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed",
+    "Payload": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions"
+    "ObjectName": "initEnsureSshWarningBannerIsEnabled",
+    "Payload": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAppropriateCiphersForSsh"
+    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions",
+    "Payload": "no"
   },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAppropriateCiphersForSsh",
+    "Payload": "aes128-ctr,aes192-ctr,aes256-ctr"
+  },  
   {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -140,7 +140,8 @@
   },
   {
     "Action": "LoadModule",
-    "Module": "securitybaseline.so"
+    "Module": "securitybaseline.so",
+    "Delay": "30"
   },
   {
     "ObjectType": "Desired",

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -18,217 +18,122 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig",
+    "ObjectName": "remediateEnsurePermissionsOnEtcSshSshdConfig",
     "Payload": "600"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPortIsConfigured",
+    "ObjectName": "remediateEnsureSshPortIsConfigured",
     "Payload": "22"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshBestPracticeProtocol",
+    "ObjectName": "remediateEnsureSshBestPracticeProtocol",
     "Payload": "2"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts",
+    "ObjectName": "remediateEnsureSshBestPracticeIgnoreRhosts",
     "Payload": "yes"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshLogLevelIsSet",
+    "ObjectName": "remediateEnsureSshLogLevelIsSet",
     "Payload": "INFO"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshMaxAuthTriesIsSet",
+    "ObjectName": "remediateEnsureSshMaxAuthTriesIsSet",
     "Payload": "6"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAllowUsersIsConfigured",
+    "ObjectName": "remediateEnsureAllowUsersIsConfigured",
     "Payload": "*@*"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureDenyUsersIsConfigured",
+    "ObjectName": "remediateEnsureDenyUsersIsConfigured",
     "Payload": "root"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAllowGroupsIsConfigured",
+    "ObjectName": "remediateEnsureAllowGroupsIsConfigured",
     "Payload": "*"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureDenyGroupsConfigured",
+    "ObjectName": "remediateEnsureDenyGroupsConfigured",
     "Payload": "root"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled",
+    "ObjectName": "remediateEnsureSshHostbasedAuthenticationIsDisabled",
     "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled",
+    "ObjectName": "remediateEnsureSshPermitRootLoginIsDisabled",
     "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled",
+    "ObjectName": "remediateEnsureSshPermitEmptyPasswordsIsDisabled",
     "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured",
+    "ObjectName": "remediateEnsureSshClientIntervalCountMaxIsConfigured",
     "Payload": "0"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshClientAliveIntervalIsConfigured",
+    "ObjectName": "remediateEnsureSshClientAliveIntervalIsConfigured",
     "Payload": "3600"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshLoginGraceTimeIsSet",
+    "ObjectName": "remediateEnsureSshLoginGraceTimeIsSet",
     "Payload": "60"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed",
+    "ObjectName": "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed",
     "Payload": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureSshWarningBannerIsEnabled",
+    "ObjectName": "remediateEnsureSshWarningBannerIsEnabled",
     "Payload": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions",
+    "ObjectName": "remediateEnsureUsersCannotSetSshEnvironmentOptions",
     "Payload": "no"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "initEnsureAppropriateCiphersForSsh",
+    "ObjectName": "remediateEnsureAppropriateCiphersForSsh",
     "Payload": "aes128-ctr,aes192-ctr,aes256-ctr"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsurePermissionsOnEtcSshSshdConfig"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshPortIsConfigured"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshBestPracticeProtocol"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshBestPracticeIgnoreRhosts"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshLogLevelIsSet"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshMaxAuthTriesIsSet"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAllowUsersIsConfigured"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureDenyUsersIsConfigured"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAllowGroupsIsConfigured"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureDenyGroupsConfigured"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshHostbasedAuthenticationIsDisabled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshPermitRootLoginIsDisabled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshPermitEmptyPasswordsIsDisabled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshClientIntervalCountMaxIsConfigured"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshLoginGraceTimeIsSet"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureSshWarningBannerIsEnabled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureUsersCannotSetSshEnvironmentOptions"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAppropriateCiphersForSsh"
   },
   {
     "Action": "UnloadModule"
@@ -237,7 +142,7 @@
     "Action": "LoadModule",
     "Module": "securitybaseline.so"
   },
-{
+  {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig",

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -206,6 +206,108 @@
     "ObjectName": "remediateEnsureAppropriateCiphersForSsh"
   },
   {
+    "Action": "UnloadModule"
+  },
+  {
+    "Action": "LoadModule",
+    "Module": "securitybaseline.so"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsurePermissionsOnEtcSshSshdConfig"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshPortIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshBestPracticeProtocol"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshBestPracticeIgnoreRhosts"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshLogLevelIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshMaxAuthTriesIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAllowUsersIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureDenyUsersIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAllowGroupsIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureDenyGroupsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshHostbasedAuthenticationIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshPermitRootLoginIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshPermitEmptyPasswordsIsDisabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshClientIntervalCountMaxIsConfigured"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshLoginGraceTimeIsSet"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshWarningBannerIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureAppropriateCiphersForSsh"
+  },
+  {
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "auditEnsurePermissionsOnEtcSshSshdConfig"

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -141,7 +141,7 @@
   {
     "Action": "LoadModule",
     "Module": "securitybaseline.so",
-    "Delay": 30
+    "WaitSeconds": 30
   },
   {
     "ObjectType": "Desired",

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -141,7 +141,7 @@
   {
     "Action": "LoadModule",
     "Module": "securitybaseline.so",
-    "Delay": "30"
+    "Delay": 30
   },
   {
     "ObjectType": "Desired",


### PR DESCRIPTION
## Description

Making the SecurityBaseline test recipe closer to what happens in reality for SSH checks under MC: a set of remediations with real values, then a reload of the module to cause a SSH server restart, then an init sequence to tell audit what to check for, then the actual audits. 

WARNING: running this test recipe more than one time in a quick sequence (without waiting at least 15 minutes between runs) and/or in parallel with NRP execution of the SSH policy on same VM/device can risk blocking the SSH service from running and will require a fix by OS reboot on that VM/device.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.