### PR TITLE
Adding Universal NRP E2E test variants with and without OSConfig package installed

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -30,4 +30,4 @@ jobs:
           artifact: universal-nrp-test
           name: Universal NRP Test Report
           path: '*.xml'
-          reporter: dotnet-trx
+          reporter: java-junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,10 @@ jobs:
             { os: ubuntu, version: 20.04, package-type: DEB, tag: ''},
           ]
         arch: [amd64]
-        install-agent: [true, false]
+        install-osconfig: [true, false]
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}
       package-type: ${{ matrix.target.package-type }}
-      install-agent: ${{ matrix.install-agent }}
+      install-osconfig: ${{ matrix.install-osconfig }}
       tag: ${{ matrix.target.tag }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,10 @@ jobs:
             { os: ubuntu, version: 20.04, package-type: DEB, tag: ''},
           ]
         arch: [amd64]
+        install-agent: [true, false]
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}
       package-type: ${{ matrix.target.package-type }}
+      install-agent: ${{ matrix.install-agent }}
       tag: ${{ matrix.target.tag }}

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.download.outputs.download-path }}
         run: |
-          testLogSuffix=${{ inputs.install-osconfig == true && 'withAgent' || 'noAgent' }}
+          testLogSuffix=${{ inputs.install-osconfig == true && 'withOSConfig' || 'noOSConfig' }}
           script="./universalNRPTest.ps1"
           cat >$script <<EOL
           Install-Module -Name GuestConfiguration -Force

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -12,7 +12,7 @@ on:
       package-type:
         required: true
         type: string
-      install-agent:
+      install-osconfig:
         required: false
         type: boolean
         default: false
@@ -48,12 +48,12 @@ jobs:
           sudo mkdir -p /etc/osconfig
           sudo cp -r ./src/adapters/pnp/daemon/osconfig.json /etc/osconfig/osconfig.json
 
-      - name: Install agent
-        if: ${{ inputs.install-agent }}
+      - name: Install OSConfig
+        if: ${{ inputs.install-osconfig }}
         working-directory: ${{ steps.download.outputs.download-path }}/build
         run: |
           if [ "${{ inputs.package-type }}" = "DEB" ]; then
-            sudo apt install -y $(ls *.deb)
+            sudo dpkg -i $(ls *.deb)
           else
             sudo yum install -y $(ls *.rpm)
           fi
@@ -61,7 +61,7 @@ jobs:
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.download.outputs.download-path }}
         run: |
-          testLogSuffix=${{ inputs.install-agent == true && 'withAgent' || 'noAgent' }}
+          testLogSuffix=${{ inputs.install-osconfig == true && 'withAgent' || 'noAgent' }}
           script="./universalNRPTest.ps1"
           cat >$script <<EOL
           Install-Module -Name GuestConfiguration -Force
@@ -94,8 +94,20 @@ jobs:
 
           sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/omi/lib/ pwsh -Command $script
 
+      - name: Stage OSConfig Logs
+        run: |
+          mkdir  osconfig-logs
+          sudo cp -r /var/log/osconfig* osconfig-logs/
+          sudo chown $USER osconfig-logs/* 
+
       - uses: actions/upload-artifact@v3
         if: success() || failure()
         with:
           name: universal-nrp-test
           path: '${{ steps.download.outputs.download-path }}/${{ inputs.target }}-testResult*.xml'
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: universal-nrp-test-${{ inputs.install-osconfig == true && 'withOSConfig' || 'noOSConfig' }}-logs
+          path: osconfig-logs/osconfig*

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -80,7 +80,7 @@ jobs:
               TestResult = @{
                   Enabled      = \$true
                   OutputFormat = 'JUnitXml'
-                  OutputPath   = '${{ inputs.target }}-testResult-$testLogSuffix.xml'
+                  OutputPath   = '${{ inputs.target }}-UniversalNRP-testResult-$testLogSuffix.xml'
               }
               Should = @{
                   ErrorAction = 'Continue'

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -12,6 +12,10 @@ on:
       package-type:
         required: true
         type: string
+      install-agent:
+        required: false
+        type: boolean
+        default: false
       tag:
         required: false
         description: 'Pester tag to include in the test run. If not provided, all tests will be run.'
@@ -44,9 +48,20 @@ jobs:
           sudo mkdir -p /etc/osconfig
           sudo cp -r ./src/adapters/pnp/daemon/osconfig.json /etc/osconfig/osconfig.json
 
+      - name: Install agent
+        if: ${{ inputs.install-agent }}
+        working-directory: ${{ steps.download.outputs.download-path }}/build
+        run: |
+          if [ "${{ inputs.package-type }}" = "DEB" ]; then
+            sudo apt install -y $(ls *.deb)
+          else
+            sudo yum install -y $(ls *.rpm)
+          fi
+
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.download.outputs.download-path }}
         run: |
+          testLogSuffix=${{ inputs.install-agent == true && 'withAgent' || 'noAgent' }}
           script="./universalNRPTest.ps1"
           cat >$script <<EOL
           Install-Module -Name GuestConfiguration -Force
@@ -64,8 +79,8 @@ jobs:
               }
               TestResult = @{
                   Enabled      = \$true
-                  OutputFormat = 'NUnitXml'
-                  OutputPath   = '${{ inputs.target }}-testResult.xml'
+                  OutputFormat = 'JUnitXml'
+                  OutputPath   = '${{ inputs.target }}-testResult-$testLogSuffix.xml'
               }
               Should = @{
                   ErrorAction = 'Continue'
@@ -83,4 +98,4 @@ jobs:
         if: success() || failure()
         with:
           name: universal-nrp-test
-          path: '${{ steps.download.outputs.download-path }}/${{ inputs.target }}-testResult.xml'
+          path: '${{ steps.download.outputs.download-path }}/${{ inputs.target }}-testResult*.xml'

--- a/src/tests/universal-nrp-e2e/UniversalNRP.Tests.ps1
+++ b/src/tests/universal-nrp-e2e/UniversalNRP.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Validate Universal NRP' {
     # Perform monitoring - Get
     Context "Get" {
         BeforeAll {
-            $result = Get-GuestConfigurationPackageComplianceStatus -Path $PolicyPackage -Verbose
+            $result = Get-GuestConfigurationPackageComplianceStatus -Path $PolicyPackage
         }
 
         It 'Ensure the total resource instances count' {    
@@ -38,10 +38,10 @@ Describe 'Validate Universal NRP' {
     # Perform Remediation - Set
     Context "Set" {
         BeforeAll {
-            Start-GuestConfigurationPackageRemediation -Path $PolicyPackage -Verbose
+            Start-GuestConfigurationPackageRemediation -Path $PolicyPackage
             # Wait for remediation to complete
-            Start-Sleep -Seconds 60
-            $result = Get-GuestConfigurationPackageComplianceStatus -Path $PolicyPackage -Verbose
+            Start-Sleep -Seconds 30
+            $result = Get-GuestConfigurationPackageComplianceStatus -Path $PolicyPackage
         }
 
         It 'Ensure the total resource instances count' {    


### PR DESCRIPTION
## Description

* Added both agent and agentless Machine Configuration E2E Tests
* Changed tests to use jUnit instead of NUnit (as the testreporter breaks with NUnit 2.5)
* Remove `Verbose` flag from GuestConfiguration cmdlets

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.