### PR TITLE
Fixed Universal NRP E2E logs on failure

### DIFF
--- a/.github/workflows/universalnrp-test-run.yml
+++ b/.github/workflows/universalnrp-test-run.yml
@@ -105,6 +105,7 @@ jobs:
           sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/omi/lib/ pwsh -Command $script
 
       - name: Stage OSConfig Logs
+        if: success() || failure()
         run: |
           mkdir  osconfig-logs
           sudo cp -r /var/log/osconfig* osconfig-logs/


### PR DESCRIPTION
## Description

* Logs were missing on test failure, added condition to log staging to prevent skipping

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.