### PR TITLE
Stabilizing ASB v2's auditEnsureAuditdInstalled and remediateEnsureAuditdInstalled

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -533,6 +533,7 @@ static const char* g_sendmail = "sendmail";
 static const char* g_slapd = "slapd";
 static const char* g_bind9 = "bind9";
 static const char* g_dovecotCore = "dovecot-core";
+static const char* g_audit = "audit";
 static const char* g_auditd = "auditd";
 static const char* g_auditLibs = "audit-libs";
 static const char* g_auditLibsDevel = "audit-libs-devel";
@@ -1088,6 +1089,7 @@ static char* AuditEnsureDovecotCoreNotInstalled(void* log)
 static char* AuditEnsureAuditdInstalled(void* log)
 {
     char* reason = NULL;
+    RETURN_REASON_IF_ZERO(CheckPackageInstalled(g_audit, &reason, log));
     RETURN_REASON_IF_ZERO(CheckPackageInstalled(g_auditd, &reason, log));
     RETURN_REASON_IF_ZERO(CheckPackageInstalled(g_auditLibs, &reason, log));
     RETURN_REASON_IF_ZERO(CheckPackageInstalled(g_auditLibsDevel, &reason, log));
@@ -2611,7 +2613,8 @@ static int RemediateEnsureDovecotCoreNotInstalled(char* value, void* log)
 static int RemediateEnsureAuditdInstalled(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == InstallPackage(g_auditd, log)) || (0 == InstallPackage(g_auditLibs, log)) || (0 == InstallPackage(g_auditLibsDevel, log))) ? 0 : ENOENT;
+    return ((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) ||
+        (0 == InstallPackage(g_auditLibs, log)) || (0 == InstallPackage(g_auditLibsDevel, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsurePrelinkIsDisabled(char* value, void* log)
@@ -2637,8 +2640,8 @@ static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
     UNUSED(value);
-    return (((0 == InstallPackage(g_auditd, log)) || (0 == InstallPackage(g_auditLibs, log)) || (0 == InstallPackage(g_auditLibsDevel, log))) &&
-        EnableAndStartDaemon(g_auditd, log)) ? 0 : ENOENT;
+    return (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) || (0 == InstallPackage(g_auditLibs, log)) ||
+        (0 == InstallPackage(g_auditLibsDevel, log))) && EnableAndStartDaemon(g_auditd, log)) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureKernelSupportForCpuNx(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2639,7 +2639,6 @@ static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 
 static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
-    const char* command = "restorecon -r -v /var/log/audit";
     int status = ENOENT;
     UNUSED(value);
     if (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) ||
@@ -2647,10 +2646,8 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
     { 
         if (false == EnableAndStartDaemon(g_auditd, log))
         {
-            if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
-            {
-                RestartDaemon(g_auditd, log);
-            }
+            ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
+            StartDaemon(g_auditd, log);
         }
         status = CheckDaemonActive(g_auditd, NULL, log) ? 0 : ENOENT;
     }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2639,6 +2639,7 @@ static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 
 static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
+    const char* command = "restorecon -r -v /var/log/audit";
     int status = ENOENT;
     UNUSED(value);
     if (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) ||
@@ -2646,7 +2647,10 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
     { 
         if (false == EnableAndStartDaemon(g_auditd, log))
         {
-            RestartDaemon(g_auditd, log);
+            if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+            {
+                RestartDaemon(g_auditd, log);
+            }
         }
         status = CheckDaemonActive(g_auditd, NULL, log) ? 0 : ENOENT;
     }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2639,9 +2639,18 @@ static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 
 static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
+    int status = ENOENT;
     UNUSED(value);
-    return (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) || (0 == InstallPackage(g_auditLibs, log)) ||
-        (0 == InstallPackage(g_auditLibsDevel, log))) && EnableDaemon(g_auditd, log) && RestartDaemon(g_auditd, log)) ? 0 : ENOENT;
+    if (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) ||
+        (0 == InstallPackage(g_auditLibs, log)) || (0 == InstallPackage(g_auditLibsDevel, log))))
+    { 
+        if (false == EnableAndStartDaemon(g_auditd, log))
+        {
+            RestartDaemon(g_auditd, log);
+        }
+        status = CheckDaemonActive(g_auditd, NULL, log) ? 0 : ENOENT;
+    }
+    return status;
 }
 
 static int RemediateEnsureKernelSupportForCpuNx(char* value, void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2641,7 +2641,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
     UNUSED(value);
     return (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) || (0 == InstallPackage(g_auditLibs, log)) ||
-        (0 == InstallPackage(g_auditLibsDevel, log))) && EnableAndStartDaemon(g_auditd, log)) ? 0 : ENOENT;
+        (0 == InstallPackage(g_auditLibsDevel, log))) && EnableDaemon(g_auditd, log) && RestartDaemon(g_auditd, log)) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureKernelSupportForCpuNx(char* value, void* log)

--- a/src/common/commonutils/DaemonUtils.c
+++ b/src/common/commonutils/DaemonUtils.c
@@ -21,10 +21,7 @@ static int ExecuteSystemctlCommand(const char* command, const char* daemonName, 
     }
 
     result = ExecuteCommand(NULL, formattedCommand, false, false, 0, 0, NULL, NULL, log);
-    OsConfigLogInfo(log, "ExecuteSystemctlCommand: '%s' completed with %d (errno: %d)", formattedCommand, result, errno);
-
     FREE_MEMORY(formattedCommand);
-
     return result;
 }
 

--- a/src/common/commonutils/DaemonUtils.c
+++ b/src/common/commonutils/DaemonUtils.c
@@ -21,7 +21,10 @@ static int ExecuteSystemctlCommand(const char* command, const char* daemonName, 
     }
 
     result = ExecuteCommand(NULL, formattedCommand, false, false, 0, 0, NULL, NULL, log);
+    OsConfigLogInfo(log, "ExecuteSystemctlCommand: '%s' completed with %d (errno: %d)", formattedCommand, result, errno);
+
     FREE_MEMORY(formattedCommand);
+
     return result;
 }
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -26,7 +26,7 @@ int IsPresent(const char* what, void* log)
     {
         if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
         {
-            OsConfigLogInfo(log, "IsPresent: '%s' is locally present");
+            OsConfigLogInfo(log, "IsPresent: '%s' is locally installed", what);
         }
     }
     else

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -24,7 +24,10 @@ int IsPresent(const char* what, void* log)
 
     if (NULL != (command = FormatAllocateString(commandTemplate, what)))
     {
-        status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log);
+        if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+        {
+            OsConfigLogInfo(log, "IsPresent: '%s' is locally present");
+        }
     }
     else
     {
@@ -54,7 +57,10 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
         return ENOMEM;
     }
 
-    status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log);
+    if (0 != (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogError(log, "CheckOrInstallPackage: '%s' failed with %d (errno: %d)", command, status, errno);
+    }
 
     FREE_MEMORY(command);
 
@@ -95,7 +101,7 @@ int IsPackageInstalled(const char* packageName, void* log)
     }
     else
     {
-        OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is not found", packageName);
+        OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is not found (%d)", packageName, status);
     }
 
     return status;

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -389,10 +389,8 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         "auditEnsureAuthenticationRequiredForSingleUserMode",
         "auditEnsureAllBootloadersHavePasswordProtectionEnabled",
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
-        "auditEnsureAuditdServiceIsRunning",
         "auditEnsurePermissionsOnEtcPasswdDash",
         "auditEnsureSyslogRotaterServiceIsEnabled",
-        //"auditEnsureAuditdInstalled",
         "auditEnsureRemoteLoginWarningBannerIsConfigured",
         "auditEnsureZeroconfNetworkingIsDisabled"
     };
@@ -400,9 +398,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
 
     const char* skippedRemediations[] = {
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
-        "remediateEnsureAuditdServiceIsRunning",
         "remediateEnsureSyslogRotaterServiceIsEnabled",
-        //"remediateEnsureAuditdInstalled",
         "remediateEnsureRemoteLoginWarningBannerIsConfigured",
         "remediateEnsureZeroconfNetworkingIsDisabled"
     };

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -392,7 +392,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         "auditEnsureAuditdServiceIsRunning",
         "auditEnsurePermissionsOnEtcPasswdDash",
         "auditEnsureSyslogRotaterServiceIsEnabled",
-        "auditEnsureAuditdInstalled",
+        //"auditEnsureAuditdInstalled",
         "auditEnsureRemoteLoginWarningBannerIsConfigured",
         "auditEnsureZeroconfNetworkingIsDisabled"
     };
@@ -402,7 +402,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
         "remediateEnsureAuditdServiceIsRunning",
         "remediateEnsureSyslogRotaterServiceIsEnabled",
-        "remediateEnsureAuditdInstalled",
+        //"remediateEnsureAuditdInstalled",
         "remediateEnsureRemoteLoginWarningBannerIsConfigured",
         "remediateEnsureZeroconfNetworkingIsDisabled"
     };


### PR DESCRIPTION
## Description

Stabilizing ASB v2's auditEnsureAuditdInstalled and remediateEnsureAuditdInstalled, also auditEnsureAuditdServiceIsRunning and remediateEnsureAuditdServiceIsRunning.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.