### PR TITLE
Fixed upload-artifact to use v4

### DIFF
--- a/.github/actions/sign-package/action.yml
+++ b/.github/actions/sign-package/action.yml
@@ -144,7 +144,7 @@ runs:
           if os.path.isfile(os.path.join("signed", file)):
             print(f"Success!\nSigned {file}")
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact }}-signed
         path: signed


### PR DESCRIPTION
## Description

* Fixed `insiders-fast` publishing, updated missing `actions/upload-artifact` v3 to v4 conversion

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.