### PR TITLE
Improved way of safe writing to system files to keep and restore original owner, group and access mode permissions

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2736,25 +2736,19 @@ static int RemediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero(char* val
 static int RemediateEnsureNoLegacyPlusEntriesInEtcPasswd(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == ReplaceMarkedLinesInFile(g_etcPasswd, "+", NULL, '#', log)) &&
-        (0 == SetFileAccess(g_etcPasswd, 0, 42, atoi(g_desiredEnsurePermissionsOnEtcPasswd ? g_desiredEnsurePermissionsOnEtcPasswd :
-        g_defaultEnsurePermissionsOnEtcPasswd), log))) ? 0 : ENOENT;
+    return ReplaceMarkedLinesInFile(g_etcPasswd, "+", NULL, '#', log);
 }
 
 static int RemediateEnsureNoLegacyPlusEntriesInEtcShadow(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == ReplaceMarkedLinesInFile(g_etcShadow, "+", NULL, '#', log)) &&
-        (0 == SetFileAccess(g_etcShadow, 0, 42, atoi(g_desiredEnsurePermissionsOnEtcShadow ? g_desiredEnsurePermissionsOnEtcShadow : 
-        g_defaultEnsurePermissionsOnEtcShadow), log))) ? 0 : ENOENT;
+    return ReplaceMarkedLinesInFile(g_etcShadow, "+", NULL, '#', log);
 }
 
 static int RemediateEnsureNoLegacyPlusEntriesInEtcGroup(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == ReplaceMarkedLinesInFile(g_etcGroup, "+", NULL, '#', log)) &&
-        (0 == SetFileAccess(g_etcGroup, 0, 42, atoi(g_desiredEnsurePermissionsOnEtcGroup ? g_desiredEnsurePermissionsOnEtcGroup : 
-        g_defaultEnsurePermissionsOnEtcGroup), log))) ? 0 : ENOENT;
+    return ReplaceMarkedLinesInFile(g_etcGroup, "+", NULL, '#', log);
 }
 
 static int RemediateEnsureDefaultRootAccountGroupIsGidZero(char* value, void* log)

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -67,6 +67,8 @@ bool MakeFileBackupCopy(const char* fileName, const char* backupName, void* log)
 
 int CheckFileAccess(const char* fileName, int desiredOwnerId, int desiredGroupId, unsigned int desiredAccess, char** reason, void* log);
 int SetFileAccess(const char* fileName, unsigned int desiredOwnerId, unsigned int desiredGroupId, unsigned int desiredAccess, void* log);
+int GetFileAccess(const char* name, unsigned int* ownerId, unsigned int* groupId, unsigned int* mode, void* log);
+int RenameFileWithOwnerAndAccess(const char* original, const char* target, void* log);
 
 int CheckDirectoryAccess(const char* directoryName, int desiredOwnerId, int desiredGroupId, unsigned int desiredAccess, bool rootCanOverwriteOwnership, char** reason, void* log);
 int SetDirectoryAccess(const char* directoryName, unsigned int desiredOwnerId, unsigned int desiredGroupId, unsigned int desiredAccess, void* log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -632,7 +632,7 @@ int GetFileAccess(const char* name, unsigned int* ownerId, unsigned int* groupId
             *mode = DecimalToOctal(statStruct.st_mode & 07777);
 
             OsConfigLogInfo(log, "GetFileAccess: '%s' is owned by user %u, group %u and has access mode %u",
-                name, ownerId, groupId, mode);
+                name, *ownerId, *groupId, *mode);
         }
         else
         {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -625,7 +625,7 @@ int GetFileAccess(const char* name, unsigned int* ownerId, unsigned int* groupId
 
     if (FileExists(name))
     {
-        if (0 == (result = stat(name, &statStruct)))
+        if (0 == (status = stat(name, &statStruct)))
         {
             *ownerId = statStruct.st_uid;
             *groupId = statStruct.st_gid;
@@ -666,7 +666,7 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
     
     if (0 != GetFileAccess(original, &ownerId, &groupId, &mode, log))
     {
-        OsConfigLogError(log, "RenameFileWithOwnerAndAccess: cannot read owner and access mode for original file '%s' (%d), using defaults", original);
+        OsConfigLogError(log, "RenameFileWithOwnerAndAccess: cannot read owner and access mode for original file '%s', using defaults", original);
 
         ownerId = 0;
         groupId = 0;
@@ -678,7 +678,7 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
         mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
     }
 
-    if (0 == (status = rename(tempFileName, fileName)))
+    if (0 == (status = rename(original, target)))
     {
         if (0 == SetFileAccess(target, ownerId, groupId, mode, log))
         {
@@ -687,7 +687,7 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
         }
         else
         {
-            OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' without owner and access mode set (%d)",
+            OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' without owner and access mode set",
                 original, target);
         }
     }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -630,8 +630,9 @@ int GetFileAccess(const char* name, unsigned int* ownerId, unsigned int* groupId
             *ownerId = statStruct.st_uid;
             *groupId = statStruct.st_gid;
             *mode = DecimalToOctal(statStruct.st_mode & 07777);
-            
-            status = 0;
+
+            OsConfigLogInfo(log, "GetFileAccess: '%s' is owned by user %u, group %u and has access mode %u",
+                name, ownerId, groupId, mode);
         }
         else
         {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -693,6 +693,11 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
         {
             OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' without restored original owner and access mode", original, target);
         }
+        else
+        {
+            OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' with restored original owner %u, group %u and access mode %u", 
+                original, target, ownerId, groupId, mode);
+        }
     }
     else
     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -710,8 +710,10 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
 
 int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const char* newline, char commentCharacter, void* log)
 {
-    const char* tempFileNameTemplate = "/tmp/~OSConfig.ReplacingLines%u";
+    const char* tempFileNameTemplate = "%s/~OSConfig.ReplacingLines%u";
     char* tempFileName = NULL;
+    char* fileDirectory = NULL;
+    char* fileNameCopy = NULL;
     FILE* fileHandle = NULL;
     FILE* tempHandle = NULL;
     char* line = NULL;
@@ -732,7 +734,12 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         return ENOMEM;
     }
 
-    if (NULL != (tempFileName = FormatAllocateString(tempFileNameTemplate, rand())))
+    if (FileExists(fileName) && (NULL != (fileNameCopy = DuplicateString(fileName))))
+    {
+        fileDirectory = dirname(fileNameCopy);
+    }
+
+    if (NULL != (tempFileName = FormatAllocateString(tempFileNameTemplate, fileDirectory ? fileDirectory : "/tmp", rand())))
     {
         if (NULL != (fileHandle = fopen(fileName, "r")))
         {
@@ -818,6 +825,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     }
 
     FREE_MEMORY(tempFileName);
+    FREE_MEMORY(fileNameCopy);
 
     OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s') complete with %d", fileName, status);
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -103,7 +103,8 @@ bool SavePayloadToFile(const char* fileName, const char* payload, const int payl
 
 static bool InternalSecureSaveToFile(const char* fileName, const char* mode, const char* payload, const int payloadSizeBytes, void* log)
 {
-    const char* tempFileNameTemplate = "/tmp/~OSConfig.Temp%u";
+    const char* tempFileNameTemplate = "%s/~OSConfig.Temp%u";
+    char* fileDirectory = NULL;
     char* tempFileName = NULL;
     char* fileContents = NULL;
     int status = 0;
@@ -114,7 +115,10 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
         OsConfigLogError(log, "InternalSecureSaveToFile: invalid arguments");
         return false;
     }
-    else if (NULL == (tempFileName = FormatAllocateString(tempFileNameTemplate, rand())))
+
+    fileDirectory = dirname(fileName);
+
+    if (NULL == (tempFileName = FormatAllocateString(tempFileNameTemplate, fileDirectory ? fileDirectory : "", rand())))
     {
         OsConfigLogError(log, "InternalSecureSaveToFile: out of memory");
         return false;

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -630,9 +630,6 @@ int GetFileAccess(const char* name, unsigned int* ownerId, unsigned int* groupId
             *ownerId = statStruct.st_uid;
             *groupId = statStruct.st_gid;
             *mode = DecimalToOctal(statStruct.st_mode & 07777);
-
-            OsConfigLogInfo(log, "GetFileAccess: '%s' is owned by user %u, group %u and has access mode %u",
-                name, *ownerId, *groupId, *mode);
         }
         else
         {
@@ -681,15 +678,9 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
 
     if (0 == (status = rename(original, target)))
     {
-        if (0 == SetFileAccess(target, ownerId, groupId, mode, log))
+        if (0 != SetFileAccess(target, ownerId, groupId, mode, log))
         {
-            OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' with restored owner %u, group %u and access %u", 
-                original, target, ownerId, groupId, mode);
-        }
-        else
-        {
-            OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' without restored original owner and access mode",
-                original, target);
+            OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' without restored original owner and access mode", original, target);
         }
     }
     else

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -693,7 +693,7 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
         {
             OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' without restored original owner and access mode", original, target);
         }
-        else
+        else if (IsFullLoggingEnabled())
         {
             OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' with restored original owner %u, group %u and access mode %u", 
                 original, target, ownerId, groupId, mode);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -665,9 +665,9 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
         return EINVAL;
     }
     
-    if (0 != GetFileAccess(original, &ownerId, &groupId, &mode, log))
+    if (0 != GetFileAccess(target, &ownerId, &groupId, &mode, log))
     {
-        OsConfigLogError(log, "RenameFileWithOwnerAndAccess: cannot read owner and access mode for original file '%s', using defaults", original);
+        OsConfigLogError(log, "RenameFileWithOwnerAndAccess: cannot read owner and access mode for original target file '%s', using defaults", target);
 
         ownerId = 0;
         groupId = 0;
@@ -683,12 +683,12 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, void*
     {
         if (0 == SetFileAccess(target, ownerId, groupId, mode, log))
         {
-            OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' with owner %u, group %u and access %u", 
+            OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' with restored owner %u, group %u and access %u", 
                 original, target, ownerId, groupId, mode);
         }
         else
         {
-            OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' without owner and access mode set",
+            OsConfigLogError(log, "RenameFileWithOwnerAndAccess: '%s' successfully renamed to '%s' without restored original owner and access mode",
                 original, target);
         }
     }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -613,7 +613,7 @@ int GetFileAccess(const char* name, unsigned int* ownerId, unsigned int* groupId
     struct stat statStruct = {0};
     int status = ENOENT;
 
-    if ((NULL == name) || (NULL == ownerId) || (NULL == groupId) || (NULL == mode)
+    if ((NULL == name) || (NULL == ownerId) || (NULL == groupId) || (NULL == mode))
     {
         OsConfigLogError(log, "GetFileAccess: invalid arguments");
         return EINVAL;

--- a/src/common/commonutils/Internal.h
+++ b/src/common/commonutils/Internal.h
@@ -24,6 +24,7 @@
 #include <mntent.h>
 #include <dirent.h>
 #include <math.h>
+#include <libgen.h>
 #include <parson.h>
 #include <Logging.h>
 #include <CommonUtils.h>

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -373,16 +373,15 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                     {
                         if (ConcatenateFiles(tempFileNameThree, tempFileNameTwo, log))
                         {
-                            rename(tempFileNameThree, tempFileNameTwo);
+                            RenameFileWithOwnerAndAccess(tempFileNameThree, tempFileNameTwo, log);
                         }
                     }
                 }
                 
                 // When done assembling the final temp mount file two, move it in an atomic step to real mount file
-                if (0 != (status = rename(tempFileNameTwo, fsMountTable)))
+                if (0 != (status = RenameFileWithOwnerAndAccess(tempFileNameTwo, fsMountTable, log)))
                 {
-                    OsConfigLogError(log, "SetFileSystemMountingOption:  rename('%s' to '%s') failed with %d", tempFileNameTwo, fsMountTable, errno);
-                    status = (0 == errno) ? ENOENT : errno;
+                    OsConfigLogError(log, "SetFileSystemMountingOption:  RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", tempFileNameTwo, fsMountTable, status);
                 }
             }
         }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1330,7 +1330,7 @@ int RepairRootGroup(void* log)
 {
     const char* etcGroup = "/etc/group";
     const char* rootLine = "root:x:0:\n";
-    const char* tempFileName = "/tmp/~group";
+    const char* tempFileName = "/etc/~group";
     SIMPLIFIED_GROUP* groupList = NULL;
     unsigned int groupListSize = 0;
     unsigned int i = 0;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1380,10 +1380,9 @@ int RepairRootGroup(void* log)
                             if (AppendToFile(tempFileName, original, strlen(original), log))
                             {
                                 // In a single atomic operation move edited contents from temporary file to /etc/group
-                                if (0 != (status = rename(tempFileName, etcGroup)))
+                                if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, etcGroup)))
                                 {
-                                    OsConfigLogError(log, "RepairRootGroup:  rename('%s' to '%s') failed with %d", tempFileName, etcGroup, errno);
-                                    status = (0 == errno) ? ENOENT : errno;
+                                    OsConfigLogError(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", tempFileName, etcGroup, status);
                                 }
                             }
                             else

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1380,9 +1380,10 @@ int RepairRootGroup(void* log)
                             if (AppendToFile(tempFileName, original, strlen(original), log))
                             {
                                 // In a single atomic operation move edited contents from temporary file to /etc/group
-                                if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, etcGroup)))
+                                if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, etcGroup, log)))
                                 {
-                                    OsConfigLogError(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", tempFileName, etcGroup, status);
+                                    OsConfigLogError(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", 
+                                        tempFileName, etcGroup, status);
                                 }
                             }
                             else


### PR DESCRIPTION
## Description

Making the save and restore of original ownership and access universal for all code paths that invoke the atomic renames at the end of editing such system files.

Also making the functions that use the rename() call for secure system file editing to ensure the source and target files are in the same folder to avoid errors such as EXDEV 18 /* Cross-device link */ as on some Linux installations certain system folders can be separately mounted.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.