### PR TITLE
Stabilizing ASB v2's auditEnsureRemoteLoginWarningBannerIsConfigured and remediateEnsureRemoteLoginWarningBannerIsConfigured 

### DIFF
--- a/src/adapters/mc/asb/OsConfigPolicy.mof
+++ b/src/adapters/mc/asb/OsConfigPolicy.mof
@@ -517,7 +517,7 @@ instance of OsConfigResource as $OsConfigResource32ref
 
 instance of OsConfigResource as $OsConfigResource33ref
 {
-    ResourceID = "Ensure permissions on /etc/issue.net (/run/issue on SLES 15 and alike) are configured";
+    ResourceID = "Ensure permissions on /etc/issue.net are configured";
     PayloadKey = "EnsurePermissionsOnEtcIssueNet";
     ComponentName = "SecurityBaseline";
     InitObjectName = "initEnsurePermissionsOnEtcIssueNet";

--- a/src/adapters/mc/asb/OsConfigPolicy.mof
+++ b/src/adapters/mc/asb/OsConfigPolicy.mof
@@ -517,7 +517,7 @@ instance of OsConfigResource as $OsConfigResource32ref
 
 instance of OsConfigResource as $OsConfigResource33ref
 {
-    ResourceID = "Ensure permissions on /etc/issue.net are configured";
+    ResourceID = "Ensure permissions on /etc/issue.net (/run/issue on SLES 15 and alike) are configured";
     PayloadKey = "EnsurePermissionsOnEtcIssueNet";
     ComponentName = "SecurityBaseline";
     InitObjectName = "initEnsurePermissionsOnEtcIssueNet";

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1331,7 +1331,7 @@ static char* AuditEnsureCronServiceIsEnabled(void* log)
 static char* AuditEnsureRemoteLoginWarningBannerIsConfigured(void* log)
 {
     char* reason = NULL;
-    if (0 == CheckFileExists(g_etcIssueNet, reason, log))
+    if (0 == CheckFileExists(g_etcIssueNet, &reason, log))
     {
         RETURN_REASON_IF_NOT_ZERO(CheckTextIsNotFoundInFile(g_etcIssueNet, "\\m", &reason, log));
         RETURN_REASON_IF_NOT_ZERO(CheckTextIsNotFoundInFile(g_etcIssueNet, "\\r", &reason, log));
@@ -1341,7 +1341,7 @@ static char* AuditEnsureRemoteLoginWarningBannerIsConfigured(void* log)
     else if (IsCurrentOs(PRETTY_NAME_SLES_15, log))
     {
         FREE_MEMORY(reason);
-        reason = DuplicateString("'%s' does not exist in '%s'", g_etcIssueNet, PRETTY_NAME_SLES_15);
+        reason = FormatAllocateString("'%s' does not exist in '%s'", g_etcIssueNet, PRETTY_NAME_SLES_15);
     }
     return reason;
 }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1341,7 +1341,7 @@ static char* AuditEnsureRemoteLoginWarningBannerIsConfigured(void* log)
     else if (IsCurrentOs(PRETTY_NAME_SLES_15, log))
     {
         FREE_MEMORY(reason);
-        reason = FormatAllocateString("'%s' does not exist in '%s'", g_etcIssueNet, PRETTY_NAME_SLES_15);
+        reason = FormatAllocateString("%s'%s' does not exist in '%s'", g_pass, g_etcIssueNet, PRETTY_NAME_SLES_15);
     }
     return reason;
 }
@@ -2657,6 +2657,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
             ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
             StartDaemon(g_auditd, log);
         }
+        sleep(5);
         status = CheckDaemonActive(g_auditd, NULL, log) ? 0 : ENOENT;
     }
     return status;

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2661,6 +2661,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
             ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
             for (i = 0; i < 10; i++)
             {
+                sleep(1);
                 RestartDaemon(g_auditd, log);
                 if (CheckDaemonActive(g_auditd, NULL, log))
                 {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2652,19 +2652,17 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
     if (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) || 
         (0 == InstallPackage(g_auditLibs, log)) || (0 == InstallPackage(g_auditLibsDevel, log))) && EnableDaemon(g_auditd, log))
     { 
-        for (i = 0; i < 10; i++)
+        if (false == StartDaemon(g_auditd, log))
         {
-            if (false == StartDaemon(g_auditd, log))
+            ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
+            for (i = 0; i < 10; i++)
             {
-                ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
                 RestartDaemon(g_auditd, log);
-            }
-            
-            sleep(1);
-            
-            if (CheckDaemonActive(g_auditd, NULL, log))
-            {
-                break;
+                if (CheckDaemonActive(g_auditd, NULL, log))
+                {
+                    status = 0;
+                    break;
+                }
             }
         }
     }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2662,7 +2662,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
             for (i = 0; i < 10; i++)
             {
                 sleep(1);
-                RestartDaemon(g_auditd, log);
+                StartDaemon(g_auditd, log);
                 if (CheckDaemonActive(g_auditd, NULL, log))
                 {
                     status = 0;

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2652,7 +2652,11 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
     if (((0 == InstallPackage(g_audit, log)) || (0 == InstallPackage(g_auditd, log)) || 
         (0 == InstallPackage(g_auditLibs, log)) || (0 == InstallPackage(g_auditLibsDevel, log))) && EnableDaemon(g_auditd, log))
     { 
-        if (false == StartDaemon(g_auditd, log))
+        if (StartDaemon(g_auditd, log))
+        {
+            status = 0;
+        }
+        else
         {
             ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
             for (i = 0; i < 10; i++)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -26,7 +26,7 @@ int IsPresent(const char* what, void* log)
     {
         if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
         {
-            OsConfigLogInfo(log, "IsPresent: '%s' is locally installed", what);
+            OsConfigLogInfo(log, "'%s' is locally present", what);
         }
     }
     else
@@ -59,7 +59,7 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
 
     if (0 != (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
     {
-        OsConfigLogError(log, "CheckOrInstallPackage: '%s' failed with %d (errno: %d)", command, status, errno);
+        OsConfigLogError(log, "'%s' failed with %d (errno: %d)", command, status, errno);
     }
 
     FREE_MEMORY(command);

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -391,7 +391,6 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
         "auditEnsurePermissionsOnEtcPasswdDash",
         "auditEnsureSyslogRotaterServiceIsEnabled",
-        "auditEnsureRemoteLoginWarningBannerIsConfigured",
         "auditEnsureZeroconfNetworkingIsDisabled"
     };
     int numSkippedAudits = ARRAY_SIZE(skippedAudits);
@@ -399,7 +398,6 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
     const char* skippedRemediations[] = {
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
         "remediateEnsureSyslogRotaterServiceIsEnabled",
-        "remediateEnsureRemoteLoginWarningBannerIsConfigured",
         "remediateEnsureZeroconfNetworkingIsDisabled"
     };
     int numSkippedRemediations = ARRAY_SIZE(skippedRemediations);


### PR DESCRIPTION
## Description

Stabilizing ASB v2's auditEnsureRemoteLoginWarningBannerIsConfigured and remediateEnsureRemoteLoginWarningBannerIsConfigured . SLES 15 does not have /etc/issue.net.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.