### PR TITLE
Fix for ASB v2's remediateEnsureCupsServiceisDisabled and auditEnsureCupsServiceisDisabled plus updated ASB and SSH policy names

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -1,9 +1,9 @@
 {
     "properties": {
-        "displayName": "Azure Security Baseline for Linux policy",
+        "displayName": "[Preview]: Azure security baseline for Linux (powered by OsConfig)",
         "policyType": "Custom",
         "mode": "Indexed",
-        "description": "This policy audits the Azure Security Baseline for Linux",
+        "description": "This policy is powered by Azure OSConfig and its purpose is to audit and deploy the Azure Security Baseline for Linux",
         "metadata": {
             "category": "Guest Configuration",
             "version": "1.0.0.0",

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "displayName": "[Preview]: Azure security baseline for Linux (powered by OsConfig)",
+        "displayName": "[Preview]: Azure security baseline for Linux (powered by OSConfig)",
         "policyType": "Custom",
         "mode": "Indexed",
         "description": "This policy is powered by Azure OSConfig and its purpose is to audit and deploy the Azure Security Baseline for Linux",

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "588D662DAE1CE6959FBF6596CB65769337E7A46B8888BD25E7114BFDB54E04FF",
+                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "588D662DAE1CE6959FBF6596CB65769337E7A46B8888BD25E7114BFDB54E04FF",
+                                                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "588D662DAE1CE6959FBF6596CB65769337E7A46B8888BD25E7114BFDB54E04FF",
+                                                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "588D662DAE1CE6959FBF6596CB65769337E7A46B8888BD25E7114BFDB54E04FF",
+                                                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
+                "contentHash": "FA96D3686F0539B48BAD4B4CA7E10B664CEB860430BF4569C60DDAE2C7D4E72B",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
+                                                "contentHash": "FA96D3686F0539B48BAD4B4CA7E10B664CEB860430BF4569C60DDAE2C7D4E72B",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
+                                                "contentHash": "FA96D3686F0539B48BAD4B4CA7E10B664CEB860430BF4569C60DDAE2C7D4E72B",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "8FAE950D220069D65568A30204B4E27BCA631253295F9540A4225C5C002EE22C",
+                                                "contentHash": "FA96D3686F0539B48BAD4B4CA7E10B664CEB860430BF4569C60DDAE2C7D4E72B",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "displayName": "[Preview]: SSH security posture control for Linux (powered by OsConfig)",
+        "displayName": "[Preview]: SSH security posture control for Linux (powered by OSConfig)",
         "policyType": "Custom",
         "mode": "Indexed",
         "description": "This policy is powered by Azure OSConfig and its purpose is to ensure that the SSH Server is securely configured on the Linux device",

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "430DA48C00BF58D9D5533AD3C3303DF466AACE3F06AFBEBF76271742DE1B5498",
+                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "430DA48C00BF58D9D5533AD3C3303DF466AACE3F06AFBEBF76271742DE1B5498",
+                                                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "430DA48C00BF58D9D5533AD3C3303DF466AACE3F06AFBEBF76271742DE1B5498",
+                                                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "430DA48C00BF58D9D5533AD3C3303DF466AACE3F06AFBEBF76271742DE1B5498",
+                                                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
+                "contentHash": "45783F2605AB06139185A6BF448B9185AD8258CBB11C3E1A61C5D734D7E95C79",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
+                                                "contentHash": "45783F2605AB06139185A6BF448B9185AD8258CBB11C3E1A61C5D734D7E95C79",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
+                                                "contentHash": "45783F2605AB06139185A6BF448B9185AD8258CBB11C3E1A61C5D734D7E95C79",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "86FB08ABD3523E28618919205187140DC752EFBD615BC4B8DDB6E02B88999DD9",
+                                                "contentHash": "45783F2605AB06139185A6BF448B9185AD8258CBB11C3E1A61C5D734D7E95C79",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -1,9 +1,9 @@
 {
     "properties": {
-        "displayName": "[Preview] SSH Posture Control policy",
+        "displayName": "[Preview]: SSH security posture control for Linux (powered by OsConfig)",
         "policyType": "Custom",
         "mode": "Indexed",
-        "description": "This policy ensures that the SSH Server is securely configured on the Linux device",
+        "description": "This policy is powered by Azure OSConfig and its purpose is to ensure that the SSH Server is securely configured on the Linux device",
         "metadata": {
             "category": "Guest Configuration",
             "version": "1.0.0.0",

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1969,7 +1969,6 @@ static char* AuditEnsureAvahiDaemonServiceIsDisabled(void* log)
 static char* AuditEnsureCupsServiceisDisabled(void* log)
 {
     char* reason = NULL;
-    RETURN_REASON_IF_NOT_ZERO(CheckPackageNotInstalled(g_cups, &reason, log));
     CheckDaemonNotActive(g_cups, &reason, log);
     return reason;
 }

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -217,7 +217,7 @@ int InstallPackage(const char* packageName, void* log)
 int UninstallPackage(const char* packageName, void* log)
 {
     const char* commandTemplateAptGet = "%s remove -y --purge %s";
-    const char* commandTemplateAllElse = "% remove -y %s";
+    const char* commandTemplateAllElse = "%s remove -y %s";
     int status = ENOENT;
 
     if (0 == (status = IsPackageInstalled(packageName, log)))

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2382,11 +2382,9 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                 {
                     passwordExpirationDate = userList[i].lastPasswordChange + userList[i].maximumPasswordAge;
 
-                    //>>>>>>>>>> TEMPORARY
-                    OsConfigLogInfo(log, "###################### user '%s' (%u, %u) last password change: %ld days ago, maximum password age: %ld days, expiration date: %ld, current date: %ld ###############",
-                        userList[i].username, userList[i].userId, userList[i].groupId, 
-                        userList[i].lastPasswordChange, userList[i].maximumPasswordAge, passwordExpirationDate, currentDate);
-                    //<<<<<<<<<<
+                    // Temporary trace for investigation on RHEL 9 about unexpected password expiration values
+                    OsConfigLogInfo(log, "CheckPasswordExpirationLessThan: user '%s' (%u, %u) last password change: %ld days ago, maximum password age: %ld days, expiration date: %ld, current date: %ld",
+                        userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange, userList[i].maximumPasswordAge, passwordExpirationDate, currentDate);
 
                     if (passwordExpirationDate >= currentDate)
                     {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2382,6 +2382,12 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                 {
                     passwordExpirationDate = userList[i].lastPasswordChange + userList[i].maximumPasswordAge;
 
+                    //>>>>>>>>>> TEMPORARY
+                    OsConfigLogInfo(log, "###################### user '%s' (%u, %u) last password change: %ld days ago, maximum password age: %ld days, expiration date: %ld, current date: %ld ###############",
+                        userList[i].username, userList[i].userId, userList[i].groupId, 
+                        userList[i].lastPasswordChange, userList[i].maximumPasswordAge, passwordExpirationDate, currentDate);
+                    //<<<<<<<<<<
+
                     if (passwordExpirationDate >= currentDate)
                     {
                         if ((passwordExpirationDate - currentDate) <= days)

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2380,11 +2380,32 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                 }
                 else
                 {
+                    /*
+                    // Date of last change (measured in days since 1970-01-01 00:00:00 +0000 UTC) 
+                    long lastPasswordChange;
+    
+                    // Minimum number of days between password changes 
+                    long minimumPasswordAge;
+    
+                    // Maximum number of days between password changes
+                    long maximumPasswordAge;
+    
+                    // Number of days before password expires to warn user to change it 
+                    long warningPeriod;
+    
+                    // Number of days after password expires until account is disabled 
+                    long inactivityPeriod;
+    
+                    // Date when user account expires (measured in days since 1970-01-01 00:00:00 +0000 UTC) 
+                    long expirationDate;                 
+                    */
+                    
                     passwordExpirationDate = userList[i].lastPasswordChange + userList[i].maximumPasswordAge;
 
                     // Temporary trace for investigation on RHEL 9 about unexpected password expiration values
                     OsConfigLogInfo(log, "CheckPasswordExpirationLessThan: user '%s' (%u, %u) last password change: %ld days ago, maximum password age: %ld days, expiration date: %ld, current date: %ld",
                         userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange, userList[i].maximumPasswordAge, passwordExpirationDate, currentDate);
+                    OsConfigLogInfo(log, "CheckPasswordExpirationLessThan: user '%s' (%u, %u) expirationDate since 1970: %ld days", userList[i].username, userList[i].userId, userList[i].groupId, userList[i].expirationDate);
 
                     if (passwordExpirationDate >= currentDate)
                     {


### PR DESCRIPTION
## Description

Fix for ASB v2's remediateEnsureCupsServiceisDisabled (package uninstallation broken) and auditEnsureCupsServiceisDisabled (make it check just the essential, which is if service is active, ignoring the package) plus updated ASB and SSH policy names. 

Also adding support to remediateEnsurePasswordExpiration and auditEnsurePasswordExpiration for when a user's password has no expiration.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.