### PR TITLE
Various workflow updates, updated cloudtest definitions

### DIFF
--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Check last scheduled workflow status
         id: last_scheduled_workflow_status
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get RUN ID of last workflow, not the current one
           last_workflow_run_id=$(gh run list --workflow='Publish (insiders-fast)' --event=schedule --limit=2 --json databaseId -q '.[1].databaseId')
@@ -69,6 +71,7 @@ jobs:
       arch: ${{ matrix.target.arch }}
       repo: ${{ matrix.target.repo }}
       dist: ${{ matrix.target.dist }}
+      environment: insiders-fast
       # ESRP debian based repos (deb) have channels/rings on repos.
       # ESRP yum based repos (rpm) have no channels
       channel: ${{ matrix.target.package-type == 'DEB' && 'insiders-fast' || '' }}

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -50,7 +50,7 @@ env:
 
 jobs:
   package:
-    runs-on: ${{ inputs.release == true && fromJSON('["self-hosted", "1ES.Pool=release-pool", "1ES.ImageOverride=ubuntu-22.04"]') || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.release == true && fromJSON('["self-hosted", "1ES.Pool=release-pool", "1ES.ImageOverride=build-infra"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -6,6 +6,10 @@ on:
       repo:
         required: true
         type: string
+      environment:
+        type: string
+        description: The GitHub environment to use for the build.
+        required: true
       channel:
         required: true
         type: string
@@ -15,7 +19,8 @@ on:
 
 jobs:
   publish:
-    runs-on: [self-hosted, 1ES.Pool=release-pool, 1ES.ImageOverride=ubuntu-22.04]
+    runs-on: [self-hosted, 1ES.Pool=release-pool, 1ES.ImageOverride=build-infra]
+    environment: ${{ inputs.environment }}
     env:
       PMC_CLI_BASE_URL: https://pmc-ingest.trafficmanager.net/api/v4
       PMC_CLI_MSAL_CLIENT_ID: 7497d560-834a-4326-9750-ead7c3894d19

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -36,6 +36,7 @@ jobs:
       arch: ${{ matrix.target.arch }}
       repo: ${{ matrix.target.repo }}
       dist: ${{ matrix.target.dist }}
+      environment: prod
       # ESRP debian based repos (deb) have channels/rings on repos.
       # ESRP yum based repos (rpm) have no channels
       channel: ${{ matrix.target.package-type == 'DEB' && matrix.target.dist || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,10 @@ on:
       package-type:
         type: string
         required: true
+      environment:
+        type: string
+        description: The GitHub environment to use for the build.
+        required: true
       container-tag:
         type: string
         required: false
@@ -51,6 +55,7 @@ jobs:
     needs: sign
     with:
       repo: ${{ inputs.repo }}
+      environment: ${{ inputs.environment }}
       channel: ${{ inputs.channel }}
       artifact: ${{ inputs.target }}-${{ inputs.arch }}-signed
     secrets: inherit

--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -12,6 +12,9 @@ on:
       package-type:
         required: true
         type: string
+      policy-package:
+        required: true
+        type: string
       install-osconfig:
         required: false
         type: boolean
@@ -68,7 +71,7 @@ jobs:
           Install-Module Pester -Force -SkipPublisherCheck
           Import-Module Pester -Passthru
 
-          \$container = New-PesterContainer -Path ./src/tests/universal-nrp-e2e/UniversalNRP.Tests.ps1 -Data @{ PolicyPackage = './LinuxSshServerSecurityBaselinePolicy.zip' }
+          \$container = New-PesterContainer -Path ./src/tests/universal-nrp-e2e/UniversalNRP.Tests.ps1 -Data @{ PolicyPackage = './${{ inputs.policy-package }}' }
           \$pesterConfig = [PesterConfiguration]@{
               Run = @{
                   Exit = \$true

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -28,9 +28,14 @@ jobs:
           ]
         arch: [amd64]
         install-osconfig: [true, false]
+        policy-package: [LinuxSecurityBaselinePolicy.zip, LinuxSshServerSecurityBaselinePolicy.zip]
+        exclude:
+          - install-osconfig: false
+            policy-package: LinuxSecurityBaselinePolicy.zip
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}
       arch: ${{ matrix.arch }}
       package-type: ${{ matrix.target.package-type }}
+      policy-package: ${{ matrix.policy-package }}
       install-osconfig: ${{ matrix.install-osconfig }}
       tag: ${{ matrix.target.tag }}

--- a/devops/README.md
+++ b/devops/README.md
@@ -169,7 +169,7 @@ yum remove osconfig
 #### <a name="rhel8-insiders-fast">insiders-fast
 ```bash
 yum install yum-utils
-yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel8.0-insiders-fast-prod/
+yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel8.0-insiders-fast-prod/config.repo
 yum install osconfig
 ```
 ### Remove

--- a/devops/e2e/cloudtest/build-infra.json
+++ b/devops/e2e/cloudtest/build-infra.json
@@ -1,0 +1,20 @@
+// Base Image: 1ES PT - Ubuntu 22.04 - vNext
+{
+    "artifacts": [
+        {
+            "name": "linux-azcli"
+        },
+        {
+            "name": "linux-dotnet-sdk",
+            "parameters": {
+                "version": "6.0"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "apt list --installed"
+            }
+        }
+    ]
+}

--- a/devops/e2e/cloudtest/centos-8.json
+++ b/devops/e2e/cloudtest/centos-8.json
@@ -1,9 +1,22 @@
+// Base Image: OpenLogic:CentOS:8_2-gen2:latest
 {
     "artifacts": [
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo yum install -y glibc*"
+                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-centos8-insiders-fast-prod/config.repo"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y glibc* libicu wget which"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.2/powershell-7.4.2-1.rh.x86_64.rpm -O powershell.rpm && rpm -fi powershell.rpm --nodeps"
             }
         }
     ]

--- a/devops/e2e/cloudtest/debian-10.json
+++ b/devops/e2e/cloudtest/debian-10.json
@@ -1,5 +1,12 @@
+// Base Image: debian:debian-10:10-gen2:latest
 {
     "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo sed -i 's/debian-archive.trafficmanager.net/archive.debian.org/g' /etc/apt/sources.list && sudo sed -i '/debian-security/d' /etc/apt/sources.list"
+            }
+        },
         {
             "name": "linux-install-packages",
             "parameters": {
@@ -7,21 +14,21 @@
             }
         },
         {
-            "name": "linux-add-key",
+            "name": "linux-bash-command",
             "parameters": {
-                "key": "https://packages.microsoft.com/keys/microsoft.asc"
-            }
-        },
-        {
-            "name": "linux-add-repository",
-            "parameters": {
-                "repository": "https://packages.microsoft.com/debian/10/prod"
+                "command": "wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && sudo dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb"
+                "command": "wget https://packages.microsoft.com/config/debian/10/prod.list -O /etc/apt/sources.list.d/packages-microsoft-com_prod.list"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://packages.microsoft.com/config/debian/10/insiders-fast.list -O /etc/apt/sources.list.d/packages-microsoft-com_insiders-fast.list"
             }
         },
         {

--- a/devops/e2e/cloudtest/debian-11.json
+++ b/devops/e2e/cloudtest/debian-11.json
@@ -1,5 +1,12 @@
+// Base Image: debian:debian-11:11-gen2:latest
 {
     "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo apt update"
+            }
+        },
         {
             "name": "linux-install-packages",
             "parameters": {
@@ -7,21 +14,21 @@
             }
         },
         {
-            "name": "linux-add-key",
+            "name": "linux-bash-command",
             "parameters": {
-                "key": "https://packages.microsoft.com/keys/microsoft.asc"
-            }
-        },
-        {
-            "name": "linux-add-repository",
-            "parameters": {
-                "repository": "https://packages.microsoft.com/debian/11/prod"
+                "command": "wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && sudo dpkg -i packages-microsoft-prod.deb && rm packages-microsoft-prod.deb"
+                "command": "wget https://packages.microsoft.com/config/debian/11/prod.list -O /etc/apt/sources.list.d/packages-microsoft-com_prod.list"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://packages.microsoft.com/config/debian/11/insiders-fast.list -O /etc/apt/sources.list.d/packages-microsoft-com_insiders-fast.list"
             }
         },
         {

--- a/devops/e2e/cloudtest/debian-12.json
+++ b/devops/e2e/cloudtest/debian-12.json
@@ -1,3 +1,4 @@
+// Base Image: debian:debian-12:12-gen2:latest
 {
     "artifacts": [
         {
@@ -7,21 +8,27 @@
             }
         },
         {
-            "name": "linux-add-key",
+            "name": "linux-bash-command",
             "parameters": {
-                "key": "https://packages.microsoft.com/keys/microsoft.asc"
+                "command": "wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/packages-microsoft-com_key.asc"
             }
         },
         {
-            "name": "linux-add-repository",
+            "name": "linux-bash-command",
             "parameters": {
-                "repository": "https://packages.microsoft.com/debian/12/prod"
+                "command": "wget https://packages.microsoft.com/config/debian/12/prod.list -O /etc/apt/sources.list.d/packages-microsoft-com_prod.list"
             }
         },
         {
-            "name": "linux-install-packages",
+            "name": "linux-bash-command",
             "parameters": {
-                "packages": "dotnet-sdk-6.0 jq omi"
+                "command": "wget https://packages.microsoft.com/config/debian/12/insiders-fast.list -O /etc/apt/sources.list.d/packages-microsoft-com_insiders-fast.list"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo apt update && sudo apt install -y dotnet-sdk-6.0 jq omi"
             }
         },
         {

--- a/devops/e2e/cloudtest/mariner-2.json
+++ b/devops/e2e/cloudtest/mariner-2.json
@@ -1,5 +1,12 @@
+// Base Image: MicrosoftCBLMariner:cblmariner:cbl-mariner-2:latest
 {
     "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo tdnf install -y dnf-plugins-core && dnf config-manager --add-repo https://packages.microsoft.com/yumrepos/cbl-mariner-2.0-preview-Microsoft-x86_64/config.repo"
+            }
+        },
         {
             "name": "linux-bash-command",
             "parameters": {

--- a/devops/e2e/cloudtest/oraclelinux-8.json
+++ b/devops/e2e/cloudtest/oraclelinux-8.json
@@ -1,3 +1,4 @@
+// Base Image: Oracle:Oracle-Linux:ol89-lvm-gen2:latest
 {
     "artifacts": [
         {

--- a/devops/e2e/cloudtest/rhel-8.json
+++ b/devops/e2e/cloudtest/rhel-8.json
@@ -1,9 +1,16 @@
+// Base Image: RedHat:RHEL:8-lvm-gen2:latest
 {
     "artifacts": [
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel8.0-prod/ && sudo yum install -y powershell omi"
+                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel8.0-insiders-fast-prod/config.repo"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel8.0-prod/ && sudo yum install -y powershell omi"
             }
         }
     ]

--- a/devops/e2e/cloudtest/rhel-9.json
+++ b/devops/e2e/cloudtest/rhel-9.json
@@ -1,5 +1,12 @@
+// Base Image: RedHat:RHEL:9-lvm-gen2:latest
 {
     "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/yumrepos/microsoft-rhel9.0-insiders-fast-prod/config.repo"
+            }
+        },
         {
             "name": "linux-bash-command",
             "parameters": {

--- a/devops/e2e/cloudtest/rockylinux-9.json
+++ b/devops/e2e/cloudtest/rockylinux-9.json
@@ -1,5 +1,12 @@
+// Base Image: resf:rockylinux-x86_64:9-base:latest
 {
     "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo yum install -y yum-utils && yum-config-manager --add-repo https://packages.microsoft.com/config/rocky/9/insiders-fast.repo"
+            }
+        },
         {
             "name": "linux-bash-command",
             "parameters": {

--- a/devops/e2e/cloudtest/sles-15.json
+++ b/devops/e2e/cloudtest/sles-15.json
@@ -1,5 +1,12 @@
+// Base Image: suse:sles-15-sp4-byos:gen2:latest
 {
     "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo zypper ar -f https://packages.microsoft.com/yumrepos/microsoft-sles15-insiders-fast-prod/config.repo"
+            }
+        },
         {
             "name": "linux-bash-command",
             "parameters": {

--- a/devops/e2e/cloudtest/ubuntu-20_04.json
+++ b/devops/e2e/cloudtest/ubuntu-20_04.json
@@ -1,3 +1,4 @@
+// Base Image: canonical:0001-com.ubuntu-server.focal:20_04-lts-gen2:latest
 {
     "artifacts": [
         {
@@ -10,6 +11,18 @@
             "name": "linux-add-repository",
             "parameters": {
                 "repository": "https://packages.microsoft.com/ubuntu/20.04/prod"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://packages.microsoft.com/config/ubuntu/20.04/insiders-fast.list -O /etc/apt/sources.list.d/packages-microsoft-com_insiders-fast.list"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo apt update"
             }
         },
         {

--- a/devops/e2e/cloudtest/ubuntu-22_04.json
+++ b/devops/e2e/cloudtest/ubuntu-22_04.json
@@ -1,21 +1,22 @@
+// Base Image: canonical:0001-com.ubuntu-server.focal:22_04-lts-gen2:latest
 {
     "artifacts": [
         {
-            "name": "linux-add-key",
+            "name": "linux-bash-command",
             "parameters": {
-                "key": "https://packages.microsoft.com/keys/microsoft.asc"
+                "command": "wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && sudo wget https://packages.microsoft.com/config/ubuntu/22.04/prod.list -O /etc/apt/sources.list.d/packages-microsoft-com_prod.list && sudo wget https://packages.microsoft.com/config/ubuntu/22.04/insiders-fast.list -O /etc/apt/sources.list.d/packages-microsoft-com_insiders-fast.list"
             }
         },
         {
-            "name": "linux-add-repository",
+            "name": "linux-bash-command",
             "parameters": {
-                "repository": "https://packages.microsoft.com/ubuntu/22.04/prod"
+                "command": "sudo apt update"
             }
         },
         {
             "name": "linux-install-packages",
             "parameters": {
-                "packages": "aziot-identity-service jq"
+                "packages": "aziot-identity-service jq omi powershell libgsl-dev libgsl27 libgslcblas0"
             }
         },
         {
@@ -25,6 +26,12 @@
             "name": "linux-dotnet-sdk",
             "parameters": {
                 "version": "6.0"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "apt list --installed"
             }
         }
     ]

--- a/src/adapters/mc/asb/CMakeLists.txt
+++ b/src/adapters/mc/asb/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(stage_create_zip
     DEPENDS OsConfigResourceAsb)
 
 add_custom_target(create_zip ALL
-    BYPRODUCTS ${OsConfigRootBinaryDir}/OsConfigPolicy.zip
+    BYPRODUCTS ${OsConfigRootBinaryDir}/LinuxSecurityBaselinePolicy.zip
     COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${OsConfigRootBinaryDir}/LinuxSecurityBaselinePolicy.zip" --format=zip .
     DEPENDS stage_create_zip
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)

--- a/src/adapters/mc/ssh/CMakeLists.txt
+++ b/src/adapters/mc/ssh/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(stage_create_zip_ssh
     DEPENDS OsConfigResourceSsh)
 
 add_custom_target(create_zip_ssh ALL
-    BYPRODUCTS ${OsConfigRootBinaryDir}/OsConfigPolicy.zip
+    BYPRODUCTS ${OsConfigRootBinaryDir}/LinuxSshServerSecurityBaselinePolicy.zip
     COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${OsConfigRootBinaryDir}/LinuxSshServerSecurityBaselinePolicy.zip" --format=zip .
     DEPENDS stage_create_zip_ssh
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)


### PR DESCRIPTION
## Description

* Use new `build-infra` image for our container build infrastructure host instead of overloading the `ubuntu-22.04` image
* Added multi policy support for the Universal NRP test workflows allowing for testing both `LinuxSecurityBaselinePolicy.zip` and `LinuxSshServerSecurityBaselinePolicy.zip`
* Added `insiders-fast` / `prod` github environment mappings to package-build workflows for better PMC deployment tracking.
* Fixed `insiders-fast` publishing, added missing gh token.
* Updated VM image definitions to also include their base image reference

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.