### PR TITLE
Updating the ASB v2 and SSH Posture Control test policy definitions

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "86706A44CC0900D731FEAF3A5E439B8EF200F154323062D5B89A7694A700D9ED",
+                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "86706A44CC0900D731FEAF3A5E439B8EF200F154323062D5B89A7694A700D9ED",
+                                                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "86706A44CC0900D731FEAF3A5E439B8EF200F154323062D5B89A7694A700D9ED",
+                                                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "86706A44CC0900D731FEAF3A5E439B8EF200F154323062D5B89A7694A700D9ED",
+                                                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "81EC751F6DDAE11CB41CEC7B4D0E23395111D2C6A43910E29D72E2E266DF8A67",
+                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "81EC751F6DDAE11CB41CEC7B4D0E23395111D2C6A43910E29D72E2E266DF8A67",
+                                                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "81EC751F6DDAE11CB41CEC7B4D0E23395111D2C6A43910E29D72E2E266DF8A67",
+                                                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "81EC751F6DDAE11CB41CEC7B4D0E23395111D2C6A43910E29D72E2E266DF8A67",
+                                                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {


### PR DESCRIPTION
## Description

Updating the ASB v2 and SSH Posture Control test policy definitions to match todays and latest set of published packages.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.