### PR TITLE
Advancing remediation implementation for ASB v2 and adding reasons for corrupted user and group databases

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3322,7 +3322,7 @@ static int RemediateEnsureTftpServiceisDisabled(char* value, void* log)
 
 static int RemediateEnsureAtCronIsRestrictedToAuthorizedUsers(char* value, void* log)
 {
-    const char* payload = "root";
+    const char* payload = "root\n";
     UNUSED(value);
     remove(g_etcCronDeny);
     remove(g_etcAtDeny);

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1720,10 +1720,7 @@ static char* AuditEnsureLoggerConfigurationFilesAreRestricted(void* log)
 {
     char* reason = NULL;
     RETURN_REASON_IF_NON_ZERO(CheckFileAccess(g_etcRsyslogConf, 0, 0, 640, &reason, log));
-    if (FileExists(g_etcSyslogNgSyslogNgConf))
-    {
-        CheckFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, &reason, log);
-    }
+    CheckFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, &reason, log);
     return reason;
 }
 
@@ -3269,7 +3266,7 @@ static int RemediateEnsureFilePermissionsForAllRsyslogLogFiles(char* value, void
 static int RemediateEnsureLoggerConfigurationFilesAreRestricted(char* value, void* log)
 {
     UNUSED(value);
-    return ((false == FileExists(g_etcSyslogNgSyslogNgConf) || (0 == SetFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, log))) &&
+    return ((0 == SetFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, log)) &&
         (0 == SetFileAccess(g_etcRsyslogConf, 0, 0, 640, log))) ? 0 : ENOENT;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3329,7 +3329,9 @@ static int RemediateEnsureAtCronIsRestrictedToAuthorizedUsers(char* value, void*
     return (SecureSaveToFile(g_etcCronAllow, payload, strlen(payload), log) &&
         SecureSaveToFile(g_etcAtAllow, payload, strlen(payload), log) &&
         (0 != CheckFileExists(g_etcCronDeny, NULL, log)) &&
-        (0 != CheckFileExists(g_etcAtDeny, NULL, log))) ? 0 : ENOENT;
+        (0 != CheckFileExists(g_etcAtDeny, NULL, log)) &&
+        (0 == SetFileAccess(g_etcCronAllow, 0, 0, 600, log)) &&
+        (0 == SetFileAccess(g_etcAtAllow, 0, 0, 600, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureSshPortIsConfigured(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1720,7 +1720,10 @@ static char* AuditEnsureLoggerConfigurationFilesAreRestricted(void* log)
 {
     char* reason = NULL;
     RETURN_REASON_IF_NON_ZERO(CheckFileAccess(g_etcRsyslogConf, 0, 0, 640, &reason, log));
-    CheckFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, &reason, log);
+    if (FileExists(g_etcSyslogNgSyslogNgConf))
+    {
+        CheckFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, &reason, log);
+    }
     return reason;
 }
 
@@ -3266,7 +3269,7 @@ static int RemediateEnsureFilePermissionsForAllRsyslogLogFiles(char* value, void
 static int RemediateEnsureLoggerConfigurationFilesAreRestricted(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == SetFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, log)) &&
+    return ((false == FileExists(g_etcSyslogNgSyslogNgConf) || (0 == SetFileAccess(g_etcSyslogNgSyslogNgConf, 0, 0, 640, log))) &&
         (0 == SetFileAccess(g_etcRsyslogConf, 0, 0, 640, log))) ? 0 : ENOENT;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1728,8 +1728,8 @@ static char* AuditEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(void* log)
 {
     const char* fileGroup = "$FileGroup adm";
     char* reason = NULL;
-    RETURN_REASON_IF_NON_ZERO(CheckTextIsFoundInFile(g_etcRsyslogConf, fileGroupAdm, &reason, log));
-    CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', fileGroupAdm, &reason, log);
+    RETURN_REASON_IF_NON_ZERO(CheckTextIsFoundInFile(g_etcRsyslogConf, fileGroup, &reason, log));
+    CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', fileGroup, &reason, log);
     return reason;
 }
 
@@ -3238,14 +3238,14 @@ static int RemediateEnsureFilePermissionsForAllRsyslogLogFiles(char* value, void
 
     if ((0 == (status = ConvertStringToIntegers(g_desiredEnsureFilePermissionsForAllRsyslogLogFiles, ',', &modes, &numberOfModes, log))) && (numberOfModes > 0))
     {
-        if (NULL != (formattedMode = FormatAllocateString(formatTemplate, mode[numberOfModes - 1])))
+        if (NULL != (formattedMode = FormatAllocateString(formatTemplate, modes[numberOfModes - 1])))
         {
             status = SetEtcConfValue(g_etcRsyslogConf, g_fileCreateMode, formattedMode, log);
             FREE_MEMORY(formattedMode);
         }
         else
         {
-            OsConfigLogError("RemediateEnsureFilePermissionsForAllRsyslogLogFiles: out of memory");
+            OsConfigLogError(log, "RemediateEnsureFilePermissionsForAllRsyslogLogFiles: out of memory");
             status = ENOMEM;
         }
     }
@@ -3315,8 +3315,8 @@ static int RemediateEnsureAtCronIsRestrictedToAuthorizedUsers(char* value, void*
 {
     const char* payload = "root";
     UNUSED(value);
-    remove(g_atCronDeny);
-    remove(g_atAtDeny);
+    remove(g_etcCronDeny);
+    remove(g_etcAtDeny);
     return (SecureSaveToFile(g_etcCronAllow, payload, strlen(payload), log) &&
         SecureSaveToFile(g_etcAtAllow, payload, strlen(payload), log) &&
         (0 != CheckFileExists(g_etcCronDeny, NULL, log)) &&

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3236,17 +3236,26 @@ static int RemediateEnsureFilePermissionsForAllRsyslogLogFiles(char* value, void
 
     InitEnsureFilePermissionsForAllRsyslogLogFiles(value);
 
-    if ((0 == (status = ConvertStringToIntegers(g_desiredEnsureFilePermissionsForAllRsyslogLogFiles, ',', &modes, &numberOfModes, log))) && (numberOfModes > 0))
+    if (0 == (status = ConvertStringToIntegers(g_desiredEnsureFilePermissionsForAllRsyslogLogFiles, ',', &modes, &numberOfModes, log)))
     {
-        if (NULL != (formattedMode = FormatAllocateString(formatTemplate, modes[numberOfModes - 1])))
+        if (numberOfModes > 0)
         {
-            status = SetEtcConfValue(g_etcRsyslogConf, g_fileCreateMode, formattedMode, log);
-            FREE_MEMORY(formattedMode);
+            if (NULL != (formattedMode = FormatAllocateString(formatTemplate, modes[numberOfModes - 1])))
+            {
+                status = SetEtcConfValue(g_etcRsyslogConf, g_fileCreateMode, formattedMode, log);
+                FREE_MEMORY(formattedMode);
+            }
+            else
+            {
+                OsConfigLogError(log, "RemediateEnsureFilePermissionsForAllRsyslogLogFiles: out of memory");
+                status = ENOMEM;
+            }
         }
         else
         {
-            OsConfigLogError(log, "RemediateEnsureFilePermissionsForAllRsyslogLogFiles: out of memory");
-            status = ENOMEM;
+            OsConfigLogError(log, "RemediateEnsureFilePermissionsForAllRsyslogLogFiles: failed to parse desired value '%s'", 
+                g_desiredEnsureFilePermissionsForAllRsyslogLogFiles);
+            status = ENOENT;
         }
     }
 

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -103,6 +103,7 @@ int CheckTextFoundInCommandOutput(const char* command, const char* text, char** 
 char* GetStringOptionFromBuffer(const char* buffer, const char* option, char separator, void* log);
 int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char separator, void* log);
 int CheckTextNotFoundInCommandOutput(const char* command, const char* text, char** reason, void* log);
+int SetEtcConfValue(const char* file, const char* name, const char* value, void* log);
 int SetEtcLoginDefValue(const char* name, const char* value, void* log);
 int CheckLockoutForFailedPasswordAttempts(const char* fileName, const char* pamSo, char commentCharacter, char** reason, void* log);
 int SetLockoutForFailedPasswordAttempts(void* log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1579,7 +1579,6 @@ int SetEtcConfValue(const char* file, const char* name, const char* value, void*
 {
     const char* newlineTemplate = "%s %s\n";
     char* newline = NULL;
-    char* original = NULL;
     int status = 0;
 
     if ((NULL == file) || (NULL == name) || (0 == strlen(name)) || (NULL == value) || (0 == strlen(value)))

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -273,7 +273,7 @@ static int CheckIfUserHasPassword(SIMPLIFIED_USER* user, void* log)
     }
     else
     {
-        OsConfigLogError(log, "CheckIfUserHasPassword: getspnam(%s) failed (%d)", user->username, errno);
+        OsConfigLogError(log, "CheckIfUserHasPassword: getspnam('%s') failed (%d)", user->username, errno);
         status = ENOENT;
     }
 

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -69,11 +69,11 @@ extern "C"
 {
 #endif
 
-int EnumerateUsers(SIMPLIFIED_USER** userList, unsigned int* size, void* log);
+int EnumerateUsers(SIMPLIFIED_USER** userList, unsigned int* size, char** reason, void* log);
 void FreeUsersList(SIMPLIFIED_USER** source, unsigned int size);
 
-int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, unsigned int* size, void* log);
-int EnumerateAllGroups(SIMPLIFIED_GROUP** groupList, unsigned int* size, void* log);
+int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, unsigned int* size, char** reason, void* log);
+int EnumerateAllGroups(SIMPLIFIED_GROUP** groupList, unsigned int* size, char** reason, void* log);
 void FreeGroupList(SIMPLIFIED_GROUP** groupList, unsigned int size);
 
 int CheckAllEtcPasswdGroupsExistInEtcGroup(char** reason, void* log);

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1303,7 +1303,7 @@ TEST_F(CommonUtilsTest, EnumerateUsersAndTheirGroups)
     struct SIMPLIFIED_GROUP* groupList = NULL;
     unsigned int groupListSize = 0;
 
-    EXPECT_EQ(0, EnumerateUsers(&userList, &userListSize, nullptr));
+    EXPECT_EQ(0, EnumerateUsers(&userList, &userListSize, nullptr, nullptr));
     EXPECT_EQ(userListSize, GetNumberOfLinesInFile("/etc/passwd"));
     EXPECT_NE(nullptr, userList);
 
@@ -1311,7 +1311,7 @@ TEST_F(CommonUtilsTest, EnumerateUsersAndTheirGroups)
     {
         EXPECT_NE(nullptr, userList[i].username);
         
-        EXPECT_EQ(0, EnumerateUserGroups(&userList[i], &groupList, &groupListSize, nullptr));
+        EXPECT_EQ(0, EnumerateUserGroups(&userList[i], &groupList, &groupListSize, nullptr, nullptr));
         EXPECT_NE(nullptr, groupList);
         
         for (unsigned int j = 0; j < groupListSize; j++)
@@ -1332,7 +1332,7 @@ TEST_F(CommonUtilsTest, EnumerateAllGroups)
     SIMPLIFIED_GROUP* groupList = NULL;
     unsigned int groupListSize = 0;
 
-    EXPECT_EQ(0, EnumerateAllGroups(&groupList, &groupListSize, nullptr));
+    EXPECT_EQ(0, EnumerateAllGroups(&groupList, &groupListSize, nullptr, nullptr));
     EXPECT_EQ(groupListSize, GetNumberOfLinesInFile("/etc/group"));
     EXPECT_NE(nullptr, groupList);
 


### PR DESCRIPTION
## Description

Changes in this PR advance remediation implementation for ASB v2, completing the following checks:

RemediateEnsureFilePermissionsForAllRsyslogLogFiles
RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup
RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser
RemediateEnsureRsyslogNotAcceptingRemoteMessages
RemediateEnsureSyslogRotaterServiceIsEnabled
RemediateEnsureTelnetServiceIsDisabled
RemediateEnsureRcprshServiceIsDisabled
RemediateEnsureTftpServiceisDisabled
RemediateEnsureAtCronIsRestrictedToAuthorizedUsers

And also adding reasons for audits that fail when users and groups cannot be enumerated due to potential database corruption.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.