### PR TITLE
Continuing stabilization for ASB v2 audit and remediation

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2631,8 +2631,9 @@ static int RemediateEnsureTalkClientIsNotInstalled(char* value, void* log)
 static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 {
     UNUSED(value);
-    return (((0 == InstallPackage(g_cron, log)) || (0 == InstallPackage(g_cronie, log))) &&
-        EnableAndStartDaemon(g_crond, log)) ? 0 : ENOENT;
+
+    return (((0 == InstallPackage(g_cron, log)) && EnableAndStartDaemon(g_cron, log)) || 
+        (((0 == InstallPackage(g_cronie, log)) && EnableAndStartDaemon(g_crond, log)))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2631,7 +2631,7 @@ static int RemediateEnsureTalkClientIsNotInstalled(char* value, void* log)
 static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == InstallPackage(g_cron, log)) || (0 == InstallPackage(g_cronie, log))) &&
+    return (((0 == InstallPackage(g_cron, log)) || (0 == InstallPackage(g_cronie, log))) &&
         EnableAndStartDaemon(g_crond, log)) ? 0 : ENOENT;
 }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -141,7 +141,7 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
 
     if (NULL == (fileDirectory = dirname(fileNameCopy)))
     {
-        OsConfigLogInfo(log, "InternalSecureSaveToFile: no directory name for '%s' (%d)", errno);
+        OsConfigLogInfo(log, "InternalSecureSaveToFile: no directory name for '%s' (%d)", fileNameCopy, errno);
     }
  
     if (NULL != (tempFileName = FormatAllocateString(tempFileNameTemplate, fileDirectory ? fileDirectory : "/tmp", rand())))

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -133,12 +133,17 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
         OsConfigLogError(log, "InternalSecureSaveToFile: invalid arguments");
         return false;
     }
-
-    if (FileExists(fileName) && (NULL != (fileNameCopy = DuplicateString(fileName))))
+    else if (NULL == (fileNameCopy = DuplicateString(fileName)))
     {
-        fileDirectory = dirname(fileNameCopy);
+        OsConfigLogError(log, "InternalSecureSaveToFile: out of memory");
+        return false;
     }
 
+    if (NULL == (fileDirectory = dirname(fileNameCopy)))
+    {
+        OsConfigLogInfo(log, "InternalSecureSaveToFile: no directory name for '%s' (%d)", errno);
+    }
+ 
     if (NULL != (tempFileName = FormatAllocateString(tempFileNameTemplate, fileDirectory ? fileDirectory : "/tmp", rand())))
     {
         if ((0 == strcmp(mode, "a") && FileExists(fileName)))


### PR DESCRIPTION
## Description

Adding that RedHat and Debian based distros use different names for Cron and Audit packages, plus fixing situation for secure file write when the target file does not exist yet to not revert to using /tmp.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.