### PR TITLE
Prevent CheckFileContents cause an invalid reason to fail json_value_init_string and cascade into a false passing audit

### DIFF
--- a/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -640,7 +640,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                                                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -735,7 +735,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                                                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -830,7 +830,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                                                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                                                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                                                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "6B1EFABAFA53D495EF17EF8D637D400FA554427419712E9A91EF986EDED5A539",
+                                                "contentHash": "AC3073C6E894F68C56D067E749B5FB49CDFEBFE14EBF6E38A4C82269834A9035",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                                                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                                                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                                                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                                                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                                                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AA5B7D60EB3CA84066493A4372E090C629F786AA1E2D7DAB2EA0EC33847E1F31",
+                                                "contentHash": "C2CD04DBFC2521DDCBD86206C0F5F09D3B60A3E6BBC4A581F2B163EBEC78C3FD",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -4420,12 +4420,11 @@ int AsbMmiGet(const char* componentName, const char* objectName, char** payload,
 
     if (0 == status)
     {
-        if (NULL == result)
+        if ((NULL == result) || (NULL == (jsonValue = json_value_init_string(result))))
         {
-            OsConfigLogError(log, "AsbMmiGet(%s, %s): audit failure without a reason", componentName, objectName);
-            result = DuplicateString(g_fail);
-
-            if (NULL == result)
+            OsConfigLogError(log, "AsbMmiGet(%s, %s): audit failure without a valid reason", componentName, objectName);
+            FREE_MEMORY(result);
+            if (NULL == (result = DuplicateString(g_fail)))
             {
                 OsConfigLogError(log, "AsbMmiGet: DuplicateString failed");
                 status = ENOMEM;
@@ -4434,7 +4433,7 @@ int AsbMmiGet(const char* componentName, const char* objectName, char** payload,
         
         if (NULL != result)
         {
-            if (NULL == (jsonValue = json_value_init_string(result)))
+            if ((NULL == jsonValue) && (NULL == (jsonValue = json_value_init_string(result))))
             {
                 OsConfigLogError(log, "AsbMmiGet(%s, %s): json_value_init_string(%s) failed", componentName, objectName, result);
                 status = ENOMEM;

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -904,7 +904,7 @@ int EnableVirtualMemoryRandomization(void* log)
     }
     else
     {
-        if (SecureSaveToFile(procSysKernelRandomizeVaSpace, fullRandomization, strlen(fullRandomization), log))
+        if (SavePayloadToFile(procSysKernelRandomizeVaSpace, fullRandomization, strlen(fullRandomization), log))
         {
             OsConfigLogInfo(log, "EnableVirtualMemoryRandomization: '%s' was written to '%s'", fullRandomization, procSysKernelRandomizeVaSpace);
         }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1288,8 +1288,8 @@ int CheckFileContents(const char* fileName, const char* text, char** reason, voi
         }
         else
         {
-            OsConfigLogInfo(log, "CheckFileContents: '%s' does not match contents of '%s' ('%s')", text, fileName, contents);
-            OsConfigCaptureReason(reason, "'%s' does not match contents of '%s' ('%s')", text, fileName, contents);
+            OsConfigLogInfo(log, "CheckFileContents: '%s' does not match contents of '%s'", text, fileName);
+            OsConfigCaptureReason(reason, "'%s' does not match contents of '%s'", text, fileName);
             status = ENOENT;
         }
     }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1288,7 +1288,7 @@ int CheckFileContents(const char* fileName, const char* text, char** reason, voi
         }
         else
         {
-            OsConfigLogInfo(log, "CheckFileContents: '%s' does not match contents of '%s'", text, fileName);
+            OsConfigLogInfo(log, "CheckFileContents: '%s' does not match contents of '%s' ('%s')", text, fileName, contents);
             OsConfigCaptureReason(reason, "'%s' does not match contents of '%s'", text, fileName);
             status = ENOENT;
         }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1271,6 +1271,7 @@ int CheckTextNotFoundInEnvironmentVariable(const char* variableName, const char*
 int CheckFileContents(const char* fileName, const char* text, char** reason, void* log)
 {
     char* contents = NULL;
+    size_t textLength = 0, contentsLength = 0;
     int status = 0;
 
     if ((NULL == fileName) || (NULL == text) || (0 == strlen(fileName)) || (0 == strlen(text)))
@@ -1281,7 +1282,10 @@ int CheckFileContents(const char* fileName, const char* text, char** reason, voi
 
     if (NULL != (contents = LoadStringFromFile(fileName, false, log)))
     {
-        if (0 == strncmp(contents, text, strlen(text)))
+        textLength = strlen(text);
+        contentsLength = strlen(text);
+        
+        if (0 == strncmp(contents, text, (textLength <= contentsLength) ? textLength : contentsLength))
         {
             OsConfigLogInfo(log, "CheckFileContents: '%s' matches contents of '%s'", text, fileName);
             OsConfigCaptureSuccessReason(reason, "'%s' matches contents of '%s'", text, fileName);

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -80,6 +80,16 @@ TEST_F(CommonUtilsTest, LoadStringWithEolFromFile)
     EXPECT_TRUE(Cleanup(m_path));
 }
 
+TEST_F(CommonUtilsTest, LoadStringFromSingleByteFile)
+{
+    const char* data = "0";
+    char* contents = NULL;
+    EXPECT_TRUE(CreateTestFile(m_path, data));
+    EXPECT_STREQ(data, contents = LoadStringFromFile(m_path, true, nullptr));
+    FREE_MEMORY(contents);
+    EXPECT_TRUE(Cleanup(m_path));
+}
+
 TEST_F(CommonUtilsTest, SavePayloadToFile)
 {
     char* contents = NULL;

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -86,7 +86,11 @@ TEST_F(CommonUtilsTest, LoadStringFromSingleByteFile)
     char* contents = NULL;
     EXPECT_TRUE(CreateTestFile(m_path, data));
     EXPECT_STREQ(data, contents = LoadStringFromFile(m_path, true, nullptr));
+    EXPECT_EQ(1, strlen(contents));
+    EXPECT_EQ(data[0], contents[0]);
+    EXPECT_EQ(0, contents[1]);
     FREE_MEMORY(contents);
+    EXPECT_EQ(0, CheckFileContents(m_path, data, nullptr, nullptr);
     EXPECT_TRUE(Cleanup(m_path));
 }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -90,7 +90,7 @@ TEST_F(CommonUtilsTest, LoadStringFromSingleByteFile)
     EXPECT_EQ(data[0], contents[0]);
     EXPECT_EQ(0, contents[1]);
     FREE_MEMORY(contents);
-    EXPECT_EQ(0, CheckFileContents(m_path, data, nullptr, nullptr);
+    EXPECT_EQ(0, CheckFileContents(m_path, data, nullptr, nullptr));
     EXPECT_TRUE(Cleanup(m_path));
 }
 


### PR DESCRIPTION
## Description

Prevent CheckFileContents cause an invalid reason to fail json_value_init_string and cascade into a false passing audit. Random contents from checked system files can cause breaks into the JSON envelope for transport if included in the reason, skip those. Also, if still an invalid reason arrives, switch it to a generic fail reason.

Also, write directly to '/proc/sys/kernel/randomize_va_space' rather than staged via a temp file to avoid case where on SUSE the staged write may fail due to parent directory access.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.