### PR TITLE
Fixing ASB v2 audit and remediation for user accounts to be removed and reasons for SSH protocol audit

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3616,7 +3616,7 @@ static int RemediateEnsureRloginServiceIsDisabled(char* value, void* log)
 static int RemediateEnsureUnnecessaryAccountsAreRemoved(char* value, void* log)
 {
     InitEnsureUnnecessaryAccountsAreRemoved(value);
-    return RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, log);
+    return 0;//RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, log);
 }
 
 int AsbMmiGet(const char* componentName, const char* objectName, char** payload, int* payloadSizeBytes, unsigned int maxPayloadSizeBytes, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3615,9 +3615,8 @@ static int RemediateEnsureRloginServiceIsDisabled(char* value, void* log)
 
 static int RemediateEnsureUnnecessaryAccountsAreRemoved(char* value, void* log)
 {
-    UNUSED(log);
     InitEnsureUnnecessaryAccountsAreRemoved(value);
-    return 0;//RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, log);
+    return RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, log);
 }
 
 int AsbMmiGet(const char* componentName, const char* objectName, char** payload, int* payloadSizeBytes, unsigned int maxPayloadSizeBytes, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3615,6 +3615,7 @@ static int RemediateEnsureRloginServiceIsDisabled(char* value, void* log)
 
 static int RemediateEnsureUnnecessaryAccountsAreRemoved(char* value, void* log)
 {
+    UNUSED(log);
     InitEnsureUnnecessaryAccountsAreRemoved(value);
     return 0;//RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, log);
 }

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -664,13 +664,11 @@ int CheckSshProtocol(char** reason, void* log)
     if (0 == (status = CheckLineFoundNotCommentedOut(g_sshServerConfiguration, '#', protocol, reason, log)))
     {
         OsConfigLogInfo(log, "CheckSshProtocol: '%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
-        OsConfigCaptureSuccessReason(reason, "'%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
         status = 0;
     }
     else
     {
         OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
-        OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
         status = ENOENT;
 
         if (0 == IsSshConfigIncludeSupported(log))

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -695,13 +695,11 @@ int CheckSshProtocol(char** reason, void* log)
             else if (0 == (status = CheckLineFoundNotCommentedOut(g_osconfigRemediationConf, '#', protocol, reason, log)))
             {
                 OsConfigLogInfo(log, "CheckSshProtocol: '%s' is found uncommented in %s", protocol, g_osconfigRemediationConf);
-                OsConfigCaptureSuccessReason(reason, "'%s' is found uncommented in %s", protocol, g_osconfigRemediationConf);
                 status = 0;
             }
             else
             {
                 OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_osconfigRemediationConf);
-                OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s", protocol, g_osconfigRemediationConf);
                 status = ENOENT;
             }
 

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -661,14 +661,24 @@ int CheckSshProtocol(char** reason, void* log)
         OsConfigCaptureReason(reason, "'%s' is not present on this device", g_sshServerConfiguration);
         status = EEXIST;
     }
+    if (0 == (status = CheckLineFoundNotCommentedOut(g_sshServerConfiguration, '#', protocol, reason, log)))
+    {
+        OsConfigLogInfo(log, "CheckSshProtocol: '%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
+        OsConfigCaptureSuccessReason(reason, "'%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
+        status = 0;
+    }
     else
     {
+        OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
+        OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
+        status = ENOENT;
+
         if (0 == IsSshConfigIncludeSupported(log))
         {
             if (false == FileExists(g_osconfigRemediationConf))
             {
                 OsConfigLogError(log, "CheckSshProtocol: the OSConfig remediation file '%s' is not present on this device", g_osconfigRemediationConf);
-                OsConfigCaptureReason(reason, "'%s' is not present on this device", g_osconfigRemediationConf);
+                OsConfigCaptureReason(reason, "The OSConfig remediation file '%s' is not present on this device", g_osconfigRemediationConf);
                 status = EEXIST;
             }
             else if (NULL == (inclusion = FormatInclusionForRemediation(log)))
@@ -696,21 +706,6 @@ int CheckSshProtocol(char** reason, void* log)
             }
 
             FREE_MEMORY(inclusion);
-        }
-        else
-        {
-            if (0 == (status = CheckLineFoundNotCommentedOut(g_sshServerConfiguration, '#', protocol, reason, log)))
-            {
-                OsConfigLogInfo(log, "CheckSshProtocol: '%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
-                OsConfigCaptureSuccessReason(reason, "'%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
-                status = 0;
-            }
-            else
-            {
-                OsConfigLogError(log, "CheckSshProtocol: '%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
-                OsConfigCaptureReason(reason, "'%s' is not found uncommented with '#' in %s", protocol, g_sshServerConfiguration);
-                status = ENOENT;
-            }
         }
     }
     

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3114,8 +3114,6 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
     
     if (0 == (status = EnumerateUsers(&userList, &userListSize, reason, log)))
     {
-        OsConfigLogInfo(log, "### Enumerated %u users ###", userListSize); ////////////////////////////////////
-        
         status = ENOENT;
 
         for (i = 0; i < userListSize; i++)
@@ -3131,8 +3129,6 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
                 else
                 {
                     TruncateAtFirst(name, ',');
-
-                    OsConfigLogInfo(log, "### Check user No 2 '%s', current user is '%s' ###", name, userList[i].username); ////////////////////////////////////
 
                     if (0 == strcmp(userList[i].username, name))
                     {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3219,7 +3219,7 @@ int RemoveUserAccounts(const char* names, void* log)
         return EINVAL;
     }
 
-    if (0 != CheckUserAccountsNotFound(names, NULL, log))
+    if (0 == CheckUserAccountsNotFound(names, NULL, log))
     {
         OsConfigLogInfo(log, "RemoveUserAccounts: user accounts '%s' are not found", names);
         return 0;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3120,12 +3120,8 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
 
         for (i = 0; i < userListSize; i++)
         {
-            OsConfigLogInfo(log, "### i: %u ###", i); ////////////////////////////////////
-
             for (j = 0; j < namesLength; j++)
             {
-                OsConfigLogInfo(log, "### j: %u ###", j); ////////////////////////////////////
-                
                 if (NULL == (name = DuplicateString(&(names[j]))))
                 {
                     OsConfigLogError(log, "CheckUserAccountsNotFound: failed to duplicate string");
@@ -3134,8 +3130,6 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
                 }
                 else
                 {
-                    OsConfigLogInfo(log, "### Check user No 1 is '%s' ###", name); ////////////////////////////////////
-
                     TruncateAtFirst(name, ',');
 
                     OsConfigLogInfo(log, "### Check user No 2 '%s', current user is '%s' ###", name, userList[i].username); ////////////////////////////////////
@@ -3161,14 +3155,13 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
                 }
 
                 j += strlen(name);
-                OsConfigLogInfo(log, "### j becomes: %u ###", j); ////////////////////////////////////
                 FREE_MEMORY(name);
             }
 
-            /*if (0 != status)
+            if (0 == status)
             {
                 break;
-            }*/
+            }
         }
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3114,6 +3114,8 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
     
     if (0 == (status = EnumerateUsers(&userList, &userListSize, reason, log)))
     {
+        OsConfigLogInfo(log, "### Enumerated %u users ###", userListSize); ////////////////////////////////////
+        
         status = ENOENT;
 
         for (i = 0; i < userListSize; i++)

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3120,8 +3120,12 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
 
         for (i = 0; i < userListSize; i++)
         {
+            OsConfigLogInfo(log, "### i: %u ###", i); ////////////////////////////////////
+
             for (j = 0; j < namesLength; j++)
             {
+                OsConfigLogInfo(log, "### j: %u ###", j); ////////////////////////////////////
+                
                 if (NULL == (name = DuplicateString(&(names[j]))))
                 {
                     OsConfigLogError(log, "CheckUserAccountsNotFound: failed to duplicate string");
@@ -3157,13 +3161,14 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
                 }
 
                 j += strlen(name);
+                OsConfigLogInfo(log, "### j becomes: %u ###", j); ////////////////////////////////////
                 FREE_MEMORY(name);
             }
 
-            if (0 != status)
+            /*if (0 != status)
             {
                 break;
-            }
+            }*/
         }
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3130,7 +3130,11 @@ int CheckUserAccountsNotFound(const char* names, char** reason, void* log)
                 }
                 else
                 {
+                    OsConfigLogInfo(log, "### Check user No 1 is '%s' ###", name); ////////////////////////////////////
+
                     TruncateAtFirst(name, ',');
+
+                    OsConfigLogInfo(log, "### Check user No 2 '%s', current user is '%s' ###", name, userList[i].username); ////////////////////////////////////
 
                     if (0 == strcmp(userList[i].username, name))
                     {


### PR DESCRIPTION
## Description

Fix in the APIs used by auditing and remediating user accounts desired to be removed, also a re-arrangement in the reasons issued for the SSH protocol audit to make them friendlier in audit-only case when OSConfig remediation does not exist.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.