### PR TITLE
Preventing ASB v2 audit checks from overwriting themselves and other improvements

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1374,7 +1374,7 @@ static char* AuditEnsureDefaultDenyFirewallPolicyIsSet(void* log)
 static char* AuditEnsurePacketRedirectSendingIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.send_redirects = 0", &reason, log);
+    MariusNi/OsConfig_ASB_May29_2024CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.send_redirects = 0", &reason, log);
     CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.send_redirects = 0", &reason, log);
     return reason;
 }
@@ -1382,11 +1382,11 @@ static char* AuditEnsurePacketRedirectSendingIsDisabled(void* log)
 static char* AuditEnsureIcmpRedirectsIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.accept_redirects = 0", &reason, log);
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.secure_redirects = 0", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.accept_redirects = 0", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.accept_redirects = 0", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.accept_redirects = 0", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.accept_redirects = 0", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.secure_redirects = 0", &reason, log));
     CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.secure_redirects = 0", &reason, log);
     return reason;
 }
@@ -1394,7 +1394,7 @@ static char* AuditEnsureIcmpRedirectsIsDisabled(void* log)
 static char* AuditEnsureSourceRoutedPacketsIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/all/accept_source_route", '#', "0", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/all/accept_source_route", '#', "0", &reason, log));
     CheckLineFoundNotCommentedOut("/proc/sys/net/ipv6/conf/all/accept_source_route", '#', "0", &reason, log);
     return reason;
 }
@@ -1402,7 +1402,7 @@ static char* AuditEnsureSourceRoutedPacketsIsDisabled(void* log)
 static char* AuditEnsureAcceptingSourceRoutedPacketsIsDisabled(void* log)
 {
     char* reason = 0;
-    CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/all/accept_source_route", '#', "0", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/all/accept_source_route", '#', "0", &reason, log));
     CheckLineFoundNotCommentedOut("/proc/sys/net/ipv6/conf/default/accept_source_route", '#', "0", &reason, log);
     return reason;
 }
@@ -1424,7 +1424,7 @@ static char* AuditEnsureIgnoringIcmpEchoPingsToMulticast(void* log)
 static char* AuditEnsureMartianPacketLoggingIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.log_martians = 1", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.log_martians = 1", &reason, log));
     CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.log_martians = 1", &reason, log);
     return reason;
 }
@@ -1432,7 +1432,7 @@ static char* AuditEnsureMartianPacketLoggingIsEnabled(void* log)
 static char* AuditEnsureReversePathSourceValidationIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/all/rp_filter", '#', "2", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/all/rp_filter", '#', "2", &reason, log));
     CheckLineFoundNotCommentedOut("/proc/sys/net/ipv4/conf/default/rp_filter", '#', "2", &reason, log);
     return reason;
 }
@@ -1449,8 +1449,8 @@ static char* AuditEnsureSystemNotActingAsNetworkSniffer(void* log)
     const char* command = "ip address";
     const char* text = "PROMISC";
     char* reason = NULL;
-    CheckTextNotFoundInCommandOutput(command, text, &reason, log);
-    CheckLineNotFoundOrCommentedOut(g_etcNetworkInterfaces, '#', text, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextNotFoundInCommandOutput(command, text, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckLineNotFoundOrCommentedOut(g_etcNetworkInterfaces, '#', text, &reason, log));
     CheckLineNotFoundOrCommentedOut(g_etcRcLocal, '#', text, &reason, log);
     return reason;
 }
@@ -1474,7 +1474,7 @@ static char* AuditEnsureAllWirelessInterfacesAreDisabled(void* log)
 static char* AuditEnsureIpv6ProtocolIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.disable_ipv6 = 0", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.all.disable_ipv6 = 0", &reason, log));
     CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv6.conf.default.disable_ipv6 = 0", &reason, log);
     return reason;
 }
@@ -1510,8 +1510,8 @@ static char* AuditEnsureTipcIsDisabled(void* log)
 static char* AuditEnsureZeroconfNetworkingIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive(g_avahiDaemon, &reason, log);
-    CheckLineNotFoundOrCommentedOut(g_etcNetworkInterfaces, '#', g_ipv4ll, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive(g_avahiDaemon, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckLineNotFoundOrCommentedOut(g_etcNetworkInterfaces, '#', g_ipv4ll, &reason, log));
     if (FileExists(g_etcSysconfigNetwork))
     {
         CheckLineFoundNotCommentedOut(g_etcSysconfigNetwork, '#', "NOZEROCONF=yes", &reason, log);
@@ -1525,8 +1525,8 @@ static char* AuditEnsurePermissionsOnBootloaderConfig(void* log)
         g_desiredEnsurePermissionsOnBootloaderConfig : g_defaultEnsurePermissionsOnBootloaderConfig;
     unsigned int mode = (unsigned int)atoi(value);
     char* reason = NULL;
-    CheckFileAccess("/boot/grub/grub.cfg", 0, 0, mode, &reason, log);
-    CheckFileAccess("/boot/grub/grub.conf", 0, 0, mode, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileAccess("/boot/grub/grub.cfg", 0, 0, mode, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileAccess("/boot/grub/grub.conf", 0, 0, mode, &reason, log));
     CheckFileAccess("/boot/grub2/grub.cfg", 0, 0, mode, &reason, log);
     return reason;
 }
@@ -1550,8 +1550,8 @@ static char* AuditEnsureCoreDumpsAreRestricted(void* log)
 {
     const char* fsSuidDumpable = "fs.suid_dumpable = 0";
     char* reason = NULL;
-    CheckLineFoundNotCommentedOut("/etc/security/limits.conf", '#', "hard core 0", &reason, log);
-    CheckTextFoundInFolder("/etc/security/limits.d", fsSuidDumpable, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineFoundNotCommentedOut("/etc/security/limits.conf", '#', "hard core 0", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInFolder("/etc/security/limits.d", fsSuidDumpable, &reason, log));
     CheckTextFoundInCommandOutput(g_sysCtlA, fsSuidDumpable, &reason, log);
     return reason;
 }
@@ -1642,8 +1642,8 @@ static char* AuditEnsureAllBootloadersHavePasswordProtectionEnabled(void* log)
 {
     const char* password = "password";
     char* reason = NULL;
-    CheckLineFoundNotCommentedOut("/boot/grub/grub.cfg", '#', password, &reason, log);
-    CheckLineFoundNotCommentedOut("/boot/grub/grub.conf", '#', password, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineFoundNotCommentedOut("/boot/grub/grub.cfg", '#', password, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckLineFoundNotCommentedOut("/boot/grub/grub.conf", '#', password, &reason, log));
     CheckLineFoundNotCommentedOut("/boot/grub2/grub.conf", '#', password, &reason, log);
     return reason;
 }
@@ -1673,7 +1673,7 @@ static char* AuditEnsureSyslogPackageIsInstalled(void* log)
 static char* AuditEnsureSystemdJournaldServicePersistsLogMessages(void* log)
 {
     char* reason = NULL;
-    CheckPackageInstalled(g_systemd, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageInstalled(g_systemd, &reason, log));
     CheckDirectoryAccess("/var/log/journal", 0, -1, 2775, false, &reason, log);
     return reason;
 }
@@ -1723,7 +1723,7 @@ static char* AuditEnsureFilePermissionsForAllRsyslogLogFiles(void* log)
 static char* AuditEnsureLoggerConfigurationFilesAreRestricted(void* log)
 {
     char* reason = NULL;
-    CheckFileAccess(g_etcRsyslogConf, 0, 0, 640, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileAccess(g_etcRsyslogConf, 0, 0, 640, &reason, log));
     CheckFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, &reason, log);
     return reason;
 }
@@ -1731,7 +1731,7 @@ static char* AuditEnsureLoggerConfigurationFilesAreRestricted(void* log)
 static char* AuditEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(void* log)
 {
     char* reason = NULL;
-    CheckTextIsFoundInFile(g_etcRsyslogConf, "FileGroup adm", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsFoundInFile(g_etcRsyslogConf, "FileGroup adm", &reason, log));
     CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', "FileGroup adm", &reason, log);
     return reason;
 }
@@ -1739,7 +1739,7 @@ static char* AuditEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(void* log)
 static char* AuditEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(void* log)
 {
     char* reason = NULL;
-    CheckTextIsFoundInFile(g_etcRsyslogConf, "FileOwner syslog", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsFoundInFile(g_etcRsyslogConf, "FileOwner syslog", &reason, log));
     CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', "FileOwner syslog", &reason, log);
     return reason;
 }
@@ -1747,7 +1747,7 @@ static char* AuditEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(void* log)
 static char* AuditEnsureRsyslogNotAcceptingRemoteMessages(void* log)
 {
     char* reason = NULL;
-    CheckLineNotFoundOrCommentedOut(g_etcRsyslogConf, '#', "ModLoad imudp", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineNotFoundOrCommentedOut(g_etcRsyslogConf, '#', "ModLoad imudp", &reason, log));
     CheckLineNotFoundOrCommentedOut(g_etcRsyslogConf, '#', "ModLoad imtcp", &reason, log);
     return reason;
 }
@@ -1755,7 +1755,7 @@ static char* AuditEnsureRsyslogNotAcceptingRemoteMessages(void* log)
 static char* AuditEnsureSyslogRotaterServiceIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckPackageInstalled("logrotate", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageInstalled("logrotate", &reason, log));
     CheckFileAccess("/etc/cron.daily/logrotate", 0, 0, 755, &reason, log);
     return reason;
 }
@@ -1763,7 +1763,7 @@ static char* AuditEnsureSyslogRotaterServiceIsEnabled(void* log)
 static char* AuditEnsureTelnetServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive("telnet.socket", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive("telnet.socket", &reason, log));
     CheckLineNotFoundOrCommentedOut(g_etcInetdConf, '#', "telnet", &reason, log);
     return reason;
 }
@@ -1771,7 +1771,7 @@ static char* AuditEnsureTelnetServiceIsDisabled(void* log)
 static char* AuditEnsureRcprshServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive("rcp.socket", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive("rcp.socket", &reason, log));
     CheckDaemonNotActive("rsh.socket", &reason, log);
     return reason;
 }
@@ -1779,7 +1779,7 @@ static char* AuditEnsureRcprshServiceIsDisabled(void* log)
 static char* AuditEnsureTftpServiceisDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive("tftpd-hpa", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive("tftpd-hpa", &reason, log));
     CheckLineNotFoundOrCommentedOut(g_etcInetdConf, '#', "tftp", &reason, log);
     return reason;
 }
@@ -1789,11 +1789,11 @@ static char* AuditEnsureAtCronIsRestrictedToAuthorizedUsers(void* log)
     const char* etcCronAllow = "/etc/cron.allow";
     const char* etcAtAllow = "/etc/at.allow";
     char* reason = NULL;
-    CheckFileNotFound("/etc/cron.deny", &reason, log);
-    CheckFileNotFound("/etc/at.deny", &reason, log);
-    CheckFileExists(etcCronAllow, &reason, log);
-    CheckFileExists(etcAtAllow, &reason, log);
-    CheckFileAccess(etcCronAllow, 0, 0, 600, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileNotFound("/etc/cron.deny", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileNotFound("/etc/at.deny", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileExists(etcCronAllow, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileExists(etcAtAllow, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileAccess(etcCronAllow, 0, 0, 600, &reason, log));
     CheckFileAccess(etcAtAllow, 0, 0, 600, &reason, log);
     return reason;
 }
@@ -1941,7 +1941,7 @@ static char* AuditEnsureAvahiDaemonServiceIsDisabled(void* log)
 static char* AuditEnsureCupsServiceisDisabled(void* log)
 {
     char* reason = NULL;
-    CheckPackageNotInstalled(g_cups, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_cups, &reason, log));
     CheckDaemonNotActive(g_cups, &reason, log);
     return reason;
 }
@@ -1966,7 +1966,7 @@ static char* AuditEnsurePostfixNetworkListeningIsDisabled(void* log)
 static char* AuditEnsureRpcgssdServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive(g_rpcgssd, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive(g_rpcgssd, &reason, log));
     CheckDaemonNotActive(g_rpcGssd, &reason, log);
     return reason;
 }
@@ -1974,7 +1974,7 @@ static char* AuditEnsureRpcgssdServiceIsDisabled(void* log)
 static char* AuditEnsureRpcidmapdServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive(g_rpcidmapd, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive(g_rpcidmapd, &reason, log));
     CheckDaemonNotActive(g_nfsIdmapd, &reason, log);
     return reason;
 }
@@ -1982,8 +1982,8 @@ static char* AuditEnsureRpcidmapdServiceIsDisabled(void* log)
 static char* AuditEnsurePortmapServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive(g_rpcbind, &reason, log);
-    CheckDaemonNotActive(g_rpcbindService, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive(g_rpcbind, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive(g_rpcbindService, &reason, log));
     CheckDaemonNotActive(g_rpcbindSocket, &reason, log);
     return reason;
 }
@@ -1998,7 +1998,7 @@ static char* AuditEnsureNetworkFileSystemServiceIsDisabled(void* log)
 static char* AuditEnsureRpcsvcgssdServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckLineNotFoundOrCommentedOut(g_etcInetdConf, '#', g_needSvcgssd, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLineNotFoundOrCommentedOut(g_etcInetdConf, '#', g_needSvcgssd, &reason, log));
     CheckDaemonNotActive(g_rpcSvcgssd, &reason, log);
     return reason;
 }
@@ -2027,7 +2027,7 @@ static char* AuditEnsureNisServerIsDisabled(void* log)
 static char* AuditEnsureRshClientNotInstalled(void* log)
 {
     char* reason = NULL;
-    CheckPackageNotInstalled(g_rsh, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_rsh, &reason, log));
     CheckPackageNotInstalled(g_rshClient, &reason, log);
     return reason;
 }
@@ -2039,7 +2039,7 @@ static char* AuditEnsureSmbWithSambaIsDisabled(void* log)
     
     if (false == CheckDaemonNotActive(g_samba, &reason, log))
     {
-        CheckLineNotFoundOrCommentedOut(g_etcSambaConf, '#', minProtocol, &reason, log);
+        RETURN_REASON_IF_NON_ZERO(CheckLineNotFoundOrCommentedOut(g_etcSambaConf, '#', minProtocol, &reason, log));
         CheckLineNotFoundOrCommentedOut(g_etcSambaConf, ';', minProtocol, &reason, log);
     }
     return reason;
@@ -2091,10 +2091,10 @@ static char* AuditEnsureNoUsersHaveDotRhostsFiles(void* log)
 static char* AuditEnsureRloginServiceIsDisabled(void* log)
 {
     char* reason = NULL;
-    CheckDaemonNotActive(g_rlogin, &reason, log);
-    CheckPackageNotInstalled(g_rlogin, &reason, log);
-    CheckPackageNotInstalled(g_inetd, &reason, log);
-    CheckPackageNotInstalled(g_inetUtilsInetd, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckDaemonNotActive(g_rlogin, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_rlogin, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_inetd, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_inetUtilsInetd, &reason, log));
     CheckTextIsNotFoundInFile(g_etcInetdConf, "login", &reason, log);
     return reason;
 }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -853,10 +853,16 @@ static char* AuditEnsureKernelSupportForCpuNx(void* log)
     return reason;
 }
 
+#define RETURN_REASON_IF_NON_ZERO(call) {\
+    if (call) {\
+        return reason;\
+    }\
+}\
+
 static char* AuditEnsureNodevOptionOnHomePartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_home, NULL, g_nodev, &reason, log); 
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_home, NULL, g_nodev, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_home, NULL, g_nodev, &reason, log);
     return reason;
 }
@@ -864,7 +870,7 @@ static char* AuditEnsureNodevOptionOnHomePartition(void* log)
 static char* AuditEnsureNodevOptionOnTmpPartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_tmp, NULL, g_nodev, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_tmp, NULL, g_nodev, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_tmp, NULL, g_nodev, &reason, log);
     return reason;
 }
@@ -872,7 +878,7 @@ static char* AuditEnsureNodevOptionOnTmpPartition(void* log)
 static char* AuditEnsureNodevOptionOnVarTmpPartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_varTmp, NULL, g_nodev, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_varTmp, NULL, g_nodev, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_varTmp, NULL, g_nodev, &reason, log);
     return reason;
 }
@@ -880,7 +886,7 @@ static char* AuditEnsureNodevOptionOnVarTmpPartition(void* log)
 static char* AuditEnsureNosuidOptionOnTmpPartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_tmp, NULL, g_nosuid, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_tmp, NULL, g_nosuid, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_tmp, NULL, g_nosuid, &reason, log);
     return reason;
 }
@@ -888,7 +894,7 @@ static char* AuditEnsureNosuidOptionOnTmpPartition(void* log)
 static char* AuditEnsureNosuidOptionOnVarTmpPartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_varTmp, NULL, g_nosuid, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_varTmp, NULL, g_nosuid, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_varTmp, NULL, g_nosuid, &reason, log);
     return reason;
 }
@@ -896,7 +902,7 @@ static char* AuditEnsureNosuidOptionOnVarTmpPartition(void* log)
 static char* AuditEnsureNoexecOptionOnVarTmpPartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_varTmp, NULL, g_noexec, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_varTmp, NULL, g_noexec, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_varTmp, NULL, g_noexec, &reason, log);
     return reason;
 }
@@ -904,7 +910,7 @@ static char* AuditEnsureNoexecOptionOnVarTmpPartition(void* log)
 static char* AuditEnsureNoexecOptionOnDevShmPartition(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_devShm, NULL, g_noexec, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_devShm, NULL, g_noexec, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_devShm, NULL, g_noexec, &reason, log);
     return reason;
 }
@@ -912,7 +918,7 @@ static char* AuditEnsureNoexecOptionOnDevShmPartition(void* log)
 static char* AuditEnsureNodevOptionEnabledForAllRemovableMedia(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_media, NULL, g_nodev, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_media, NULL, g_nodev, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_media, NULL, g_nodev, &reason, log);
     return reason;
 }
@@ -920,7 +926,7 @@ static char* AuditEnsureNodevOptionEnabledForAllRemovableMedia(void* log)
 static char* AuditEnsureNoexecOptionEnabledForAllRemovableMedia(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_media, NULL, g_noexec, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_media, NULL, g_noexec, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_media, NULL, g_noexec, &reason, log);
     return reason;
 }
@@ -928,7 +934,7 @@ static char* AuditEnsureNoexecOptionEnabledForAllRemovableMedia(void* log)
 static char* AuditEnsureNosuidOptionEnabledForAllRemovableMedia(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, g_media, NULL, g_nosuid, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, g_media, NULL, g_nosuid, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, g_media, NULL, g_nosuid, &reason, log);
     return reason;
 }
@@ -936,9 +942,9 @@ static char* AuditEnsureNosuidOptionEnabledForAllRemovableMedia(void* log)
 static char* AuditEnsureNoexecNosuidOptionsEnabledForAllNfsMounts(void* log)
 {
     char* reason = NULL;
-    CheckFileSystemMountingOption(g_etcMtab, NULL, g_nfs, g_noexec, &reason, log);
-    CheckFileSystemMountingOption(g_etcMtab, NULL, g_nfs, g_nosuid, &reason, log);
-    CheckFileSystemMountingOption(g_etcFstab, NULL, g_nfs, g_noexec, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, NULL, g_nfs, g_noexec, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcMtab, NULL, g_nfs, g_nosuid, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckFileSystemMountingOption(g_etcFstab, NULL, g_nfs, g_noexec, &reason, log));
     CheckFileSystemMountingOption(g_etcFstab, NULL, g_nfs, g_nosuid, &reason, log);
     return reason;
 }
@@ -946,7 +952,7 @@ static char* AuditEnsureNoexecNosuidOptionsEnabledForAllNfsMounts(void* log)
 static char* AuditEnsureInetdNotInstalled(void* log)
 {
     char* reason = NULL;
-    CheckPackageNotInstalled(g_inetd, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_inetd, &reason, log));
     CheckPackageNotInstalled(g_inetUtilsInetd, &reason, log);
     return reason;
 }
@@ -996,7 +1002,7 @@ static char* AuditEnsureReadaheadFedoraNotInstalled(void* log)
 static char* AuditEnsureBluetoothHiddNotInstalled(void* log)
 {
     char* reason = NULL;
-    CheckPackageNotInstalled(g_bluetooth, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageNotInstalled(g_bluetooth, &reason, log));
     CheckDaemonNotActive(g_bluetooth, &reason, log);
     return reason;
 }
@@ -1151,7 +1157,7 @@ static char* AuditEnsureDefaultRootAccountGroupIsGidZero(void* log)
 static char* AuditEnsureRootIsOnlyUidZeroAccount(void* log)
 {
     char* reason = NULL;
-    CheckRootGroupExists(&reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckRootGroupExists(&reason, log));
     CheckRootIsOnlyUidZeroAccount(&reason, log);
     return reason;
 }
@@ -1210,8 +1216,8 @@ static char* AuditEnsureMinDaysBetweenPasswordChanges(void* log)
 static char* AuditEnsureInactivePasswordLockPeriod(void* log)
 {
     char* reason = NULL;
-    CheckLockoutAfterInactivityLessThan(atoi(g_desiredEnsureInactivePasswordLockPeriod ? 
-        g_desiredEnsureInactivePasswordLockPeriod : g_defaultEnsureInactivePasswordLockPeriod), &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckLockoutAfterInactivityLessThan(atoi(g_desiredEnsureInactivePasswordLockPeriod ?
+        g_desiredEnsureInactivePasswordLockPeriod : g_defaultEnsureInactivePasswordLockPeriod), &reason, log));
     CheckUsersRecordedPasswordChangeDates(&reason, log);
     return reason;
 }
@@ -1273,10 +1279,10 @@ static char* AuditEnsureDotDoesNotAppearInRootsPath(void* log)
     const char* path = "PATH";
     const char* dot = ".";
     char* reason = NULL;
-    CheckTextNotFoundInEnvironmentVariable(path, dot, false, &reason, log);
-    CheckMarkedTextNotFoundInFile("/etc/sudoers", "secure_path", dot, &reason, log);
-    CheckMarkedTextNotFoundInFile(g_etcEnvironment, path, dot, &reason, log);
-    CheckMarkedTextNotFoundInFile(g_etcProfile, path, dot, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextNotFoundInEnvironmentVariable(path, dot, false, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckMarkedTextNotFoundInFile("/etc/sudoers", "secure_path", dot, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckMarkedTextNotFoundInFile(g_etcEnvironment, path, dot, &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckMarkedTextNotFoundInFile(g_etcProfile, path, dot, &reason, log));
     CheckMarkedTextNotFoundInFile("/root/.profile", path, dot, &reason, log);
     return reason;
 }
@@ -1284,7 +1290,7 @@ static char* AuditEnsureDotDoesNotAppearInRootsPath(void* log)
 static char* AuditEnsureCronServiceIsEnabled(void* log)
 {
     char* reason = NULL;
-    CheckPackageInstalled(g_cron, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckPackageInstalled(g_cron, &reason, log));
     CheckDaemonActive(g_cron, &reason, log);
     return reason;
 }
@@ -1292,9 +1298,9 @@ static char* AuditEnsureCronServiceIsEnabled(void* log)
 static char* AuditEnsureRemoteLoginWarningBannerIsConfigured(void* log)
 {
     char* reason = NULL;
-    CheckTextIsNotFoundInFile(g_etcIssueNet, "\\m", &reason, log);
-    CheckTextIsNotFoundInFile(g_etcIssueNet, "\\r", &reason, log);
-    CheckTextIsNotFoundInFile(g_etcIssueNet, "\\s", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsNotFoundInFile(g_etcIssueNet, "\\m", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsNotFoundInFile(g_etcIssueNet, "\\r", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsNotFoundInFile(g_etcIssueNet, "\\s", &reason, log));
     CheckTextIsNotFoundInFile(g_etcIssueNet, "\\v", &reason, log);
     return reason;
 }
@@ -1302,9 +1308,9 @@ static char* AuditEnsureRemoteLoginWarningBannerIsConfigured(void* log)
 static char* AuditEnsureLocalLoginWarningBannerIsConfigured(void* log)
 {
     char* reason = NULL;
-    CheckTextIsNotFoundInFile(g_etcIssue, "\\m", &reason, log);
-    CheckTextIsNotFoundInFile(g_etcIssue, "\\r", &reason, log);
-    CheckTextIsNotFoundInFile(g_etcIssue, "\\s", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsNotFoundInFile(g_etcIssue, "\\m", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsNotFoundInFile(g_etcIssue, "\\r", &reason, log));
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsNotFoundInFile(g_etcIssue, "\\s", &reason, log));
     CheckTextIsNotFoundInFile(g_etcIssue, "\\v", &reason, log);
     return reason;
 }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -14,6 +14,12 @@
 #include <Logging.h>
 #include <Asb.h>
 
+#define RETURN_REASON_IF_NON_ZERO(call) {\
+    if (call) {\
+        return reason;\
+    }\
+}\
+
 static const char* g_asbName = "Azure Security Baseline for Linux";
 
 static const char* g_securityBaselineComponentName = "SecurityBaseline";
@@ -852,12 +858,6 @@ static char* AuditEnsureKernelSupportForCpuNx(void* log)
     }
     return reason;
 }
-
-#define RETURN_REASON_IF_NON_ZERO(call) {\
-    if (call) {\
-        return reason;\
-    }\
-}\
 
 static char* AuditEnsureNodevOptionOnHomePartition(void* log)
 {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1374,7 +1374,7 @@ static char* AuditEnsureDefaultDenyFirewallPolicyIsSet(void* log)
 static char* AuditEnsurePacketRedirectSendingIsDisabled(void* log)
 {
     char* reason = NULL;
-    MariusNi/OsConfig_ASB_May29_2024CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.send_redirects = 0", &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.all.send_redirects = 0", &reason, log));
     CheckTextFoundInCommandOutput(g_sysCtlA, "net.ipv4.conf.default.send_redirects = 0", &reason, log);
     return reason;
 }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1458,16 +1458,7 @@ static char* AuditEnsureSystemNotActingAsNetworkSniffer(void* log)
 static char* AuditEnsureAllWirelessInterfacesAreDisabled(void* log)
 {
     char* reason = NULL;
-    if (0 == CheckAllWirelessInterfacesAreDisabled(&reason, log))
-    {
-        FREE_MEMORY(reason);
-        reason = FormatAllocateString("%sNo active wireless interfaces are present", g_pass);
-    }
-    else
-    {
-        FREE_MEMORY(reason);
-        reason = DuplicateString("At least one active wireless interface is present");
-    }
+    CheckAllWirelessInterfacesAreDisabled(&reason, log);
     return reason;
 }
 

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -293,28 +293,19 @@ int ConvertStringToIntegers(const char* source, char separator, int** integers, 
 
 int CheckAllWirelessInterfacesAreDisabled(char** reason, void* log)
 {
-    /*
-    if [[ -z $(ip link show | grep -E '^[0-9]+: [a-zA-Z0-9]+: <.*UP.*>.*mtu [0-9]+') ]]; then
-        echo "No wireless interfaces are enabled."
-    else
-        echo "Wireless interfaces are enabled."
-    fi
-    */
-    
-    //return CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", reason, log);
     const char* command = "ip link show | grep - E '^[0-9]+: [a-zA-Z0-9]+: <.*UP.*>.*mtu [0-9]+'";
     int status = 0;
-
-    UNUSED(reason);
 
     if (0 == (status = ExecuteCommand(NULL, command, true, false, 0, 0, NULL, NULL, log)))
     {
         OsConfigLogError(log, "CheckAllWirelessInterfacesAreDisabled: wireless interfaces are enabled");
+        OsConfigCaptureReason(reason, "At least one active wireless interface is present");
         status = ENOENT;
     }
     else
     {
         OsConfigLogInfo(log, "CheckAllWirelessInterfacesAreDisabled: no wireless interfaces are enabled");
+        OsConfigCaptureSuccessReason(reason, "No active wireless interfaces are present");
         status = 0;
     }
     

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -293,7 +293,32 @@ int ConvertStringToIntegers(const char* source, char separator, int** integers, 
 
 int CheckAllWirelessInterfacesAreDisabled(char** reason, void* log)
 {
-    return CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", reason, log);
+    /*
+    if [[ -z $(ip link show | grep -E '^[0-9]+: [a-zA-Z0-9]+: <.*UP.*>.*mtu [0-9]+') ]]; then
+        echo "No wireless interfaces are enabled."
+    else
+        echo "Wireless interfaces are enabled."
+    fi
+    */
+    
+    //return CheckTextNotFoundInCommandOutput("/sbin/iwconfig 2>&1 | /bin/egrep -v 'no wireless extensions|not found'", "Frequency", reason, log);
+    const char* command = "ip link show | grep - E '^[0-9]+: [a-zA-Z0-9]+: <.*UP.*>.*mtu [0-9]+'";
+    int status = 0;
+
+    UNUSED(reason);
+
+    if (0 == (status = ExecuteCommand(NULL, command, true, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "CheckAllWirelessInterfacesAreDisabled: wireless interfaces are enabled");
+        status = ENOENT;
+    }
+    else
+    {
+        OsConfigLogInfo(log, "CheckAllWirelessInterfacesAreDisabled: no wireless interfaces are enabled");
+        status = 0;
+    }
+    
+    return status;
 }
 
 int DisableAllWirelessInterfaces(void* log)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -197,7 +197,7 @@ int InstallPackage(const char* packageName, void* log)
 
     if (0 != (status = IsPackageInstalled(packageName, log)))
     {
-        InstallOrUpdatePackage(packageName, log);
+        status = InstallOrUpdatePackage(packageName, log);
     }
     else
     {


### PR DESCRIPTION
## Description

Making ASB v2 audit checks that contains multiple sub-checks in an AND situation to fail at first sub-check fail in order to prevent a passing next sub-check from overwriting that audit result.

Also, changing the way presence of enabled wireless interfaces is checked to increase compatibility with various distros.

Plus, fixing a bug affecting remediation checks that need to install packages.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.