### PR TITLE
Avoiding SEGFAULT calling pthread_join on an expired thread with id 0

### DIFF
--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -634,20 +634,11 @@ void MpiInitialize(void)
 
 void MpiShutdown(void)
 {
-    int status = 0;
-
     g_serverActive = false;
 
-    if (0 == (status = pthread_cancel(g_mpiServerWorker)))
+    if (g_mpiServerWorker > 0)
     {
-        if (0 != (status = pthread_join(g_mpiServerWorker, NULL)))
-        {
-            OsConfigLogError(GetPlatformLog(), "MpiShutdown: pthread_join failed with %d", status);
-        }
-    }
-    else
-    {
-        OsConfigLogError(GetPlatformLog(), "MpiShutdown: pthread_cancel failed with %d", status);
+        pthread_join(g_mpiServerWorker, NULL);
     }
 
     UnloadModules();


### PR DESCRIPTION
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.