### PR TITLE
Fixing ASB v2's auditEnsureSystemdJournaldServicePersistsLogMessages and remediateEnsureSystemdJournaldServicePersistsLogMessages

### DIFF
--- a/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -640,7 +640,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                                                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -735,7 +735,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                                                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -830,7 +830,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                                                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -640,7 +640,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -735,7 +735,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -830,7 +830,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -640,7 +640,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -735,7 +735,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -830,7 +830,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/19params/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -640,7 +640,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -735,7 +735,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -830,7 +830,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
+                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                                                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                                                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "E7798E0E539C7A5E545ECDFA4980560740F198D2FA984156261647CABAF04469",
+                                                "contentHash": "C79CE86C44481316A94D3A69F75BC83C38165CE45B0C18B4B54EA7B812AB9070",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
+                                                "contentHash": "5E0075405F8E8A1EACDBFF86991529A282B8FE1768441DA5F05CE40AF7691FD7",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/LinuxSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -625,7 +625,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -716,7 +716,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -807,7 +807,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSecurityBaseline.zip",
-                                                "contentHash": "A92CA8F438CD39C51B78FAB0FCB9C6BA4808920E254E1E9EAEE739D02E8164B0",
+                                                "contentHash": "75BE551A7F76D1FAC66E99ACD1E49CCDBDC3DEBFFB39BBDFBC00740F9E61048A",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                                                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                                                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                                                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "6768ADF43D3A6C3601502E52F19CBB6F4C6C468B8ABD639008FE202504AB2FAE",
+                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
+                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "8B88C76F6ED52E53609867E89311089E9E9841422FA6648D964F6EA0726A915E",
+                                                "contentHash": "98A5FCFF5FA3543A6AB416341572F444617A57CD8DE1073FECE8356DADEA1B56",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                                                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                                                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "AFA6EC6A23BACD6D44C319E467DC1D8557E3221BB944CCAC299C2C2D715A8A09",
+                                                "contentHash": "29D9C8A8660C7424D73E277D80B8225D2A107966C7FF4AA10D65503AAB20BA60",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -627,6 +627,7 @@ static char* g_desiredEnsureUnnecessaryAccountsAreRemoved = NULL;
 static char* g_desiredEnsureDefaultDenyFirewallPolicyIsSet = NULL;
 
 static const int g_shadowGid = 42;
+static const int g_varLogJournalMode = 2755;
 
 void AsbInitialize(void* log)
 {
@@ -692,6 +693,11 @@ void AsbInitialize(void* log)
     }
     FREE_MEMORY(prettyName);
     FREE_MEMORY(kernelVersion);
+
+    if (IsCommodore(log))
+    {
+        OsConfigLogInfo(log, "AsbInitialize: running on product '%s'", PRODUCT_NAME_AZURE_COMMODORE);
+    }
 
     OsConfigLogInfo(log, "%s initialized", g_asbName);
 }
@@ -1722,7 +1728,7 @@ static char* AuditEnsureSystemdJournaldServicePersistsLogMessages(void* log)
 {
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckPackageInstalled(g_systemd, &reason, log));
-    CheckDirectoryAccess(g_varLogJournal, 0, -1, 2775, false, &reason, log);
+    CheckDirectoryAccess(g_varLogJournal, 0, -1, g_varLogJournalMode, false, &reason, log);
     return reason;
 }
 
@@ -3301,7 +3307,7 @@ static int RemediateEnsureSystemdJournaldServicePersistsLogMessages(char* value,
 {
     UNUSED(value);
     return ((0 == InstallPackage(g_systemd, log)) &&
-        (0 == SetDirectoryAccess(g_varLogJournal, 0, -1, 2775, log))) ? 0 : ENOENT;
+        (0 == SetDirectoryAccess(g_varLogJournal, 0, -1, g_varLogJournalMode, log))) ? 0 : ENOENT;
 }
 
 static int RemediateEnsureALoggingServiceIsEnabled(char* value, void* log)

--- a/src/common/asb/Asb.h
+++ b/src/common/asb/Asb.h
@@ -5,6 +5,7 @@
 #define ASB_H
 
 #define PRETTY_NAME_AZURE_LINUX_2 "CBL-Mariner/Linux"
+#define PRODUCT_NAME_AZURE_COMMODORE "Azure Commodore"
 #define PRETTY_NAME_ALMA_LINUX_9 "AlmaLinux 9 (Beryllium)"
 #define PRETTY_NAME_ALMA_LINUX_9_3 "AlmaLinux 9.3 (Shamrock Pampas Cat)"
 #define PRETTY_NAME_AMAZON_LINUX_2 "Amazon Linux 2"

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -169,6 +169,7 @@ int SetPassMaxDays(long days, void* log);
 int SetPassWarnAge(long days, void* log);
 bool IsCurrentOs(const char* name, void* log);
 bool IsRedHatBased(void* log);
+bool IsCommodore(void* log);
 
 void RemovePrefixBlanks(char* target);
 void RemovePrefixUpTo(char* target, char marker);

--- a/src/common/commonutils/DaemonUtils.c
+++ b/src/common/commonutils/DaemonUtils.c
@@ -27,14 +27,7 @@ static int ExecuteSystemctlCommand(const char* command, const char* daemonName, 
 
 bool IsDaemonActive(const char* daemonName, void* log)
 {
-    bool status = false;
-
-    if (0 == ExecuteSystemctlCommand("is-active", daemonName, log))
-    {
-        status = true;
-    }
-
-    return status;
+    return (0 == ExecuteSystemctlCommand("is-active", daemonName, log)) ? true : false;
 }
 
 bool CheckDaemonActive(const char* daemonName, char** reason, void* log)

--- a/src/common/commonutils/DaemonUtils.c
+++ b/src/common/commonutils/DaemonUtils.c
@@ -27,11 +27,11 @@ static int ExecuteSystemctlCommand(const char* command, const char* daemonName, 
 
 bool IsDaemonActive(const char* daemonName, void* log)
 {
-    bool status = true;
+    bool status = false;
 
-    if (ESRCH == ExecuteSystemctlCommand("is-active", daemonName, log))
+    if (0 == ExecuteSystemctlCommand("is-active", daemonName, log))
     {
-        status = false;
+        status = true;
     }
 
     return status;

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -917,3 +917,36 @@ int EnableVirtualMemoryRandomization(void* log)
     
     return status;
 }
+
+bool IsCommodore(void* log)
+{
+    const char* productNameCommand = "cat /etc/os-subrelease | grep PRODUCT_NAME=";
+    char* textResult = NULL;
+    bool status = false;
+
+    if (0 == ExecuteCommand(NULL, productNameCommand, true, true, 0, 0, &textResult, NULL, log))
+    {
+        RemovePrefixBlanks(textResult);
+        RemoveTrailingBlanks(textResult);
+        RemovePrefixUpTo(textResult, '=');
+        RemovePrefixBlanks(textResult);
+    }
+    else
+    {
+        FREE_MEMORY(textResult);
+    }
+
+    if (IsFullLoggingEnabled())
+    {
+        OsConfigLogInfo(log, "'/etc/os-subrelease' PRODUCT_NAME: '%s'", textResult);
+    }
+
+    if (0 == strcmp(textResult, PRODUCT_NAME_AZURE_COMMODORE))
+    {
+        status = true;
+    }
+
+    FREE_MEMORY(textResult);
+
+    return status;
+}

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -930,15 +930,11 @@ bool IsCommodore(void* log)
         RemoveTrailingBlanks(textResult);
         RemovePrefixUpTo(textResult, '=');
         RemovePrefixBlanks(textResult);
-    }
-    else
-    {
-        FREE_MEMORY(textResult);
-    }
 
-    if (0 == strcmp(textResult, PRODUCT_NAME_AZURE_COMMODORE))
-    {
-        status = true;
+        if (0 == strcmp(textResult, PRODUCT_NAME_AZURE_COMMODORE))
+        {
+            status = true;
+        }
     }
 
     FREE_MEMORY(textResult);

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -936,11 +936,6 @@ bool IsCommodore(void* log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsFullLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "'/etc/os-subrelease' PRODUCT_NAME: '%s'", textResult);
-    }
-
     if (0 == strcmp(textResult, PRODUCT_NAME_AZURE_COMMODORE))
     {
         status = true;

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -829,58 +829,6 @@ static int SetSshWarningBanner(unsigned int desiredBannerFileAccess, const char*
     return status;
 }
 
-static int UnblockSshPort(const char* sshPort, void* log)
-{
-    const char* seStatusCommand = "sestatus";
-    const char* checkPortTemplate = "semanage port -l | grep -w \"ssh_port_t\" | grep -w \"%s\"";
-    const char* seManagePortTemplate = "semanage port -a -t ssh_port_t -p tcp %s";
-    const char* policyCoreUtilsPython = "policycoreutils-python";
-    const char* policyCorePythonUtils = "policycoreutils-python-utils";
-    char* checkPortCommand = NULL;
-    char* seManagePortCommand = NULL;
-    int status = 0;
-
-    if (NULL == sshPort)
-    {
-        OsConfigLogError(log, "UnblockSshPort: invalid argument");
-        return EINVAL;
-    }
-    
-    if ((NULL == (checkPortCommand = FormatAllocateString(checkPortTemplate, sshPort))) ||
-        (NULL == (seManagePortCommand = FormatAllocateString(seManagePortTemplate, sshPort))))
-    {
-        OsConfigLogError(log, "UnblockSshPort: out of memory");
-        status = ENOMEM;
-    }
-    else
-    {
-        if (0 != (status = ExecuteCommand(NULL, seStatusCommand, true, false, 0, 0, NULL, NULL, NULL)))
-        {
-            OsConfigLogInfo(log, "UnblockSshPort: '%s' returned %d, assuming SELinux is not present", seStatusCommand, status);
-            status = 0;
-        }
-        else if ((0 != InstallPackage(policyCoreUtilsPython, log)) && (0 != InstallPackage(policyCorePythonUtils, log)))
-        {
-            OsConfigLogError(log, "UnblockSshPort: SELinux management tools package is not installed and "
-                "cannot be installed, SSH may not work with the new port '%s'", sshPort);
-        }
-        else if (0 == (status = ExecuteCommand(NULL, checkPortCommand, true, false, 0, 0, NULL, NULL, NULL)))
-        {
-            OsConfigLogInfo(log, "UnblockSshPort: SSH port '%s' appears to be already set with SELinux", sshPort);
-        }
-        else if (0 != (status = ExecuteCommand(NULL, seManagePortCommand, true, false, 0, 0, NULL, NULL, NULL)))
-        {
-            OsConfigLogError(log, "UnblockSshPort: failed to unblock port '%s' with SELinux, '%s' failed with %d, SSH may not work", 
-                sshPort, seManagePortCommand, status);
-        }
-    }
-    
-    FREE_MEMORY(checkPortCommand);
-    FREE_MEMORY(seManagePortCommand);
-
-    return status;
-}
-
 static char* FormatRemediationValues(void* log)
 {
     const char* remediationTemplate = "%s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n%s %s\n";
@@ -1218,11 +1166,6 @@ void SshAuditCleanup(void* log)
 
         if (configurationChanged)
         {
-            if (g_desiredSshPort)
-            {
-                UnblockSshPort(g_desiredSshPort, log);
-            }
-            
             // Signal to the SSH Server service to reload configuration
             RestartDaemon(g_sshServerService, log);
         }

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -832,7 +832,7 @@ static int SetSshWarningBanner(unsigned int desiredBannerFileAccess, const char*
 static int UnblockSshPort(const char* sshPort, void* log)
 {
     const char* seStatusCommand = "sestatus";
-    const char* checkPortTemplate = "semanage port -l | grep -w \"ssh_port_t\" | grep -w \"%s\";
+    const char* checkPortTemplate = "semanage port -l | grep -w \"ssh_port_t\" | grep -w \"%s\"";
     const char* seManagePortTemplate = "semanage port -a -t ssh_port_t -p tcp %s";
     char* checkPortCommand = NULL;
     char* seManagePortCommand = NULL;

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -854,7 +854,7 @@ static int UnblockSshPort(const char* sshPort, void* log)
     {
         if (0 != (status = ExecuteCommand(NULL, seStatusCommand, true, false, 0, 0, NULL, NULL, NULL)))
         {
-            OsConfigLogError(log, "UnblockSshPort: '%s' returned %d, assuming SELinux is not present", status);
+            OsConfigLogError(log, "UnblockSshPort: '%s' returned %d, assuming SELinux is not present", seStatusCommand, status);
             status = 0;
         }
         else if (0 == (status = ExecuteCommand(NULL, checkPortCommand, true, false, 0, 0, NULL, NULL, NULL)))

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -829,7 +829,7 @@ static int SetSshWarningBanner(unsigned int desiredBannerFileAccess, const char*
     return status;
 }
 
-static int UnblockSshPort(const char* sshPort, void* log);
+static int UnblockSshPort(const char* sshPort, void* log)
 {
     const char* seStatusCommand = "sestatus";
     const char* checkPortTemplate = "semanage port -l | grep -w \"ssh_port_t\" | grep -w \"%s\";

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1485,7 +1485,7 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, void* log
                 g_desiredPermissionsOnEtcSshSshdConfig : g_sshDefaultSshSshdConfigAccess), log);
         }
     }
-    else if ((0 == strcmp(name, g_remediateEnsureSshPortIsConfiguredObject) ||
+    else if ((0 == strcmp(name, g_remediateEnsureSshPortIsConfiguredObject)) ||
         (0 == strcmp(name, g_remediateEnsureSshBestPracticeProtocolObject)) ||
         (0 == strcmp(name, g_remediateEnsureSshBestPracticeIgnoreRhostsObject)) ||
         (0 == strcmp(name, g_remediateEnsureSshLogLevelIsSetObject)) ||

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -854,7 +854,7 @@ static int UnblockSshPort(const char* sshPort, void* log)
     {
         if (0 != (status = ExecuteCommand(NULL, seStatusCommand, true, false, 0, 0, NULL, NULL, NULL)))
         {
-            OsConfigLogError(log, "UnblockSshPort: '%s' returned %d, assuming SELinux is not present", seStatusCommand, status);
+            OsConfigLogInfo(log, "UnblockSshPort: '%s' returned %d, assuming SELinux is not present", seStatusCommand, status);
             status = 0;
         }
         else if (0 == (status = ExecuteCommand(NULL, checkPortCommand, true, false, 0, 0, NULL, NULL, NULL)))

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -867,7 +867,6 @@ static int UnblockSshPort(const char* sshPort, void* log)
                 sshPort, seManagePortCommand, status);
         }
     }
-
     
     FREE_MEMORY(checkPortCommand);
     FREE_MEMORY(seManagePortCommand);

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -834,6 +834,8 @@ static int UnblockSshPort(const char* sshPort, void* log)
     const char* seStatusCommand = "sestatus";
     const char* checkPortTemplate = "semanage port -l | grep -w \"ssh_port_t\" | grep -w \"%s\"";
     const char* seManagePortTemplate = "semanage port -a -t ssh_port_t -p tcp %s";
+    const char* policyCoreUtilsPython = "policycoreutils-python";
+    const char* policyCorePythonUtils = "policycoreutils-python-utils";
     char* checkPortCommand = NULL;
     char* seManagePortCommand = NULL;
     int status = 0;
@@ -856,6 +858,11 @@ static int UnblockSshPort(const char* sshPort, void* log)
         {
             OsConfigLogInfo(log, "UnblockSshPort: '%s' returned %d, assuming SELinux is not present", seStatusCommand, status);
             status = 0;
+        }
+        else if ((0 != InstallPackage(policyCoreUtilsPython, log)) && (0 != InstallPackage(policyCorePythonUtils, log)))
+        {
+            OsConfigLogError(log, "UnblockSshPort: SELinux management tools package is not installed and "
+                "cannot be installed, SSH may not work with the new port '%s'", sshPort);
         }
         else if (0 == (status = ExecuteCommand(NULL, checkPortCommand, true, false, 0, 0, NULL, NULL, NULL)))
         {


### PR DESCRIPTION
## Description

Fixing ASB v2's auditEnsureSystemdJournaldServicePersistsLogMessages and remediateEnsureSystemdJournaldServicePersistsLogMessages and adding detection (for now, just with tracing, ASB customization if any to come in later) for Azure Commodore.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.