### PR TITLE
Add more log tracing for the invoked package managers operations

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
+                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
+                                                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
+                                                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6E58CCBA2236ED616C7003C80AB600C83461889A10521235C15B15C228C74E33",
+                                                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
+                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
+                                                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
+                                                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "602C8A966101CF220262D8A0109C41842297A8A5AF44CBA88086CA8761C9D1F2",
+                                                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -80,6 +80,8 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
     }
 
     status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log);
+    
+    OsConfigLogInfo(log, "Package manager '%s' command '%s' complete with %d (errno: %d)", packageManager, command, status, errno);
 
     FREE_MEMORY(command);
 


### PR DESCRIPTION
## Description

For distros that have multiple package managers installed, add tracing that logs precisely for each invoked package manager operation which package manager and what command are being invoked. In order to help easier diagnose of PM operations on RHEL, SUSE and other distros.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.