### PR TITLE
Adding a new ASBv2 policy parameter for EnsureDefaultDenyFirewallPolicyIsSet and fixing AuditEnsureIpv6ProtocolIsEnabled

### DIFF
--- a/src/adapters/mc/asb/OsConfigPolicy.mof
+++ b/src/adapters/mc/asb/OsConfigPolicy.mof
@@ -626,10 +626,11 @@ instance of OsConfigResource as $OsConfigResource40ref
     ResourceID = "Ensure default deny firewall policy is set";
     PayloadKey = "EnsureDefaultDenyFirewallPolicyIsSet";
     ComponentName = "SecurityBaseline";
+    InitObjectName = "initEnsureDefaultDenyFirewallPolicyIsSet";
     ReportedObjectName = "auditEnsureDefaultDenyFirewallPolicyIsSet";
     ExpectedObjectValue = "PASS";
     DesiredObjectName = "remediateEnsureDefaultDenyFirewallPolicyIsSet";
-    DesiredObjectValue = "PASS";
+    DesiredObjectValue = "0";
     ModuleName = "GuestConfiguration";
     ModuleVersion = "1.0.0";
     ConfigurationName = "LinuxSecurityBaseline";

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -412,6 +412,7 @@ static const char* g_initEnsurePasswordCreationRequirementsObject = "initEnsureP
 static const char* g_initEnsureFilePermissionsForAllRsyslogLogFilesObject = "initEnsureFilePermissionsForAllRsyslogLogFiles";
 static const char* g_initEnsureUsersDotFilesArentGroupOrWorldWritableObject = "initEnsureUsersDotFilesArentGroupOrWorldWritable";
 static const char* g_initEnsureUnnecessaryAccountsAreRemovedObject = "initEnsureUnnecessaryAccountsAreRemoved";
+static const char* g_initEnsureDefaultDenyFirewallPolicyIsSetObject = "initEnsureDefaultDenyFirewallPolicyIsSet";
 
 // Default values for checks that support configuration (and initialization)
 static const char* g_defaultEnsurePermissionsOnEtcIssue = "644";
@@ -447,6 +448,7 @@ static const char* g_defaultEnsurePasswordCreationRequirements = "3,14,4,-1,-1,-
 static const char* g_defaultEnsureFilePermissionsForAllRsyslogLogFiles = "600,640";
 static const char* g_defaultEnsureUsersDotFilesArentGroupOrWorldWritable = "600,644,664,700,744";
 static const char* g_defaultEnsureUnnecessaryAccountsAreRemoved = "games,test";
+static const char* g_defaultEnsureDefaultDenyFirewallPolicyIsSet = "0"; //0: audit, 1: forced remediation
 
 static const char* g_etcIssue = "/etc/issue";
 static const char* g_etcIssueNet = "/etc/issue.net";
@@ -584,6 +586,7 @@ static char* g_desiredEnsurePasswordCreationRequirements = NULL;
 static char* g_desiredEnsureFilePermissionsForAllRsyslogLogFiles = NULL;
 static char* g_desiredEnsureUsersDotFilesArentGroupOrWorldWritable = NULL;
 static char* g_desiredEnsureUnnecessaryAccountsAreRemoved = NULL;
+static char* g_desiredEnsureDefaultDenyFirewallPolicyIsSet = NULL;
 
 void AsbInitialize(void* log)
 {
@@ -621,7 +624,8 @@ void AsbInitialize(void* log)
         (NULL == (g_desiredEnsurePasswordCreationRequirements = DuplicateString(g_defaultEnsurePasswordCreationRequirements))) ||
         (NULL == (g_desiredEnsureFilePermissionsForAllRsyslogLogFiles = DuplicateString(g_defaultEnsureFilePermissionsForAllRsyslogLogFiles))) ||
         (NULL == (g_desiredEnsureUsersDotFilesArentGroupOrWorldWritable = DuplicateString(g_defaultEnsureUsersDotFilesArentGroupOrWorldWritable))) ||
-        (NULL == (g_desiredEnsureUnnecessaryAccountsAreRemoved = DuplicateString(g_defaultEnsureUnnecessaryAccountsAreRemoved))))
+        (NULL == (g_desiredEnsureUnnecessaryAccountsAreRemoved = DuplicateString(g_defaultEnsureUnnecessaryAccountsAreRemoved))) ||
+        (NULL == (g_desiredEnsureDefaultDenyFirewallPolicyIsSet = DuplicateString(g_defaultEnsureDefaultDenyFirewallPolicyIsSet))))
     {
         OsConfigLogError(log, "AsbInitialize: failed to allocate memory");
     }
@@ -674,6 +678,7 @@ void AsbShutdown(void* log)
     FREE_MEMORY(g_desiredEnsureFilePermissionsForAllRsyslogLogFiles);
     FREE_MEMORY(g_desiredEnsureUsersDotFilesArentGroupOrWorldWritable);
     FREE_MEMORY(g_desiredEnsureUnnecessaryAccountsAreRemoved);
+    FREE_MEMORY(g_desiredEnsureDefaultDenyFirewallPolicyIsSet);
 
     SshAuditCleanup(log);
 }
@@ -1344,15 +1349,16 @@ static char* AuditEnsureDefaultDenyFirewallPolicyIsSet(void* log)
 {
     const char* readIpTables = "iptables -S";
     char* reason = NULL;
+    int forceDrop = atoi(g_desiredEnsureDefaultDenyFirewallPolicyIsSet ? g_desiredEnsureDefaultDenyFirewallPolicyIsSet : g_defaultEnsureDefaultDenyFirewallPolicyIsSet);
     
     if ((0 != CheckTextFoundInCommandOutput(readIpTables, "-P INPUT DROP", &reason, log)) ||
         (0 != CheckTextFoundInCommandOutput(readIpTables, "-P FORWARD DROP", &reason, log)) ||
         (0 != CheckTextFoundInCommandOutput(readIpTables, "-P OUTPUT DROP", &reason, log)))
     {
         FREE_MEMORY(reason);
-        reason = DuplicateString("Ensure that all necessary communication channels have explicit "
+        reason = FormatAllocateString("Ensure that all necessary communication channels have explicit "
             "ACCEPT firewall policies set and then manually set the default firewall policy for "
-            "INPUT, FORWARD and OUTPUT to DROP. Automatic remediation is not possible");
+            "INPUT, FORWARD and OUTPUT to DROP%s", forceDrop ? "." : ". Automatic remediation is not possible");
     }
         
     return reason;
@@ -1461,9 +1467,8 @@ static char* AuditEnsureAllWirelessInterfacesAreDisabled(void* log)
 static char* AuditEnsureIpv6ProtocolIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckLineFoundNotCommentedOut("/sys/module/ipv6/parameters/disable", '#', "0", &reason, log);
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.disable_ipv6 = 0", &reason, log);
     CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.disable_ipv6 = 0", &reason, log);
+    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.disable_ipv6 = 0", &reason, log);
     return reason;
 }
 
@@ -2376,6 +2381,11 @@ static int InitEnsureUnnecessaryAccountsAreRemoved(char* value)
     return ReplaceString(&g_desiredEnsureUnnecessaryAccountsAreRemoved, value, g_defaultEnsureUnnecessaryAccountsAreRemoved);
 }
 
+static int InitEnsureDefaultDenyFirewallPolicyIsSet(char* value)
+{
+    return ReplaceString(&g_desiredEnsureDefaultDenyFirewallPolicyIsSet, value, g_defaultEnsureDefaultDenyFirewallPolicyIsSet);
+}
+
 static int RemediateEnsurePermissionsOnEtcIssue(char* value, void* log)
 {
     InitEnsurePermissionsOnEtcIssue(value);
@@ -2914,11 +2924,20 @@ static int RemediateEnsureKernelCompiledFromApprovedSources(char* value, void* l
 
 static int RemediateEnsureDefaultDenyFirewallPolicyIsSet(char* value, void* log)
 {
+    int status = 0;
     UNUSED(value);
-    OsConfigLogInfo(log, "Automatic remediation is not possible. Manually ensure that "
-        "all necessary communication channels have explicit ACCEPT firewall policies set "
-        "and then set the default firewall policy for INPUT, FORWARD and OUTPUT to DROP");
-    return 0;
+    InitEnsureDefaultDenyFirewallPolicyIsSet(value);
+    if (atoi(g_desiredEnsureDefaultDenyFirewallPolicyIsSet))
+    {
+        status = SetDefaultDenyFirewallPolicy(void* log)
+    }
+    else
+    {
+        OsConfigLogInfo(log, "Automatic remediation is not possible. Manually ensure that "
+            "all necessary communication channels have explicit ACCEPT firewall policies set "
+            "and then set the default firewall policy for INPUT, FORWARD and OUTPUT to DROP");
+    }
+    return status;
 }
 
 static int RemediateEnsurePacketRedirectSendingIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2929,7 +2929,7 @@ static int RemediateEnsureDefaultDenyFirewallPolicyIsSet(char* value, void* log)
     InitEnsureDefaultDenyFirewallPolicyIsSet(value);
     if (atoi(g_desiredEnsureDefaultDenyFirewallPolicyIsSet))
     {
-        status = SetDefaultDenyFirewallPolicy(void* log)
+        status = SetDefaultDenyFirewallPolicy(log);
     }
     else
     {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -5272,6 +5272,10 @@ int AsbMmiSet(const char* componentName, const char* objectName, const char* pay
         {
             status = InitEnsureUnnecessaryAccountsAreRemoved(jsonString);
         }
+        else if (0 == strcmp(objectName, g_initEnsureEnsureDefaultDenyFirewallPolicyIsSetObject))
+        {
+            status = InitEnsureDefaultDenyFirewallPolicyIsSet(jsonString);
+        }
         else
         {
             OsConfigLogError(log, "AsbMmiSet called for an unsupported object name: %s", objectName);

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -448,7 +448,7 @@ static const char* g_defaultEnsurePasswordCreationRequirements = "3,14,4,-1,-1,-
 static const char* g_defaultEnsureFilePermissionsForAllRsyslogLogFiles = "600,640";
 static const char* g_defaultEnsureUsersDotFilesArentGroupOrWorldWritable = "600,644,664,700,744";
 static const char* g_defaultEnsureUnnecessaryAccountsAreRemoved = "games,test";
-static const char* g_defaultEnsureDefaultDenyFirewallPolicyIsSet = "0"; //0: audit, 1: forced remediation
+static const char* g_defaultEnsureDefaultDenyFirewallPolicyIsSet = "1"; //"0"; //0: audit, 1: forced remediation
 
 static const char* g_etcIssue = "/etc/issue";
 static const char* g_etcIssueNet = "/etc/issue.net";

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -448,7 +448,7 @@ static const char* g_defaultEnsurePasswordCreationRequirements = "3,14,4,-1,-1,-
 static const char* g_defaultEnsureFilePermissionsForAllRsyslogLogFiles = "600,640";
 static const char* g_defaultEnsureUsersDotFilesArentGroupOrWorldWritable = "600,644,664,700,744";
 static const char* g_defaultEnsureUnnecessaryAccountsAreRemoved = "games,test";
-static const char* g_defaultEnsureDefaultDenyFirewallPolicyIsSet = "1"; //"0"; //0: audit, 1: forced remediation
+static const char* g_defaultEnsureDefaultDenyFirewallPolicyIsSet = "0"; //zero: audit-only, non-zero: add forced remediation
 
 static const char* g_etcIssue = "/etc/issue";
 static const char* g_etcIssueNet = "/etc/issue.net";
@@ -1349,7 +1349,8 @@ static char* AuditEnsureDefaultDenyFirewallPolicyIsSet(void* log)
 {
     const char* readIpTables = "iptables -S";
     char* reason = NULL;
-    int forceDrop = atoi(g_desiredEnsureDefaultDenyFirewallPolicyIsSet ? g_desiredEnsureDefaultDenyFirewallPolicyIsSet : g_defaultEnsureDefaultDenyFirewallPolicyIsSet);
+    int forceDrop = atoi(g_desiredEnsureDefaultDenyFirewallPolicyIsSet ? 
+        g_desiredEnsureDefaultDenyFirewallPolicyIsSet : g_defaultEnsureDefaultDenyFirewallPolicyIsSet);
     
     if ((0 != CheckTextFoundInCommandOutput(readIpTables, "-P INPUT DROP", &reason, log)) ||
         (0 != CheckTextFoundInCommandOutput(readIpTables, "-P FORWARD DROP", &reason, log)) ||

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -5272,7 +5272,7 @@ int AsbMmiSet(const char* componentName, const char* objectName, const char* pay
         {
             status = InitEnsureUnnecessaryAccountsAreRemoved(jsonString);
         }
-        else if (0 == strcmp(objectName, g_initEnsureEnsureDefaultDenyFirewallPolicyIsSetObject))
+        else if (0 == strcmp(objectName, g_initEnsureDefaultDenyFirewallPolicyIsSetObject))
         {
             status = InitEnsureDefaultDenyFirewallPolicyIsSet(jsonString);
         }

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -190,6 +190,7 @@ char* GetHttpProxyData(void* log);
 char* RepairBrokenEolCharactersIfAny(const char* value);
 
 int DisableAllWirelessInterfaces(void* log);
+int SetDefaultDenyFirewallPolicy(void* log);
 
 typedef struct REPORTED_PROPERTY
 {

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -308,6 +308,8 @@ int DisableAllWirelessInterfaces(void* log)
         OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", rfKillBlockAll, status);
     }
 
+    OsConfigLogInfo(log, "DisableAllWirelessInterfaces completed with %d", status);
+
     return status;
 }
 
@@ -353,5 +355,6 @@ int SetDefaultDenyFirewallPolicy(void* log)
     }
 
     OsConfigLogInfo(log, "SetDefaultDenyFirewallPolicy completed with %d", status);
+
     return 0;
 }

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -313,7 +313,7 @@ int DisableAllWirelessInterfaces(void* log)
 
 int SetDefaultDenyFirewallPolicy(void* log)
 {
-    const char* acceptInput = "iptables -A INPUT-j ACCEPT";
+    const char* acceptInput = "iptables -A INPUT -j ACCEPT";
     const char* acceptForward = "iptables -A FORWARD -j ACCEPT";
     const char* acceptOutput = "iptables -A OUTPUT -j ACCEPT";
     const char* dropInput = "iptables -P INPUT DROP";

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -310,3 +310,48 @@ int DisableAllWirelessInterfaces(void* log)
 
     return status;
 }
+
+int SetDefaultDenyFirewallPolicy(void* log)
+{
+    const char* acceptInput = "iptables -A INPUT-j ACCEPT";
+    const char* acceptForward = "iptables -A FORWARD -j ACCEPT";
+    const char* acceptOutput = "iptables -A OUTPUT -j ACCEPT";
+    const char* dropInput = "iptables -P INPUT DROP";
+    const char* dropForward = "iptables -P FORWARD DROP";
+    const char* dropOutput = "iptables -P OUTPUT DROP";
+    int status = 0;
+
+    // First, ensure all current traffic is accepted:
+    if (0 != (status = ExecuteCommand(NULL, acceptInput, true, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "SetDefaultDenyFirewallPolicy: '%s' failed with %d", acceptInput, status);
+    }
+    else if (0 != (status = ExecuteCommand(NULL, acceptForward, true, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "SetDefaultDenyFirewallPolicy: '%s' failed with %d", acceptForward, status);
+    }
+    else if (0 != (status = ExecuteCommand(NULL, acceptOutput, true, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "SetDefaultDenyFirewallPolicy: '%s' failed with %d", acceptOutput, status);
+    }
+
+    if (0 == status)
+    {
+        // Then set default to drop:
+        if (0 != (status = ExecuteCommand(NULL, dropInput, true, false, 0, 0, NULL, NULL, log)))
+        {
+            OsConfigLogError(log, "SetDefaultDenyFirewallPolicy: '%s' failed with %d", dropInput, status);
+        }
+        else if (0 != (status = ExecuteCommand(NULL, dropForward, true, false, 0, 0, NULL, NULL, log)))
+        {
+            OsConfigLogError(log, "SetDefaultDenyFirewallPolicy: '%s' failed with %d", dropForward, status);
+        }
+        else if (0 != (status = ExecuteCommand(NULL, dropOutput, true, false, 0, 0, NULL, NULL, log)))
+        {
+            OsConfigLogError(log, "SetDefaultDenyFirewallPolicy: '%s' failed with %d", dropOutput, status);
+        }
+    }
+
+    OsConfigLogInfo(log, "SetDefaultDenyFirewallPolicy completed with %d", status);
+    return 0;
+}

--- a/src/modules/mim/securitybaseline.json
+++ b/src/modules/mim/securitybaseline.json
@@ -2333,6 +2333,12 @@
           "type": "mimObject",
           "desired": true,
           "schema": "string"
+        },
+        {
+          "name": "initEnsureDefaultDenyFirewallPolicyIsSet",
+          "type": "mimObject",
+          "desired": true,
+          "schema": "string"
         }
       ]
     }


### PR DESCRIPTION
## Description

Adding a new initialization object and new policy parameter for ensuring default firewall policy is set to drop all to allow forcing remediation with first taking a snapshot and allowing all current channels and then blocking all new channels from there on. AuditEnsureDefaultDenyFirewallPolicyIsSet remains the same, RemediateEnsureDefaultDenyFirewallPolicyIsSet either does the same no-op or acts depending on this policy parameter which is currently set to disabled (0). Also fixing AuditEnsureIpv6ProtocolIsEnabled to not look for a system file that may not be correctly updated.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.