### PR TITLE
Adding way for Security Baseline checks to easily detect on which OS distro they are running

### DIFF
--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -9,6 +9,23 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#define PRETTY_NAME_AZURE_LINUX_2 "CBL-Mariner/Linux"
+#define PRETTY_NAME_AMAZON_LINUX_2 "Amazon Linux 2"
+#define PRETTY_NAME_CENTOS_7 "CentOS Linux 7"
+#define PRETTY_NAME_CENTOS_8 "CentOS Stream 8"
+#define PRETTY_NAME_DEBIAN_10 "Debian GNU/Linux 10"
+#define PRETTY_NAME_DEBIAN_11 "Debian GNU/Linux 11"
+#define PRETTY_NAME_DEBIAN_12 "Debian GNU/Linux 12"
+#define PRETTY_NAME_ORACLE_LINUX_SERVER_7 "Oracle Linux Server 7"
+#define PRETTY_NAME_ORACLE_LINUX_SERVER_8 "Oracle Linux Server 8"
+#define PRETTY_NAME_RHEL_7 "Red Hat Enterprise Linux Server 7"
+#define PRETTY_NAME_RHEL_8 "Red Hat Enterprise Linux 8"
+#define PRETTY_NAME_RHEL_9 "Red Hat Enterprise Linux 9"
+#define PRETTY_NAME_ROCKY_LINUX_9 "Rocky Linux 9"
+#define PRETTY_NAME_SLES_15 "SUSE Linux Enterprise Server 15"
+#define PRETTY_NAME_UBUNTU_20_04 "Ubuntu 20.04"
+#define PRETTY_NAME_UBUNTU_22_04 "Ubuntu 22.04"
+
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
 #define UNUSED(a) (void)(a)

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -127,6 +127,7 @@ char* HashCommand(const char* source, void* log);
 
 bool ParseHttpProxyData(const char* proxyData, char** hostAddress, int* port, char**username, char** password, void* log);
 
+char* GetOsPrettyName(void* log);
 char* GetOsName(void* log);
 char* GetOsVersion(void* log);
 char* GetOsKernelName(void* log);
@@ -150,6 +151,7 @@ int CheckLoginUmask(const char* desired, char** reason, void* log);
 long GetPassMinDays(void* log);
 long GetPassMaxDays(void* log);
 long GetPassWarnAge(void* log);
+bool IsCurrentOs(const char* name, void* log);
 
 void RemovePrefixBlanks(char* target);
 void RemovePrefixUpTo(char* target, char marker);

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -743,20 +743,30 @@ long GetPassWarnAge(void* log)
 bool IsCurrentOs(const char* name, void* log)
 {
     char* prettyName = NULL;
+    size_t prettyNameLength = 0;
+    size_t nameLength = 0;
     bool result = false;
 
-    if (NULL != (prettyName = GetOsPrettyName(log)))
+    if ((NULL == name) || (0 == (nameLength = strlen(name))))
     {
-        result = (0 == strncmp(name, prettyName, strlen(name))) ? true : false;
+        OsConfigLogError(log, "IsCurrentOs called with an invalid argument");
+        return result;
     }
 
-    if (result)
+    if ((NULL == (prettyName = GetOsPrettyName(log))) || (0 == prettyNameLength = strlen(prettyName)))
     {
-        OsConfigLogInfo(log, "This is distro '%s' ('%s')", name, prettyName);
+        OsConfigLogError(log, "IsCurrentOs: no valid PRETTY_NAME found under /etc/*-release");
     }
     else
     {
-        OsConfigLogInfo(log, "This is not distro '%s' ('%s')", name, prettyName);
+        if (result = (0 == strncmp(name, prettyName, ((nameLength <= prettyNameLength) ? nameLength : prettyNameLength) ? true : false)
+        {
+            OsConfigLogInfo(log, "This is distro '%s' ('%s')", name, prettyName);
+        }
+        else
+        {
+            OsConfigLogInfo(log, "This is not distro '%s' ('%s')", name, prettyName);
+        }
     }
 
     FREE_MEMORY(prettyName);

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -759,7 +759,7 @@ bool IsCurrentOs(const char* name, void* log)
     }
     else
     {
-        if (result = (0 == strncmp(name, prettyName, ((nameLength <= prettyNameLength) ? nameLength : prettyNameLength) ? true : false)))
+        if (true == (result = (0 == strncmp(name, prettyName, ((nameLength <= prettyNameLength) ? nameLength : prettyNameLength) ? true : false))))
         {
             OsConfigLogInfo(log, "This is distro '%s' ('%s')", name, prettyName);
         }

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -747,7 +747,7 @@ bool IsCurrentOs(const char* name, void* log)
 
     if (NULL != (prettyName = GetOsPrettyName(log)))
     {
-        result = (0 == strncmp(name, prettyName, strlen(name)) ? true : false;
+        result = (0 == strncmp(name, prettyName, strlen(name))) ? true : false;
     }
 
     if (result)

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -755,7 +755,7 @@ bool IsCurrentOs(const char* name, void* log)
 
     if ((NULL == (prettyName = GetOsPrettyName(log))) || (0 == (prettyNameLength = strlen(prettyName))))
     {
-        OsConfigLogError(log, "IsCurrentOs: no valid PRETTY_NAME found under /etc/*-release");
+        OsConfigLogError(log, "IsCurrentOs: no valid PRETTY_NAME found in /etc/os-release, assuming this is not the '%s' distro", name);
     }
     else
     {

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -753,13 +753,13 @@ bool IsCurrentOs(const char* name, void* log)
         return result;
     }
 
-    if ((NULL == (prettyName = GetOsPrettyName(log))) || (0 == prettyNameLength = strlen(prettyName)))
+    if ((NULL == (prettyName = GetOsPrettyName(log))) || (0 == (prettyNameLength = strlen(prettyName))))
     {
         OsConfigLogError(log, "IsCurrentOs: no valid PRETTY_NAME found under /etc/*-release");
     }
     else
     {
-        if (result = (0 == strncmp(name, prettyName, ((nameLength <= prettyNameLength) ? nameLength : prettyNameLength) ? true : false)
+        if (result = (0 == strncmp(name, prettyName, ((nameLength <= prettyNameLength) ? nameLength : prettyNameLength) ? true : false)))
         {
             OsConfigLogInfo(log, "This is distro '%s' ('%s')", name, prettyName);
         }

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -110,6 +110,10 @@ char* GetOsPrettyName(void* log)
         RemovePrefixUpTo(textResult, '=');
         RemovePrefixBlanks(textResult);
     }
+    else
+    {
+        FREE_MEMORY(textResult);
+    }
 
     if (IsFullLoggingEnabled())
     {

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1698,8 +1698,13 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
 
 TEST_F(CommonUtilsTest, IsCurrentOs)
 {
-    char* osName = NULL;
-    EXPECT_NE(nullptr, osName = GetOsName(nullptr));
-    EXPECT_EQ(true, IsCurrentOs(osName, nullptr));
-    FREE_MEMORY(osName);
+    char* name = NULL;
+
+    EXPECT_NE(nullptr, name = GetOsName(nullptr));
+    EXPECT_EQ(true, IsCurrentOs(name, nullptr));
+    FREE_MEMORY(name);
+
+    EXPECT_NE(nullptr, name = GetOsPrettyName(nullptr));
+    EXPECT_EQ(true, IsCurrentOs(name, nullptr));
+    FREE_MEMORY(name);
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -621,6 +621,7 @@ TEST_F(CommonUtilsTest, InvalidArgumentsHttpProxyDataParsing)
 
 TEST_F(CommonUtilsTest, OsProperties)
 {
+    char* osPrettyName = NULL;
     char* osName = NULL;
     char* osVersion = NULL;
     char* cpuType = NULL;
@@ -634,6 +635,7 @@ TEST_F(CommonUtilsTest, OsProperties)
     char* kernelRelease = NULL;
     char* umask = NULL;
 
+    EXPECT_NE(nullptr, osPrettyName = GetOsPrettyName(nullptr));
     EXPECT_NE(nullptr, osName = GetOsName(nullptr));
     EXPECT_NE(nullptr, osVersion = GetOsVersion(nullptr));
     EXPECT_NE(nullptr, cpuType = GetCpuType(nullptr));
@@ -650,6 +652,7 @@ TEST_F(CommonUtilsTest, OsProperties)
     EXPECT_NE(nullptr, kernelRelease = GetOsKernelRelease(nullptr));
     EXPECT_NE(nullptr, umask = GetLoginUmask(nullptr));
 
+    FREE_MEMORY(osPrettyName);
     FREE_MEMORY(osName);
     FREE_MEMORY(osVersion);
     FREE_MEMORY(cpuType);
@@ -1691,4 +1694,12 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     EXPECT_NE(0, CheckPackageInstalled("rolldice", nullptr));
 
     EXPECT_EQ(0, CheckPackageInstalled("gcc", nullptr));
+}
+
+TEST_F(CommonUtilsTest, IsCurrentOs)
+{
+    char* osName = NULL;
+    EXPECT_NE(nullptr, osName = GetOsName(nullptr));
+    EXPECT_EQ(true, IsCurrentOs(osName, nullptr));
+    FREE_MEMORY(osName);
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1700,6 +1700,10 @@ TEST_F(CommonUtilsTest, IsCurrentOs)
 {
     char* name = NULL;
 
+    EXPECT_EQ(false, IsCurrentOs(nullptr, nullptr));
+    EXPECT_EQ(false, IsCurrentOs("Test", nullptr));
+    EXPECT_EQ(false, IsCurrentOs("Test Distro That Does Not Exist", nullptr));
+
     EXPECT_NE(nullptr, name = GetOsName(nullptr));
     EXPECT_EQ(true, IsCurrentOs(name, nullptr));
     FREE_MEMORY(name);
@@ -1707,4 +1711,5 @@ TEST_F(CommonUtilsTest, IsCurrentOs)
     EXPECT_NE(nullptr, name = GetOsPrettyName(nullptr));
     EXPECT_EQ(true, IsCurrentOs(name, nullptr));
     FREE_MEMORY(name);
+
 }

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1246,10 +1246,11 @@ static char* AuditEnsurePasswordCreationRequirements(void)
     int ucreditOption = 0;
     int ocreditOption = 0;
     int lcreditOption = 0;
+    char* result = NULL;
     
     if (IsCurrentOs(g_suseLinuxEnterpriseServer15, SecurityBaselineGetLog()))
     {
-        return ((14 == (minlenOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "minlen", '=', SecurityBaselineGetLog()))) &&
+        result = ((14 == (minlenOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "minlen", '=', SecurityBaselineGetLog()))) &&
             ((4 == (minclassOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "minclass", '=', SecurityBaselineGetLog()))) ||
             ((-1 == (dcreditOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "dcredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ucreditOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "ucredit", '=', SecurityBaselineGetLog()))) &&
@@ -1261,15 +1262,17 @@ static char* AuditEnsurePasswordCreationRequirements(void)
     }
     else
     {
-        return (CheckFileExists(g_etcSecurityPwQualityConf, SecurityBaselineGetLog()) && 
+        result = ((CheckFileExists(g_etcSecurityPwQualityConf, SecurityBaselineGetLog())) && 
             ((4 == (minclassOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "minclass", '=', SecurityBaselineGetLog())) || 
             ((-1 == (dcreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "dcredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ucreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "ucredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ocreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "ocredit", '=', SecurityBaselineGetLog()))) &&
-            (-1 == (lcreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "lcredit", '=', SecurityBaselineGetLog())))))) ? DuplicateString(g_pass) :
+            (-1 == (lcreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "lcredit", '=', SecurityBaselineGetLog()))))))) ? DuplicateString(g_pass) :
             FormatAllocateString("In %s, 'minclass' missing or set to %d instead of 4, or: 'dcredit', 'ucredit', 'ocredit' or 'lcredit' missing or set to %d, %d, %d, %d respectively instead of -1 each",
                 g_etcSecurityPwQualityConf, minlenOption, minclassOption, dcreditOption, ucreditOption, ocreditOption, lcreditOption);
     }
+
+    return result;
 }
 
 static char* AuditEnsureLockoutForFailedPasswordAttempts(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -398,22 +398,22 @@ static const char* g_securityBaselineModuleInfo = "{\"Name\": \"SecurityBaseline
     "\"Lifetime\": 2,"
     "\"UserAccount\": 0}";
 
-static const char* g_azureLinux2 = "CBL-Mariner/Linux";
-static const char* g_amazonLinux2 = "Amazon Linux 2";
-static const char* g_centOs7 = "CentOS Linux 7";
-static const char* g_centOs8 = "CentOS Stream 8";
-static const char* g_debian10 = "Debian GNU/Linux 10";
-static const char* g_debian11 = "Debian GNU/Linux 11";
-static const char* g_debian12 = "Debian GNU/Linux 12";
-static const char* g_oracleLinuxServer7 = "Oracle Linux Server 7";
-static const char* g_oracleLinuxServer8 = "Oracle Linux Server 8";
-static const char* g_redHatEnterpriseLinux7 = "Red Hat Enterprise Linux Server 7";
-static const char* g_redHatEnterpriseLinux8 = "Red Hat Enterprise Linux 8";
-static const char* g_redHatEnterpriseLinux9 = "Red Hat Enterprise Linux 9";
-static const char* g_rockyLinux9 = "Rocky Linux 9";
+//static const char* g_azureLinux2 = "CBL-Mariner/Linux";
+//static const char* g_amazonLinux2 = "Amazon Linux 2";
+//static const char* g_centOs7 = "CentOS Linux 7";
+//static const char* g_centOs8 = "CentOS Stream 8";
+//static const char* g_debian10 = "Debian GNU/Linux 10";
+//static const char* g_debian11 = "Debian GNU/Linux 11";
+//static const char* g_debian12 = "Debian GNU/Linux 12";
+//static const char* g_oracleLinuxServer7 = "Oracle Linux Server 7";
+//static const char* g_oracleLinuxServer8 = "Oracle Linux Server 8";
+//static const char* g_redHatEnterpriseLinux7 = "Red Hat Enterprise Linux Server 7";
+//static const char* g_redHatEnterpriseLinux8 = "Red Hat Enterprise Linux 8";
+//static const char* g_redHatEnterpriseLinux9 = "Red Hat Enterprise Linux 9";
+//static const char* g_rockyLinux9 = "Rocky Linux 9";
 static const char* g_suseLinuxEnterpriseServer15 = "SUSE Linux Enterprise Server 15";
-static const char* g_ubuntu20_04 = "Ubuntu 20.04";
-static const char* g_ubuntu22_04 = "Ubuntu 22.04";
+//static const char* g_ubuntu20_04 = "Ubuntu 20.04";
+//static const char* g_ubuntu22_04 = "Ubuntu 22.04";
 
 static const char* g_etcIssue = "/etc/issue";
 static const char* g_etcIssueNet = "/etc/issue.net";

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1262,13 +1262,13 @@ static char* AuditEnsurePasswordCreationRequirements(void)
     }
     else
     {
-        result = ((CheckFileExists(g_etcSecurityPwQualityConf, SecurityBaselineGetLog())) && 
-            ((4 == (minclassOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "minclass", '=', SecurityBaselineGetLog())) || 
+        result = ((CheckFileExists(g_etcSecurityPwQualityConf, SecurityBaselineGetLog())) &&
+            ((4 == (minclassOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "minclass", '=', SecurityBaselineGetLog())) ||
             ((-1 == (dcreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "dcredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ucreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "ucredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ocreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "ocredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (lcreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "lcredit", '=', SecurityBaselineGetLog()))))))) ? DuplicateString(g_pass) :
-            FormatAllocateString("In %s, 'minclass' missing or set to %d instead of 4, or: 'dcredit', 'ucredit', 'ocredit' or 'lcredit' missing or set to %d, %d, %d, %d respectively instead of -1 each",
+            FormatAllocateString("'%s' mising, or 'minclass' missing or set to %d instead of 4, or: 'dcredit', 'ucredit', 'ocredit' or 'lcredit' missing or set to %d, %d, %d, %d respectively instead of -1 each",
                 g_etcSecurityPwQualityConf, minlenOption, minclassOption, dcreditOption, ucreditOption, ocreditOption, lcreditOption);
     }
 

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -1268,8 +1268,8 @@ static char* AuditEnsurePasswordCreationRequirements(void)
             (-1 == (ucreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "ucredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ocreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "ocredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (lcreditOption = GetIntegerOptionFromFile(g_etcSecurityPwQualityConf, "lcredit", '=', SecurityBaselineGetLog()))))))) ? DuplicateString(g_pass) :
-            FormatAllocateString("'%s' mising, or 'minclass' missing or set to %d instead of 4, or: 'dcredit', 'ucredit', 'ocredit' or 'lcredit' missing or set to %d, %d, %d, %d respectively instead of -1 each",
-                g_etcSecurityPwQualityConf, minlenOption, minclassOption, dcreditOption, ucreditOption, ocreditOption, lcreditOption);
+            FormatAllocateString("'%s' mising, or 'minclass' missing or set to %d instead of 4, or: 'dcredit', 'ucredit', 'ocredit' or 'lcredit' missing or set to "
+                "%d, %d, %d, %d respectively instead of -1 each", g_etcSecurityPwQualityConf, minclassOption, dcreditOption, ucreditOption, ocreditOption, lcreditOption);
     }
 
     return result;

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -398,22 +398,7 @@ static const char* g_securityBaselineModuleInfo = "{\"Name\": \"SecurityBaseline
     "\"Lifetime\": 2,"
     "\"UserAccount\": 0}";
 
-//static const char* g_azureLinux2 = "CBL-Mariner/Linux";
-//static const char* g_amazonLinux2 = "Amazon Linux 2";
-//static const char* g_centOs7 = "CentOS Linux 7";
-//static const char* g_centOs8 = "CentOS Stream 8";
-//static const char* g_debian10 = "Debian GNU/Linux 10";
-//static const char* g_debian11 = "Debian GNU/Linux 11";
-//static const char* g_debian12 = "Debian GNU/Linux 12";
-//static const char* g_oracleLinuxServer7 = "Oracle Linux Server 7";
-//static const char* g_oracleLinuxServer8 = "Oracle Linux Server 8";
-//static const char* g_redHatEnterpriseLinux7 = "Red Hat Enterprise Linux Server 7";
-//static const char* g_redHatEnterpriseLinux8 = "Red Hat Enterprise Linux 8";
-//static const char* g_redHatEnterpriseLinux9 = "Red Hat Enterprise Linux 9";
-//static const char* g_rockyLinux9 = "Rocky Linux 9";
-static const char* g_suseLinuxEnterpriseServer15 = "SUSE Linux Enterprise Server 15";
-//static const char* g_ubuntu20_04 = "Ubuntu 20.04";
-//static const char* g_ubuntu22_04 = "Ubuntu 22.04";
+static const char* g_suse = "SUSE";
 
 static const char* g_etcIssue = "/etc/issue";
 static const char* g_etcIssueNet = "/etc/issue.net";
@@ -1248,7 +1233,7 @@ static char* AuditEnsurePasswordCreationRequirements(void)
     int lcreditOption = 0;
     char* result = NULL;
     
-    if (IsCurrentOs(g_suseLinuxEnterpriseServer15, SecurityBaselineGetLog()))
+    if (IsCurrentOs(g_suse, SecurityBaselineGetLog()))
     {
         result = ((14 == (minlenOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "minlen", '=', SecurityBaselineGetLog()))) &&
             ((4 == (minclassOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "minclass", '=', SecurityBaselineGetLog()))) ||
@@ -1256,9 +1241,9 @@ static char* AuditEnsurePasswordCreationRequirements(void)
             (-1 == (ucreditOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "ucredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (ocreditOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "ocredit", '=', SecurityBaselineGetLog()))) &&
             (-1 == (lcreditOption = GetIntegerOptionFromFile(g_etcPamdCommonPassword, "lcredit", '=', SecurityBaselineGetLog())))))) ? DuplicateString(g_pass) :
-            FormatAllocateString("In %s, 'minlen' missing or set to %d instead of 14, 'minclass' missing or set to %d instead of 4, "
+            FormatAllocateString("%s detected, in %s, 'minlen' missing or set to %d instead of 14, 'minclass' missing or set to %d instead of 4, "
                 "or: 'dcredit', 'ucredit', 'ocredit' or 'lcredit' missing or set to %d, %d, %d, %d respectively instead of -1 each",
-                g_etcPamdCommonPassword, minlenOption, minclassOption, dcreditOption, ucreditOption, ocreditOption, lcreditOption);
+                g_suse, g_etcPamdCommonPassword, minlenOption, minclassOption, dcreditOption, ucreditOption, ocreditOption, lcreditOption);
     }
     else
     {


### PR DESCRIPTION
## Description

A select set of Security Baseline checks require different actions per distro. This PR adds that and applies it to one check from the ones that need it: AuditEnsurePasswordCreationRequirements, The pretty name values are for future uses which need the exact distro name.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.