### PR TITLE
Corrected apt release channel to use distribution name

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -38,7 +38,7 @@ jobs:
       dist: ${{ matrix.target.dist }}
       # ESRP debian based repos (deb) have channels/rings on repos.
       # ESRP yum based repos (rpm) have no channels
-      channel: ${{ matrix.target.package-type == 'DEB' && 'prod' || '' }}
+      channel: ${{ matrix.target.package-type == 'DEB' && '${{ matrix.target.dist }}' || '' }}
       package-type: ${{ matrix.target.package-type }}
     secrets: inherit
 


### PR DESCRIPTION
## Description

* Corrected apt repos to use the distribution name for `prod` releases

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.