### PR TITLE
Updating the ASB v2 policy package name for the MC CI automation tests

### DIFF
--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -30,7 +30,7 @@ jobs:
         policy-package:
           [
             { path: LinuxSshServerSecurityBaseline.zip, short-name: SSH, resource-count: 20 },
-            { path: LinuxSecurityBaseline.zip, short-name: ASB, resource-count: 168 },
+            { path: AzureLinuxBaseline.zip, short-name: ASB, resource-count: 168 },
           ]
         arch: [amd64]
         install-osconfig: [false]


### PR DESCRIPTION
## Description

The policy package name for ASB v2 was recently changed in order to match the name of the ASB v1 package that it will replace. There was one missed instance that affects the automated MC CI pipeline. This PR fixes that.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.