### PR TITLE
Allowing read access to the NRP logs under /var/log

### DIFF
--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -74,8 +74,8 @@ void __attribute__((destructor)) Destroy()
     CloseLog(&g_log);
 
     // Allow others read access to the NRP logs
-    SetFileAccess(LOG_FILE, 0, 0, 644, NULL);
-    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 644, NULL);
+    SetFileAccess(LOG_FILE, 0, 0, 6774, NULL);
+    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 6774, NULL);
 }
 
 static void LogCurrentDistro(MI_Context* context)

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -75,7 +75,7 @@ void __attribute__((destructor)) Destroy()
 
     // Allow others read-only access to the NRP logs
     SetFileAccess(LOG_FILE, 0, 0, 744, NULL);
-    SetFileAccess(OSCONFIG_LOG_HANDLE, 0, 0, 744, NULL);
+    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 744, NULL);
 }
 
 static void LogCurrentDistro(MI_Context* context)

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -73,9 +73,9 @@ void __attribute__((destructor)) Destroy()
 
     CloseLog(&g_log);
 
-    // Allow others read-only access to the NRP logs
-    SetFileAccess(LOG_FILE, 0, 0, 744, NULL);
-    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 744, NULL);
+    // Allow others read access to the NRP logs
+    SetFileAccess(LOG_FILE, 0, 0, 644, NULL);
+    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 644, NULL);
 }
 
 static void LogCurrentDistro(MI_Context* context)

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -73,7 +73,7 @@ void __attribute__((destructor)) Destroy()
 
     CloseLog(&g_log);
 
-    // Allow others read access to the NRP logs
+    // When the NRP is done, allow others read-only (no write, search or execute) access to the NRP logs
     SetFileAccess(LOG_FILE, 0, 0, 6774, NULL);
     SetFileAccess(ROLLED_LOG_FILE, 0, 0, 6774, NULL);
 }

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -72,6 +72,10 @@ void __attribute__((destructor)) Destroy()
     OsConfigLogInfo(GetLog(), "[OsConfigResource] SO library unloaded by host process %d", getpid());
 
     CloseLog(&g_log);
+
+    // Allow others read-only access to the NRP logs
+    SetFileAccess(LOG_FILE, 0, 0, 744, NULL);
+    SetFileAccess(OSCONFIG_LOG_HANDLE, 0, 0, 744, NULL);
 }
 
 static void LogCurrentDistro(MI_Context* context)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -36,7 +36,7 @@ bool IsFullLoggingEnabled()
 
 static int RestrictAccessToRootOnly(const char* fileName)
 {
-    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP | S_IROTH);
+    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP);
 }
 
 OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -36,7 +36,7 @@ bool IsFullLoggingEnabled()
 
 static int RestrictAccessToRootOnly(const char* fileName)
 {
-    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP);
+    return chmod(fileName, /*S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP*/744);
 }
 
 OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -36,7 +36,7 @@ bool IsFullLoggingEnabled()
 
 static int RestrictAccessToRootOnly(const char* fileName)
 {
-    return chmod(fileName, /*S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP*/744);
+    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP | S_IROTH);
 }
 
 OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName)


### PR DESCRIPTION
## Description

Our CI needs to have access to NRP logs and cannot elevate to root after running the ASB v2 remediation. There is no reason to restrict the /var/log/ NRP logs to root-only. Once the NRP is done and is about to exit, we give others access to read the logs. Then once again the NRP resumes writing to the logs access gets automatically restricted back to root-only, the default.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.