### PR TITLE
Run native amd64 containers without QEMU

### DIFF
--- a/.github/actions/container-run/action.yml
+++ b/.github/actions/container-run/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Setup QEMU
-      if: ${{ inputs.useQEMU }}
+      if: inputs.useQEMU
       uses: docker/setup-qemu-action@v3
 
     - name: Setup container

--- a/.github/actions/container-run/action.yml
+++ b/.github/actions/container-run/action.yml
@@ -12,6 +12,11 @@ inputs:
   mount:
     description: The volume to mount.
     required: true
+  useQEMU:
+    description: Use QEMU for emulation.
+    required: false
+    type: boolean
+    default: false
   tag:
     description: The container tag.
     required: false
@@ -26,6 +31,7 @@ runs:
   using: composite
   steps:
     - name: Setup QEMU
+      if: ${{ inputs.useQEMU }}
       uses: docker/setup-qemu-action@v3
 
     - name: Setup container

--- a/.github/actions/container-run/action.yml
+++ b/.github/actions/container-run/action.yml
@@ -12,11 +12,6 @@ inputs:
   mount:
     description: The volume to mount.
     required: true
-  useQEMU:
-    description: Use QEMU for emulation.
-    required: false
-    type: boolean
-    default: false
   tag:
     description: The container tag.
     required: false
@@ -30,10 +25,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Setup QEMU
-      if: inputs.useQEMU
-      uses: docker/setup-qemu-action@v3
-
     - name: Setup container
       id: setup
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Setup QEMU
+        if: ${{ matrix.target.arch != 'amd64' }}
+        uses: docker/setup-qemu-action@v3
+
       - name: Run container
         id: container
         uses: ./.github/actions/container-run
@@ -91,7 +95,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           container: azure/azure-osconfig/${{ matrix.target.name }}-${{ matrix.target.arch }}
           mount: ${{ github.workspace }}:${{ env.MOUNT }}
-          useQEMU: ${{ matrix.target.arch != 'amd64' }}
           tag: ${{ matrix.target.tag }}
 
       - name: Generate build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           container: azure/azure-osconfig/${{ matrix.target.name }}-${{ matrix.target.arch }}
           mount: ${{ github.workspace }}:${{ env.MOUNT }}
+          useQEMU: ${{ matrix.target.arch == 'amd64' && false || true }}
           tag: ${{ matrix.target.tag }}
 
       - name: Generate build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  push:
   pull_request:
   schedule:
     - cron: '0 20 * * *' # Every day at 12pm PST (UTC-8)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: '0 20 * * *' # Every day at 12pm PST (UTC-8)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           container: azure/azure-osconfig/${{ matrix.target.name }}-${{ matrix.target.arch }}
           mount: ${{ github.workspace }}:${{ env.MOUNT }}
-          useQEMU: ${{ matrix.target.arch == 'amd64' && false || true }}
+          useQEMU: ${{ matrix.target.arch != 'amd64' }}
           tag: ${{ matrix.target.tag }}
 
       - name: Generate build

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -58,6 +58,10 @@ jobs:
           clean: true
           ref: ${{ inputs.ref }}
 
+      - name: Setup QEMU
+        if: ${{ matrix.target.arch != 'amd64' }}
+        uses: docker/setup-qemu-action@v3
+
       - name: Run container
         id: container
         uses: ./.github/actions/container-run
@@ -65,7 +69,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           container: azure/azure-osconfig/${{ inputs.target }}-${{ inputs.arch }}
           mount: ${{ github.workspace }}:${{ env.MOUNT }}
-          useQEMU: ${{ inputs.arch != 'amd64' }}
           tag: ${{ inputs.container-tag }}
 
       - name: Set tweak

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -65,7 +65,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           container: azure/azure-osconfig/${{ inputs.target }}-${{ inputs.arch }}
           mount: ${{ github.workspace }}:${{ env.MOUNT }}
-          useQEMU: ${{ inputs.arch == 'amd64' && false || true }}
+          useQEMU: ${{ inputs.arch != 'amd64' }}
           tag: ${{ inputs.container-tag }}
 
       - name: Set tweak

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -65,6 +65,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           container: azure/azure-osconfig/${{ inputs.target }}-${{ inputs.arch }}
           mount: ${{ github.workspace }}:${{ env.MOUNT }}
+          useQEMU: ${{ inputs.arch == 'amd64' && false || true }}
           tag: ${{ inputs.container-tag }}
 
       - name: Set tweak


### PR DESCRIPTION
## Description

* Running into docker rate-limiting on occasion, removed the excessive pulling of binfmt from `docker/setup-qemu-action@v3`

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.