### PR TITLE
Added workflow ability to build explicit git refs

### DIFF
--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -1,6 +1,7 @@
 name: Publish (insiders-fast)
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 8 * * *' # Every day at 8am UTC (12am PST)
 

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -34,6 +34,10 @@ on:
         type: boolean
         required: false
         default: false
+      ref:
+        type: string
+        required: false
+        default: ${{ github.ref }}
 
 env:
   BUILD_TYPE: Release
@@ -48,6 +52,7 @@ jobs:
         with:
           submodules: recursive
           clean: true
+          ref: ${{ inputs.ref }}
 
       - name: Run container
         id: container

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -2,6 +2,12 @@ name: Publish (prod)
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish'
+        required: true
+        default: ${{ github.ref }}
+        type: string
   push:
     tags:
       - v*.*.*


### PR DESCRIPTION
## Description

* Added explicit `ref` to perform package-building on a particular git ref
* Added `workflow_dispatch` for manual `insider-fast` publishing

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.