### PR TITLE
Backport GTest on older distros

### DIFF
--- a/devops/docker/almalinux-9-amd64/Dockerfile
+++ b/devops/docker/almalinux-9-amd64/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
 
 # GTest
-RUN git clone https://github.com/google/googletest --recursive
+RUN git clone https://github.com/google/googletest --recursive -b v1.12.0
 RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest
 
 # rapidjson

--- a/devops/docker/amazonlinux-2-amd64/Dockerfile
+++ b/devops/docker/amazonlinux-2-amd64/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
 
 # GTest
-RUN git clone https://github.com/google/googletest --recursive
+RUN git clone https://github.com/google/googletest --recursive -b v1.12.0
 RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest
 
 # rapidjson


### PR DESCRIPTION
## Description

* Backporting GTest on older distros (almalinux-9, amazonlinux-2)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.