### PR TITLE
devops/docker/debian-12*: actually use debian 12 base

### DIFF
--- a/devops/docker/debian-12-amd64/Dockerfile
+++ b/devops/docker/debian-12-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mirror/docker/library/debian:bullseye
+FROM mcr.microsoft.com/mirror/docker/library/debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/devops/docker/debian-12-arm64/Dockerfile
+++ b/devops/docker/debian-12-arm64/Dockerfile
@@ -1,5 +1,5 @@
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
-FROM arm64v8/debian:bullseye
+FROM arm64v8/debian:bookworm
 
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 


### PR DESCRIPTION
## Description

Not sure if it was intentional, but switching to the debian 12 (bookworm) base image. (`bullseye` is debian 11)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.