### PR TITLE
Ensuring the package managers presence is only checked once per ASB instance run

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2669,9 +2669,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
     int status = 0, i = 0;
     UNUSED(value);
-    if ((0 != IsPackageInstalled(g_audit, log)) && (0 != IsPackageInstalled(g_auditd, log)) &&
-        (0 != IsPackageInstalled(g_auditLibs, log)) && (0 != IsPackageInstalled(g_auditLibsDevel, log)) &&
-        (0 != InstallPackage(g_audit, log)) && (0 != InstallPackage(g_auditd, log)) &&
+    if ((0 != InstallPackage(g_audit, log)) && (0 != InstallPackage(g_auditd, log)) &&
         (0 != InstallPackage(g_auditLibs, log)) && (0 != InstallPackage(g_auditLibsDevel, log)))
     {
         status = ENOENT;
@@ -2679,20 +2677,8 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
     else if ((false == CheckDaemonActive(g_auditd, NULL, log)) && (false == EnableAndStartDaemon(g_auditd, log)))
     {
         ExecuteCommand(NULL, "restorecon -r -v /var/log/audit", false, false, 0, 0, NULL, NULL, log);
-        if (false == StartDaemon(g_auditd, log))
-        {
-            status = ENOENT;
-            for (i = 0; i < 3; i++)
-            {
-                sleep(1);
-                StartDaemon(g_auditd, log);
-                if (CheckDaemonActive(g_auditd, NULL, log))
-                {
-                    status = 0;
-                    break;
-                }
-            }
-        }
+        EnableAndStartDaemon(g_auditd, log);
+        status = CheckDaemonActive(g_auditd, NULL, log) ? 0 : ENOENT;
     }
     return status;
 }
@@ -3291,8 +3277,8 @@ static int RemediateEnsureAllBootloadersHavePasswordProtectionEnabled(char* valu
 static int RemediateEnsureLoggingIsConfigured(char* value, void* log)
 {
     UNUSED(value);
-    return (((0 == InstallPackage(g_systemd, log) && ((0 == InstallPackage(g_rsyslog, log)) ||
-        (0 == InstallPackage(g_syslog, log)))) || (0 == InstallPackage(g_syslogNg, log))) &&
+    return (((0 == InstallPackage(g_systemd, log) && 
+        ((0 == InstallPackage(g_rsyslog, log)) || (0 == InstallPackage(g_syslog, log)))) || (0 == InstallPackage(g_syslogNg, log))) &&
         (((0 == CheckPackageInstalled(g_systemd, NULL, log)) && EnableAndStartDaemon(g_systemdJournald, log))) &&
         ((((0 == CheckPackageInstalled(g_rsyslog, NULL, log)) && EnableAndStartDaemon(g_rsyslog, log))) || 
         (((0 == CheckPackageInstalled(g_syslog, NULL, log)) && EnableAndStartDaemon(g_syslog, log))) ||

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2667,7 +2667,7 @@ static int RemediateEnsureCronServiceIsEnabled(char* value, void* log)
 
 static int RemediateEnsureAuditdServiceIsRunning(char* value, void* log)
 {
-    int status = 0, i = 0;
+    int status = 0;
     UNUSED(value);
     if ((0 != InstallPackage(g_audit, log)) && (0 != InstallPackage(g_auditd, log)) &&
         (0 != InstallPackage(g_auditLibs, log)) && (0 != InstallPackage(g_auditLibsDevel, log)))

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -3,6 +3,13 @@
 
 #include "Internal.h"
 
+static const char* g_aptGet = "apt-get";
+static const char* g_dpkg = "dpkg";
+static const char* g_tdnf = "tdnf";
+static const char* g_dnf = "dnf";
+static const char* g_yum = "yum";
+static const char* g_zypper = "zypper";
+
 static bool g_checkedPackageManagersPresence = false;
 static bool g_aptGetIsPresent = false;
 static bool g_dpkgIsPresent = false;
@@ -43,22 +50,15 @@ int IsPresent(const char* what, void* log)
 
 static void CheckPackageManagersPresence(void* log)
 {
-    const char* aptGet = "apt-get";
-    const char* dpkg = "dpkg";
-    const char* tdnf = "tdnf";
-    const char* dnf = "dnf";
-    const char* yum = "yum";
-    const char* zypper = "zypper";
-
     if (false == g_checkedPackageManagersPresence)
     {
         g_checkedPackageManagersPresence = true;
-        g_aptGetIsPresent = (0 = IsPresent(aptGet, log)) ? true : false;
-        g_dpkgIsPresent = (0 = IsPresent(dpkg, log)) ? true : false;
-        g_tdnfIsPresent = (0 = IsPresent(tdnf, log)) ? true : false;
-        g_dnfIsPresent = (0 = IsPresent(dnf, log)) ? true : false;
-        g_yumIsPresent = (0 = IsPresent(yum, log)) ? true : false;
-        g_zypperIsPresent = (0 = IsPresent(zypper, log)) ? true : false;
+        g_aptGetIsPresent = (0 == IsPresent(g_aptGet, log)) ? true : false;
+        g_dpkgIsPresent = (0 == IsPresent(g_dpkg, log)) ? true : false;
+        g_tdnfIsPresent = (0 == IsPresent(g_tdnf, log)) ? true : false;
+        g_dnfIsPresent = (0 == IsPresent(g_dnf, log)) ? true : false;
+        g_yumIsPresent = (0 == IsPresent(g_yum, log)) ? true : false;
+        g_zypperIsPresent = (0 == IsPresent(g_zypper, log)) ? true : false;
     }
 }
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -3,12 +3,13 @@
 
 #include "Internal.h"
 
-const char* g_aptGet = "apt-get";
-const char* g_dpkg = "dpkg";
-const char* g_tdnf = "tdnf";
-const char* g_dnf = "dnf";
-const char* g_yum = "yum";
-const char* g_zypper = "zypper";
+static bool g_checkedPackageManagersPresence = false;
+static bool g_aptGetIsPresent = false;
+static bool g_dpkgIsPresent = false;
+static bool g_tdnfIsPresent = false;
+static bool g_dnfIsPresent = false;
+static bool g_yumIsPresent = false;
+static bool g_zypperIsPresent = false;
 
 int IsPresent(const char* what, void* log)
 {
@@ -38,6 +39,27 @@ int IsPresent(const char* what, void* log)
     FREE_MEMORY(command);
 
     return status;
+}
+
+static void CheckPackageManagersPresence(void* log)
+{
+    const char* aptGet = "apt-get";
+    const char* dpkg = "dpkg";
+    const char* tdnf = "tdnf";
+    const char* dnf = "dnf";
+    const char* yum = "yum";
+    const char* zypper = "zypper";
+
+    if (false == g_checkedPackageManagersPresence)
+    {
+        g_checkedPackageManagersPresence = true;
+        g_aptGetIsPresent = (0 = IsPresent(aptGet, log)) ? true : false;
+        g_dpkgIsPresent = (0 = IsPresent(dpkg, log)) ? true : false;
+        g_tdnfIsPresent = (0 = IsPresent(tdnf, log)) ? true : false;
+        g_dnfIsPresent = (0 = IsPresent(dnf, log)) ? true : false;
+        g_yumIsPresent = (0 = IsPresent(yum, log)) ? true : false;
+        g_zypperIsPresent = (0 = IsPresent(zypper, log)) ? true : false;
+    }
 }
 
 static int CheckOrInstallPackage(const char* commandTemplate, const char* packageManager, const char* packageName, void* log)
@@ -71,23 +93,25 @@ int IsPackageInstalled(const char* packageName, void* log)
     const char* commandTemplateZypper = "%s se -x %s";
     int status = ENOENT;
 
-    if (0 == (status = IsPresent(g_dpkg, log)))
+    CheckPackageManagersPresence(log);
+
+    if (g_dpkgIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplateDpkg, g_dpkg, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_tdnf, log)))
+    else if (g_tdnfIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplateAllElse, g_tdnf, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_dnf, log)))
+    else if (g_dnfIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplateAllElse, g_dnf, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_yum, log)))
+    else if (g_yumIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplateAllElse, g_yum, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_zypper, log)))
+    else if (g_zypperIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplateZypper, g_zypper, packageName, log);
     }
@@ -156,23 +180,25 @@ int InstallOrUpdatePackage(const char* packageName, void* log)
     const char* commandTemplate = "%s install -y %s";
     int status = ENOENT;
 
-    if (0 == (status = IsPresent(g_aptGet, log)))
+    CheckPackageManagersPresence(log);
+    
+    if (g_aptGetIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplate, g_aptGet, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_tdnf, log)))
+    else if (g_tdnfIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplate, g_tdnf, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_dnf, log)))
+    else if (g_dnfIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplate, g_dnf, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_yum, log)))
+    else if (g_yumIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplate, g_yum, packageName, log);
     }
-    else if (0 == (status = IsPresent(g_zypper, log)))
+    else if (g_zypperIsPresent)
     {
         status = CheckOrInstallPackage(commandTemplate, g_zypper, packageName, log);
     }
@@ -217,25 +243,27 @@ int UninstallPackage(const char* packageName, void* log)
     const char* commandTemplateAllElse = "%s remove -y %s";
     int status = ENOENT;
 
+    CheckPackageManagersPresence(log);
+
     if (0 == (status = IsPackageInstalled(packageName, log)))
     {
-        if (0 == (status = IsPresent(g_aptGet, log)))
+        if (g_aptGetIsPresent)
         {
             status = CheckOrInstallPackage(commandTemplateAptGet, g_aptGet, packageName, log);
         }
-        else if (0 == (status = IsPresent(g_tdnf, log)))
+        else if (g_tdnfIsPresent)
         {
             status = CheckOrInstallPackage(commandTemplateAllElse, g_tdnf, packageName, log);
         }
-        else if (0 == (status = IsPresent(g_dnf, log)))
+        else if (g_dnfIsPresent)
         {
             status = CheckOrInstallPackage(commandTemplateAllElse, g_dnf, packageName, log);
         }
-        else if (0 == (status = IsPresent(g_yum, log)))
+        else if (g_yumIsPresent)
         {
             status = CheckOrInstallPackage(commandTemplateAllElse, g_yum, packageName, log);
         }
-        else if (0 == (status = IsPresent(g_zypper, log)))
+        else if (g_zypperIsPresent)
         {
             status = CheckOrInstallPackage(commandTemplateAllElse, g_zypper, packageName, log);
         }


### PR DESCRIPTION
## Description

Ensuring the package managers presence is only checked once per ASB instance run.
Also reducing the risk to hit 'service started too quickly' for auditd and improving remediateEnsureAuditdServiceIsRunning

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.