### PR TITLE
Stabilizing ASB v2's auditEnsurePasswordCreationRequirements and remediateEnsurePasswordCreationRequirements

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3506,7 +3506,6 @@ static int RemediateEnsurePortmapServiceIsDisabled(char* value, void* log)
         DisableDaemon(g_rpcbind, log);
         MaskDaemon(g_rpcbind, log);
     }
-
     if (CheckDaemonActive(g_rpcbindSocket, NULL, log))
     {
         RestartDaemon(g_rpcbindSocket, log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -934,7 +934,8 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     FREE_MEMORY(tempFileName);
     FREE_MEMORY(fileNameCopy);
 
-    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s') complete with %d", fileName, status);
+    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile(file '%s', marker '%s', newline '%s', comment '%c') complete with %d", 
+        fileName, marker, newline ? newline : "<null>", commentCharacter, status);
 
     return status;
 }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -934,8 +934,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     FREE_MEMORY(tempFileName);
     FREE_MEMORY(fileNameCopy);
 
-    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile(file '%s', marker '%s', newline '%s', comment '%c') complete with %d", 
-        fileName, marker, newline ? newline : "<null>", commentCharacter, status);
+    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s', '%s') complete with %d", fileName, marker, status);
 
     return status;
 }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -435,8 +435,6 @@ static int CheckPasswordRequirementFromBuffer(const char* buffer, const char* op
         return INT_ENOENT;
     }
 
-    OsConfigLogInfo(log, "CheckPasswordRequirementFromBuffer: --- '%s' ----", buffer); //////////////////////////////
-
     if (desired == (value = GetIntegerOptionFromBuffer(buffer, option, separator, log)))
     {
         if (comment == buffer[0])
@@ -455,8 +453,8 @@ static int CheckPasswordRequirementFromBuffer(const char* buffer, const char* op
     {
         if (comment == buffer[0])
         {
-            OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to %d instead of %d in '%s' but it's commented out", option, value, desired, fileName);
-            OsConfigCaptureReason(reason, "'%s' is set to %d instead of %d in '%s' but it's commented out", option, value, desired, fileName);
+            OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to %d instead of %d in '%s' and it's commented out", option, value, desired, fileName);
+            OsConfigCaptureReason(reason, "'%s' is set to %d instead of %d in '%s' and it's commented out", option, value, desired, fileName);
         }
         else
         {
@@ -663,12 +661,6 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
                 OsConfigLogError(log, "SetPasswordCreationRequirements: out of memory when allocating new line for '%s'", g_etcSecurityPwQualityConf);
             }
         }
-
-        /////////////
-        char* payload = LoadStringFromFile(g_etcSecurityPwQualityConf, false, log);
-        OsConfigLogInfo(log, "SetPasswordCreationRequirements: %s >>>\n'%s'\n<<<", g_etcSecurityPwQualityConf, payload); //////////////////////////////
-        FREE_MEMORY(payload);
-        /////////////
     }
 
     if ((0 == _status) || (_status && (0 == status)))

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -434,15 +434,15 @@ static int CheckPasswordRequirementFromBuffer(const char* buffer, const char* op
         OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: invalid arguments");
         return INT_ENOENT;
     }
-    
+
+    OsConfigLogInfo(log, "CheckPasswordRequirementFromBuffer: --- '%s' ----", buffer); //////////////////////////////
+
     if (desired == (value = GetIntegerOptionFromBuffer(buffer, option, separator, log)))
     {
-        OsConfigLogInfo(log, "CheckPasswordRequirementFromBuffer: buffer is '%s'", buffer); //////
-        
-        if (comment != buffer[0])
+        if (comment == buffer[0])
         {
-            OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to correct value %d in '%s' but is commented out", option, value, fileName);
-            OsConfigCaptureReason(reason, "'%s' is set to correct value %d in '%s' but is commented out", option, value, fileName);
+            OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to correct value %d in '%s' but it's commented out", option, value, fileName);
+            OsConfigCaptureReason(reason, "'%s' is set to correct value %d in '%s' but it's commented out", option, value, fileName);
         }
         else
         {
@@ -453,8 +453,16 @@ static int CheckPasswordRequirementFromBuffer(const char* buffer, const char* op
     }
     else
     {
-        OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to %d instead of %d in '%s'", option, value, desired, fileName);
-        OsConfigCaptureReason(reason, "'%s' is set to %d instead of %d in '%s'", option, value, desired, fileName);
+        if (comment == buffer[0])
+        {
+            OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to %d instead of %d in '%s' but it's commented out", option, value, desired, fileName);
+            OsConfigCaptureReason(reason, "'%s' is set to %d instead of %d in '%s' but it's commented out", option, value, desired, fileName);
+        }
+        else
+        {
+            OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to %d instead of %d in '%s'", option, value, desired, fileName);
+            OsConfigCaptureReason(reason, "'%s' is set to %d instead of %d in '%s'", option, value, desired, fileName);
+        }
     }
 
     return status;
@@ -651,6 +659,12 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
                 OsConfigLogError(log, "SetPasswordCreationRequirements: out of memory when allocating new line for '%s'", g_etcSecurityPwQualityConf);
             }
         }
+
+        /////////////
+        char* payload = LoadStringFromFile(g_etcSecurityPwQualityConf, false, log);
+        OsConfigLogInfo(log, "SetPasswordCreationRequirements: %s >>>\n'%s'\n<<<", g_etcSecurityPwQualityConf, payload); //////////////////////////////
+        FREE_MEMORY(payload);
+        /////////////
     }
 
     if ((0 == _status) || (_status && (0 == status)))

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -595,6 +595,8 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     //
     // Separate lines for /etc/security/pwquality.conf:
     //
+    // 'retry = 3'
+    // 'minlen = 14'
     // 'minclass = 4' 
     // 'dcredit = -1'
     // 'ucredit = -1'
@@ -615,7 +617,7 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     const char* etcPamdCommonPasswordLineTemplate = "password requisite pam_pwquality.so retry=%d minlen=%d lcredit=%d ucredit=%d ocredit=%d dcredit=%d\n";
     const char* etcSecurityPwQualityConfLineTemplate = "%s = %d\n";
     const char* etcPamdCommonPasswordMarker = "pam_pwquality.so";
-    PASSWORD_CREATION_REQUIREMENTS entries[] = {{"minclass", 0 }, {"dcredit", 0}, {"ucredit", 0}, {"ocredit", 0}, {"lcredit", 0}};
+    PASSWORD_CREATION_REQUIREMENTS entries[] = {{"retry", 0}, {"minlen", 0}, {"minclass", 0}, {"dcredit", 0}, {"ucredit", 0}, {"ocredit", 0}, {"lcredit", 0}};
     int numEntries = ARRAY_SIZE(entries);
     char* line = NULL;
     int i = 0, status = 0, _status = 0;
@@ -641,11 +643,13 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
     if (0 == CheckFileExists(g_etcSecurityPwQualityConf, NULL, log))
     {
-        entries[0].value = minclass;
-        entries[1].value = dcredit;
-        entries[2].value = ucredit;
-        entries[3].value = ocredit;
-        entries[4].value = lcredit;
+        entries[0].value = retry;
+        entries[1].value = minlen;
+        entries[2].value = minclass;
+        entries[3].value = dcredit;
+        entries[4].value = ucredit;
+        entries[5].value = ocredit;
+        entries[6].value = lcredit;
         
         for (i = 0; i < numEntries; i++)
         {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -437,6 +437,8 @@ static int CheckPasswordRequirementFromBuffer(const char* buffer, const char* op
     
     if (desired == (value = GetIntegerOptionFromBuffer(buffer, option, separator, log)))
     {
+        OsConfigLogInfo(log, "CheckPasswordRequirementFromBuffer: buffer is '%s'", buffer); //////
+        
         if (comment != buffer[0])
         {
             OsConfigLogError(log, "CheckPasswordRequirementFromBuffer: '%s' is set to correct value %d in '%s' but is commented out", option, value, fileName);

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -391,8 +391,6 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
         "auditEnsureAuditdServiceIsRunning",
         "auditEnsurePermissionsOnEtcPasswdDash",
-        "auditEnsureReversePathSourceValidationIsEnabled",
-        "auditEnsurePasswordCreationRequirements",
         "auditEnsureLoggingIsConfigured",
         "auditEnsureSyslogRotaterServiceIsEnabled",
         "auditEnsureAuditdInstalled",


### PR DESCRIPTION
## Description

Continued stabilization for ASB v2, here for auditEnsurePasswordCreationRequirements and remediateEnsurePasswordCreationRequirements. 

Plus enabling for test the stabilized auditEnsureReversePathSourceValidationIsEnabled and 
remediateEnsureReversePathSourceValidationIsEnabled.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.