### PR TITLE
Fixing Samba service name used to check if Samba is running and more stabilization for ASB v2

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -564,6 +564,7 @@ static const char* g_rhosts = "rhosts";
 static const char* g_systemdJournald = "systemd-journald";
 static const char* g_allTelnetd = "*telnetd*";
 static const char* g_samba = "samba";
+static const char* g_smbd = "smbd";
 static const char* g_rpcSvcgssd = "rpc.svcgssd";
 static const char* g_needSvcgssd = "NEED_SVCGSSD = yes";
 static const char* g_inetInterfacesLocalhost = "inet_interfaces localhost";
@@ -2039,7 +2040,7 @@ static char* AuditEnsureSmbWithSambaIsDisabled(void* log)
     const char* minProtocol = "min protocol = SMB2";
     char* reason = NULL;
     
-    if (false == CheckDaemonNotActive(g_samba, &reason, log))
+    if (false == CheckDaemonNotActive(g_smbd, &reason, log))
     {
         RETURN_REASON_IF_NOT_ZERO(CheckLineNotFoundOrCommentedOut(g_etcSambaConf, '#', minProtocol, &reason, log));
         CheckLineNotFoundOrCommentedOut(g_etcSambaConf, ';', minProtocol, &reason, log);
@@ -3550,7 +3551,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, void* log)
 
     UNUSED(value);
 
-    if (IsDaemonActive(g_samba, log))
+    if (IsDaemonActive(g_smbd, log))
     {
         status = ((0 == ReplaceMarkedLinesInFile(g_etcSambaConf, "SMB1", NULL, '#', log)) && 
             (0 == ExecuteCommand(NULL, command, true, false, 0, 0, NULL, NULL, log))) ? 0 : ENOENT;

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -662,7 +662,7 @@ void AsbInitialize(void* log)
 
     if (false == FileExists(g_etcFstabCopy))
     {
-        if (false == MakeFileBackupCopy(g_etcFstab, g_etcFstabCopy, log))
+        if (false == MakeFileBackupCopy(g_etcFstab, g_etcFstabCopy, true, log))
         {
             OsConfigLogError(log, "AsbInitialize: failed to make a local backup copy of '%s'", g_etcFstab);
         }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2773,19 +2773,19 @@ static int RemediateEnsureNonRootAccountsHaveUniqueUidsGreaterThanZero(char* val
 static int RemediateEnsureNoLegacyPlusEntriesInEtcPasswd(char* value, void* log)
 {
     UNUSED(value);
-    return ReplaceMarkedLinesInFile(g_etcPasswd, "+", NULL, '#', log);
+    return ReplaceMarkedLinesInFile(g_etcPasswd, "+", NULL, '#', true, log);
 }
 
 static int RemediateEnsureNoLegacyPlusEntriesInEtcShadow(char* value, void* log)
 {
     UNUSED(value);
-    return ReplaceMarkedLinesInFile(g_etcShadow, "+", NULL, '#', log);
+    return ReplaceMarkedLinesInFile(g_etcShadow, "+", NULL, '#', true, log);
 }
 
 static int RemediateEnsureNoLegacyPlusEntriesInEtcGroup(char* value, void* log)
 {
     UNUSED(value);
-    return ReplaceMarkedLinesInFile(g_etcGroup, "+", NULL, '#', log);
+    return ReplaceMarkedLinesInFile(g_etcGroup, "+", NULL, '#', true, log);
 }
 
 static int RemediateEnsureDefaultRootAccountGroupIsGidZero(char* value, void* log)
@@ -2956,8 +2956,8 @@ static int RemediateEnsurePacketRedirectSendingIsDisabled(char* value, void* log
     UNUSED(value);
     return ((0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.send_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.send_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.send_redirects", "net.ipv4.conf.all.send_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.send_redirects", "net.ipv4.conf.default.send_redirects = 0\n", '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.send_redirects", "net.ipv4.conf.all.send_redirects = 0\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.send_redirects", "net.ipv4.conf.default.send_redirects = 0\n", '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureIcmpRedirectsIsDisabled(char* value, void* log)
@@ -2969,12 +2969,12 @@ static int RemediateEnsureIcmpRedirectsIsDisabled(char* value, void* log)
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv6.conf.all.accept_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.secure_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.secure_redirects=0", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.accept_redirects", "net.ipv4.conf.default.accept_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.default.accept_redirects", "net.ipv6.conf.default.accept_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.accept_redirects", "net.ipv4.conf.all.accept_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.all.accept_redirects", "net.ipv6.conf.all.accept_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.secure_redirects", "net.ipv4.conf.default.secure_redirects = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.secure_redirects", "net.ipv4.conf.all.secure_redirects = 0\n", '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.accept_redirects", "net.ipv4.conf.default.accept_redirects = 0\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.default.accept_redirects", "net.ipv6.conf.default.accept_redirects = 0\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.accept_redirects", "net.ipv4.conf.all.accept_redirects = 0\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.all.accept_redirects", "net.ipv6.conf.all.accept_redirects = 0\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.secure_redirects", "net.ipv4.conf.default.secure_redirects = 0\n", true, '#', log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.secure_redirects", "net.ipv4.conf.all.secure_redirects = 0\n", '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureSourceRoutedPacketsIsDisabled(char* value, void* log)
@@ -3008,8 +3008,8 @@ static int RemediateEnsureMartianPacketLoggingIsEnabled(char* value, void* log)
     UNUSED(value);
     return ((0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.all.log_martians=1", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv4.conf.default.log_martians=1", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.log_martians", "net.ipv4.conf.all.log_martians = 1\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.log_martians", "net.ipv4.conf.default.log_martians = 1\n", '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.all.log_martians", "net.ipv4.conf.all.log_martians = 1\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv4.conf.default.log_martians", "net.ipv4.conf.default.log_martians = 1\n", '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureReversePathSourceValidationIsEnabled(char* value, void* log)
@@ -3028,8 +3028,8 @@ static int RemediateEnsureTcpSynCookiesAreEnabled(char* value, void* log)
 static int RemediateEnsureSystemNotActingAsNetworkSniffer(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == ReplaceMarkedLinesInFile(g_etcNetworkInterfaces, "PROMISC", NULL, '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcRcLocal, "PROMISC", NULL, '#', log))) ? 0 : ENOENT;
+    return ((0 == ReplaceMarkedLinesInFile(g_etcNetworkInterfaces, "PROMISC", NULL, '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcRcLocal, "PROMISC", NULL, '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureAllWirelessInterfacesAreDisabled(char* value, void* log)
@@ -3043,8 +3043,8 @@ static int RemediateEnsureIpv6ProtocolIsEnabled(char* value, void* log)
     UNUSED(value);
     return ((0 == ExecuteCommand(NULL, "sysctl -w net.ipv6.conf.default.disable_ipv6=0", true, false, 0, 0, NULL, NULL, log)) &&
         (0 == ExecuteCommand(NULL, "sysctl -w net.ipv6.conf.all.disable_ipv6=0", true, false, 0, 0, NULL, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.default.disable_ipv6", "net.ipv6.conf.default.disable_ipv6 = 0\n", '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.all.disable_ipv6", "net.ipv6.conf.all.disable_ipv6 = 0\n", '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.default.disable_ipv6", "net.ipv6.conf.default.disable_ipv6 = 0\n", '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysctlConf, "net.ipv6.conf.all.disable_ipv6", "net.ipv6.conf.all.disable_ipv6 = 0\n", '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureDccpIsDisabled(char* value, void* log)
@@ -3084,8 +3084,8 @@ static int RemediateEnsureZeroconfNetworkingIsDisabled(char* value, void* log)
     UNUSED(value);
     StopAndDisableDaemon(g_avahiDaemon, log);
     return ((false == IsDaemonActive(g_avahiDaemon, log)) && 
-        (0 == ReplaceMarkedLinesInFile(g_etcNetworkInterfaces, g_ipv4ll, NULL, '#', log)) && 
-        (0 == ReplaceMarkedLinesInFile(g_etcSysconfigNetwork, "NOZEROCONF", "NOZEROCONF=yes\n", '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcNetworkInterfaces, g_ipv4ll, NULL, '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcSysconfigNetwork, "NOZEROCONF", "NOZEROCONF=yes\n", '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsurePermissionsOnBootloaderConfig(char* value, void* log)
@@ -3118,7 +3118,7 @@ static int RemediateEnsureCoreDumpsAreRestricted(char* value, void* log)
     const char* hardCore = "hard core";
     int status = 0;
     UNUSED(value);
-    if ((0 == (status = ReplaceMarkedLinesInFile(g_etcSecurityLimitsConf, hardCore, g_hardCoreZero, '#', log))) && DirectoryExists(g_etcSecurityLimitsD))
+    if ((0 == (status = ReplaceMarkedLinesInFile(g_etcSecurityLimitsConf, hardCore, g_hardCoreZero, '#', true, log))) && DirectoryExists(g_etcSecurityLimitsD))
     {
         status = SecureSaveToFile(fileName, g_fsSuidDumpable, strlen(g_fsSuidDumpable), log) ? 0 : ENOENT;
     }
@@ -3301,8 +3301,8 @@ static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, vo
 static int RemediateEnsureRsyslogNotAcceptingRemoteMessages(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == ReplaceMarkedLinesInFile(g_etcRsyslogConf, "$ModLoad imudp", NULL, '#', log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcRsyslogConf, "$ModLoad imtcp", NULL, '#', log))) ? 0 : ENOENT;
+    return ((0 == ReplaceMarkedLinesInFile(g_etcRsyslogConf, "$ModLoad imudp", NULL, '#', true, log)) &&
+        (0 == ReplaceMarkedLinesInFile(g_etcRsyslogConf, "$ModLoad imtcp", NULL, '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureSyslogRotaterServiceIsEnabled(char* value, void* log)
@@ -3317,7 +3317,7 @@ static int RemediateEnsureTelnetServiceIsDisabled(char* value, void* log)
     UNUSED(value);
     StopAndDisableDaemon(g_telnet, log);
     return ((false == CheckDaemonActive(g_telnet, NULL, log)) && 
-        (0 == ReplaceMarkedLinesInFile(g_etcInetdConf, g_telnet, NULL, '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcInetdConf, g_telnet, NULL, '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureRcprshServiceIsDisabled(char* value, void* log)
@@ -3333,7 +3333,7 @@ static int RemediateEnsureTftpServiceisDisabled(char* value, void* log)
     UNUSED(value);
     StopAndDisableDaemon(g_tftpHpa, log);
     return ((false == CheckDaemonActive(g_tftpHpa, NULL, log)) &&
-        (0 == ReplaceMarkedLinesInFile(g_etcInetdConf, g_tftp, NULL, '#', log))) ? 0 : ENOENT;
+        (0 == ReplaceMarkedLinesInFile(g_etcInetdConf, g_tftp, NULL, '#', true, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureAtCronIsRestrictedToAuthorizedUsers(char* value, void* log)
@@ -3511,7 +3511,7 @@ static int RemediateEnsureRpcsvcgssdServiceIsDisabled(char* value, void* log)
     StopAndDisableDaemon(g_rpcSvcgssd, log);
     if (FileExists(g_etcInetdConf))
     {
-        status = ReplaceMarkedLinesInFile(g_etcInetdConf, g_needSvcgssd, NULL, '#', log);
+        status = ReplaceMarkedLinesInFile(g_etcInetdConf, g_needSvcgssd, NULL, '#', true, log);
     }
     return ((0 == status) && (false == IsDaemonActive(g_rpcSvcgssd, log))) ? 0 : ENOENT;
 }
@@ -3553,7 +3553,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, void* log)
 
     if (IsDaemonActive(g_smbd, log))
     {
-        status = ((0 == ReplaceMarkedLinesInFile(g_etcSambaConf, "SMB1", NULL, '#', log)) && 
+        status = ((0 == ReplaceMarkedLinesInFile(g_etcSambaConf, "SMB1", NULL, '#', true, log)) &&
             (0 == ExecuteCommand(NULL, command, true, false, 0, 0, NULL, NULL, log))) ? 0 : ENOENT;
     }
     else

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -47,7 +47,7 @@ bool SavePayloadToFile(const char* fileName, const char* payload, const int payl
 bool AppendPayloadToFile(const char* fileName, const char* payload, const int payloadSizeBytes, void* log);
 bool SecureSaveToFile(const char* fileName, const char* payload, const int payloadSizeBytes, void* log);
 bool AppendToFile(const char* fileName, const char* payload, const int payloadSizeBytes, void* log);
-bool ConcatenateFiles(const char* firstFileName, const char* secondFileName, void* log);
+bool ConcatenateFiles(const char* firstFileName, const char* secondFileName, bool preserveAccess, void* log);
 int RenameFile(const char* original, const char* target, void* log);
 
 void SetCommandLogging(bool commandLogging);
@@ -89,7 +89,7 @@ int UninstallPackage(const char* packageName, void* log);
 unsigned int GetNumberOfLinesInFile(const char* fileName);
 bool CharacterFoundInFile(const char* fileName, char what);
 int CheckNoLegacyPlusEntriesInFile(const char* fileName, char** reason, void* log);
-int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const char* newline, char commentCharacter, void* log);
+int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const char* newline, char commentCharacter, bool preserveAccess, void* log);
 int FindTextInFile(const char* fileName, const char* text, void* log);
 int CheckTextIsFoundInFile(const char* fileName, const char* text, char** reason, void* log);
 int CheckTextIsNotFoundInFile(const char* fileName, const char* text, char** reason, void* log);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -65,7 +65,7 @@ bool DirectoryExists(const char* directoryName);
 int CheckFileExists(const char* fileName, char** reason, void* log);
 int CheckFileNotFound(const char* fileName, char** reason, void* log);
 
-bool MakeFileBackupCopy(const char* fileName, const char* backupName, void* log);
+bool MakeFileBackupCopy(const char* fileName, const char* backupName, bool preserveAccess, void* log);
 
 int CheckFileAccess(const char* fileName, int desiredOwnerId, int desiredGroupId, unsigned int desiredAccess, char** reason, void* log);
 int SetFileAccess(const char* fileName, unsigned int desiredOwnerId, unsigned int desiredGroupId, unsigned int desiredAccess, void* log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -208,7 +208,7 @@ bool AppendToFile(const char* fileName, const char* payload, const int payloadSi
     return InternalSecureSaveToFile(fileName, "a", payload, payloadSizeBytes, log);
 }
 
-bool MakeFileBackupCopy(const char* fileName, const char* backupName, void* log)
+bool MakeFileBackupCopy(const char* fileName, const char* backupName, bool preserveAccess, void* log)
 {
     char* fileContents = NULL;
     char* newFileName = NULL;
@@ -220,7 +220,14 @@ bool MakeFileBackupCopy(const char* fileName, const char* backupName, void* log)
         {
             if (NULL != (fileContents = LoadStringFromFile(fileName, false, log)))
             {
-                result = SecureSaveToFile(backupName, fileContents, strlen(fileContents), log);
+                if (preserveAccess)
+                {
+                    result = SecureSaveToFile(backupName, fileContents, strlen(fileContents), log);
+                }
+                else
+                {
+                    result = SavePayloadToFile(backupName, fileContents, strlen(fileContents), log);
+                }
             }
             else
             {

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -245,10 +245,13 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                     if (NULL != newLine)
                     {
-                        if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
+                        if (0 != FindTextInFile(tempFileNameOne, newline, log))
                         {
-                            OsConfigLogError(log, "SetFileSystemMountingOption: failed collecting entries from '%s'", fsMountTable);
-                            break;
+                            if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
+                            {
+                                OsConfigLogError(log, "SetFileSystemMountingOption: failed collecting entries from '%s'", fsMountTable);
+                                break;
+                            }
                         }
                     }
                     else
@@ -265,11 +268,20 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                     if (NULL != (newLine = FormatAllocateString(newLineAsIsTemplate, mountStruct->mnt_fsname, mountStruct->mnt_dir, mountStruct->mnt_type,
                         mountStruct->mnt_opts, mountStruct->mnt_freq, mountStruct->mnt_passno)))
                     {
-                        if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
+                        if (0 != FindTextInFile(tempFileNameOne, newline, log))
                         {
-                            OsConfigLogError(log, "SetFileSystemMountingOption: failed copying existing entries from '%s'", fsMountTable);
-                            break;
+                            if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
+                            {
+                                OsConfigLogError(log, "SetFileSystemMountingOption: failed copying existing entries from '%s'", fsMountTable);
+                                break;
+                            }
                         }
+                    }
+                    else
+                    {
+                        OsConfigLogError(log, "SetFileSystemMountingOption: out of memory");
+                        status = ENOMEM;
+                        break;
                     }
                 }
 
@@ -322,10 +334,13 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                                 if (NULL != newLine)
                                 {
-                                    if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
+                                    if (0 != FindTextInFile(tempFileNameOne, newline, log))
                                     {
-                                        OsConfigLogError(log, "SetFileSystemMountingOption: failed collecting entry from '%s'", mountTable);
-                                        break;
+                                        if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
+                                        {
+                                            OsConfigLogError(log, "SetFileSystemMountingOption: failed collecting entry from '%s'", mountTable);
+                                            break;
+                                        }
                                     }
                                 }
                                 else

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -245,7 +245,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                     if (NULL != newLine)
                     {
-                        if (0 != FindTextInFile(tempFileNameOne, newline, log))
+                        if (0 != FindTextInFile(tempFileNameOne, newLine, log))
                         {
                             if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                             {
@@ -268,7 +268,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                     if (NULL != (newLine = FormatAllocateString(newLineAsIsTemplate, mountStruct->mnt_fsname, mountStruct->mnt_dir, mountStruct->mnt_type,
                         mountStruct->mnt_opts, mountStruct->mnt_freq, mountStruct->mnt_passno)))
                     {
-                        if (0 != FindTextInFile(tempFileNameOne, newline, log))
+                        if (0 != FindTextInFile(tempFileNameOne, newLine, log))
                         {
                             if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                             {
@@ -334,7 +334,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                                 if (NULL != newLine)
                                 {
-                                    if (0 != FindTextInFile(tempFileNameOne, newline, log))
+                                    if (0 != FindTextInFile(tempFileNameOne, newLine, log))
                                     {
                                         if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                                         {

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -283,7 +283,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                 OsConfigLogInfo(log, "SetFileSystemMountingOption: mount directory '%s' and/or mount type '%s' not found in '%s'",
                     mountDirectory ? mountDirectory : "-", mountType ? mountType : "-", fsMountTable);
 
-                // No relevant mount entries found in /etc/fstab, try to find and copy entries from /etc/tab if there are any matching
+                // No relevant mount entries found in /etc/fstab, try to find and copy entries from /etc/mtab if there are any matching
                 if (FileExists(mountTable))
                 {
                     if (NULL != (mountHandle = setmntent(mountTable, "r")))
@@ -367,7 +367,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
             if (0 == (status = CopyMountTableFile(tempFileNameOne, tempFileNameTwo, log)))
             {
                 // Optionally, try to preserve the commented out lines from original /etc/fstab
-                if (MakeFileBackupCopy(fsMountTable, tempFileNameThree, log))
+                if (MakeFileBackupCopy(fsMountTable, tempFileNameThree, false, log))
                 {
                     if (0 == ReplaceMarkedLinesInFile(tempFileNameThree, "/", NULL, '#', log))
                     {

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -185,7 +185,7 @@ static int LineAlreadyExistsInFile(const char* fileName, const char* text)
 
     if (NULL == (contents = LoadStringFromFile(fileName, false, log)))
     {
-        status = EACCESS;
+        status = EACCES;
     }
     else
     {

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -369,9 +369,9 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                 // Optionally, try to preserve the commented out lines from original /etc/fstab
                 if (MakeFileBackupCopy(fsMountTable, tempFileNameThree, false, log))
                 {
-                    if (0 == ReplaceMarkedLinesInFile(tempFileNameThree, "/", NULL, '#', log))
+                    if (0 == ReplaceMarkedLinesInFile(tempFileNameThree, "/", NULL, '#', false, log))
                     {
-                        if (ConcatenateFiles(tempFileNameThree, tempFileNameTwo, log))
+                        if (ConcatenateFiles(tempFileNameThree, tempFileNameTwo, false, log))
                         {
                             RenameFile(tempFileNameThree, tempFileNameTwo, log);
                         }

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -415,7 +415,9 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                 // Optionally, try to preserve the commented out lines from original /etc/fstab
                 if (MakeFileBackupCopy(fsMountTable, tempFileNameThree, false, log))
                 {
-                    if (0 == ReplaceMarkedLinesInFile(tempFileNameThree, "/", NULL, '#', false, log))
+                    // Skip all lines containing either paths or 'UUID' entries 
+                    if ((0 == ReplaceMarkedLinesInFile(tempFileNameThree, "/", NULL, '#', false, log)) &&
+                        (0 == ReplaceMarkedLinesInFile(tempFileNameThree, "UUID", NULL, '#', false, log)))
                     {
                         if (ConcatenateFiles(tempFileNameThree, tempFileNameTwo, false, log))
                         {

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -243,9 +243,29 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                             mountStruct->mnt_opts, desiredOption, mountStruct->mnt_freq, mountStruct->mnt_passno);
                     }
 
+                    /*
+                    # /etc/fstab: static file system information.
+                    #
+                    # Use 'blkid' to print the universally unique identifier for a
+                    # device; this may be used with UUID= as a more robust way to name devices
+                    # that works even if disks are added and removed. See fstab(5).
+                    #
+                    # <file system> <mount point>   <type>  <options>       <dump>  <pass>
+                    # / was on /dev/sda6 during installation
+                    # /boot/efi was on /dev/sda3 during installation
+                    # swap was on /dev/sda5 during installation
+                    UUID=744ab6fb-13d3-45b9-9152-8e2b2f133907 none            swap    sw              0       0
+                    UUID=744ab6fb-13d3-45b9-9152-8e2b2f133907 none swap sw 0 0
+                    UUID=744ab6fb-13d3-45b9-9152-8e2b2f133907 none swap sw 0 0
+                    UUID=744ab6fb-13d3-45b9-9152-8e2b2f133907 none swap sw 0 0
+                    UUID=12013753-03b7-420e-9742-04ca763943d6 / ext4 errors=remount-ro 0 1
+                    UUID=A19E-0DCF /boot/efi vfat umask=0077 0 1
+                    tmpfs /dev/shm tmpfs rw,nosuid,nodev,inode64,noexec 0 0
+                    */
+
                     if (NULL != newLine)
                     {
-                        if (0 != FindTextInFile(tempFileNameOne, newLine, log))
+                        if ((false == FileExists(tempFileNameOne)) || (0 != FindTextInFile(tempFileNameOne, newLine, log)))
                         {
                             if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                             {
@@ -268,7 +288,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                     if (NULL != (newLine = FormatAllocateString(newLineAsIsTemplate, mountStruct->mnt_fsname, mountStruct->mnt_dir, mountStruct->mnt_type,
                         mountStruct->mnt_opts, mountStruct->mnt_freq, mountStruct->mnt_passno)))
                     {
-                        if (0 != FindTextInFile(tempFileNameOne, newLine, log))
+                        if ((false == FileExists(tempFileNameOne)) || (0 != FindTextInFile(tempFileNameOne, newLine, log)))
                         {
                             if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                             {
@@ -334,7 +354,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                                 if (NULL != newLine)
                                 {
-                                    if (0 != FindTextInFile(tempFileNameOne, newLine, log))
+                                    if ((false == FileExists(tempFileNameOne)) || (0 != FindTextInFile(tempFileNameOne, newLine, log)))
                                     {
                                         if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                                         {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -48,7 +48,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     {
         if (NULL != (newline = FormatAllocateString(etcPamdCommonPasswordTemplate, g_remember, remember)))
         {
-            status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, g_remember, newline, '#', log);
+            status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, g_remember, newline, '#', true, log);
             FREE_MEMORY(newline);
         }
         else
@@ -63,7 +63,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     {
         if (NULL != (newline = FormatAllocateString(etcPamdSystemAuthTemplate, g_remember, remember)))
         {
-            _status = ReplaceMarkedLinesInFile(g_etcPamdSystemAuth, g_remember, newline, '#', log);
+            _status = ReplaceMarkedLinesInFile(g_etcPamdSystemAuth, g_remember, newline, '#', true, log);
             FREE_MEMORY(newline);
         }
         else
@@ -229,12 +229,12 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))
     {
-        status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, marker, pamFailLockLine, '#', log);
+        status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, marker, pamFailLockLine, '#', true, log);
     }
 
     if (0 == CheckFileExists(etcPamdPasswordAuth, NULL, log))
     {
-        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdPasswordAuth, marker, pamFailLockLine, '#', log))) && (0 == status))
+        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdPasswordAuth, marker, pamFailLockLine, '#', true, log))) && (0 == status))
         {
             status = _status;
         }
@@ -242,7 +242,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if (0 == CheckFileExists(etcPamdLogin, NULL, log))
     {
-        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdLogin, marker, pamTally2Line, '#', log))) && (0 == status))
+        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdLogin, marker, pamTally2Line, '#', true, log))) && (0 == status))
         {
             status = _status;
         }
@@ -616,7 +616,7 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     {
         if (NULL != (line = FormatAllocateString(etcPamdCommonPasswordLineTemplate, retry, minlen, lcredit, ucredit, ocredit, dcredit)))
         {
-            status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, etcPamdCommonPasswordMarker, line, '#', log);
+            status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, etcPamdCommonPasswordMarker, line, '#', true, log);
             FREE_MEMORY(line);
         }
         else
@@ -631,7 +631,7 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
         {
             if (NULL != (line = FormatAllocateString(etcSecurityPwQualityConfLineTemplate, entries[i])))
             {
-                _status = ReplaceMarkedLinesInFile(g_etcSecurityPwQualityConf, entries[i], line, '#', log);
+                _status = ReplaceMarkedLinesInFile(g_etcSecurityPwQualityConf, entries[i], line, '#', true, log);
                 FREE_MEMORY(line);
             }
             else

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1373,7 +1373,7 @@ int RepairRootGroup(void* log)
             if (SavePayloadToFile(tempFileName, rootLine, strlen(rootLine), log))
             {
                 // Delete from temporary file any lines containing "root"
-                if (0 == (status = ReplaceMarkedLinesInFile(tempFileName, g_root, NULL, '#', log)))
+                if (0 == (status = ReplaceMarkedLinesInFile(tempFileName, g_root, NULL, '#', false, log)))
                 {
                     // Free the previously loaded content, we'll reload
                     FREE_MEMORY(original);

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -202,14 +202,14 @@ TEST_F(CommonUtilsTest, ConcatenateFiles)
     const char* complete = "First line of text\nSecond line of text\nAnd third line of text";
     char* contents = NULL;
 
-    EXPECT_FALSE(ConcatenateFiles(nullptr, nullptr, nullptr));
-    EXPECT_FALSE(ConcatenateFiles(testPath1, nullptr, nullptr));
-    EXPECT_FALSE(ConcatenateFiles(nullptr, testPath2, nullptr));
+    EXPECT_FALSE(ConcatenateFiles(nullptr, nullptr, true, nullptr));
+    EXPECT_FALSE(ConcatenateFiles(testPath1, nullptr, true, nullptr));
+    EXPECT_FALSE(ConcatenateFiles(nullptr, testPath2, true, nullptr));
 
     EXPECT_TRUE(SavePayloadToFile(testPath1, original, strlen(original), nullptr));
     EXPECT_TRUE(SavePayloadToFile(testPath2, added, strlen(added), nullptr));
 
-    EXPECT_TRUE(ConcatenateFiles(testPath1, testPath2, nullptr));
+    EXPECT_TRUE(ConcatenateFiles(testPath1, testPath2, true, nullptr));
     EXPECT_STREQ(complete, contents = LoadStringFromFile(testPath1, false, nullptr));
     FREE_MEMORY(contents);
 
@@ -2106,46 +2106,46 @@ TEST_F(CommonUtilsTest, ReplaceMarkedLinesInFile)
 
     EXPECT_TRUE(CreateTestFile(m_path, inFile));
 
-    EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, "+", "T", '#', nullptr));
-    EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, nullptr, nullptr, '#', nullptr));
-    EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(m_path, nullptr, nullptr, '#', nullptr));
+    EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, "+", "T", '#', false, nullptr));
+    EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, nullptr, nullptr, '#', false, nullptr));
+    EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(m_path, nullptr, nullptr, '#', false, nullptr));
 
-    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker1, newline1, '#', nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker1, newline1, '#', true, nullptr));
     EXPECT_STREQ(outFile1, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
 
     EXPECT_TRUE(Cleanup(m_path));
     EXPECT_TRUE(CreateTestFile(m_path, inFile));
 
-    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker2, newline2, '#', nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker2, newline2, '#', true, nullptr));
     EXPECT_STREQ(outFile2, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
 
     EXPECT_TRUE(Cleanup(m_path));
     EXPECT_TRUE(CreateTestFile(m_path, inFile));
 
-    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker3, nullptr, '#', nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker3, nullptr, '#', true, nullptr));
     EXPECT_STREQ(outFile3, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
 
     EXPECT_TRUE(Cleanup(m_path));
     EXPECT_TRUE(CreateTestFile(m_path, inFile));
 
-    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker4, "", '#', nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker4, "", '#', true, nullptr));
     EXPECT_STREQ(outFile4, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
 
     EXPECT_TRUE(Cleanup(m_path));
     EXPECT_TRUE(CreateTestFile(m_path, inFile));
 
-    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker5, newline5, '#', nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker5, newline5, '#', false, nullptr));
     EXPECT_STREQ(outFile5, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
 
     EXPECT_TRUE(Cleanup(m_path));
     EXPECT_TRUE(CreateTestFile(m_path, inFile));
 
-    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker6, newline6, '#', nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker6, newline6, '#', false, nullptr));
     EXPECT_STREQ(outFile6, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -184,7 +184,7 @@ TEST_F(CommonUtilsTest, MakeFileBackupCopy)
     EXPECT_STREQ(m_data, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);
     
-    EXPECT_TRUE(MakeFileBackupCopy(m_path, fileCopyPath, nullptr));
+    EXPECT_TRUE(MakeFileBackupCopy(m_path, fileCopyPath, true, nullptr));
     EXPECT_TRUE(FileExists(fileCopyPath));
     EXPECT_STREQ(m_data, contents = LoadStringFromFile(fileCopyPath, false, nullptr));
     FREE_MEMORY(contents);


### PR DESCRIPTION
## Description

Continued stabilization for ASB v2, including:

- Correcting the Samba service to look for in order to decide when Samba is active.
- Several improvements to file system mounting option remediations to cut unnecessary code and prevent a recursive buildup when lines without paths exist at top of the mounting table.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.