### PR TITLE
Fixing ASB v2's remediateEnsureLockoutForFailedPasswordAttempts for Red Hat based distributions

### DIFF
--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -222,7 +222,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     // - 'unlock_time=900': allow access after 900 seconds (15 minutes) following a failed attempt
 
     const char* pamTally2Line = "auth required pam_tally2.so file=/var/log/tallylog onerr=fail audit silent deny=5 unlock_time=900 even_deny_root\n";
-    const char* pamFailLockLine = "auth required [default=die] pam_faillock.so preauth silent audit deny=3 unlock_time=900 even_deny_roo\nt";
+    const char* pamFailLockLine = "auth required [default=die] pam_faillock.so preauth silent audit deny=3 unlock_time=900 even_deny_root\n";
     const char* etcPamdLogin = "/etc/pam.d/login";
     const char* etcPamdSystemAuth = "/etc/pam.d/system-auth";
     const char* etcPamdPasswordAuth = "/etc/pam.d/password-auth";


### PR DESCRIPTION
## Description

Fixing a bug in the ASB v2's remediateEnsureLockoutForFailedPasswordAttempts implementation for Red Hat based distributions leading to corrupted /etc/pam.d/system-auth and denial of users to execute sudo. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.