### PR TITLE
MC E2E Distro Expansion

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -21,13 +21,3 @@ jobs:
           name: CI report
           path: '*.xml'
           reporter: java-junit
-
-  nrp-e2e-report:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dorny/test-reporter@v1
-        with:
-          artifact: universal-nrp-test
-          name: Universal NRP Test Report
-          path: '*.xml'
-          reporter: java-junit

--- a/.github/workflows/universalnrp-test-report.yml
+++ b/.github/workflows/universalnrp-test-report.yml
@@ -20,4 +20,4 @@ jobs:
           artifact: universal-nrp-test
           name: Universal NRP Test Report
           path: '*.xml'
-          reporter: dotnet-trx
+          reporter: java-junit

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Install OSConfig
         if: ${{ inputs.install-osconfig }}
-        working-directory: ${{ steps.download.outputs.download-path }}/build
+        working-directory: ${{ steps.download.outputs.download-path }}
         run: |
           if [ "${{ inputs.package-type }}" = "DEB" ]; then
             sudo dpkg -i $(ls *.deb)
           else
-            sudo yum install -y $(ls *.rpm)
+            sudo rpm -fi $(ls *.rpm)
           fi
 
       - name: Run Guest Configuration Test

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -1,7 +1,6 @@
 name: Universal NRP Test
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 20 * * *' # Every day at 12pm PST (UTC-8)

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -1,6 +1,9 @@
 name: Universal NRP Test
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *' # Every day at 8am UTC (12am PST)
 
 jobs:
   test:
@@ -11,7 +14,18 @@ jobs:
       matrix:
         target:
           [
+            { os: centos, version: 8, package-type: RPM, tag: ''},
+            { os: debian, version: 10, package-type: DEB, tag: ''},
+            { os: debian, version: 11, package-type: DEB, tag: ''},
+            # { os: debian, version: 12, package-type: DEB, tag: ''},
+            { os: mariner, version: 2, package-type: RPM, tag: ''},
+            { os: oraclelinux, version: 8, package-type: RPM, tag: ''},
+            { os: rhel, version: 8, package-type: RPM, tag: ''},
+            { os: rhel, version: 9, package-type: RPM, tag: ''},
+            # { os: rockylinux, version: 9, package-type: RPM, tag: ''},
+            { os: sles, version: 15, package-type: RPM, tag: ''},
             { os: ubuntu, version: 20.04, package-type: DEB, tag: ''},
+            { os: ubuntu, version: 22.04, package-type: DEB, tag: ''},
           ]
         arch: [amd64]
     with:

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -1,9 +1,10 @@
 name: Universal NRP Test
 
 on:
+  push:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * *' # Every day at 8am UTC (12am PST)
+    - cron: '0 20 * * *' # Every day at 12pm PST (UTC-8)
 
 jobs:
   test:
@@ -17,19 +18,20 @@ jobs:
             { os: centos, version: 8, package-type: RPM, tag: ''},
             { os: debian, version: 10, package-type: DEB, tag: ''},
             { os: debian, version: 11, package-type: DEB, tag: ''},
-            # { os: debian, version: 12, package-type: DEB, tag: ''},
             { os: mariner, version: 2, package-type: RPM, tag: ''},
             { os: oraclelinux, version: 8, package-type: RPM, tag: ''},
             { os: rhel, version: 8, package-type: RPM, tag: ''},
             { os: rhel, version: 9, package-type: RPM, tag: ''},
-            # { os: rockylinux, version: 9, package-type: RPM, tag: ''},
+            { os: rockylinux, version: 9, package-type: RPM, tag: ''},
             { os: sles, version: 15, package-type: RPM, tag: ''},
             { os: ubuntu, version: 20.04, package-type: DEB, tag: ''},
             { os: ubuntu, version: 22.04, package-type: DEB, tag: ''},
           ]
         arch: [amd64]
+        install-osconfig: [true, false]
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}
       package-type: ${{ matrix.target.package-type }}
+      install-osconfig: ${{ matrix.install-osconfig }}
       tag: ${{ matrix.target.tag }}

--- a/devops/e2e/cloudtest/debian-10.json
+++ b/devops/e2e/cloudtest/debian-10.json
@@ -33,7 +33,7 @@
         {
             "name": "linux-install-packages",
             "parameters": {
-                "packages": "dotnet-sdk-6.0 jq"
+                "packages": "dotnet-sdk-6.0 jq powershell omi"
             }
         },
         {

--- a/devops/e2e/cloudtest/debian-11.json
+++ b/devops/e2e/cloudtest/debian-11.json
@@ -33,7 +33,7 @@
         {
             "name": "linux-install-packages",
             "parameters": {
-                "packages": "dotnet-sdk-6.0 jq"
+                "packages": "dotnet-sdk-6.0 jq powershell omi"
             }
         },
         {

--- a/devops/e2e/cloudtest/debian-12.json
+++ b/devops/e2e/cloudtest/debian-12.json
@@ -1,0 +1,37 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-install-packages",
+            "parameters": {
+                "packages": "software-properties-common gnupg2"
+            }
+        },
+        {
+            "name": "linux-add-key",
+            "parameters": {
+                "key": "https://packages.microsoft.com/keys/microsoft.asc"
+            }
+        },
+        {
+            "name": "linux-add-repository",
+            "parameters": {
+                "repository": "https://packages.microsoft.com/debian/12/prod"
+            }
+        },
+        {
+            "name": "linux-install-packages",
+            "parameters": {
+                "packages": "dotnet-sdk-6.0 jq omi"
+            }
+        },
+        {
+            "name": "linux-azcli"
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell_7.4.1-1.deb_amd64.deb -O powershell.deb && sudo dpkg -i powershell.deb && sudo apt-get install -f"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/mariner-2.json
+++ b/devops/e2e/cloudtest/mariner-2.json
@@ -9,7 +9,7 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_110.ulinux.s.x64.rpm -O omi.rpm && if [ $(md5sum omi.rpm | awk '{print $1}') != '50a9f7f1a89e0dbd274ff1128fb9b8dc' ]; then exit 1; else sudo tdnf install -y omi.rpm; fi"
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_110.ulinux.s.x64.rpm -O omi.rpm && sudo tdnf install -y omi.rpm"
             }
         }
     ]

--- a/devops/e2e/cloudtest/mariner-2.json
+++ b/devops/e2e/cloudtest/mariner-2.json
@@ -1,0 +1,16 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo tdnf -y install dotnet-sdk-8.0 powershell"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_110.ulinux.s.x64.rpm -O omi.rpm && if [ $(md5sum omi.rpm | awk '{print $1}') != '50a9f7f1a89e0dbd274ff1128fb9b8dc' ]; then exit 1; else sudo tdnf install -y omi.rpm; fi"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/oraclelinux-8.json
+++ b/devops/e2e/cloudtest/oraclelinux-8.json
@@ -9,13 +9,13 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_300.ulinux.s.x64.rpm -O omi.rpm && if [ $(md5sum omi.rpm | awk '{print $1}') != '63db2ff0af4ade266f836c935374fedf' ]; then exit 1; else rpm -fi omi.rpm; fi"
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_110.ulinux.s.x64.rpm -O omi.rpm && rpm -fi omi.rpm"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && if [ $(md5sum powershell.rpm | awk '{print $1}') != 'be68d1e5c567415848deab0587202726' ]; then exit 1; else rpm -fi powershell.rpm --nodeps; fi"
+                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && rpm -fi powershell.rpm --nodeps"
             }
         }
     ]

--- a/devops/e2e/cloudtest/oraclelinux-8.json
+++ b/devops/e2e/cloudtest/oraclelinux-8.json
@@ -3,13 +3,13 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo zypper ar -f https://packages.microsoft.com/yumrepos/microsoft-sles15-prod/config.repo"
+                "command": "sudo yum install -y glibc* libicu wget which"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo yum install -y glibc* libicu wget"
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_300.ulinux.s.x64.rpm -O omi.rpm && if [ $(md5sum omi.rpm | awk '{print $1}') != '63db2ff0af4ade266f836c935374fedf' ]; then exit 1; else rpm -fi omi.rpm; fi"
             }
         },
         {

--- a/devops/e2e/cloudtest/rhel-8.json
+++ b/devops/e2e/cloudtest/rhel-8.json
@@ -1,0 +1,10 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel8.0-prod/ && sudo yum install -y powershell omi"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/rhel-9.json
+++ b/devops/e2e/cloudtest/rhel-9.json
@@ -1,0 +1,10 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel9.0-prod/ && sudo yum install -y powershell omi"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/rockylinux-9.json
+++ b/devops/e2e/cloudtest/rockylinux-9.json
@@ -1,0 +1,22 @@
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y glibc* libicu wget which awk"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_300.ulinux.s.x64.rpm -O omi.rpm && rpm -fi omi.rpm; fi"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && rpm -fi powershell.rpm --nodeps; fi"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/rockylinux-9.json
+++ b/devops/e2e/cloudtest/rockylinux-9.json
@@ -3,19 +3,19 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo yum install -y glibc* libicu wget which awk"
+                "command": "sudo yum install -y glibc* libicu wget which"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_300.ulinux.s.x64.rpm -O omi.rpm && rpm -fi omi.rpm; fi"
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_300.ulinux.s.x64.rpm -O omi.rpm && rpm -fi omi.rpm"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && rpm -fi powershell.rpm --nodeps; fi"
+                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && rpm -fi powershell.rpm --nodeps"
             }
         }
     ]

--- a/devops/e2e/cloudtest/sles-15.json
+++ b/devops/e2e/cloudtest/sles-15.json
@@ -9,13 +9,13 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo yum install -y glibc* libicu wget"
+                "command": "wget https://github.com/microsoft/omi/releases/download/v1.8.1-0/omi-1.8.1-0.ssl_110.ulinux.s.x64.rpm -O omi.rpm && rpm -fi omi.rpm"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && if [ $(md5sum powershell.rpm | awk '{print $1}') != 'be68d1e5c567415848deab0587202726' ]; then exit 1; else rpm -fi powershell.rpm --nodeps; fi"
+                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell-7.4.1-1.rh.x86_64.rpm -O powershell.rpm && rpm -fi powershell.rpm --nodeps"
             }
         }
     ]


### PR DESCRIPTION
## Description

 * Added Machine Configuration e2e workflow targeting the following distros (daily + workflow dispatch):
   * Centos 8
   * Debian 10, 11
   * Mariner 2 (aka Azure Linux)
   * Oracle Linux 8
   * Red Hat Enterprise Linux 8, 9
   * Suse Linux Enterprise (aka sles) 15
   * Ubuntu 20.04, 22.04
 * Removed MC e2e from CI
 * Updated Cloudtest manifests

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.