### PR TITLE
Removed expression from workflow default value

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -6,7 +6,7 @@ on:
       ref:
         description: 'Git ref to publish'
         required: true
-        default: ${{ github.ref }}
+        default: main
         type: string
   push:
     tags:


### PR DESCRIPTION
## Description

* Removed GitHub expression from workflow input, set to `main` branch

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.