### PR TITLE
Fixing missed reason for ASB v2's auditEnsurePasswordReuseIsLimited leading to 'audit failure without a reason'

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
+                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
+                                                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
+                                                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "BB0A66C1D4E43EDDDD8084CEF6515DB9D27E6F7C5425F29260372FEAB260E8BA",
+                                                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
+                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
+                                                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
+                                                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "2DB90AF66A960546791419F03765241CCD9E9223481F613D824BBFB64244DAF2",
+                                                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -66,13 +66,13 @@ int CheckEnsurePasswordReuseIsLimited(int remember, char** reason, void* log)
     if (0 == CheckFileExists(g_etcPamdCommonPassword, NULL, log))
     {
         // On Debian-based systems '/etc/pam.d/common-password' is expected to exist
-        status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdCommonPassword, '#', g_remember, NULL, log)) &&
+        status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdCommonPassword, '#', g_remember, reason, log)) &&
             (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdCommonPassword, g_remember, '=', remember, reason, log))) ? 0 : ENOENT;
     }
     else if (0 == CheckFileExists(g_etcPamdSystemAuth, NULL, log))
     {
         // On Red Hat-based systems '/etc/pam.d/system-auth' is expected to exist
-        status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdSystemAuth, '#', g_remember, NULL, log)) &&
+        status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdSystemAuth, '#', g_remember, reason, log)) &&
             (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemAuth, g_remember, '=', remember, reason, log))) ? 0 : ENOENT;
     }
     else


### PR DESCRIPTION
## Description

Fixing missed reason for ASB v2's auditEnsurePasswordReuseIsLimited leading to 'audit failure without a reason'.

Problem reported for the private preview policy package. Repro obtained in the CI automation:

[FileUtils.c:434] CheckFileExists: file '/etc/pam.d/common-password' exists
[FileUtils.c:434] CheckFileExists: file '/usr/lib/x86_64-linux-gnu/security/pam_unix.so' exists
[PassUtils.c:52] FindPamModule: the PAM module 'pam_unix.so' is present on this system as '/usr/lib/x86_64-linux-gnu/security/pam_unix.so'
[Asb.c:4422] [ERROR] AsbMmiGet(SecurityBaseline, auditEnsurePasswordReuseIsLimited): audit failure without a reason <<<
[Asb.c:4471] AsbMmiGet(SecurityBaseline, auditEnsurePasswordReuseIsLimited, "FAIL", 6) returning 0

And then fix confirmed in CI automation for this PR:

[2024-08-16 17:53:06] [FileUtils.c:434] CheckFileExists: file '/etc/pam.d/common-password' exists
[2024-08-16 17:53:06] [FileUtils.c:434] CheckFileExists: file '/usr/lib/x86_64-linux-gnu/security/pam_unix.so' exists
[2024-08-16 17:53:06] [PassUtils.c:52] FindPamModule: the PAM module 'pam_unix.so' is present on this system as '/usr/lib/x86_64-linux-gnu/security/pam_unix.so'
[2024-08-16 17:53:06] [Asb.c:4474] AsbMmiGet(SecurityBaseline, auditEnsurePasswordReuseIsLimited, "'remember' not found in '\/etc\/pam.d\/common-password' or it's commented out with '#'", 88) returning 0

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.