### PR TITLE
Downgrading GTest on RHEL 9

### DIFF
--- a/devops/docker/rhel-9-amd64/Dockerfile
+++ b/devops/docker/rhel-9-amd64/Dockerfile
@@ -22,7 +22,7 @@ RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
 
 # GTest
-RUN git clone https://github.com/google/googletest --recursive
+RUN git clone https://github.com/google/googletest --recursive -b v1.12.0
 RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest
 
 # rapidjson


### PR DESCRIPTION
## Description

* Downgrade GTest on RHEL 9 container

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.