### PR TITLE
Stabilizing the ASB v2 RemediateEnsurePortmapServiceIsDisabled check

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3505,9 +3505,9 @@ static int RemediateEnsurePortmapServiceIsDisabled(char* value, void* log)
     StopAndDisableDaemon(g_rpcbindService, log);
     StopAndDisableDaemon(g_rpcbind, log);
 
-    return ((0 == CheckDaemonNotActive(g_rpcbind, NULL, log)) &&
-        (0 == CheckDaemonNotActive(g_rpcbindService, NULL, log)) &&
-        (0 == CheckDaemonNotActive(g_rpcbindSocket, NULL, log))) ? 0 : ENOENT;
+    return (CheckDaemonNotActive(g_rpcbind, NULL, log) && 
+        CheckDaemonNotActive(g_rpcbindService, NULL, log) &&
+        CheckDaemonNotActive(g_rpcbindSocket, NULL, log)) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureNetworkFileSystemServiceIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3501,10 +3501,13 @@ static int RemediateEnsureRpcidmapdServiceIsDisabled(char* value, void* log)
 static int RemediateEnsurePortmapServiceIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    StopAndDisableDaemon(g_rpcbind, log);
-    StopAndDisableDaemon(g_rpcbindService, log);
     StopAndDisableDaemon(g_rpcbindSocket, log);
-    return (0 == strncmp(g_pass, AuditEnsurePortmapServiceIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    StopAndDisableDaemon(g_rpcbindService, log);
+    StopAndDisableDaemon(g_rpcbind, log);
+
+    return ((0 == CheckDaemonNotActive(g_rpcbind, NULL, log)) &&
+        (0 == CheckDaemonNotActive(g_rpcbindService, NULL, log)) &&
+        (0 == CheckDaemonNotActive(g_rpcbindSocket, NULL, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureNetworkFileSystemServiceIsDisabled(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3501,10 +3501,18 @@ static int RemediateEnsureRpcidmapdServiceIsDisabled(char* value, void* log)
 static int RemediateEnsurePortmapServiceIsDisabled(char* value, void* log)
 {
     UNUSED(value);
-    StopAndDisableDaemon(g_rpcbindSocket, log);
-    StopAndDisableDaemon(g_rpcbindService, log);
-    StopAndDisableDaemon(g_rpcbind, log);
-
+    if (IsDaemonActive(g_rpcbindSocket, log))
+    {
+        StopAndDisableDaemon(g_rpcbindSocket, log);
+    }
+    if (IsDaemonActive(g_rpcbindService, log))
+    {
+        StopAndDisableDaemon(g_rpcbindService, log);
+    }
+    if (IsDaemonActive(g_rpcbind, log))
+    {
+        StopAndDisableDaemon(g_rpcbind, log);
+    }
     return (CheckDaemonNotActive(g_rpcbind, NULL, log) && 
         CheckDaemonNotActive(g_rpcbindService, NULL, log) &&
         CheckDaemonNotActive(g_rpcbindSocket, NULL, log)) ? 0 : ENOENT;


### PR DESCRIPTION
## Description

The order in which rpcbind daemons are stopped and disabled matter on some of the distros.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.