### PR TITLE
Fixed pmc bug, added explicit msal auth_type for pmc

### DIFF
--- a/.github/actions/pmc/entrypoint.sh
+++ b/.github/actions/pmc/entrypoint.sh
@@ -2,6 +2,7 @@
 
 output=$(pmc \
     --base-url $PMC_CLI_BASE_URL \
+    --auth-type msal \
     --msal-client-id $PMC_CLI_MSAL_CLIENT_ID \
     --msal-scope $PMC_CLI_MSAL_SCOPE \
     --msal-authority $PMC_CLI_MSAL_AUTHORITY \


### PR DESCRIPTION
## Description

* Due to an internal change to the pmc image used for publishing, the pmc cli auth_type is required even though msal_client_id is set.  Added an explicit `msal` auth-type.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.