### PR TITLE
Avoiding double close on temp file handle

### DIFF
--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1000,11 +1000,11 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
                 }
                 else
                 {
+                    close(tempDescriptor);
+
                     OsConfigLogError(log, "ReplaceMarkedLinesInFile: failed to open temporary file '%s', fdopen() failed (%d)", tempFileName, errno);
                     status = EACCES;
                 }
-
-                close(tempDescriptor);
             }
             else
             {


### PR DESCRIPTION
## Description

If we call both close() and fclose() on the same file descriptor and file stream, it can lead to undefined behavior:
- fclose(): This function flushes the stream, writes any buffered output data, and closes the underlying file descriptor. After calling fclose(), any further access to the stream results in undefined behavior.
- close(): This function closes the file descriptor. If we call close() after fclose(), we are attempting to close an already closed file descriptor, which can lead to errors or unexpected behavior.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.