### PR TITLE
Adding the kernel version alongside pretty name to log at start of the ASB v2 run to more precisely identify the OS image ASB is running on

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
+                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
+                                                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
+                                                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
+                                                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "709F738A808DB79EF7253B1D3C2900F9753E373258F254CB8063A5C03772ACB4",
+                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "709F738A808DB79EF7253B1D3C2900F9753E373258F254CB8063A5C03772ACB4",
+                                                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "709F738A808DB79EF7253B1D3C2900F9753E373258F254CB8063A5C03772ACB4",
+                                                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "709F738A808DB79EF7253B1D3C2900F9753E373258F254CB8063A5C03772ACB4",
+                                                "contentHash": "69F6AC62050646D349F64CA2B69DBB7572A211345DB8BDD39B4DACA466DFAD42",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
+                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
+                                                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
+                                                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
+                                                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "BF3A9E6087B90ED493EF9BF54FC4D7C28FF97832FECB77906E1AA9AF45F182B7",
+                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "BF3A9E6087B90ED493EF9BF54FC4D7C28FF97832FECB77906E1AA9AF45F182B7",
+                                                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "BF3A9E6087B90ED493EF9BF54FC4D7C28FF97832FECB77906E1AA9AF45F182B7",
+                                                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "BF3A9E6087B90ED493EF9BF54FC4D7C28FF97832FECB77906E1AA9AF45F182B7",
+                                                "contentHash": "25E878AB06D43E9049F242ECCC025A08BD79C8C6F1C2C054CD1A9F137C5E6F85",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -631,6 +631,7 @@ static const int g_shadowGid = 42;
 void AsbInitialize(void* log)
 {
     char* prettyName = NULL;
+    char* kernelVersion = NULL;
     
     InitializeSshAudit(log);
 
@@ -680,15 +681,17 @@ void AsbInitialize(void* log)
         }
     }
     
+    kernelVersion = GetOsKernelVersion(log);
     if (NULL != (prettyName = GetOsPrettyName(log)))
     {
-        OsConfigLogInfo(log, "AsbInitialize: running on '%s'", prettyName);
-        FREE_MEMORY(prettyName);
+        OsConfigLogInfo(log, "AsbInitialize: running on '%s' ('%s')", prettyName, kernelVersion);
     }
     else
     {
-        OsConfigLogInfo(log, "AsbInitialize: running on an unknown distribution without a valid PRETTY_NAME in /etc/os-release");
+        OsConfigLogInfo(log, "AsbInitialize: running on an unknown Linux distribution with kernel version '%s' and without a valid PRETTY_NAME in /etc/os-release", kernelVersion);
     }
+    FREE_MEMORY(prettyName);
+    FREE_MEMORY(kernelVersion);
 
     OsConfigLogInfo(log, "%s initialized", g_asbName);
 }

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -111,9 +111,9 @@ int SetEnsurePasswordReuseIsLimited(int remember, void* log)
     // - 'password required': specifies that the password module is required for authentication
     // - 'pam_unix.so': the PAM module responsible for traditional Unix authentication
     // - 'sha512': indicates that the SHA-512 hashing algorithm shall be used to hash passwords
-    //- 'shadow': specifies that the password information shall be stored in the /etc/shadow file
-    //- 'remember=n': sets the number of previous passwords to remember to prevent password reuse
-    //- 'retry=3': the number of times a user can retry entering their password before failing
+    // - 'shadow': specifies that the password information shall be stored in the /etc/shadow file
+    // - 'remember=n': sets the number of previous passwords to remember to prevent password reuse
+    // - 'retry=3': the number of times a user can retry entering their password before failing
     //
     // An alternative is:
     //


### PR DESCRIPTION
## Description

Adding the kernel version alongside pretty name to log at start of the ASB v2 run to more precisely identify the OS image ASB is running on.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.