### PR TITLE
Advancing implementation for ASB v2 remediation and audit stabilization 

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -544,7 +544,6 @@ static const char* g_etcPostfixMainCf = "/etc/postfix/main.cf";
 static const char* g_inetInterfacesLocalhost = "inet_interfaces localhost";
 static const char* g_autofs = "autofs";
 static const char* g_ipv4ll = "ipv4ll";
-static const char* g_noZeroConf = "NOZEROCONF=yes";
 
 static const char* g_pass = SECURITY_AUDIT_PASS;
 static const char* g_fail = SECURITY_AUDIT_FAIL;

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -546,6 +546,7 @@ static const char* g_etcPostfixMainCf = "/etc/postfix/main.cf";
 static const char* g_inetInterfacesLocalhost = "inet_interfaces localhost";
 static const char* g_autofs = "autofs";
 static const char* g_ipv4ll = "ipv4ll";
+static const char* g_sysCtlA = "sysctl -a";
 
 static const char* g_pass = SECURITY_AUDIT_PASS;
 static const char* g_fail = SECURITY_AUDIT_FAIL;
@@ -1359,23 +1360,21 @@ static char* AuditEnsureDefaultDenyFirewallPolicyIsSet(void* log)
 
 static char* AuditEnsurePacketRedirectSendingIsDisabled(void* log)
 {
-    const char* command = "sysctl -a";
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.all.send_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.default.send_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.send_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.send_redirects = 0", &reason, log);
     return reason;
 }
 
 static char* AuditEnsureIcmpRedirectsIsDisabled(void* log)
 {
-    const char* command = "sysctl -a";
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.default.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv6.conf.default.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.all.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv6.conf.all.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.default.secure_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.all.secure_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.accept_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.accept_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.accept_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.accept_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.secure_redirects = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.secure_redirects = 0", &reason, log);
     return reason;
 }
 
@@ -1411,10 +1410,9 @@ static char* AuditEnsureIgnoringIcmpEchoPingsToMulticast(void* log)
 
 static char* AuditEnsureMartianPacketLoggingIsEnabled(void* log)
 {
-    const char* command = "sysctl -a";
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.all.log_martians = 1", &reason, log);
-    CheckTextFoundInCommandOutput(command, "net.ipv4.conf.default.log_martians = 1", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.log_martians = 1", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.log_martians = 1", &reason, log);
     return reason;
 }
 
@@ -1463,7 +1461,9 @@ static char* AuditEnsureAllWirelessInterfacesAreDisabled(void* log)
 static char* AuditEnsureIpv6ProtocolIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckTextFoundInCommandOutput("cat /sys/module/ipv6/parameters/disable", "0", &reason, log);
+    CheckLineFoundNotCommentedOut("/sys/module/ipv6/parameters/disable", '#', "0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.disable_ipv6 = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.disable_ipv6 = 0", &reason, log);
     return reason;
 }
 
@@ -1540,7 +1540,7 @@ static char* AuditEnsureCoreDumpsAreRestricted(void* log)
     char* reason = NULL;
     CheckLineFoundNotCommentedOut("/etc/security/limits.conf", '#', "hard core 0", &reason, log);
     CheckTextFoundInFolder("/etc/security/limits.d", fsSuidDumpable, &reason, log);
-    CheckTextFoundInCommandOutput("sysctl -a", fsSuidDumpable, &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, fsSuidDumpable, &reason, log);
     return reason;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2943,7 +2943,7 @@ static int RemediateEnsureIcmpRedirectsIsDisabled(char* value, void* log)
         (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.accept_redirects", "net.ipv4.conf.all.accept_redirects = 0\n", '#', log)) &&
         (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.all.accept_redirects", "net.ipv6.conf.all.accept_redirects = 0\n", '#', log)) &&
         (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.secure_redirects", "net.ipv4.conf.default.secure_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.secure_redirects", "net.ipv4.conf.all.secure_redirects = 0\n", '#', log)))
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.secure_redirects", "net.ipv4.conf.all.secure_redirects = 0\n", '#', log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureSourceRoutedPacketsIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3029,8 +3029,8 @@ static int RemediateEnsureTipcIsDisabled(char* value, void* log)
 static int RemediateEnsureZeroconfNetworkingIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    StopAndDisableDaemon(g_avahiDaemon, NULL, log);
-    return ((false == IsDaemonActive(g_avahiDaemon)) && 
+    StopAndDisableDaemon(g_avahiDaemon, log);
+    return ((false == IsDaemonActive(g_avahiDaemon, log)) && 
         (0 == ReplaceMarkedLinesInFile(g_etcNetworkInterfaces, g_ipv4ll, NULL, '#', log)) && 
         (0 == ReplaceMarkedLinesInFile(g_etcSysconfigNetwork, "NOZEROCONF", "NOZEROCONF=yes", '#', log))) ? 0 : ENOENT;
 }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -481,6 +481,7 @@ static const char* g_etcRsyslogConf = "/etc/rsyslog.conf";
 static const char* g_etcSyslogNgSyslogNgConf = "/etc/syslog-ng/syslog-ng.conf";
 static const char* g_etcNetworkInterfaces = "/etc/network/interfaces";
 static const char* g_etcSysconfigNetwork = "/etc/sysconfig/network";
+static const char* g_etcSysctlConf = "/etc/sysctl.conf";
 
 static const char* g_home = "/home";
 static const char* g_devShm = "/dev/shm";
@@ -2921,19 +2922,28 @@ static int RemediateEnsureDefaultDenyFirewallPolicyIsSet(char* value, void* log)
 
 static int RemediateEnsurePacketRedirectSendingIsDisabled(char* value, void* log)
 {
-    const char* etcSysctlConf = "/etc/sysctl.conf";
     UNUSED(value);
     return ((0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(etcSysctlConf, "net.ipv4.conf.all.accept_redirects", "net.ipv4.conf.all.accept_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(etcSysctlConf, "net.ipv4.conf.default.accept_redirects", "net.ipv4.conf.default.accept_redirects = 0\n", '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.accept_redirects", "net.ipv4.conf.all.accept_redirects = 0\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.accept_redirects", "net.ipv4.conf.default.accept_redirects = 0\n", '#', log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureIcmpRedirectsIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    return ((0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "sysctl -w net.ipv6.conf.default.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "sysctl -w net.ipv6.conf.all.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.secure_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.secure_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.accept_redirects", "net.ipv4.conf.default.accept_redirects = 0\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.default.accept_redirects", "net.ipv6.conf.default.accept_redirects = 0\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.accept_redirects", "net.ipv4.conf.all.accept_redirects = 0\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.all.accept_redirects", "net.ipv6.conf.all.accept_redirects = 0\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.secure_redirects", "net.ipv4.conf.default.secure_redirects = 0\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.secure_redirects", "net.ipv4.conf.all.secure_redirects = 0\n", '#', log)))
 }
 
 static int RemediateEnsureSourceRoutedPacketsIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2905,8 +2905,9 @@ static int RemediateEnsureKernelCompiledFromApprovedSources(char* value, void* l
 static int RemediateEnsureDefaultDenyFirewallPolicyIsSet(char* value, void* log)
 {
     UNUSED(value);
-    UNUSED(log);
-    return 0; //TODO: add remediation respecting all existing patterns
+    return ((0 == ExecuteCommand(NULL, "iptables - P INPUT DROP", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "iptables - P FORWARD DROP", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "iptables - P OUTPUT DROP", true, false, 0, 0, NULL, NULL, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsurePacketRedirectSendingIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2978,7 +2978,7 @@ static int RemediateEnsureMartianPacketLoggingIsEnabled(char* value, void* log)
     UNUSED(value);
     return ((0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.log_martians=1", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.log_martians=1", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "nnet.ipv4.conf.all.log_martians", "net.ipv4.conf.all.log_martians = 1\n", '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.log_martians", "net.ipv4.conf.all.log_martians = 1\n", '#', log)) &&
         (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.log_martians", "net.ipv4.conf.default.log_martians = 1\n", '#', log))) ? 0 : ENOENT;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2905,9 +2905,9 @@ static int RemediateEnsureKernelCompiledFromApprovedSources(char* value, void* l
 static int RemediateEnsureDefaultDenyFirewallPolicyIsSet(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == ExecuteCommand(NULL, "iptables - P INPUT DROP", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ExecuteCommand(NULL, "iptables - P FORWARD DROP", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ExecuteCommand(NULL, "iptables - P OUTPUT DROP", true, false, 0, 0, NULL, NULL, log))) ? 0 : ENOENT;
+    return ((0 == ExecuteCommand(NULL, "iptables -P INPUT DROP", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "iptables -P FORWARD DROP", true, false, 0, 0, NULL, NULL, log)) &&
+        (0 == ExecuteCommand(NULL, "iptables -P OUTPUT DROP", true, false, 0, 0, NULL, NULL, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsurePacketRedirectSendingIsDisabled(char* value, void* log)

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -189,6 +189,8 @@ char* GetHttpProxyData(void* log);
 
 char* RepairBrokenEolCharactersIfAny(const char* value);
 
+int DisableAllWirelessInterfaces(void* log);
+
 typedef struct REPORTED_PROPERTY
 {
     char componentName[MAX_COMPONENT_NAME];

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -730,8 +730,8 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     }
     else if (false == FileExists(fileName))
     {
-        OsConfigLogError(log, "ReplaceMarkedLinesInFile called for a file that does not exist: '%s'", fileName);
-        return EINVAL;
+        OsConfigLogInfo(log, "ReplaceMarkedLinesInFile called for a file that does not exist: '%s'", fileName);
+        return 0;
     }
     else if (NULL == (line = malloc(lineMax + 1)))
     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -723,9 +723,14 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     bool replacedLine = false;
     int status = 0;
 
-    if ((NULL == fileName) || (false == FileExists(fileName)) || (NULL == marker))
+    if ((NULL == fileName) || (NULL == marker))
     {
         OsConfigLogError(log, "ReplaceMarkedLinesInFile called with invalid arguments");
+        return EINVAL;
+    }
+    else if (false == FileExists(fileName))
+    {
+        OsConfigLogError(log, "ReplaceMarkedLinesInFile called for a file that does not exist: '%s'", fileName);
         return EINVAL;
     }
     else if (NULL == (line = malloc(lineMax + 1)))
@@ -734,7 +739,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         return ENOMEM;
     }
 
-    if (FileExists(fileName) && (NULL != (fileNameCopy = DuplicateString(fileName))))
+    if (NULL != (fileNameCopy = DuplicateString(fileName)))
     {
         fileDirectory = dirname(fileNameCopy);
     }

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -290,3 +290,23 @@ int ConvertStringToIntegers(const char* source, char separator, int** integers, 
 
     return status;
 }
+
+int DisableAllWirelessInterfaces(void* log)
+{
+    const char* nmCliRadioAllOff = "nmcli radio all off";
+    const char* rfKillBlockAll = "rfkill block all";
+
+    int status = 0;
+    
+    if (0 != (status = ExecuteCommand(NULL, nmCliRadioAllOff, true, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", nmCliRadioAllOff, status);
+    }
+    
+    if (0 != (status = ExecuteCommand(NULL, rfKillBlockAll, true, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", rfKillBlockAll, status);
+    }
+
+    return status;
+}

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -33,8 +33,6 @@ int CheckEnsurePasswordReuseIsLimited(int remember, char** reason, void* log)
 
 int SetEnsurePasswordReuseIsLimited(int remember, void* log)
 {
-    const char* etcPamdCommonPasswordCopy = "/etc/pam.d/~common-password.copy";
-    const char* etcPamdSystemAuthCopy = "/etc/pam.d/~system-auth.copy";
     const char* etcPamdCommonPasswordTemplate = "password required pam_unix.so sha512 shadow %s=%d\n";
     const char* etcPamdSystemAuthTemplate = "password required pam_pwcheck.so nullok %s=%d\n";
     char* newline = NULL;
@@ -50,7 +48,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     {
         if (NULL != (newline = FormatAllocateString(etcPamdCommonPasswordTemplate, g_remember, remember)))
         {
-            status = ReplaceMarkedLinesInFile(etcPamdCommonPasswordCopy, g_remember, newline, '#', log);
+            status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, g_remember, newline, '#', log);
             FREE_MEMORY(newline);
         }
         else
@@ -65,7 +63,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     {
         if (NULL != (newline = FormatAllocateString(etcPamdSystemAuthTemplate, g_remember, remember)))
         {
-            _status = ReplaceMarkedLinesInFile(etcPamdSystemAuthCopy, g_remember, newline, '#', log);
+            _status = ReplaceMarkedLinesInFile(g_etcPamdSystemAuth, g_remember, newline, '#', log);
             FREE_MEMORY(newline);
         }
         else


### PR DESCRIPTION
## Description

Here are fixes for the following audit checks:

AuditEnsureSystemNotActingAsNetworkSniffer
AuditEnsureIpv6ProtocolIsEnabled
AuditEnsureZeroconfNetworkingIsDisabled

And completed implementations for the following remediation checks (with the exception of first, which is by design disabled due to possible disastrous effect):

RemediateEnsureDefaultDenyFirewallPolicyIsSet (no remediation)
RemediateEnsurePacketRedirectSendingIsDisabled
RemediateEnsureIcmpRedirectsIsDisabled
RemediateEnsureSourceRoutedPacketsIsDisabled
RemediateEnsureAcceptingSourceRoutedPacketsIsDisabled
RemediateEnsureIgnoringBogusIcmpBroadcastResponses
RemediateEnsureIgnoringIcmpEchoPingsToMulticast
RemediateEnsureMartianPacketLoggingIsEnabled
RemediateEnsureReversePathSourceValidationIsEnabled
RemediateEnsureTcpSynCookiesAreEnabled
RemediateEnsureSystemNotActingAsNetworkSniffer
RemediateEnsureAllWirelessInterfacesAreDisabled
RemediateEnsureIpv6ProtocolIsEnabled
RemediateEnsureZeroconfNetworkingIsDisabled

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.