### PR TITLE
Stabilizing ASB v2's auditEnsureSyslogRotaterServiceIsEnabled and remediateEnsureSyslogRotaterServiceIsEnabled

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -626,8 +626,8 @@ static char* g_desiredEnsureDefaultDenyFirewallPolicyIsSet = NULL;
 
 static bool IsRedHatBased(void* log)
 {
-    return (IsCurrentOs("Red Hat", log) && IsCurrentOs("CentOS", log) && IsCurrentOs("AlmaLinux", log) &&
-        IsCurrentOs("Oracle Linux", log) && IsCurrentOs("Rocky Linux", log)) ? true : false;
+    return (IsCurrentOs("Red Hat", log) || IsCurrentOs("CentOS", log) || IsCurrentOs("AlmaLinux", log) ||
+        IsCurrentOs("Oracle Linux", log) || IsCurrentOs("Rocky Linux", log)) ? true : false;
 }
 
 void AsbInitialize(void* log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -624,6 +624,12 @@ static char* g_desiredEnsureUsersDotFilesArentGroupOrWorldWritable = NULL;
 static char* g_desiredEnsureUnnecessaryAccountsAreRemoved = NULL;
 static char* g_desiredEnsureDefaultDenyFirewallPolicyIsSet = NULL;
 
+static bool IsRedHatBased(void* log)
+{
+    return (IsCurrentOs("Red Hat", log) && IsCurrentOs("CentOS", log) && IsCurrentOs("AlmaLinux", log) &&
+        IsCurrentOs("Oracle Linux", log) && IsCurrentOs("Rocky Linux", log)) ? true : false;
+}
+
 void AsbInitialize(void* log)
 {
     char* prettyName = NULL;
@@ -1779,7 +1785,7 @@ static char* AuditEnsureSyslogRotaterServiceIsEnabled(void* log)
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_logrotate, &reason, log));
     RETURN_REASON_IF_NOT_ZERO(CheckFileAccess(g_etcCronDailyLogRotate, 0, 0, 755, &reason, log));
-    if (false == IsCurrentOs(PRETTY_NAME_SLES_15, log))
+    if (false == IsRedHatBased(log))
     {
         CheckDaemonActive(g_logrotateTimer, &reason, log);
     }
@@ -3362,7 +3368,7 @@ static int RemediateEnsureSyslogRotaterServiceIsEnabled(char* value, void* log)
     if ((0 == InstallPackage(g_logrotate, log)) && (0 == SetFileAccess(g_etcCronDailyLogRotate, 0, 0, 755, log)))
     {
         status = 0;
-        if (false == IsCurrentOs(PRETTY_NAME_SLES_15, log))
+        if (false == IsRedHatBased(log))
         {
             status = EnableAndStartDaemon(g_logrotateTimer, log) ? 0 : ENOENT;
         }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1778,8 +1778,8 @@ static char* AuditEnsureSyslogRotaterServiceIsEnabled(void* log)
 {
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_logrotate, &reason, log));
-    RETURN_REASON_IF_NOT_ZERO(CheckFileExists(g_etcCronDailyLogRotate, &reason, log));
-    CheckFileAccess(g_etcCronDailyLogRotate, 0, 0, 755, &reason, log);
+    RETURN_REASON_IF_NOT_ZERO(CheckFileAccess(g_etcCronDailyLogRotate, 0, 0, 755, &reason, log));
+    CheckDaemonActive(g_logrotateTimer, log);
     return reason;
 }
 
@@ -3355,7 +3355,7 @@ static int RemediateEnsureRsyslogNotAcceptingRemoteMessages(char* value, void* l
 static int RemediateEnsureSyslogRotaterServiceIsEnabled(char* value, void* log)
 {
     UNUSED(value);
-    return ((0 == InstallPackage(g_logrotate, log)) && (0 == CheckFileExists(g_etcCronDailyLogRotate, NULL, log)) && 
+    return ((0 == InstallPackage(g_logrotate, log)) && 
         (0 == SetFileAccess(g_etcCronDailyLogRotate, 0, 0, 755, log)) && EnableAndStartDaemon(g_logrotateTimer, log)) ? 0 : ENOENT;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3364,7 +3364,7 @@ static int RemediateEnsureSyslogRotaterServiceIsEnabled(char* value, void* log)
         status = 0;
         if (false == IsCurrentOs(PRETTY_NAME_SLES_15, log))
         {
-            status = EnableAndStartDaemon(g_logrotateTimer, log)) ? 0 : ENOENT;
+            status = EnableAndStartDaemon(g_logrotateTimer, log) ? 0 : ENOENT;
         }
     }
     return status;

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1779,7 +1779,7 @@ static char* AuditEnsureSyslogRotaterServiceIsEnabled(void* log)
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_logrotate, &reason, log));
     RETURN_REASON_IF_NOT_ZERO(CheckFileAccess(g_etcCronDailyLogRotate, 0, 0, 755, &reason, log));
-    CheckDaemonActive(g_logrotateTimer, log);
+    CheckDaemonActive(g_logrotateTimer, &reason, log);
     return reason;
 }
 

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -390,14 +390,12 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         "auditEnsureAllBootloadersHavePasswordProtectionEnabled",
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
         "auditEnsurePermissionsOnEtcPasswdDash",
-        "auditEnsureSyslogRotaterServiceIsEnabled",
         "auditEnsureZeroconfNetworkingIsDisabled"
     };
     int numSkippedAudits = ARRAY_SIZE(skippedAudits);
 
     const char* skippedRemediations[] = {
         // Following are temporarily disabled and they will be re-enabled and fixed one by one for all target distros
-        "remediateEnsureSyslogRotaterServiceIsEnabled",
         "remediateEnsureZeroconfNetworkingIsDisabled"
     };
     int numSkippedRemediations = ARRAY_SIZE(skippedRemediations);


### PR DESCRIPTION
## Description

Stabilizing ASB v2's auditEnsureSyslogRotaterServiceIsEnabled and remediateEnsureSyslogRotaterServiceIsEnabled. 

On Red Hat based distributions, the logrotate.timer service is not required for log rotation. The logrotate package handles log rotation automatically without the need to manually enable or start the timer service.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.