### PR TITLE
Fixing one reversed Security Baseline audit check (AuditEnsureBind9NotInstalled is reversed)

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1021,7 +1021,7 @@ static char* AuditEnsureSldapdNotInstalled(void* log)
 static char* AuditEnsureBind9NotInstalled(void* log)
 {
     char* reason = NULL;
-    CheckPackageInstalled(g_bind9, &reason, log);
+    CheckPackageNotInstalled(g_bind9, &reason, log);
     return reason;
 }
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.