### PR TITLE
Downgraded download/upload-artifact to v3

### DIFF
--- a/.github/actions/sign-package/action.yml
+++ b/.github/actions/sign-package/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.artifact }}
         path: unsigned
@@ -144,7 +144,7 @@ runs:
           if os.path.isfile(os.path.join("signed", file)):
             print(f"Success!\nSigned {file}")
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifact }}-signed
         path: signed

--- a/.github/workflows/e2e-run.yml
+++ b/.github/workflows/e2e-run.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.target }}
           path: package
@@ -129,14 +129,14 @@ jobs:
             ${{ runner.temp }}/osconfig_platform.log
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: ${{ inputs.target }}-logs
           path: ${{ runner.temp }}/osconfig*
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: e2e-report

--- a/.github/workflows/module-test-run.yml
+++ b/.github/workflows/module-test-run.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         id: download
         with:
           name: ${{ inputs.target }}
@@ -75,7 +75,7 @@ jobs:
 
           exit $result
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: ${{ inputs.target }}-logs

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -103,7 +103,7 @@ jobs:
           arch: ${{ matrix.variant.arch }}
           package-type: ${{ inputs.package-type }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: ${{ inputs.test }}
         with:
           name: ${{ inputs.artifact }}
@@ -112,7 +112,7 @@ jobs:
             ./build/modules/test/moduletest
             ./build/modules/bin/*.so
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: ${{ !inputs.test }}
         with:
           name: ${{ inputs.artifact }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact }}
           path: packages

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -38,22 +38,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: ubuntu-20.04-signed
           path: packages
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: ubuntu-22.04-signed
           path: packages
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: debian-10-signed
           path: packages
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: debian-11-signed
           path: packages


### PR DESCRIPTION
## Description

* v4 upload/download actions are not backward compatible with downstream actions not using v4 (ex dorny-testreporter - https://github.com/dorny/test-reporter/issues/363). Downgraded all to v3 given the unintended consequences. Will upgrade at later time.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.