### PR TITLE
For ASB v2's remediateEnsurePasswordExpiration ensure that all user passwords have dates of last changes

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "C618A254472BC53F0A82B5A4B4518AC32FB44C04DE9B6B4B9E6F525816168C2F",
+                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "C618A254472BC53F0A82B5A4B4518AC32FB44C04DE9B6B4B9E6F525816168C2F",
+                                                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "C618A254472BC53F0A82B5A4B4518AC32FB44C04DE9B6B4B9E6F525816168C2F",
+                                                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "C618A254472BC53F0A82B5A4B4518AC32FB44C04DE9B6B4B9E6F525816168C2F",
+                                                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
+                "contentHash": "22470C3C3B91C10529A15FEF1ADA98F776BB7B9DFA4803EE758619288B5EA50E",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
+                                                "contentHash": "22470C3C3B91C10529A15FEF1ADA98F776BB7B9DFA4803EE758619288B5EA50E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
+                                                "contentHash": "22470C3C3B91C10529A15FEF1ADA98F776BB7B9DFA4803EE758619288B5EA50E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "2E9BBC86C6EB93719BDD23AA31B2B13B4068941A49BBD9DCADE28E2F901CA43B",
+                                                "contentHash": "22470C3C3B91C10529A15FEF1ADA98F776BB7B9DFA4803EE758619288B5EA50E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "D7655DA524E32327A1FA123B16687BE495973309199B11A2D4269011A8F767DB",
+                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "D7655DA524E32327A1FA123B16687BE495973309199B11A2D4269011A8F767DB",
+                                                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "D7655DA524E32327A1FA123B16687BE495973309199B11A2D4269011A8F767DB",
+                                                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "D7655DA524E32327A1FA123B16687BE495973309199B11A2D4269011A8F767DB",
+                                                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
+                "contentHash": "7C81A17C64F4128F3D9AD2F5EFA2459A7C3181072C0222F92ECE43D139C57BAA",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
+                                                "contentHash": "7C81A17C64F4128F3D9AD2F5EFA2459A7C3181072C0222F92ECE43D139C57BAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
+                                                "contentHash": "7C81A17C64F4128F3D9AD2F5EFA2459A7C3181072C0222F92ECE43D139C57BAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "924C668E8A82F126FC118C1A5F23CCF16AAC4E7F90B55259EF9D649DB424B7CC",
+                                                "contentHash": "7C81A17C64F4128F3D9AD2F5EFA2459A7C3181072C0222F92ECE43D139C57BAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1270,7 +1270,7 @@ static char* AuditEnsureMaxDaysBetweenPasswordChanges(void* log)
 static char* AuditEnsurePasswordExpiration(void* log)
 {
     char* reason = NULL;
-    CheckPasswordExpirationLessThan(atoi(g_desiredEnsurePasswordExpiration ? 
+    CheckPasswordExpirationLessThan(atol(g_desiredEnsurePasswordExpiration ? 
         g_desiredEnsurePasswordExpiration : g_defaultEnsurePasswordExpiration), &reason, log);
     return reason;
 }
@@ -1278,7 +1278,7 @@ static char* AuditEnsurePasswordExpiration(void* log)
 static char* AuditEnsurePasswordExpirationWarning(void* log)
 {
     char* reason = NULL;
-    CheckPasswordExpirationWarning(atoi(g_desiredEnsurePasswordExpirationWarning ? 
+    CheckPasswordExpirationWarning(atol(g_desiredEnsurePasswordExpirationWarning ? 
         g_desiredEnsurePasswordExpirationWarning : g_defaultEnsurePasswordExpirationWarning), &reason, log);
     return reason;
 }
@@ -2910,7 +2910,7 @@ static int RemediateEnsurePasswordExpiration(char* value, void* log)
 {
     InitEnsurePasswordExpiration(value);
     return ((0 == EnsureUsersHaveDatesOfLastPasswordChanges(log)) &&
-        (0 == SetMaxDaysBetweenPasswordChanges(g_desiredEnsurePasswordExpiration, log)) &&
+        (0 == SetMaxDaysBetweenPasswordChanges(atol(g_desiredEnsurePasswordExpiration), log)) &&
         (0 == CheckPasswordExpirationLessThan(atol(g_desiredEnsurePasswordExpiration), NULL, log))) ? 0 : ENOENT;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2909,8 +2909,8 @@ static int RemediateEnsureMaxDaysBetweenPasswordChanges(char* value, void* log)
 static int RemediateEnsurePasswordExpiration(char* value, void* log)
 {
     InitEnsurePasswordExpiration(value);
-    return ((0 == SetMaxDaysBetweenPasswordChanges(atol(g_desiredEnsureMaxDaysBetweenPasswordChanges ? 
-        g_desiredEnsureMaxDaysBetweenPasswordChanges : g_defaultEnsureMaxDaysBetweenPasswordChanges), log)) &&
+    return ((0 == EnsureUsersHaveDatesOfLastPasswordChanges(log)) &&
+        (0 == SetMaxDaysBetweenPasswordChanges(g_desiredEnsurePasswordExpiration, log)) &&
         (0 == CheckPasswordExpirationLessThan(atol(g_desiredEnsurePasswordExpiration), NULL, log))) ? 0 : ENOENT;
 }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2359,7 +2359,7 @@ int EnsureUsersHaveDatesOfLastPasswordChanges(void* log)
             }
             else if (userList[i].lastPasswordChange < 0)
             {
-                OsConfigLogInfo(log, "EnsureUsersHaveDatesOfLastPasswordChanges: password for user '%s' (%u, %u) was never changed",
+                OsConfigLogInfo(log, "EnsureUsersHaveDatesOfLastPasswordChanges: password for user '%s' (%u, %u) was never changed (%lu)",
                     userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange);
 
                 if (NULL == (command = FormatAllocateString(commandTemplate, currentDate, userList[i].username)))

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2420,22 +2420,21 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                 {
                     OsConfigLogError(log, "CheckPasswordExpirationLessThan: password for user '%s' (%u, %u) has no expiration date (%ld)",
                         userList[i].username, userList[i].userId, userList[i].groupId, userList[i].maximumPasswordAge);
-                    OsConfigCaptureReason(reason, "User '%s' (%u, %u) password has no expiration date (%ld)",
+                    OsConfigCaptureReason(reason, "Password for user '%s' (%u, %u) has no expiration date (%ld)",
                         userList[i].username, userList[i].userId, userList[i].groupId, userList[i].maximumPasswordAge);
+                    status = ENOENT;
+                }
+                else if (userList[i].lastPasswordChange < 0)
+                {
+                    OsConfigLogError(log, "CheckPasswordExpirationLessThan: password for user '%s' (%u, %u) has no recorded change date (%ld)",
+                        userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange);
+                    OsConfigCaptureReason(reason, "Password for user '%s' (%u, %u) has no recorded last change date (%ld)",
+                        userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange);
                     status = ENOENT;
                 }
                 else
                 {
-                    if (userList[i].lastPasswordChange < 0)
-                    {
-                        OsConfigLogInfo(log, "CheckPasswordExpirationLessThan: password for user '%s' (%u, %u) has no recorded change date (%ld)",
-                            userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange);
-                        passwordExpirationDate = currentDate + userList[i].maximumPasswordAge;
-                    }
-                    else
-                    {
-                        passwordExpirationDate = userList[i].lastPasswordChange + userList[i].maximumPasswordAge;
-                    }
+                    passwordExpirationDate = userList[i].lastPasswordChange + userList[i].maximumPasswordAge;
 
                     if (passwordExpirationDate >= currentDate)
                     {
@@ -2450,7 +2449,7 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                         {
                             OsConfigLogError(log, "CheckPasswordExpirationLessThan: password for user '%s' (%u, %u) will expire in %ld days, more than requested maximum of %ld days",
                                 userList[i].username, userList[i].userId, userList[i].groupId, passwordExpirationDate - currentDate, days);
-                            OsConfigCaptureReason(reason, "User '%s' (%u, %u) password will expire in %ld days, more than requested maximum of %ld days",
+                            OsConfigCaptureReason(reason, "Password for user '%s' (%u, %u) will expire in %ld days, more than requested maximum of %ld days",
                                 userList[i].username, userList[i].userId, userList[i].groupId, passwordExpirationDate - currentDate, days);
                             status = ENOENT;
                         }
@@ -2463,6 +2462,7 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                             userList[i].username, userList[i].userId, userList[i].groupId, currentDate - passwordExpirationDate, currentDate, passwordExpirationDate);
                     }
                 }
+            }
             }
         }
     }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2360,7 +2360,7 @@ int EnsureUsersHaveDatesOfLastPasswordChanges(void* log)
             else if (userList[i].lastPasswordChange < 0)
             {
                 OsConfigLogInfo(log, "EnsureUsersHaveDatesOfLastPasswordChanges: password for user '%s' (%u, %u) was never changed",
-                    userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange, currentDate);
+                    userList[i].username, userList[i].userId, userList[i].groupId, userList[i].lastPasswordChange);
 
                 if (NULL == (command = FormatAllocateString(commandTemplate, currentDate, userList[i].username)))
                 {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2372,7 +2372,6 @@ int EnsureUsersHaveDatesOfLastPasswordChanges(void* log)
                 {
                     if (0 == (_status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
                     {
-                        userList[i].maximumPasswordAge = days;
                         OsConfigLogInfo(log, "EnsureUsersHaveDatesOfLastPasswordChanges: user '%s' (%u, %u) date of last password change is now set to %ld days since epoch (today)",
                             userList[i].username, userList[i].userId, userList[i].groupId, currentDate);
                     }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2463,7 +2463,6 @@ int CheckPasswordExpirationLessThan(long days, char** reason, void* log)
                     }
                 }
             }
-            }
         }
     }
 

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -107,6 +107,7 @@ int CheckMinDaysBetweenPasswordChanges(long days, char** reason, void* log);
 int SetMinDaysBetweenPasswordChanges(long days, void* log);
 int CheckMaxDaysBetweenPasswordChanges(long days, char** reason, void* log);
 int SetMaxDaysBetweenPasswordChanges(long days, void* log);
+int EnsureUsersHaveDatesOfLastPasswordChanges(void* log);
 int CheckPasswordExpirationLessThan(long days, char** reason, void* log);
 int CheckPasswordExpirationWarning(long days, char** reason, void* log);
 int SetPasswordExpirationWarning(long days, void* log);


### PR DESCRIPTION
## Description

For ASB v2's remediateEnsurePasswordExpiration ensure that all user passwords have dates of last changes and if none, set those to today's dates at the time the remediation is ran. This together with setting the maximum number of days between password changes ensure the right expiration for user passwords. So new user accounts that never changed their password and have their passwords to never expire also get the correct expiration applied in the desired number of days from today.

Also removing from auditEnsurePasswordExpiration the previous workaround to assume that when there is no last password change then the expiration is from today as this is not only not necessary anymore, but can also hide audit failures for first time passwords without expiration dates.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.