### PR TITLE
Universal NRP stabilization for shutting down in fallback and OSConfig modes

### DIFF
--- a/src/adapters/mc/OsConfigPolicy.mof
+++ b/src/adapters/mc/OsConfigPolicy.mof
@@ -320,9 +320,9 @@ instance of OsConfigResource as $OsConfigResource19ref
 
 instance of OMI_ConfigurationDocument
 {
-    Version="1.0.3";
+    Version="1.0.5";
     CompatibleVersionAdditionalProperties= {"Omi_BaseResource:ConfigurationName"};
     Author="Microsoft";
-    GenerationDate="2/20/2024 10:12:00 AM PST";
+    GenerationDate="3/18/2024 16:50:00 PST";
     Name="OsConfigSshServerSecurity";
 };

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -35,6 +35,7 @@ MPI_HANDLE g_mpiHandle = NULL;
 
 static OSCONFIG_LOG_HANDLE g_log = NULL;
 
+const char* g_osconfig = "osconfig";
 const char* g_mpiServer = "osconfig-platform";
 
 OSCONFIG_LOG_HANDLE GetLog(void)
@@ -158,7 +159,7 @@ void MI_CALL OsConfigResource_Unload(
         CallMpiClose(g_mpiHandle, GetLog());
         g_mpiHandle = NULL;
 
-        RestartDaemon(g_mpiServer, NULL);
+        RestartDaemon(IsDaemonActive(g_osconfig, GetLog()) ? g_osconfig : g_mpiServer, NULL);
     }
 
     MI_Context_PostResult(context, MI_RESULT_OK);

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -119,7 +119,7 @@ void MI_CALL OsConfigResource_Load(
     // Fallback for SSH policy
     InitializeSshAudit(GetLog());
 
-    LogInfo(GetLog(), "[OsConfigResource] Loaded and running (PID: %d, MPI handle: %p)", getpid(), g_mpiHandle);
+    LogInfo(context, GetLog(), "[OsConfigResource] Loaded and running (PID: %d, MPI handle: %p)", getpid(), g_mpiHandle);
 
     MI_Context_PostResult(context, MI_RESULT_OK);
 }

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -117,7 +117,7 @@ void MI_CALL OsConfigResource_Load(
     // Fallback for SSH policy
     InitializeSshAudit(GetLog());
 
-    LogInfo(context, GetLog(), "[OsConfigResource] Loaded and running (PID: %d, MPI handle: %p)", getpid(), g_mpiHandle);
+    LogInfo(context, GetLog(), "[OsConfigResource] Load (PID: %d, MPI handle: %p)", getpid(), g_mpiHandle);
 
     MI_Context_PostResult(context, MI_RESULT_OK);
 }
@@ -128,7 +128,7 @@ void MI_CALL OsConfigResource_Unload(
 {
     MI_UNREFERENCED_PARAMETER(self);
 
-    LogInfo(context, GetLog(), "[OsConfigResource] Stopping and unloading (PID: %d, MPI handle: %p)", getpid(), g_mpiHandle);
+    LogInfo(context, GetLog(), "[OsConfigResource] Unload (PID: %d, MPI handle: %p)", getpid(), g_mpiHandle);
 
     if (NULL != g_mpiHandle)
     {

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -117,10 +117,10 @@ void MI_CALL OsConfigResource_Load(
 
     *self = NULL;
 
-    if (NULL != mpiHandle)
+    if (NULL != g_mpiHandle)
     {
-        CallMpiClose(mpiHandle, GetLog());
-        mpiHandle = NULL;
+        CallMpiClose(g_mpiHandle, GetLog());
+        g_mpiHandle = NULL;
     }
     
     if (NULL == (g_mpiHandle = RefreshMpiClientSession(g_mpiHandle))

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -110,8 +110,6 @@ void MI_CALL OsConfigResource_Load(
 {
     MI_UNREFERENCED_PARAMETER(selfModule);
 
-    LogInfo(context, GetLog(), "[OsConfigResource] Load");
-
     *self = NULL;
 
     RefreshMpiClientSession();

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -123,7 +123,7 @@ void MI_CALL OsConfigResource_Load(
         g_mpiHandle = NULL;
     }
     
-    if (NULL == (g_mpiHandle = RefreshMpiClientSession(g_mpiHandle))
+    if (NULL == (g_mpiHandle = RefreshMpiClientSession(g_mpiHandle)))
     {
         // Fallback for SSH policy
         InitializeSshAudit(GetLog());

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -634,8 +634,21 @@ void MpiInitialize(void)
 
 void MpiShutdown(void)
 {
+    int status = 0;
+
     g_serverActive = false;
-    pthread_join(g_mpiServerWorker, NULL);
+
+    if (0 == (status = pthread_cancel(g_mpiServerWorker)))
+    {
+        if (0 != (status = pthread_join(g_mpiServerWorker, NULL)))
+        {
+            OsConfigLogError(GetPlatformLog(), "MpiShutdown: pthread_join failed with %d", status);
+        }
+    }
+    else
+    {
+        OsConfigLogError(GetPlatformLog(), "MpiShutdown: pthread_cancel failed with %d", status);
+    }
 
     UnloadModules();
 


### PR DESCRIPTION
## Description

The Universal NRP needs to restart the OSConfig Platform at the end of a session in order to make the Security Baseline module to be unloaded (as the Module Manager does not yet implement automatic unload of short-lived modules) and give a chance for SSH configuration to be written and the OpenSSH server restarted to load it. This restart is either direct when the OSConfig Agent is not running, or via the OSConfig Agent when that's running.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.