### PR TITLE
Improving disabling all wireless interfaces for ASB v2

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1452,7 +1452,7 @@ static char* AuditEnsureSystemNotActingAsNetworkSniffer(void* log)
 static char* AuditEnsureAllWirelessInterfacesAreDisabled(void* log)
 {
     char* reason = NULL;
-    if (0 == CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", &reason, log))
+    if (0 == CheckAllWirelessInterfacesAreDisabled(&reason, log))
     {
         FREE_MEMORY(reason);
         reason = FormatAllocateString("%sNo active wireless interfaces are present", g_pass);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -189,6 +189,7 @@ char* GetHttpProxyData(void* log);
 
 char* RepairBrokenEolCharactersIfAny(const char* value);
 
+int CheckAllWirelessInterfacesAreDisabled(char** reason, void* log);
 int DisableAllWirelessInterfaces(void* log);
 int SetDefaultDenyFirewallPolicy(void* log);
 

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -76,6 +76,7 @@ int SetDirectoryAccess(const char* directoryName, unsigned int desiredOwnerId, u
 int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDirectory, const char* mountType, const char* desiredOption, char** reason, void* log);
 int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, void* log);
 
+int IsPresent(const char* what, void* log);
 int IsPackageInstalled(const char* packageName, void* log);
 int CheckPackageInstalled(const char* packageName, char** reason, void* log);
 int CheckPackageNotInstalled(const char* packageName, char** reason, void* log);

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -305,9 +305,9 @@ int DisableAllWirelessInterfaces(void* log)
 
     int status = 0;
    
-    if (0 == AreAllWirelessInterfacesDisabled(log))
+    if (0 == CheckAllWirelessInterfacesAreDisabled(NULL, log))
     {
-        OsConfigLogInfo(log, "DisableAllWirelessInterfaces: No active wireless interfaces are present");
+        OsConfigLogInfo(log, "DisableAllWirelessInterfaces: no active wireless interfaces are present");
         return 0;
     }
 

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -293,7 +293,7 @@ int ConvertStringToIntegers(const char* source, char separator, int** integers, 
 
 int CheckAllWirelessInterfacesAreDisabled(char** reason, void* log)
 {
-    return CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", &reason, log);
+    return CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", reason, log);
 }
 
 int DisableAllWirelessInterfaces(void* log)

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -291,21 +291,54 @@ int ConvertStringToIntegers(const char* source, char separator, int** integers, 
     return status;
 }
 
+int CheckAllWirelessInterfacesAreDisabled(char** reason, void* log)
+{
+    return CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", &reason, log);
+}
+
 int DisableAllWirelessInterfaces(void* log)
 {
+    const char* nmcli = "nmcli";
+    const char* rfkill = "rfkill";
     const char* nmCliRadioAllOff = "nmcli radio all off";
     const char* rfKillBlockAll = "rfkill block all";
 
     int status = 0;
-    
-    if (0 != (status = ExecuteCommand(NULL, nmCliRadioAllOff, true, false, 0, 0, NULL, NULL, log)))
+   
+    if (0 == AreAllWirelessInterfacesDisabled(log))
     {
-        OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", nmCliRadioAllOff, status);
+        OsConfigLogInfo(log, "DisableAllWirelessInterfaces: No active wireless interfaces are present");
+        return 0;
     }
-    
-    if (0 != (status = ExecuteCommand(NULL, rfKillBlockAll, true, false, 0, 0, NULL, NULL, log)))
+
+    if ((0 != IsPresent(nmcli, log)) && (0 != IsPresent(rfkill, log)))
     {
-        OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", rfKillBlockAll, status);
+        OsConfigLogInfo(log, "DisableAllWirelessInterfaces: neither '%s' or '%s' are installed", nmcli, rfkill);
+        if (0 != (status = InstallOrUpdatePackage(rfkill, log)))
+        {
+            OsConfigLogError(log, "DisableAllWirelessInterfaces: neither '%s' or '%s' are installed, also failed "
+                "to install '%s', automatic remediation is not possible", nmcli, rfkill, rfkill);
+            status = ENOENT;
+        }
+    }
+
+    if (0 == status)
+    {
+        if (0 == IsPresent(nmcli, log))
+        {
+            if (0 != (status = ExecuteCommand(NULL, nmCliRadioAllOff, true, false, 0, 0, NULL, NULL, log)))
+            {
+                OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", nmCliRadioAllOff, status);
+            }
+        }
+
+        if (0 == IsPresent(rfkill, log))
+        {
+            if (0 != (status = ExecuteCommand(NULL, rfKillBlockAll, true, false, 0, 0, NULL, NULL, log)))
+            {
+                OsConfigLogError(log, "DisableAllWirelessInterfaces: '%s' failed with %d", rfKillBlockAll, status);
+            }
+        }
     }
 
     OsConfigLogInfo(log, "DisableAllWirelessInterfaces completed with %d", status);

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -10,7 +10,7 @@ const char* g_dnf = "dnf";
 const char* g_yum = "yum";
 const char* g_zypper = "zypper";
 
-static int IsPresent(const char* what, void* log)
+int IsPresent(const char* what, void* log)
 {
     const char* commandTemplate = "command -v %s";
     char* command = NULL;


### PR DESCRIPTION
## Description

The invoked commands to disable wireless interfaces may be not present by default on all Linux distributions. One is optional (Network Manager) and we use it only if present, the other (RF Kill) is supposed to be present and if it's not, we try to install it and then execute it to disable all wireless interfaces. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.