### PR TITLE
Adding for Azure Security Baseline v2's EnsurePasswordReuseIsLimited check remediation and consolidating audit

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -458,7 +458,6 @@ static const char* g_etcGShadow = "/etc/gshadow";
 static const char* g_etcGShadowDash = "/etc/gshadow-";
 static const char* g_etcPasswd = "/etc/passwd";
 static const char* g_etcPasswdDash = "/etc/passwd-";
-static const char* g_etcPamdCommonPassword = "/etc/pam.d/common-password";
 static const char* g_etcPamdPasswordAuth = "/etc/pam.d/password-auth";
 static const char* g_etcPamdSystemAuth = "/etc/pam.d/system-auth";
 static const char* g_etcPamdLogin = "/etc/pam.d/login";
@@ -1501,7 +1500,7 @@ static char* AuditEnsurePasswordReuseIsLimited(void* log)
 {
     char* reason = NULL;
     CheckEnsurePasswordReuseIsLimited(atoi(g_desiredEnsurePasswordReuseIsLimited ?
-        g_desiredEnsurePasswordReuseIsLimited : g_defaultEnsurePasswordReuseIsLimited), reason, log);
+        g_desiredEnsurePasswordReuseIsLimited : g_defaultEnsurePasswordReuseIsLimited), &reason, log);
     return reason;
 }
 
@@ -3039,7 +3038,7 @@ static int RemediateEnsurePermissionsOnBootloaderConfig(char* value, void* log)
 static int RemediateEnsurePasswordReuseIsLimited(char* value, void* log)
 {
     InitEnsurePasswordReuseIsLimited(value);
-    return SetEnsurePasswordReuseIsLimited(atoi(g_desiredEnsurePasswordReuseIsLimited, log);
+    return SetEnsurePasswordReuseIsLimited(atoi(g_desiredEnsurePasswordReuseIsLimited), log);
 }
 
 static int RemediateEnsureMountingOfUsbStorageDevicesIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2999,29 +2999,33 @@ static int RemediateEnsureIpv6ProtocolIsEnabled(char* value, void* log)
 static int RemediateEnsureDccpIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "/etc/modprobe.d/dccp.conf";
+    const char* payload = "install dccp /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureSctpIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/sctp.conf";
+    const char* payload = "install sctp /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureDisabledSupportForRds(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/rds.conf";
+    const char* payload = "install rds /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureTipcIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/tipc.conf";
+    const char* payload = "install tipc /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureZeroconfNetworkingIsDisabled(char* value, void* log)
@@ -3092,36 +3096,41 @@ static int RemediateEnsureLockoutForFailedPasswordAttempts(char* value, void* lo
 static int RemediateEnsureDisabledInstallationOfCramfsFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/cramfs.conf";
+    const char* payload = "install cramfs /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureDisabledInstallationOfFreevxfsFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/freevxfs.conf";
+    const char* payload = "install freevxfs /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureDisabledInstallationOfHfsFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/hfs.conf";
+    const char* payload = "install hfs /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureDisabledInstallationOfHfsplusFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/hfsplus.conf";
+    const char* payload = "install hfsplus /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureDisabledInstallationOfJffs2FileSystem(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    const char* fileName = "etc/modprobe.d/jffs2.conf";
+    const char* payload = "install jffs2 /bin/true";
+    return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureVirtualMemoryRandomizationIsEnabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1500,11 +1500,8 @@ static char* AuditEnsurePermissionsOnBootloaderConfig(void* log)
 static char* AuditEnsurePasswordReuseIsLimited(void* log)
 {
     char* reason = NULL;
-    if (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdCommonPassword, "remember", '=', 5, &reason, log))
-    {
-        return reason;
-    }
-    CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemAuth, "remember", '=', 5, &reason, log);
+    CheckEnsurePasswordReuseIsLimited(atoi(g_desiredEnsurePasswordReuseIsLimited ?
+        g_desiredEnsurePasswordReuseIsLimited : g_defaultEnsurePasswordReuseIsLimited), reason, log);
     return reason;
 }
 
@@ -3042,8 +3039,7 @@ static int RemediateEnsurePermissionsOnBootloaderConfig(char* value, void* log)
 static int RemediateEnsurePasswordReuseIsLimited(char* value, void* log)
 {
     InitEnsurePasswordReuseIsLimited(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    return SetEnsurePasswordReuseIsLimited(atoi(g_desiredEnsurePasswordReuseIsLimited, log);
 }
 
 static int RemediateEnsureMountingOfUsbStorageDevicesIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3332,14 +3332,15 @@ static int RemediateEnsureAvahiDaemonServiceIsDisabled(char* value, void* log)
 {
     UNUSED(value);
     StopAndDisableDaemon(g_avahiDaemon, log);
-    return (0 == strncmp(g_pass, AuditEnsureAvahiDaemonServiceIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckDaemonNotActive(g_avahiDaemon, NULL, log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureCupsServiceisDisabled(char* value, void* log)
 {
     UNUSED(value);
     StopAndDisableDaemon(g_cups, log);
-    return UninstallPackage(g_cups, log);
+    UninstallPackage(g_cups, log);
+    return CheckDaemonNotActive(g_cups, NULL, log) ? 0 : ENOENT;
 }
 
 static int RemediateEnsurePostfixPackageIsUninstalled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1630,8 +1630,14 @@ static char* AuditEnsureLoggingIsConfigured(void* log)
 static char* AuditEnsureSyslogPackageIsInstalled(void* log)
 {
     char* reason = NULL;
-    CheckPackageInstalled(g_syslog, &reason, log);
-    CheckPackageInstalled(g_rsyslog, &reason, log);
+    if ((0 == CheckPackageInstalled(g_systemd, &reason, log)) && (0 == CheckPackageInstalled(g_rsyslog, &reason, log)))
+    {
+        return reason;
+    }
+    if ((0 == CheckPackageInstalled(g_systemd, &reason, log)) && (0 == CheckPackageInstalled(g_syslog, &reason, log)))
+    {
+        return reason;
+    }
     CheckPackageInstalled(g_syslogNg, &reason, log);
     return reason;
 }
@@ -3143,7 +3149,7 @@ static int RemediateEnsureSyslogPackageIsInstalled(char* value, void* log)
 {
     UNUSED(value);
     return ((0 == InstallPackage(g_systemd, log) && 
-        ((0 == InstallPackage(g_rsyslog, log)) || (0 == InstallPackage(g_syslog, log)))) ||
+        ((0 == InstallPackage(g_rsyslog, log)) || (0 == InstallPackage(g_syslog, log)))) || 
         ((0 == InstallPackage(g_syslogNg, log)))) ? 0 : ENOENT;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3007,7 +3007,7 @@ static int RemediateEnsureDccpIsDisabled(char* value, void* log)
 static int RemediateEnsureSctpIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/sctp.conf";
+    const char* fileName = "/etc/modprobe.d/sctp.conf";
     const char* payload = "install sctp /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3015,7 +3015,7 @@ static int RemediateEnsureSctpIsDisabled(char* value, void* log)
 static int RemediateEnsureDisabledSupportForRds(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/rds.conf";
+    const char* fileName = "/etc/modprobe.d/rds.conf";
     const char* payload = "install rds /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3023,7 +3023,7 @@ static int RemediateEnsureDisabledSupportForRds(char* value, void* log)
 static int RemediateEnsureTipcIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/tipc.conf";
+    const char* fileName = "/etc/modprobe.d/tipc.conf";
     const char* payload = "install tipc /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3096,7 +3096,7 @@ static int RemediateEnsureLockoutForFailedPasswordAttempts(char* value, void* lo
 static int RemediateEnsureDisabledInstallationOfCramfsFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/cramfs.conf";
+    const char* fileName = "/etc/modprobe.d/cramfs.conf";
     const char* payload = "install cramfs /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3104,7 +3104,7 @@ static int RemediateEnsureDisabledInstallationOfCramfsFileSystem(char* value, vo
 static int RemediateEnsureDisabledInstallationOfFreevxfsFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/freevxfs.conf";
+    const char* fileName = "/etc/modprobe.d/freevxfs.conf";
     const char* payload = "install freevxfs /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3112,7 +3112,7 @@ static int RemediateEnsureDisabledInstallationOfFreevxfsFileSystem(char* value, 
 static int RemediateEnsureDisabledInstallationOfHfsFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/hfs.conf";
+    const char* fileName = "/etc/modprobe.d/hfs.conf";
     const char* payload = "install hfs /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3120,7 +3120,7 @@ static int RemediateEnsureDisabledInstallationOfHfsFileSystem(char* value, void*
 static int RemediateEnsureDisabledInstallationOfHfsplusFileSystem(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/hfsplus.conf";
+    const char* fileName = "/etc/modprobe.d/hfsplus.conf";
     const char* payload = "install hfsplus /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }
@@ -3128,7 +3128,7 @@ static int RemediateEnsureDisabledInstallationOfHfsplusFileSystem(char* value, v
 static int RemediateEnsureDisabledInstallationOfJffs2FileSystem(char* value, void* log)
 {
     UNUSED(value);
-    const char* fileName = "etc/modprobe.d/jffs2.conf";
+    const char* fileName = "/etc/modprobe.d/jffs2.conf";
     const char* payload = "install jffs2 /bin/true";
     return SecureSaveToFile(fileName, payload, strlen(payload), log) ? 0 : ENOENT;
 }

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -105,6 +105,8 @@ int CheckLockoutForFailedPasswordAttempts(const char* fileName, const char* pamS
 int SetLockoutForFailedPasswordAttempts(void* log);
 int CheckPasswordCreationRequirements(int retry, int minlen, int minclass, int dcredit, int ucredit, int ocredit, int lcredit, char** reason, void* log);
 int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcredit, int ucredit, int ocredit, int lcredit, void* log);
+int CheckEnsurePasswordReuseIsLimited(int remember, char** reason, void* log);
+int SetEnsurePasswordReuseIsLimited(int remember, void* log);
 
 char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, void* log);
 int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, void* log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -705,9 +705,13 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         {
             OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to append line '%s' at end of '%s'", newline, fileName);
         }
+        else
+        {
+            replacedLine = true;
+        }
     }
 
-    if ((0 == status) && (false == replacedLine))
+    if ((0 == status) && replacedLine)
     {
         if (0 != (status = rename(tempFileName, fileName)))
         {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -705,13 +705,9 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         {
             OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to append line '%s' at end of '%s'", newline, fileName);
         }
-        else
-        {
-            replacedLine = true;
-        }
     }
 
-    if ((0 == status) && replacedLine)
+    if (0 == status)
     {
         if (0 != (status = rename(tempFileName, fileName)))
         {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -707,7 +707,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         }
     }
 
-    if (0 == status)
+    if ((0 == status) && (false == replacedLine))
     {
         if (0 != (status = rename(tempFileName, fileName)))
         {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -720,6 +720,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
 
     FREE_MEMORY(tempFileName);
 
+    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s', '%s', '%s', '%c') complete with %d", fileName, marker, newline, commentCharacter, status);
     return status;
 }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -720,7 +720,8 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
 
     FREE_MEMORY(tempFileName);
 
-    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s', '%s', '%s', '%c') complete with %d", fileName, marker, newline, commentCharacter, status);
+    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s') complete with %d", fileName, status);
+
     return status;
 }
 

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -78,16 +78,17 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
             }
             else
             {
-                OsConfigLogError(log, "SetEnsurePasswordReuseIsLimited: out of memory");
-                status = ENOMEM;
+                OsConfigLogError(log, "SetEnsurePasswordReuseIsLimited: failed reading '%s", g_etcPamdCommonPassword);
+                status = ENOENT;
             }
 
             FREE_MEMORY(newline);
         }
         else
         {
-            OsConfigLogError(log, "SetEnsurePasswordReuseIsLimited: failed reading '%s", g_etcPamdCommonPassword);
-            status = EACCES;
+            
+            OsConfigLogError(log, "SetEnsurePasswordReuseIsLimited: out of memory");
+            status = ENOMEM;
         }
     }
 
@@ -286,7 +287,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* etcPamdPasswordAuthCopy = "/etc/pam.d/~password-auth.copy";
     const char* marker = "auth";
     char* original = NULL;
-    int status = ENOENT, _status = ENOENT;
+    int status = ENOENT, _status = 0;
 
     if (0 == CheckFileExists(g_etcPamdSystemAuth, NULL, log))
     {
@@ -312,6 +313,11 @@ int SetLockoutForFailedPasswordAttempts(void* log)
             }
 
             FREE_MEMORY(original);
+        }
+        else
+        {
+            OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed reading '%s", g_etcPamdSystemAuth);
+            status = ENOENT;
         }
     }
     
@@ -340,12 +346,28 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
             FREE_MEMORY(original);
         }
+        else
+        {
+            OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed reading '%s", etcPamdPasswordAuth);
+            _status = ENOENT;
+        }
 
         if (_status && (0 == status))
         {
             status = _status;
         }
     }
+
+    /*
+    [2024-05-17 14:38:12] [main.c:526] Step 208 of 434
+    [2024-05-17 14:38:12] [main.c:536] Running desired test 'SecurityBaseline.remediateEnsureLockoutForFailedPasswordAttempts'
+    [2024-05-17 14:38:12] [FileUtils.c:285] CheckFileExists: file '/etc/pam.d/system-auth' is not found
+    [2024-05-17 14:38:12] [FileUtils.c:285] CheckFileExists: file '/etc/pam.d/password-auth' is not found
+    [2024-05-17 14:38:12] [FileUtils.c:280] CheckFileExists: file '/etc/pam.d/login' exists
+    [2024-05-17 14:38:12] [Asb.c:5199] AsbMmiSet(SecurityBaseline, remediateEnsureLockoutForFailedPasswordAttempts, , 0) returning 2
+    [2024-05-17 14:38:12] [SecurityBaseline.c:160] MmiSet(0x77c3e1b1d0a0, SecurityBaseline, remediateEnsureLockoutForFailedPasswordAttempts, , 0) returning 2
+    [2024-05-17 14:38:12] [main.c:458] [ERROR] Assertion failed, expected result '0', actual '2'
+    */
 
     if (0 == CheckFileExists(etcPamdLogin, NULL, log))
     {
@@ -371,6 +393,11 @@ int SetLockoutForFailedPasswordAttempts(void* log)
             }
 
             FREE_MEMORY(original);
+        }
+        else
+        {
+            OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed reading '%s", etcPamdLogin);
+            _status = ENOENT;
         }
 
         if (_status && (0 == status))
@@ -774,6 +801,11 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
                 FREE_MEMORY(original);
             }
+            else
+            {
+                OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed reading '%s", g_etcPamdCommonPassword);
+                status = EACCES;
+            }
 
             FREE_MEMORY(line);
         }
@@ -807,6 +839,11 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
                     }
 
                     FREE_MEMORY(original);
+                }
+                else
+                {
+                    OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed reading '%s", g_etcSecurityPwQualityConf);
+                    status = EACCES;
                 }
 
                 FREE_MEMORY(line);

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -227,7 +227,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* etcPamdSystemAuth = "/etc/pam.d/system-auth";
     const char* etcPamdPasswordAuth = "/etc/pam.d/password-auth";
     const char* marker = "auth";
-    int status = ENOENT, _status = 0;
+    int status = 0, _status = 0;
 
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))
     {
@@ -606,7 +606,7 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     int numEntries = ARRAY_SIZE(entries);
     char* line = NULL;
     int i = 0;
-    int status = ENOENT, _status = ENOENT;
+    int status = 0, _status = 0;
 
     if (0 == (status = CheckPasswordCreationRequirements(retry, minlen, minclass, lcredit, dcredit, ucredit, ocredit, NULL, log)))
     {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -671,6 +671,10 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
                         remove(etcSecurityPwQualityConfCopy);
                     }
+
+                    FREE_MEMORY(original);
+                }
+
                 FREE_MEMORY(line);
             }
             else
@@ -684,8 +688,6 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
             status = _status;
         }
     }
-
-    FREE_MEMORY(line);
 
     return status;
 }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -15,12 +15,12 @@ int CheckEnsurePasswordReuseIsLimited(int remember, char** reason, void* log)
     if (0 == CheckFileExists(g_etcPamdCommonPassword, NULL, log))
     {
         // On Debian-based systems 'etc/pam.d/common-password' is expected to exist
-        status = CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdCommonPassword, g_remember, '=', reason, &reason, log);
+        status = CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdCommonPassword, g_remember, '=', remember, reason, log);
     }
     else if (0 == CheckFileExists(g_etcPamdSystemAuth, NULL, log))
     {
         // On Red Hat-based systems '/etc/pam.d/system-auth' is expected to exist
-        status = CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemAuth, g_remember, '=', reason, &reason, log);
+        status = CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemAuth, g_remember, '=', remember, reason, log);
     }
     else
     {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -151,7 +151,6 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* etcPamdSystemAuthCopy = "/etc/pam.d/~system-auth.copy";
     const char* etcPamdPasswordAuthCopy = "/etc/pam.d/~password-auth.copy";
     const char* marker = "auth";
-
     char* original = NULL;
     int status = ENOENT, _status = ENOENT;
 
@@ -599,12 +598,11 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     const char* etcPamdCommonPasswordMarker = "pam_pwquality.so";
     const char* etcPamdCommonPasswordCopy = "/etc/pam.d/~common-password.copy";
     const char* etcSecurityPwQualityConfCopy = "/etc/security/~pwquality.conf.copy";
-    
     const char* entries[] = { "minclass", "dcredit", "ucredit", "ocredit", "lcredit" };
     int numEntries = ARRAY_SIZE(entries);
-    int i = 0;
-
+    char* original = NULL;
     char* line = NULL;
+    int i = 0;
     int status = ENOENT, _status = ENOENT;
 
     if (0 == (status = CheckPasswordCreationRequirements(retry, minlen, minclass, lcredit, dcredit, ucredit, ocredit, NULL, log)))
@@ -625,7 +623,8 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
                     {
                         if (0 != (status = rename(etcPamdCommonPasswordCopy, g_etcPamdCommonPassword)))
                         {
-                            OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: rename('%s' to '%s') failed with %d", etcPamdCommonPasswordCopy, g_etcPamdCommonPassword, errno);
+                            OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: rename('%s' to '%s') failed with %d", 
+                                etcPamdCommonPasswordCopy, g_etcPamdCommonPassword, errno);
                             status = (0 == errno) ? ENOENT : errno;
                         }
                     }
@@ -634,7 +633,8 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
                 }
                 else
                 {
-                    OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed saving copy of '%s' to temp file '%s", etcPamdSystemAuth, etcPamdSystemAuthCopy);
+                    OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: failed saving copy of '%s' to temp file '%s", 
+                        g_etcPamdCommonPassword, etcPamdCommonPasswordCopy);
                     status = EPERM;
                 }
 
@@ -663,7 +663,8 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
                         {
                             if (0 != (status = rename(etcSecurityPwQualityConfCopy, g_etcSecurityPwQualityConf)))
                             {
-                                OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: rename('%s' to '%s') failed with %d", etcSecurityPwQualityConfCopy, g_etcSecurityPwQualityConf, errno);
+                                OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: rename('%s' to '%s') failed with %d", 
+                                    etcSecurityPwQualityConfCopy, g_etcSecurityPwQualityConf, errno);
                                 _status = (0 == errno) ? ENOENT : errno;
                             }
                         }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -229,8 +229,6 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* marker = "auth";
     int status = ENOENT, _status = 0;
 
-    // ReplaceMarkedLinesInFile does a secure file edit
-
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))
     {
         status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, marker, pamFailLockLine, '#', log);

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -38,8 +38,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     const char* etcPamdCommonPasswordTemplate = "password required pam_unix.so sha512 shadow %s=%d\n";
     const char* etcPamdSystemAuthTemplate = "password required pam_pwcheck.so nullok %s=%d\n";
     char* newline = NULL;
-    char* original = NULL;
-    int status = 0;
+    int status = 0, _status = 0;
 
     if (0 == (status = CheckEnsurePasswordReuseIsLimited(remember, NULL, log)))
     {
@@ -607,7 +606,6 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
     const char* entries[] = { "minclass", "dcredit", "ucredit", "ocredit", "lcredit" };
     int numEntries = ARRAY_SIZE(entries);
-    char* original = NULL;
     char* line = NULL;
     int i = 0;
     int status = ENOENT, _status = ENOENT;
@@ -635,9 +633,9 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     {
         for (i = 0; i < numEntries; i++)
         {
-            if (NULL != (line = FormatAllocateString(g_etcSecurityPwQualityConf, entries[i])))
+            if (NULL != (line = FormatAllocateString(etcSecurityPwQualityConfLineTemplate, entries[i])))
             {
-                _status = ReplaceMarkedLinesInFile(etcSecurityPwQualityConfCopy, entries[i], line, '#', log);
+                _status = ReplaceMarkedLinesInFile(g_etcSecurityPwQualityConf, entries[i], line, '#', log);
                 FREE_MEMORY(line);
             }
             else

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -35,8 +35,8 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
 {
     const char* etcPamdCommonPasswordCopy = "/etc/pam.d/~common-password.copy";
     const char* etcPamdSystemAuthCopy = "/etc/pam.d/~system-auth.copy";
-    const char* etcPamdCommonPasswordTemplate = "password required pam_unix.so sha512 shadow %s=%d";
-    const char* etcPamdSystemAuthTemplate = "password required pam_pwcheck.so nullok %s=%d";
+    const char* etcPamdCommonPasswordTemplate = "password required pam_unix.so sha512 shadow %s=%d\n";
+    const char* etcPamdSystemAuthTemplate = "password required pam_pwcheck.so nullok %s=%d\n";
     char* newline = NULL;
     char* original = NULL;
     int status = 0;


### PR DESCRIPTION
## Description

This PR started with ensuring the manner in which system files are not directly updated but instead, copied to a temporary copy, edited there then atomically renamed at the very end. Adding implementation for EnsurePasswordReuseIsLimited's remediation and consolidating audit, plus fixing implementation for the EnsureAvahiDaemonServiceIsDisabled  and EnsureCupsServiceisDisabled's remediation, also adding several remediations based on added configuration files to disable certain components, under /etc/modprobe.d.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.