### PR TITLE
Fix for MPI server code

### DIFF
--- a/src/common/asb/Asb.h
+++ b/src/common/asb/Asb.h
@@ -4,6 +4,28 @@
 #ifndef ASB_H
 #define ASB_H
 
+#define PRETTY_NAME_AZURE_LINUX_2 "CBL-Mariner/Linux"
+#define PRETTY_NAME_ALMA_LINUX_9 "AlmaLinux 9 (Beryllium)"
+#define PRETTY_NAME_ALMA_LINUX_9_3 "AlmaLinux 9.3 (Shamrock Pampas Cat)"
+#define PRETTY_NAME_AMAZON_LINUX_2 "Amazon Linux 2"
+#define PRETTY_NAME_CENTOS_7 "CentOS Linux 7"
+#define PRETTY_NAME_CENTOS_8 "CentOS Stream 8"
+#define PRETTY_NAME_DEBIAN_10 "Debian GNU/Linux 10"
+#define PRETTY_NAME_DEBIAN_11 "Debian GNU/Linux 11"
+#define PRETTY_NAME_DEBIAN_12 "Debian GNU/Linux 12"
+#define PRETTY_NAME_ORACLE_LINUX_SERVER_7 "Oracle Linux Server 7"
+#define PRETTY_NAME_ORACLE_LINUX_SERVER_8 "Oracle Linux Server 8"
+#define PRETTY_NAME_RHEL_7 "Red Hat Enterprise Linux Server 7"
+#define PRETTY_NAME_RHEL_8 "Red Hat Enterprise Linux 8"
+#define PRETTY_NAME_RHEL_9 "Red Hat Enterprise Linux 9"
+#define PRETTY_NAME_ROCKY_LINUX_9 "Rocky Linux 9"
+#define PRETTY_NAME_SLES_15 "SUSE Linux Enterprise Server 15"
+#define PRETTY_NAME_UBUNTU_20_04 "Ubuntu 20.04"
+#define PRETTY_NAME_UBUNTU_22_04 "Ubuntu 22.04"
+
+#define SECURITY_AUDIT_PASS "PASS"
+#define SECURITY_AUDIT_FAIL "FAIL"
+
 #define InternalOsConfigAddReason(reason, format, ...) {\
     char* last = NULL;\
     char* temp = FormatAllocateString("%s, also ", *reason);\

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -9,28 +9,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#define PRETTY_NAME_AZURE_LINUX_2 "CBL-Mariner/Linux"
-#define PRETTY_NAME_ALMA_LINUX_9 "AlmaLinux 9 (Beryllium)"
-#define PRETTY_NAME_ALMA_LINUX_9_3 "AlmaLinux 9.3 (Shamrock Pampas Cat)"
-#define PRETTY_NAME_AMAZON_LINUX_2 "Amazon Linux 2"
-#define PRETTY_NAME_CENTOS_7 "CentOS Linux 7"
-#define PRETTY_NAME_CENTOS_8 "CentOS Stream 8"
-#define PRETTY_NAME_DEBIAN_10 "Debian GNU/Linux 10"
-#define PRETTY_NAME_DEBIAN_11 "Debian GNU/Linux 11"
-#define PRETTY_NAME_DEBIAN_12 "Debian GNU/Linux 12"
-#define PRETTY_NAME_ORACLE_LINUX_SERVER_7 "Oracle Linux Server 7"
-#define PRETTY_NAME_ORACLE_LINUX_SERVER_8 "Oracle Linux Server 8"
-#define PRETTY_NAME_RHEL_7 "Red Hat Enterprise Linux Server 7"
-#define PRETTY_NAME_RHEL_8 "Red Hat Enterprise Linux 8"
-#define PRETTY_NAME_RHEL_9 "Red Hat Enterprise Linux 9"
-#define PRETTY_NAME_ROCKY_LINUX_9 "Rocky Linux 9"
-#define PRETTY_NAME_SLES_15 "SUSE Linux Enterprise Server 15"
-#define PRETTY_NAME_UBUNTU_20_04 "Ubuntu 20.04"
-#define PRETTY_NAME_UBUNTU_22_04 "Ubuntu 22.04"
-
-#define SECURITY_AUDIT_PASS "PASS"
-#define SECURITY_AUDIT_FAIL "FAIL"
-
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
 #define UNUSED(a) (void)(a)

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -503,7 +503,7 @@ static void* MpiServerWorker(void* arguments)
                 OsConfigLogError(GetPlatformLog(), "Failed to read request URI %d", socketHandle);
                 status = HTTP_BAD_REQUEST;
             }
-            else if ((contentLength = ReadHttpContentLengthFromSocket(socketHandle, GetPlatformLog())))
+            else if (0 != (contentLength = ReadHttpContentLengthFromSocket(socketHandle, GetPlatformLog())))
             {
                 if (NULL == (requestBody = (char*)malloc(contentLength + 1)))
                 {


### PR DESCRIPTION
## Description

Build break on Mariner 2 and Debian 12 with new hardened compiler warnings. Bad structure in MPI Server code potentially causing segfault crash on low memory conditions. Plus some minor cleanup for ASB.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.