### PR TITLE
Making the MIM test recipe for Security Baseline module test in full ASB v2, including confirming audits passing

### DIFF
--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(testlib Module.c)
 target_link_libraries(testlib
     ${CMAKE_DL_LIBS}
     commonutils
+    asb
     logging
     pthread
     parsonlib)

--- a/src/modules/test/Common.h
+++ b/src/modules/test/Common.h
@@ -18,6 +18,7 @@
 
 #include <CommonUtils.h>
 #include <Logging.h>
+#include <Asb.h>
 #include <Mmi.h>
 #include <version.h>
 

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -25,6 +25,7 @@
 #define RECIPE_JSON "Json"
 #define RECIPE_STATUS "ExpectedResult"
 #define RECIPE_WAIT_SECONDS "WaitSeconds"
+#define SECURITY_BASELINE "SecurityBaseline"
 
 #define RECIPE_RUN_COMMAND "RunCommand"
 
@@ -429,6 +430,14 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                 {
                     LOG_ERROR("Failed to parse expected JSON payload: %s", test->payload);
                     result = EINVAL;
+                }
+                if (0 == strcmp(test->component, SECURITY_BASELINE))
+                {
+                    if (0 != strncmp(payloadString, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
+                    {
+                        LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, payloadString);
+                        result = -1;
+                    }
                 }
                 else if (!json_value_equals(expectedJsonValue, actualJsonValue))
                 {

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -464,7 +464,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                 }
                 else
                 {
-                    LOG_INFO("Assertion passed ('%s'): %s", SECURITY_AUDIT_PASS, reason + strlen(SECURITY_AUDIT_PASS));
+                    LOG_INFO("Assertion passed with reason: '%s'", reason + strlen(SECURITY_AUDIT_PASS));
                 }
             }
             else if (actualJsonValue != NULL)

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -434,7 +434,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                         LOG_ERROR("Assertion failed, json_value_get_string('%s') failed", json_serialize_to_string(actualJsonValue));
                         result = -1;
                     }
-                    else if (0 != strncmp(payloadString, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
+                    else if (0 != strncmp(reason, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
                     {
                         LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, reason);
                         result = -1;
@@ -458,6 +458,10 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
             LOG_ERROR("Assertion failed, expected result '%d', actual '%d'", test->status, mmiStatus);
             result = -1;
         }
+
+        
+        json_value_free(actualJsonValue);
+        FREE_MEMORY(payloadString);
     }
     else if (test->type == DESIRED)
     {

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -383,6 +383,14 @@ int RunCommand(const COMMAND_STEP* command)
 
 int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
 {
+    const char* skippedAudits[] = {
+        "auditEnsureKernelSupportForCpuNx",
+        "auditEnsureDefaultDenyFirewallPolicyIsSet",
+        "auditEnsureAuthenticationRequiredForSingleUserMode",
+        "auditEnsureAllBootloadersHavePasswordProtectionEnabled"
+    };
+    int numSkippedAudits = ARRAY_SIZE(skippedAudits);
+
     const char* audit = "audit";
     const char* reason = NULL;
     JSON_Value* actualJsonValue = NULL;
@@ -391,6 +399,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
     char* payloadString = NULL;
     bool asbAudit = false;
     int payloadSize = 0;
+    int i = 0;
     int mmiStatus = 0;
     int result = 0;
 
@@ -426,6 +435,15 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                     (0 == strncmp(test->object, audit, strlen(audit))))
                 {
                     asbAudit = true;
+                    
+                    for (i = 0; i < numSkippedAudits; i++)
+                    {
+                        if (0 == strcmp(test->object, skippedAudits[i]))
+                        {
+                            asbAudit = false;
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -460,7 +460,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                 else if (0 != strncmp(reason, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
                 {
                     LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, reason);
-                    result = -1;
+                    result = EFAULT;
                 }
                 else
                 {
@@ -472,26 +472,26 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                 if (NULL == (expectedJsonValue = json_parse_string(test->payload)))
                 {
                     LOG_ERROR("Failed to parse expected JSON payload: %s", test->payload);
-                    result = -1;
+                    result = EFAULT;
                 }
                 else if (0 == json_value_equals(expectedJsonValue, actualJsonValue))
                 {
                     LOG_ERROR("Assertion failed, expected: '%s', actual: '%s'", 
                         json_serialize_to_string(expectedJsonValue), json_serialize_to_string(actualJsonValue));
-                    result = -1;
+                    result = EFAULT;
                 }
             }
             else
             {
                 LOG_ERROR("Assertion failed, expected: '%s', actual: (null)", test->payload);
-                result = -1;
+                result = EFAULT;
             }
         }
 
         if (test->status != mmiStatus)
         {
             LOG_ERROR("Assertion failed, expected result '%d', actual '%d'", test->status, mmiStatus);
-            result = -1;
+            result = EFAULT;
         }
         
         json_value_free(expectedJsonValue);
@@ -505,7 +505,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         if (test->status != mmiStatus)
         {
             LOG_ERROR("Assertion failed, expected result '%d', actual '%d'", test->status, mmiStatus);
-            result = -1;
+            result = EFAULT;
         }
     }
     else

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -422,33 +422,11 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                     LOG_ERROR("Failed to parse JSON payload: %s", payloadString);
                     result = EINVAL;
                 }
-                else if ((0 == strcmp(test->component, SECURITY_BASELINE)) && (0 == strncmp(test->object, audit, strlen(audit))))
+                else if ((0 == strcmp(test->component, SECURITY_BASELINE)) && 
+                    (0 == strncmp(test->object, audit, strlen(audit))))
                 {
                     asbAudit = true;
                 }
-            }
-        }
-
-        ///////////////////////////
-        if (test->payload != NULL)
-        {
-            if (actualJsonValue != NULL)
-            {
-                if (NULL == (expectedJsonValue = json_parse_string(test->payload)))
-                {
-                    LOG_ERROR("Failed to parse expected JSON payload: %s", test->payload);
-                    result = EINVAL;
-                }
-                else if (!json_value_equals(expectedJsonValue, actualJsonValue))
-                {
-                    LOG_ERROR("Assertion failed, expected: '%s', actual: '%s'", json_serialize_to_string(expectedJsonValue), json_serialize_to_string(actualJsonValue));
-                    result = -1;
-                }
-            }
-            else
-            {
-                LOG_ERROR("Assertion failed, expected: '%s', actual: (null)", test->payload);
-                result = -1;
             }
         }
 
@@ -474,7 +452,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                     LOG_ERROR("Failed to parse expected JSON payload: %s", test->payload);
                     result = -1;
                 }
-                else if (PARSON_FALSE == json_value_equals(expectedJsonValue, actualJsonValue))
+                else if (0 == json_value_equals(expectedJsonValue, actualJsonValue))
                 {
                     LOG_ERROR("Assertion failed, expected: '%s', actual: '%s'", 
                         json_serialize_to_string(expectedJsonValue), json_serialize_to_string(actualJsonValue));

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -422,7 +422,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
             }
         }
 
-        if (test->payload != NULL)
+        if (test->payload || (0 == strcmp(test->component, SECURITY_BASELINE)))
         {
             if (actualJsonValue != NULL)
             {

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -436,14 +436,14 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                     }
                     else
                     {
-                        if (NULL == (serializedPayload = json_serialize_to_string(payloadString)))
+                        if (NULL == (serializedPayload = json_serialize_to_string(actualJsonValue)))
                         {
                             LOG_ERROR("Assertion failed, json_serialize_to_string('%s') failed", payloadString);
                             result = -1;
                         }
                         else if (0 != strncmp(payloadString, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
                         {
-                            LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, payloadString);
+                            LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, serializedPayload);
                             result = -1;
                         }
                     }

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -388,7 +388,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
     JSON_Value* expectedJsonValue = NULL;
     MMI_JSON_STRING payload = NULL;
     char* payloadString = NULL;
-    char* serializedPayload = NULL;
+    char* reason = NULL;
     int payloadSize = 0;
     int mmiStatus = 0;
 
@@ -429,23 +429,15 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
             {
                 if (0 == strcmp(test->component, SECURITY_BASELINE))
                 {
-                    if (NULL == (expectedJsonValue = json_parse_string(test->payload)))
+                    if (NULL == (reason = json_value_get_string(actualJsonValue)))
                     {
-                        LOG_ERROR("Failed to parse expected JSON payload: %s", test->payload);
+                        LOG_ERROR("Assertion failed, json_value_get_string('%s') failed", json_serialize_to_string(actualJsonValue));
                         result = -1;
                     }
-                    else
+                    else if (0 != strncmp(payloadString, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
                     {
-                        if (NULL == (serializedPayload = json_serialize_to_string(actualJsonValue)))
-                        {
-                            LOG_ERROR("Assertion failed, json_serialize_to_string('%s') failed", payloadString);
-                            result = -1;
-                        }
-                        else if (0 != strncmp(payloadString, SECURITY_AUDIT_PASS, strlen(SECURITY_AUDIT_PASS)))
-                        {
-                            LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, serializedPayload);
-                            result = -1;
-                        }
+                        LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, reason);
+                        result = -1;
                     }
                 }
                 else if (!json_value_equals(expectedJsonValue, actualJsonValue))

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -388,7 +388,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
     JSON_Value* expectedJsonValue = NULL;
     MMI_JSON_STRING payload = NULL;
     char* payloadString = NULL;
-    char* reason = NULL;
+    const char* reason = NULL;
     int payloadSize = 0;
     int mmiStatus = 0;
 

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -462,6 +462,10 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                     LOG_ERROR("Assertion failed, expected: '%s...', actual: '%s'", SECURITY_AUDIT_PASS, reason);
                     result = -1;
                 }
+                else
+                {
+                    LOG_INFO("Assertion passed ('%s')", reason);
+                }
             }
             else if (actualJsonValue != NULL)
             {

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -464,7 +464,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
                 }
                 else
                 {
-                    LOG_INFO("Assertion passed ('%s')", reason);
+                    LOG_INFO("Assertion passed ('%s'): %s", SECURITY_AUDIT_PASS, reason + strlen(SECURITY_AUDIT_PASS));
                 }
             }
             else if (actualJsonValue != NULL)


### PR DESCRIPTION
## Description

Making the module tester to be able to run the test recipe for Security Baseline and validate results in full for audit, except the 4 special case checks missing automatic remediation, alongside existing remediation verification.

Also fixing couple of memory leaks in the test and improving test logging for ASB.

Example of last line for an audit reported MIM object check pass:

[2024-06-13 14:26:19] [main.c:467] Assertion passed with reason: 'None of the requested user accounts ('games,test') is present'

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.