### PR TITLE
Removing the functional Universal NRP tests from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,22 +90,3 @@ jobs:
           path: |
             ${{ matrix.target.name }}-${{ matrix.target.arch }}.log
             ${{ matrix.target.name }}-${{ matrix.target.arch }}.xml
-
-  universal-nrp-test:
-    name: Universal NRP Test
-    uses: ./.github/workflows/universalnrp-test-run.yml
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          [
-            { os: ubuntu, version: 20.04, package-type: DEB, tag: ''},
-          ]
-        arch: [amd64]
-        install-osconfig: [true, false]
-    with:
-      target: ${{ matrix.target.os }}-${{ matrix.target.version }}
-      arch: ${{ matrix.arch }}
-      package-type: ${{ matrix.target.package-type }}
-      install-osconfig: ${{ matrix.install-osconfig }}
-      tag: ${{ matrix.target.tag }}

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       target: ${{ inputs.target }}
       arch: ${{ inputs.arch }}
-      artifact: ${{ inputs.target }}
+      artifact: ${{ inputs.target }}-${{ inputs.install-osconfig == true && 'withOSConfig' || 'noOSConfig' }}
       package-type: ${{ inputs.package-type }}
       test: true
 
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/download-artifact@v3
         id: download
         with:
-          name: ${{ inputs.target }}
+          name: ${{ inputs.target }}-${{ inputs.install-osconfig == true && 'withOSConfig' || 'noOSConfig' }}
 
       - name: Create osconfig.json
         run: |


### PR DESCRIPTION
## Description

* Removed Universal NRP tests from CI
* Added suffix to artifact naming to prevent job conflicts

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.