### PR TITLE
Adding additional target distros for recipe module tests

### DIFF
--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -11,11 +11,16 @@ jobs:
       matrix:
         target:
           [
-            { os: ubuntu, version: 20.04, package-type: DEB, excluded-tests: "Sample" },
-            { os: ubuntu, version: 22.04, package-type: DEB, excluded-tests: "Sample" },
+            { os: centos, version: 8, package-type: RPM, excluded-tests: "Pmc|Sample" },
             { os: debian, version: 10, package-type: DEB, excluded-tests: "Sample" },
             { os: debian, version: 11, package-type: DEB, excluded-tests: "Sample" },
             { os: mariner, version: 2, package-type: RPM, excluded-tests: "Pmc|Sample" },
+            { os: oraclelinux, version: 8, package-type: RPM, excluded-tests: "Pmc|Sample" },
+            { os: rhel, version: 8, package-type: RPM, excluded-tests: "Pmc|Sample" },
+            { os: rhel, version: 9, package-type: RPM, excluded-tests: "Pmc|Sample" },
+            { os: sles, version: 15, package-type: RPM, excluded-tests: "Pmc|Sample" },
+            { os: ubuntu, version: 20.04, package-type: DEB, excluded-tests: "Sample" },
+            { os: ubuntu, version: 22.04, package-type: DEB, excluded-tests: "Sample" },
           ]
         arch: [amd64]
     with:

--- a/devops/e2e/cloudtest/centos-8.json
+++ b/devops/e2e/cloudtest/centos-8.json
@@ -1,0 +1,10 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y glibc*"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/sles-15.json
+++ b/devops/e2e/cloudtest/sles-15.json
@@ -1,0 +1,10 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo zypper install -y glibc*"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Description

* Onboarded the following distros to run test recipes:
  * centos-8
  * oraclelinux-8
  * rhel 8, 9
  * suse 15
* Added cloudtest artifact manifests for suse-15 (sles) and centos-8 (not needed for other distros)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.