### PR TITLE
Fixing ASB v2 temporary file creation race condition that may lead to /etc/shadow file exposure to unprivileged users

### DIFF
--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "F4093D1A56918D862F21ABB0D69D5DBCF8DF4C962173953C9ABC4C6D1D1980E0"
+        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1"
       }
     },
     "parameters": {
@@ -341,7 +341,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "F4093D1A56918D862F21ABB0D69D5DBCF8DF4C962173953C9ABC4C6D1D1980E0",
+                        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -358,7 +358,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "F4093D1A56918D862F21ABB0D69D5DBCF8DF4C962173953C9ABC4C6D1D1980E0",
+                        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -375,7 +375,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "F4093D1A56918D862F21ABB0D69D5DBCF8DF4C962173953C9ABC4C6D1D1980E0",
+                        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "A5450AC348EB49531D9ACC3A90D416F3C22135234E56B51EAF624F558655043E",
+                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1003,6 +1003,8 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
                     OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to open temporary file '%s', fdopen() failed (%d)", tempFileName, errno);
                     status = EACCES;
                 }
+
+                close(tempDescriptor);
             }
             else
             {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -915,6 +915,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     char* fileNameCopy = NULL;
     FILE* fileHandle = NULL;
     FILE* tempHandle = NULL;
+    int tempDescriptor = -1;
     char* line = NULL;
     long lineMax = sysconf(_SC_LINE_MAX);
     long newlineLength = newline ? (long)strlen(newline) : 0;
@@ -947,10 +948,11 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     {
         if (NULL != (fileHandle = fopen(fileName, "r")))
         {
-            if (NULL != (tempHandle = fopen(tempFileName, "w")))
+            // S_IRUSR (0400): Read permission, owner
+            // S_IWUSR (0200): Write permission, owner
+            if (-1 != (tempDescriptor = open(tempFileName, O_EXCL | O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR)))
             {
-                RestrictFileAccessToCurrentAccountOnly(tempFileName);
-                if (NULL != (tempHandle = freopen(tempFileName, "w", tempHandle)))
+                if (NULL != (tempHandle = fdopen(tempDescriptor, "w")))
                 {
                     while (NULL != fgets(line, lineMax + 1, fileHandle))
                     {
@@ -998,13 +1000,13 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
                 }
                 else
                 {
-                    OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to create temporary file '%s', freopen() failed (%d)", tempFileName, errno);
+                    OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to open temporary file '%s', fdopen() failed (%d)", tempFileName, errno);
                     status = EACCES;
                 }
             }
             else
             {
-                OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to create temporary file '%s', fopen() failed (%d)", tempFileName, errno);
+                OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to open temporary file '%s', open() failed (%d)", tempFileName, errno);
                 status = EACCES;
             }
 


### PR DESCRIPTION
## Description

Fixing ASB v2 temporary file creation race condition that may lead to /etc/shadow file exposure to unprivileged users. There is a window of time during which an unprivileged user may get a file descriptor of our temp file, wait for us to finish writing to it, and then read. That file content we just wrote may be of protected files such as /etc/shadow, that are not normally allowed to be read by normal users.

Many thanks to [robertwoj-microsoft](https://github.com/robertwoj-microsoft) who spotted this bug and proposed the fix.

The fix is being tested with the CI, plus manual running of unit-tests, functional test recipe tests, and also building and deploying a custom policy package containing the fix and validating results of that.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.