### PR TITLE
Removed push triggers from e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,11 +1,6 @@
 name: E2E
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - src/**
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

* Removed push triggers from E2E tests

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.