### PR TITLE
Fixed invalid conditional for "Setup QEMU" action

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -59,7 +59,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Setup QEMU
-        if: ${{ matrix.target.arch != 'amd64' }}
+        if: ${{ inputs.arch != 'amd64' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Run container


### PR DESCRIPTION
## Description

* Fixed invalid workflow reference `matrix.target.arch` from previous PR #737 

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.