### PR TITLE
Stabilizing ASB v2's auditEnsureLoggingIsConfigured and remediateEnsureLoggingIsConfigured

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1669,10 +1669,11 @@ static char* AuditEnsureAllBootloadersHavePasswordProtectionEnabled(void* log)
 static char* AuditEnsureLoggingIsConfigured(void* log)
 {
     char* reason = NULL;
-    RETURN_REASON_IF_NOT_ZERO(CheckFileExists("/var/log/syslog", &reason, log));
-    RETURN_REASON_IF_NOT_ZERO(CheckDaemonActive(g_syslog, &reason, log) ? 0 : ENOENT);
-    RETURN_REASON_IF_NOT_ZERO(CheckDaemonNotActive(g_rsyslog, &reason, log) ? 0 : ENOENT);
-    CheckDaemonActive(g_syslogNg, &reason, log);
+    RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_systemd, NULL, log));
+    RETURN_REASON_IF_NOT_ZERO(CheckDaemonActive(g_systemdJournald, NULL, log) ? 0 : ENOENT);
+    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_rsyslog, NULL, log)) && CheckDaemonActive(g_rsyslog, NULL, log)) ? 0 : ENOENT);
+    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_syslog, NULL, log)) && CheckDaemonActive(g_syslog, NULL, log)) ? 0 : ENOENT);
+    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_syslogNg, NULL, log)) && CheckDaemonActive(g_syslogNg, NULL, log)) ? 0 : ENOENT);
     return reason;
 }
 
@@ -3218,7 +3219,7 @@ static int RemediateEnsureAllBootloadersHavePasswordProtectionEnabled(char* valu
 static int RemediateEnsureLoggingIsConfigured(char* value, void* log)
 {
     UNUSED(value);
-    return (((0 == InstallPackage(g_systemd, log) && ((0 == InstallPackage(g_rsyslog, log)) || 
+    return (((0 == InstallPackage(g_systemd, log) && ((0 == InstallPackage(g_rsyslog, log)) ||
         (0 == InstallPackage(g_syslog, log)))) || (0 == InstallPackage(g_syslogNg, log))) &&
         (((0 == CheckPackageInstalled(g_systemd, NULL, log)) && EnableAndStartDaemon(g_systemdJournald, log))) &&
         ((((0 == CheckPackageInstalled(g_rsyslog, NULL, log)) && EnableAndStartDaemon(g_rsyslog, log))) || 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1669,11 +1669,11 @@ static char* AuditEnsureAllBootloadersHavePasswordProtectionEnabled(void* log)
 static char* AuditEnsureLoggingIsConfigured(void* log)
 {
     char* reason = NULL;
-    RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_systemd, NULL, log));
-    RETURN_REASON_IF_NOT_ZERO(CheckDaemonActive(g_systemdJournald, NULL, log) ? 0 : ENOENT);
-    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_rsyslog, NULL, log)) && CheckDaemonActive(g_rsyslog, NULL, log)) ? 0 : ENOENT);
-    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_syslog, NULL, log)) && CheckDaemonActive(g_syslog, NULL, log)) ? 0 : ENOENT);
-    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_syslogNg, NULL, log)) && CheckDaemonActive(g_syslogNg, NULL, log)) ? 0 : ENOENT);
+    RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_systemd, &reason, log));
+    RETURN_REASON_IF_NOT_ZERO(CheckDaemonActive(g_systemdJournald, &reason, log) ? 0 : ENOENT);
+    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_rsyslog, &reason, log)) && CheckDaemonActive(g_rsyslog, &reason, log)) ? 0 : ENOENT);
+    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_syslog, &reason, log)) && CheckDaemonActive(g_syslog, &reason, log)) ? 0 : ENOENT);
+    RETURN_REASON_IF_ZERO(((0 == CheckPackageInstalled(g_syslogNg, &reason, log)) && CheckDaemonActive(g_syslogNg, &reason, log)) ? 0 : ENOENT);
     return reason;
 }
 

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -391,7 +391,6 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
         "auditEnsureAuditdServiceIsRunning",
         "auditEnsurePermissionsOnEtcPasswdDash",
-        "auditEnsureLoggingIsConfigured",
         "auditEnsureSyslogRotaterServiceIsEnabled",
         "auditEnsureAuditdInstalled",
         "auditEnsureRemoteLoginWarningBannerIsConfigured",


### PR DESCRIPTION
## Description

Stabilizing ASB v2's auditEnsureLoggingIsConfigured and remediateEnsureLoggingIsConfigured

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.