### PR TITLE
Improving remediateEnsureLockoutForFailedPasswordAttempts, remediateEnsurePasswordCreationRequirements and remediateEnsureCoreDumpsAreRestricted and avoiding duplicating same line multiple times when replacing in a file

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
+                "contentHash": "D0A9C2B0CD5851D0BB8C130A8F7DB554D2696E3322595E0D374F033DFA291C0F",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
+                                                "contentHash": "D0A9C2B0CD5851D0BB8C130A8F7DB554D2696E3322595E0D374F033DFA291C0F",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
+                                                "contentHash": "D0A9C2B0CD5851D0BB8C130A8F7DB554D2696E3322595E0D374F033DFA291C0F",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "41F6FB2C80A2CF6FA877D471998DAB8B48F5515C3E8D777D66A1F0F212579227",
+                                                "contentHash": "D0A9C2B0CD5851D0BB8C130A8F7DB554D2696E3322595E0D374F033DFA291C0F",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
+                "contentHash": "97DAEAE6E915A690FCF4D1BD533765F61C72DF4F840B57AA2742636B42F29C55",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
+                                                "contentHash": "97DAEAE6E915A690FCF4D1BD533765F61C72DF4F840B57AA2742636B42F29C55",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
+                                                "contentHash": "97DAEAE6E915A690FCF4D1BD533765F61C72DF4F840B57AA2742636B42F29C55",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "D1FBDBDED79F5479CEA47E79630223346647C9D927892A23024C467F3C99B0FC",
+                                                "contentHash": "97DAEAE6E915A690FCF4D1BD533765F61C72DF4F840B57AA2742636B42F29C55",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -580,7 +580,7 @@ static const char* g_logrotateTimer = "logrotate.timer";
 static const char* g_telnet = "telnet";
 static const char* g_rcpSocket = "rcp.socket";
 static const char* g_rshSocket = "rsh.socket";
-static const char* g_hardCoreZero = "hard core 0";
+static const char* g_hardCoreZero = "* hard core 0";
 static const char* g_fsSuidDumpable = "fs.suid_dumpable = 0";
 static const char* g_bootGrubGrubConf = "/boot/grub/grub.conf";
 static const char* g_bootGrub2GrubCfg = "/boot/grub2/grub.cfg";

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1588,7 +1588,7 @@ static char* AuditEnsureCoreDumpsAreRestricted(void* log)
 {
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckLineFoundNotCommentedOut(g_etcSecurityLimitsConf, '#', g_hardCoreZero, &reason, log));
-    CheckLineFoundNotCommentedOut(g_sysCtlConf, '#', g_fsSuidDumpable, &reason, log)
+    CheckLineFoundNotCommentedOut(g_sysCtlConf, '#', g_fsSuidDumpable, &reason, log);
     return reason;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3189,7 +3189,7 @@ static int RemediateEnsureCoreDumpsAreRestricted(char* value, void* log)
     {
         if (false == FileExists(g_sysCtlConf))
         {
-            status = SecureSaveToFile(g_sysCtlConf, g_fsSuidDumpable, strlen(g_fsSuidDumpable), log);
+            status = SavePayloadToFile(g_sysCtlConf, g_fsSuidDumpable, strlen(g_fsSuidDumpable), log) ? 0 : ENOENT;
         }
         else
         {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3186,7 +3186,7 @@ static int RemediateEnsureCoreDumpsAreRestricted(char* value, void* log)
 {
     int status = 0;
     UNUSED(value);
-    if (0 == (status = ReplaceMarkedLinesInFile(g_etcSecurityLimitsConf, "hard core", g_hardCoreZero, '#', true, log))
+    if (0 == (status = ReplaceMarkedLinesInFile(g_etcSecurityLimitsConf, "hard core", g_hardCoreZero, '#', true, log)))
     {
         if (false == FileExists(g_sysCtlConf))
         {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -504,7 +504,6 @@ static const char* g_etcSambaConf = "/etc/samba/smb.conf";
 static const char* g_etcPostfixMainCf = "/etc/postfix/main.cf";
 static const char* g_etcCronDailyLogRotate = "/etc/cron.daily/logrotate";
 static const char* g_etcSecurityLimitsConf = "/etc/security/limits.conf";
-static const char* g_etcSecurityLimitsD = "/etc/security/limits.d";
 static const char* g_sysCtlConf = "/etc/sysctl.d/99-sysctl.conf";
 
 static const char* g_home = "/home";

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1615,10 +1615,14 @@ static char* AuditEnsurePasswordCreationRequirements(void* log)
 static char* AuditEnsureLockoutForFailedPasswordAttempts(void* log)
 {
     const char* pamFailLockSo = "pam_faillock.so";
+    const char* pamTally2So = "pam_tally2.so";
     char* reason = NULL;
     RETURN_REASON_IF_ZERO(CheckLockoutForFailedPasswordAttempts(g_etcPamdSystemAuth, pamFailLockSo, '#', &reason, log));
     RETURN_REASON_IF_ZERO(CheckLockoutForFailedPasswordAttempts(g_etcPamdPasswordAuth, pamFailLockSo, '#', &reason, log));
-    CheckLockoutForFailedPasswordAttempts(g_etcPamdLogin, "pam_tally2.so", '#', &reason, log);
+    RETURN_REASON_IF_ZERO(CheckLockoutForFailedPasswordAttempts(g_etcPamdLogin, pamFailLockSo, '#', &reason, log));
+    RETURN_REASON_IF_ZERO(CheckLockoutForFailedPasswordAttempts(g_etcPamdSystemAuth, pamTally2So, '#', &reason, log));
+    RETURN_REASON_IF_ZERO(CheckLockoutForFailedPasswordAttempts(g_etcPamdPasswordAuth, pamTally2So, '#', &reason, log));
+    CheckLockoutForFailedPasswordAttempts(g_etcPamdLogin, pamTally2So, '#', &reason, log);
     return reason;
 }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -933,10 +933,18 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
                     {
                         if ((commentCharacter != line[0]) && (EOL != line[0]) && (NULL != newline) && (1 < newlineLength))
                         {
-                            memset(line, 0, lineMax + 1);
-                            memcpy(line, newline, (newlineLength > lineMax) ? lineMax : newlineLength);
-                            skipLine = false;
-                            replacedLine = true;
+                            if (replacedLine)
+                            {
+                                // Already replaced this line once
+                                skipLine = true;
+                            }
+                            else
+                            {
+                                memset(line, 0, lineMax + 1);
+                                memcpy(line, newline, (newlineLength > lineMax) ? lineMax : newlineLength);
+                                skipLine = false;
+                                replacedLine = true;
+                            }
                         }
                         else if (commentCharacter == line[0])
                         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -57,10 +57,7 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
         return ENOMEM;
     }
 
-    if (0 != (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
-    {
-        OsConfigLogError(log, "'%s' failed with %d (errno: %d)", command, status, errno);
-    }
+    status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log);
 
     FREE_MEMORY(command);
 
@@ -101,7 +98,7 @@ int IsPackageInstalled(const char* packageName, void* log)
     }
     else
     {
-        OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is not found (%d)", packageName, status);
+        OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is not found (%d, errno: %d)", packageName, status, errno);
     }
 
     return status;
@@ -191,7 +188,7 @@ int InstallOrUpdatePackage(const char* packageName, void* log)
     }
     else
     {
-        OsConfigLogError(log, "InstallOrUpdatePackage: installation or update of package '%s' failed with %d", packageName, status);
+        OsConfigLogError(log, "InstallOrUpdatePackage: installation or update of package '%s' failed with %d (errno: %d)", packageName, status, errno);
     }
 
     return status;
@@ -254,7 +251,7 @@ int UninstallPackage(const char* packageName, void* log)
         }
         else
         {
-            OsConfigLogError(log, "UninstallPackage: uninstallation of package '%s' failed with %d", packageName, status);
+            OsConfigLogError(log, "UninstallPackage: uninstallation of package '%s' failed with %d (errno: %d)", packageName, status, errno);
         }
     }
     else if (EINVAL != status)

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -247,7 +247,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* pamFaillockSoPath = "/lib64/security/pam_faillock.so";
     const char* pamTally2SoPath = "/lib64/security/pam_tally2.so";
     const char* marker = "auth";
-    const char* pam = "pam";
+    const char* libPamCrackLib = "libpam-cracklib";
     const char* libPamModules = "libpam-modules";
     int status = 0, _status = 0;
     bool pamFaillockSoExists = (0 == CheckFileExists(pamFaillockSoPath, NULL, log)) ? true : false;
@@ -255,7 +255,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if ((false == pamFaillockSoExists) && (false == pamTally2SoExists))
     {
-        if (0 == InstallPamModulePackageIfNotPresent(pam, libPamModules, log))
+        if (0 == InstallPamModulePackageIfNotPresent(libPamCrackLib, libPamModules, log))
         {
             pamFaillockSoExists = (0 == CheckFileExists(pamFaillockSoPath, NULL, log)) ? true : false;
             pamTally2SoExists = (0 == CheckFileExists(pamTally2SoPath, NULL, log)) ? true : false;

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -320,7 +320,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
             {
                 _status = ReplaceMarkedLinesInFile(pamConfigurations[i], pamTally2So, pamTally2Line, '#', true, log);
             }
-            else if (pamTallySoExists && pamDenyExists)
+            else if (pamTallySoExists && pamDenySoExists)
             {
                 _status = ReplaceMarkedLinesInFile(pamConfigurations[i], pamTallySo, pamTallyDenyLine, '#', true, log);
             }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -700,20 +700,18 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
         if ((false == pamPwQualitySoExists) && (false == pamCrackLibSoExists))
         {
-            OsConfigLogError(log, "SetPasswordCreationRequirements: neither 'pam_pwquality.so' or 'pam_cracklib.so' PAM module is present, remediation may not work");
+            OsConfigLogError(log, "SetPasswordCreationRequirements: neither 'pam_pwquality.so' or 'pam_cracklib.so' PAM modules are present, remediation may not work");
+        }
+
+        if (NULL != (line = FormatAllocateString(etcPamdCommonPasswordLineTemplate, 
+            pamCrackLibSoExists ? pamCrackLib : pamPwQuality, retry, minlen, lcredit, ucredit, ocredit, dcredit)))
+        {
+            status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, pamCrackLibSoExists ? pamCrackLib : pamPwQuality, line, '#', true, log);
+            FREE_MEMORY(line);
         }
         else
         {
-            if (NULL != (line = FormatAllocateString(etcPamdCommonPasswordLineTemplate, 
-                pamCrackLibSoExists ? pamCrackLib : pamPwQuality, retry, minlen, lcredit, ucredit, ocredit, dcredit)))
-            {
-                status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, pamCrackLibSoExists ? pamCrackLib : pamPwQuality, line, '#', true, log);
-                FREE_MEMORY(line);
-            }
-            else
-            {
-                OsConfigLogError(log, "SetPasswordCreationRequirements: out of memory when allocating new line for '%s'", g_etcPamdCommonPassword);
-            }
+            OsConfigLogError(log, "SetPasswordCreationRequirements: out of memory when allocating new line for '%s'", g_etcPamdCommonPassword);
         }
     }
 

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -38,11 +38,12 @@ static char* FindPamModule(const char* pamModule, void* log)
     const char* paths[] = {"/usr/lib/x86_64-linux-gnu/security/%s", "/lib/security/%s", "/usr/lib/security/%s", "/lib64/security/%s"};
     int numPaths = ARRAY_SIZE(paths);
     char* result = NULL;
+    int status = 0;
 
     if (NULL == pamModule)
     {
         OsConfigLogError(log, "FindPamModule: invalid argument");
-        return EINVAL;
+        return NULL;
     }
 
     for (i = 0; i < numPaths; i++)
@@ -61,7 +62,6 @@ static char* FindPamModule(const char* pamModule, void* log)
         else
         {
             OsConfigLogError(log, "FindPamModule: out of memory");
-            status = EINVAL;
             break;
         }
     }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -269,7 +269,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     //
     // For etc/pam.d/login, /etc/pam.d/system-auth and /etc/pam.d/password-auth when pam_faillock.so exists:
     //
-    // 'auth required [default=die] pam_faillock.so preauth silent audit deny=3 unlock_time=900 even_deny_root'
+    // 'auth required pam_faillock.so preauth silent audit deny=3 unlock_time=900 even_deny_root'
     //
     // For etc/pam.d/login, /etc/pam.d/system-auth and /etc/pam.d/password-auth when pam_faillock.so does not exist and pam_tally2.so exists:
     //
@@ -283,7 +283,6 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     //
     // - 'auth': specifies that the module is invoked during authentication
     // - 'required': the module is essential for authentication to proceed
-    // - '[default=die]': sets the default behavior if the module fails (e.g., due to too many failed login attempts), then the authentication process will terminate immediately
     // - 'file=/var/log/tallylog': the default log file used to keep login counts
     // - 'onerr=fail': if an error occurs (e.g., unable to open a file), return with a PAM error code
     // - 'audit': generate an audit record for this event

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -700,15 +700,14 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
         if ((false == pamPwQualitySoExists) && (false == pamCrackLibSoExists))
         {
-            OsConfigLogError(log, "SetPasswordCreationRequirements: neither 'pam_pwquality.so' or 'pam_cracklib.so' PAM module is present, cannot remediate");
-            status = ENOENT;
+            OsConfigLogError(log, "SetPasswordCreationRequirements: neither 'pam_pwquality.so' or 'pam_cracklib.so' PAM module is present, remediation may not work");
         }
         else
         {
             if (NULL != (line = FormatAllocateString(etcPamdCommonPasswordLineTemplate, 
-                pamPwQualitySoExists ? pamPwQuality : pamCrackLib, retry, minlen, lcredit, ucredit, ocredit, dcredit)))
+                pamCrackLibSoExists ? pamCrackLib : pamPwQuality, retry, minlen, lcredit, ucredit, ocredit, dcredit)))
             {
-                status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, pamPwQualitySoExists ? pamPwQuality : pamCrackLib, line, '#', true, log);
+                status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, pamCrackLibSoExists ? pamCrackLib : pamPwQuality, line, '#', true, log);
                 FREE_MEMORY(line);
             }
             else

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -265,19 +265,18 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     if ((false == pamFaillockSoExists) && (false == pamTally2SoExists))
     {
         OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: neither 'pam_faillock.so' or 'pam_tally2.so' PAM modules are present, lockout for failed password attempts may not work");
-        // Do not fail, this is a normal limitation for some distributions such as Ubuntu 22.04
+        // Do not fail, this is a normal limitation for some distributions such as Ubuntu 22.04, just consider best default (pam_faillock.so)
+        pamFaillockSoExists = true;
     }
 
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))
     {
-        status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, marker, 
-            pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log);
+        status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, marker, pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log);
     }
 
     if (0 == CheckFileExists(etcPamdPasswordAuth, NULL, log))
     {
-        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdPasswordAuth, marker, 
-            pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log))) && (0 == status))
+        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdPasswordAuth, marker, pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log))) && (0 == status))
         {
             status = _status;
         }
@@ -285,8 +284,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if (0 == CheckFileExists(etcPamdLogin, NULL, log))
     {
-        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdLogin, marker, 
-            pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log))) && (0 == status))
+        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdLogin, marker, pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log))) && (0 == status))
         {
             status = _status;
         }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -685,13 +685,13 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     {
         if ((false == pamPwQualitySoExists) && (false == pamCrackLibSoExists))
         {
-            if (0 == InstallPamModulePackageIfNotPresent("pam_pwquality", "libpam-pwquality", log))
+            if (0 == InstallPamModulePackageIfNotPresent(pamPwQuality, libPamPwQuality, log))
             {
                 pamPwQualitySoExists = (0 == CheckFileExists(pamPwQualitySoPath, NULL, log)) ? true : false;
             }
             else
             {
-                if (0 == InstallPamModulePackageIfNotPresent("pam_cracklib", "libpam-cracklib", log))
+                if (0 == InstallPamModulePackageIfNotPresent(pamCrackLib, libPamCrackLib, log))
                 {
                     pamCrackLibSoExists = (0 == CheckFileExists(pamCrackLibSoPath, NULL, log)) ? true : false;
                 }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -305,13 +305,13 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))
     {
-        status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, pamFaillockSoExists ? pamFailLockSo : pamTally2So, 
+        status = ReplaceMarkedLinesInFile(etcPamdSystemAuth, pamFaillockSoExists ? pamFaillockSo : pamTally2So,
             pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log);
     }
 
     if (0 == CheckFileExists(etcPamdPasswordAuth, NULL, log))
     {
-        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdPasswordAuth, pamFaillockSoExists ? pamFailLockSo : pamTally2So, 
+        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdPasswordAuth, pamFaillockSoExists ? pamFaillockSo : pamTally2So,
             pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log))) && (0 == status))
         {
             status = _status;
@@ -320,7 +320,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if (0 == CheckFileExists(etcPamdLogin, NULL, log))
     {
-        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdLogin, pamFaillockSoExists ? pamFailLockSo : pamTally2So, 
+        if ((0 != (_status = ReplaceMarkedLinesInFile(etcPamdLogin, pamFaillockSoExists ? pamFaillockSo : pamTally2So,
             pamFaillockSoExists ? pamFailLockLine : pamTally2Line, '#', true, log))) && (0 == status))
         {
             status = _status;

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -38,7 +38,7 @@ static char* FindPamModule(const char* pamModule, void* log)
     const char* paths[] = {"/usr/lib/x86_64-linux-gnu/security/%s", "/lib/security/%s", "/usr/lib/security/%s", "/lib64/security/%s"};
     int numPaths = ARRAY_SIZE(paths);
     char* result = NULL;
-    int status = 0;
+    int status = 0, i = 0;
 
     if (NULL == pamModule)
     {
@@ -300,7 +300,9 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* pamDenySo = "pam_deny.so";
     const char* pamConfigurations[] = {"/etc/pam.d/login", "/etc/pam.d/system-auth", "/etc/pam.d/password-auth", "/etc/pam.d/common-auth"};
     int numPamConfigurations = ARRAY_SIZE(pamConfigurations);
-    char* pamModulePath = NULL, pamModulePath2 = NULL, line = NULL;
+    char* pamModulePath = NULL;
+    char* pamModulePath2 = NULL;
+    char* line = NULL;
     int i = 0, status = 0, _status = 0;
 
     EnsurePamModulePackagesAreInstalled(log);

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -52,6 +52,7 @@ static int IsPamModulePresent(const char* pamModule, void* log)
         {
             if (0 == CheckFileExists(pamPath, NULL, log))
             {
+                status = 0;
                 break;
             }
             else

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -123,7 +123,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     {
         return ENOENT;
     }
-    
+
     if (NULL != (newline = FormatAllocateString(endsHereIfFailsTemplate, pamModulePath, g_remember, remember)))
     {
         if (0 == CheckFileExists(g_etcPamdSystemAuth, NULL, log))

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -291,7 +291,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     // - 'deny=5': deny access if the tally (failed login attempts) for this user exceeds 5 times
     // - 'unlock_time=900': allow access after 900 seconds (15 minutes) following a failed attempt
 
-    const char* pamFailLockLineTemplate = "auth required [default=die] %s preauth silent audit deny=3 unlock_time=900 even_deny_root\n";
+    const char* pamFailLockLineTemplate = "auth required %s preauth silent audit deny=3 unlock_time=900 even_deny_root\n";
     const char* pamTally2LineTemplate = "auth required %s file=/var/log/tallylog onerr=fail audit silent deny=5 unlock_time=900 even_deny_root\n";
     const char* pamTallyDenyLineTemplate = "auth required %s onerr=fail deny=3 unlock_time=900\nauth required %s\n";
     const char* pamFaillockSo = "pam_faillock.so";

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -761,8 +761,8 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     {
         EnsurePamModulePackagesAreInstalled(log);
 
-        pamPwQualitySoExists = (NULL != (pathModulePath = FindPamModule(pamPwQualitySo, log))) ? true : false;
-        pamCrackLibSoExists = (NULL != (pathModulePath2 = FindPamModule(pamCrackLibSo, log))) ? true : false;
+        pamPwQualitySoExists = (NULL != (pamModulePath = FindPamModule(pamPwQualitySo, log))) ? true : false;
+        pamCrackLibSoExists = (NULL != (pamModulePath2 = FindPamModule(pamCrackLibSo, log))) ? true : false;
 
         if (pamPwQualitySoExists || pamCrackLibSoExists)
         {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -746,6 +746,8 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     int numEntries = ARRAY_SIZE(entries);
     bool pamPwQualitySoExists = false;
     bool pamCrackLibSoExists = false;
+    char* pamModulePath = NULL;
+    char* pamModulePath2 = NULL;
     int i = 0, status = 0, _status = 0;
     char* line = NULL;
 
@@ -759,12 +761,12 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     {
         EnsurePamModulePackagesAreInstalled(log);
 
-        pamPwQualitySoExists = (0 == FindPamModule(pamPwQualitySo, log)) ? true : false;
-        pamCrackLibSoExists = (0 == FindPamModule(pamCrackLibSo, log)) ? true : false;
+        pamPwQualitySoExists = (NULL != (pathModulePath = FindPamModule(pamPwQualitySo, log))) ? true : false;
+        pamCrackLibSoExists = (NULL != (pathModulePath2 = FindPamModule(pamCrackLibSo, log))) ? true : false;
 
         if (pamPwQualitySoExists || pamCrackLibSoExists)
         {
-            if (NULL != (line = FormatAllocateString(etcPamdCommonPasswordLineTemplate, pamPwQualitySoExists ? pamPwQualitySo : pamCrackLibSo, 
+            if (NULL != (line = FormatAllocateString(etcPamdCommonPasswordLineTemplate, pamPwQualitySoExists ? pamModulePath : pamModulePath2,
                 retry, minlen, lcredit, ucredit, ocredit, dcredit)))
             {
                 status = ReplaceMarkedLinesInFile(g_etcPamdCommonPassword, pamPwQualitySoExists ? pamPwQualitySo : pamCrackLibSo, line, '#', true, log);
@@ -779,6 +781,9 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
         {
             status = ENOENT;
         }
+
+        FREE_MEMORY(pamModulePath);
+        FREE_MEMORY(pamModulePath2);
     }
 
     if (0 == CheckFileExists(g_etcSecurityPwQualityConf, NULL, log))

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -751,11 +751,11 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     int i = 0, status = 0, _status = 0;
     char* line = NULL;
 
-    if (0 == (status = CheckPasswordCreationRequirements(retry, minlen, minclass, lcredit, dcredit, ucredit, ocredit, NULL, log)))
+    /*if (0 == (status = CheckPasswordCreationRequirements(retry, minlen, minclass, lcredit, dcredit, ucredit, ocredit, NULL, log)))
     {
         OsConfigLogInfo(log, "SetPasswordCreationRequirements: nothing to remediate");
         return 0;
-    }
+    }*/
 
     if (0 == CheckFileExists(g_etcPamdCommonPassword, NULL, log))
     {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -35,7 +35,7 @@ int CheckEnsurePasswordReuseIsLimited(int remember, char** reason, void* log)
 
 static int IsPamModulePresent(const char* pamModule, void* log)
 {
-    const char* paths[] = { "/usr/lib/x86_64-linux-gnu/security/%s", "/lib/security/%s", "/usr/lib/security/%s", "/lib64/security/%s" };
+    const char* paths[] = {"/usr/lib/x86_64-linux-gnu/security/%s", "/lib/security/%s", "/usr/lib/security/%s", "/lib64/security/%s"};
     int numPaths = ARRAY_SIZE(paths);
     char* pamPath = NULL;
     int i = 0, status = 0;
@@ -50,15 +50,11 @@ static int IsPamModulePresent(const char* pamModule, void* log)
     {
         if (NULL != (pamPath = FormatAllocateString(paths[i], pamModule)))
         {
-            if (0 == CheckFileExists(pamPath, NULL, log))
+            status = CheckFileExists(pamPath, NULL, log);
+            FREE_MEMORY(pamPath);
+            if (0 == status)
             {
-                status = 0;
                 break;
-            }
-            else
-            {
-                status = ENOENT;
-                continue;
             }
         }
         else
@@ -79,7 +75,7 @@ static int IsPamModulePresent(const char* pamModule, void* log)
 
 static void EnsurePamModulePackagesAreInstalled(void* log)
 {
-    const char* pamPackages[] = {"pam", "libpam-modules", "pam_pwquality", "libpam-cracklib"};
+    const char* pamPackages[] = {"pam", "libpam-modules", "pam_pwquality", "libpam-pwquality", "libpam-cracklib"};
     int numPamPackages = ARRAY_SIZE(pamPackages);
     int i = 0;
 
@@ -261,13 +257,13 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     // These configuration lines are used in the PAM (Pluggable Authentication Module) settings to count
     // number of attempted accesses and lock user accounts after a specified number of failed login attempts.
     //
-    // For etc/pam.d/login, /etc/pam.d/system-auth and /etc/pam.d/password-auth when pam_faillock.so does not exist and pam_tally2.so exists:
-    //
-    // 'auth required pam_tally2.so file=/var/log/tallylog onerr=fail audit silent deny=5 unlock_time=900 even_deny_root'
-    //
     // For etc/pam.d/login, /etc/pam.d/system-auth and /etc/pam.d/password-auth when pam_faillock.so exists:
     //
     // 'auth required [default=die] pam_faillock.so preauth silent audit deny=3 unlock_time=900 even_deny_root'
+    //
+    // For etc/pam.d/login, /etc/pam.d/system-auth and /etc/pam.d/password-auth when pam_faillock.so does not exist and pam_tally2.so exists:
+    //
+    // 'auth required pam_tally2.so file=/var/log/tallylog onerr=fail audit silent deny=5 unlock_time=900 even_deny_root'
     //
     // Otherwise, if pam_tally.so and  pam_deny.so exist:
     //
@@ -278,8 +274,6 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     // - 'auth': specifies that the module is invoked during authentication
     // - 'required': the module is essential for authentication to proceed
     // - '[default=die]': sets the default behavior if the module fails (e.g., due to too many failed login attempts), then the authentication process will terminate immediately
-    // - 'pam_tally2.so': the PAM pam_tally2 module, which maintains a count of attempted accesses during the authentication process
-    // - 'pam_faillock.so': the PAM_faillock module, which maintains a list of failed authentication attempts per user
     // - 'file=/var/log/tallylog': the default log file used to keep login counts
     // - 'onerr=fail': if an error occurs (e.g., unable to open a file), return with a PAM error code
     // - 'audit': generate an audit record for this event
@@ -287,41 +281,32 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     // - 'deny=5': deny access if the tally (failed login attempts) for this user exceeds 5 times
     // - 'unlock_time=900': allow access after 900 seconds (15 minutes) following a failed attempt
 
-    const char* pamTally2Line = "auth required pam_tally2.so file=/var/log/tallylog onerr=fail audit silent deny=5 unlock_time=900 even_deny_root\n";
     const char* pamFailLockLine = "auth required [default=die] pam_faillock.so preauth silent audit deny=3 unlock_time=900 even_deny_root\n";
+    const char* pamTally2Line = "auth required pam_tally2.so file=/var/log/tallylog onerr=fail audit silent deny=5 unlock_time=900 even_deny_root\n";
     const char* pamTallyDenyLine = "auth required pam_tally.so onerr=fail deny=3 unlock_time=900\nauth required pam_deny.so\n";
     const char* pamFaillockSo = "pam_faillock.so";
     const char* pamTally2So = "pam_tally2.so";
     const char* pamTallySo = "pam_tally.so";
     const char* pamDenySo = "pam_deny.so";
-    const char* pamConfigurations[] = { "/etc/pam.d/login", "/etc/pam.d/system-auth", "/etc/pam.d/password-auth", "/etc/pam.d/common-auth"};
+    const char* pamConfigurations[] = {"/etc/pam.d/login", "/etc/pam.d/system-auth", "/etc/pam.d/password-auth", "/etc/pam.d/common-auth"};
     int numPamConfigurations = ARRAY_SIZE(pamConfigurations);
-    bool pamFaillockSoExists = false;
-    bool pamTally2SoExists = false;
-    bool pamTallySoExists = false;
-    bool pamDenySoExists = false;
     int i = 0, status = 0, _status = 0;
 
     EnsurePamModulePackagesAreInstalled(log);
-
-    pamFaillockSoExists = (0 == IsPamModulePresent(pamFaillockSo, log)) ? true : false;
-    pamTally2SoExists = (0 == IsPamModulePresent(pamTally2So, log)) ? true : false;
-    pamTallySoExists = (0 == IsPamModulePresent(pamTallySo, log)) ? true : false;
-    pamDenySoExists = (0 == IsPamModulePresent(pamDenySo, log)) ? true : false;
 
     for (i = 0; i < numPamConfigurations; i++)
     {
         if (0 == CheckFileExists(pamConfigurations[i], NULL, log))
         {
-            if (pamFaillockSoExists)
+            if (0 == IsPamModulePresent(pamFaillockSo, log))
             {
                 _status = ReplaceMarkedLinesInFile(pamConfigurations[i], pamFaillockSo, pamFailLockLine, '#', true, log);
             }
-            else if (pamTally2SoExists)
+            else if (0 == IsPamModulePresent(pamTally2So, log))
             {
                 _status = ReplaceMarkedLinesInFile(pamConfigurations[i], pamTally2So, pamTally2Line, '#', true, log);
             }
-            else if (pamTallySoExists && pamDenySoExists)
+            else if ((0 == IsPamModulePresent(pamTallySo, log)) && (0 == IsPamModulePresent(pamDenySo, log)))
             {
                 _status = ReplaceMarkedLinesInFile(pamConfigurations[i], pamTallySo, pamTallyDenyLine, '#', true, log);
             }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -264,9 +264,8 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if ((false == pamFaillockSoExists) && (false == pamTally2SoExists))
     {
-        OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: neither 'pam_faillock.so' or 'pam_tally2.so' PAM modules are present, cannot set lockout for failed password attempts");
+        OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: neither 'pam_faillock.so' or 'pam_tally2.so' PAM modules are present, lockout for failed password attempts may not work");
         // Do not fail, this is a normal limitation for some distributions such as Ubuntu 22.04
-        return 0;
     }
 
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -255,7 +255,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if ((false == pamFaillockSoExists) && (false == pamTally2SoExists))
     {
-        if (0 == InstallPamModulePackageIfNotPresent(libPamModules, pam, log))
+        if (0 == InstallPamModulePackageIfNotPresent(pam, libPamModules, log))
         {
             pamFaillockSoExists = (0 == CheckFileExists(pamFaillockSoPath, NULL, log)) ? true : false;
             pamTally2SoExists = (0 == CheckFileExists(pamTally2SoPath, NULL, log)) ? true : false;

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -111,13 +111,12 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
 
     const char* endsHereIfFailsTemplate = "password required %s sha512 shadow %s=%d retry=3\n";
     const char* pamUnixSo = "pam_unix.so";
-    
     char* newline = NULL;
     int status = 0, _status = 0;
 
     EnsurePamModulePackagesAreInstalled(log);
 
-    if (0 != status = IsPamModulePresent(pamUnixSo, log))
+    if (0 != IsPamModulePresent(pamUnixSo, log))
     {
         return ENOENT;
     }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -751,12 +751,6 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
     int i = 0, status = 0, _status = 0;
     char* line = NULL;
 
-    /*if (0 == (status = CheckPasswordCreationRequirements(retry, minlen, minclass, lcredit, dcredit, ucredit, ocredit, NULL, log)))
-    {
-        OsConfigLogInfo(log, "SetPasswordCreationRequirements: nothing to remediate");
-        return 0;
-    }*/
-
     if (0 == CheckFileExists(g_etcPamdCommonPassword, NULL, log))
     {
         EnsurePamModulePackagesAreInstalled(log);

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -247,7 +247,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
     const char* pamFaillockSoPath = "/lib64/security/pam_faillock.so";
     const char* pamTally2SoPath = "/lib64/security/pam_tally2.so";
     const char* marker = "auth";
-    const char* libPamCrackLib = "libpam-cracklib";
+    const char* pam = "pam";
     const char* libPamModules = "libpam-modules";
     int status = 0, _status = 0;
     bool pamFaillockSoExists = (0 == CheckFileExists(pamFaillockSoPath, NULL, log)) ? true : false;
@@ -255,7 +255,7 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if ((false == pamFaillockSoExists) && (false == pamTally2SoExists))
     {
-        if (0 == InstallPamModulePackageIfNotPresent(libPamCrackLib, libPamModules, log))
+        if (0 == InstallPamModulePackageIfNotPresent(libPamModules, pam, log))
         {
             pamFaillockSoExists = (0 == CheckFileExists(pamFaillockSoPath, NULL, log)) ? true : false;
             pamTally2SoExists = (0 == CheckFileExists(pamTally2SoPath, NULL, log)) ? true : false;
@@ -264,8 +264,9 @@ int SetLockoutForFailedPasswordAttempts(void* log)
 
     if ((false == pamFaillockSoExists) && (false == pamTally2SoExists))
     {
-        OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: neither 'pam_faillock.so' or 'pam_tally2.so' PAM modules are present, cannot remediate");
-        return ENOENT;
+        OsConfigLogError(log, "SetLockoutForFailedPasswordAttempts: neither 'pam_faillock.so' or 'pam_tally2.so' PAM modules are present, cannot set lockout for failed password attempts");
+        // Do not fail, this is a normal limitation for some distributions such as Ubuntu 22.04
+        return 0;
     }
 
     if (0 == CheckFileExists(etcPamdSystemAuth, NULL, log))

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2053,21 +2053,16 @@ TEST_F(CommonUtilsTest, ReplaceMarkedLinesInFile)
     const char* outFile1 =
         "ABC 123\n"
         "#   Test line two   \n"
-        "ABC 123\n"
         "Test KLine 4\n"
         "abc Test4 0456 # rt 4 $"
         "Test2:     12 $!    test test\n"
-        "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
-        "ABC 123\n";
+        "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n";
 
     const char* marker2 = "Test";
     const char* newline2 = "456 DEF\n";
     const char* outFile2 =
         "456 DEF\n"
         "#   Test line two   \n"
-        "456 DEF\n"
-        "456 DEF\n"
-        "456 DEF\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "+password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1";
 


### PR DESCRIPTION
## Description

Improving remediateEnsureLockoutForFailedPasswordAttempts, remediateEnsurePasswordCreationRequirements and remediateEnsureCoreDumpsAreRestricted and avoiding duplicating same line multiple times when replacing in a file.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.