### PR TITLE
Fixed signing and updated debian-10 base image

### DIFF
--- a/.github/actions/sign-package/action.yml
+++ b/.github/actions/sign-package/action.yml
@@ -12,7 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact }}
         path: unsigned

--- a/devops/e2e/cloudtest/debian-10.json
+++ b/devops/e2e/cloudtest/debian-10.json
@@ -1,12 +1,6 @@
-// Base Image: debian:debian-10:10-gen2:latest
+// Base Image: /Debian/debian-10-daily/10-gen2/latest
 {
     "artifacts": [
-        {
-            "name": "linux-bash-command",
-            "parameters": {
-                "command": "sudo sed -i 's/debian-archive.trafficmanager.net/archive.debian.org/g' /etc/apt/sources.list && sudo sed -i '/debian-security/d' /etc/apt/sources.list"
-            }
-        },
         {
             "name": "linux-install-packages",
             "parameters": {
@@ -45,6 +39,18 @@
         },
         {
             "name": "linux-azcli"
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo apt-get --allow-releaseinfo-change-suite update && sudo apt update && sudo apt upgrade -y"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "apt list --installed"
+            }
         }
     ]
 }


### PR DESCRIPTION
## Description

* Fixed broken insiders publishing (incompatibility between actions/download-artifact@v3 and v4)
* Updated Debian-10 image to use `debian-10-daily` channel

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.