### PR TITLE
Fixing the ASB AuditEnsureKernelCompiledFromApprovedSources check to run on all targeted distros

### DIFF
--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -634,7 +634,7 @@ bool CheckOsAndKernelMatchDistro(char** reason, void* log)
     }
     
     FREE_MEMORY(kernelName);
-    FREE_MEMORY(kerneVersion);
+    FREE_MEMORY(kernelVersion);
 
     ClearOsDistroInfo(&distro);
     ClearOsDistroInfo(&os);


### PR DESCRIPTION
## Description

Some of the values being checked are not available on non-Debian/Ubuntu distros. Restricting the check to the kernel name for now, with possibility to add version in the future, helps auditing on the other distros.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.