### PR TITLE
Fixing situation when on Mariner certain system accounts are not detected as such

### DIFF
--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -163,7 +163,7 @@ static char* EncryptionName(int type)
 
 static bool IsNoLoginUser(SIMPLIFIED_USER* user)
 {
-    const char* noLoginShell[] = {"/usr/sbin/nologin", "/sbin/nologin", "/bin/false", "/bin/true", "/usr/bin/true", "/dev/null", ""};
+    const char* noLoginShell[] = {"/usr/sbin/nologin", "/sbin/nologin", "/bin/false", "/bin/true", "/usr/bin/true", "/usr/bin/false", "/dev/null", ""};
 
     int index = ARRAY_SIZE(noLoginShell);
     bool noLogin = false;


### PR DESCRIPTION
## Description

This PR fixes the problem when Mariner accounts 'systemd-coredump' (79, 79) and 'systemd-oom' (80, 80) were detected non-system/can login due to missing shell being checked.


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.