### PR TITLE
Disabling the subscription manager plugin for YUM and DNF on RedHat-based distributions for ASB v2's package installed checks

### DIFF
--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
+                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
+                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
+                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "9EA687AF4E423AD1DBCE0C55FFD7C0D3D82AD7E9BB2C18B39415CC2E8DF91764",
+                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
+                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
+                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
+                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "15EDAA0E3DDAFBFF3574837A3E92F55E1633F60EDE0A0DB02150EFB9EF8016D0",
+                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -91,7 +91,8 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
 int IsPackageInstalled(const char* packageName, void* log)
 {
     const char* commandTemplateDpkg = "%s -l %s | grep ^ii";
-    const char* commandTemplateAllElse = "%s list installed %s";
+    const char* commandTemplateYumDnf = "%s list installed %s";
+    const char* commandTemplateRedHat = "%s list installed %s --disableplugin subscription-manager";
     const char* commandTemplateZypper = "%s se -x %s";
     int status = ENOENT;
 
@@ -103,15 +104,15 @@ int IsPackageInstalled(const char* packageName, void* log)
     }
     else if (g_tdnfIsPresent)
     {
-        status = CheckOrInstallPackage(commandTemplateAllElse, g_tdnf, packageName, log);
+        status = CheckOrInstallPackage(commandTemplateYumDnf, g_tdnf, packageName, log);
     }
     else if (g_dnfIsPresent)
     {
-        status = CheckOrInstallPackage(commandTemplateAllElse, g_dnf, packageName, log);
+        status = CheckOrInstallPackage(IsRedHatBased() ? commandTemplateRedHat : commandTemplateYumDnf, g_dnf, packageName, log);
     }
     else if (g_yumIsPresent)
     {
-        status = CheckOrInstallPackage(commandTemplateAllElse, g_yum, packageName, log);
+        status = CheckOrInstallPackage(IsRedHatBased() ? commandTemplateRedHat : commandTemplateYumDnf, g_yum, packageName, log);
     }
     else if (g_zypperIsPresent)
     {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -108,11 +108,11 @@ int IsPackageInstalled(const char* packageName, void* log)
     }
     else if (g_dnfIsPresent)
     {
-        status = CheckOrInstallPackage(IsRedHatBased() ? commandTemplateRedHat : commandTemplateYumDnf, g_dnf, packageName, log);
+        status = CheckOrInstallPackage(IsRedHatBased(log) ? commandTemplateRedHat : commandTemplateYumDnf, g_dnf, packageName, log);
     }
     else if (g_yumIsPresent)
     {
-        status = CheckOrInstallPackage(IsRedHatBased() ? commandTemplateRedHat : commandTemplateYumDnf, g_yum, packageName, log);
+        status = CheckOrInstallPackage(IsRedHatBased(log) ? commandTemplateRedHat : commandTemplateYumDnf, g_yum, packageName, log);
     }
     else if (g_zypperIsPresent)
     {


### PR DESCRIPTION
## Description

Disabling the subscription manager plugin for YUM and DNF on RedHat-based distributions for ASB v2's package installed checks.  This parameter was found experimenting how we can speed up those checks on RAM constrained Hyper-V classic VMs hitting a timeout with AzPolicy otherwise. This is being tested by a deployed test policy deployed against VMs on such a RAM constrained Windows host.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.