### PR TITLE
Adding Ubuntu 14.04 and 'OSConfig for MC' policy packages build workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -43,9 +43,10 @@ jobs:
         id: matrix
         run: |
           # If this workflow is present in other_changed_files, then rebuild all containers
-          if [[ -n "${str// }" ]]; then
+          distro_list="${{ inputs.distro_list }}"
+          if [[ -n "${distro_list// }" ]]; then
             echo "Building specified containers..."
-            containers=$(echo "${{ inputs.distro_list }}" | jq -R 'split(",") | map("devops/docker/" + . + "/Dockerfile")')
+            containers=$(echo "$distro_list" | jq -R 'split(",") | map("devops/docker/" + . + "/Dockerfile")')
           elif [[ "${{ steps.changed-containers.outputs.other_changed_files }}" == *".github/workflows/build-containers.yml"* ]] || [[ "${{ inputs.rebuild_all }}" == "true" ]]; then
             echo "Workflow file changed, adding all containers to build matrix..."
             containers=$(ls -d devops/docker/**/Dockerfile | jq -R . | jq -s .)

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,33 @@
+name: Publish (GitHub)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish'
+        required: true
+        default: main
+        type: string
+  push:
+    # tags:
+    #   - v*.*.*
+
+jobs:
+  publish:
+    name: Publish
+    uses: ./.github/workflows/publish-github.yml
+    strategy:
+      matrix:
+        target:
+          [
+            { os: ubuntu, version: 14.04, arch: amd64, dist: trusty, package-type: DEB },
+          ]
+    with:
+      release-name: Test Azure Policy Packages
+      target: ${{ matrix.target.os }}-${{ matrix.target.version }}
+      arch: ${{ matrix.target.arch }}
+      dist: ${{ matrix.target.dist }}
+      environment: prod
+      package-type: ${{ matrix.target.package-type }}
+      buildForMachineConfiguration: true
+    secrets: inherit

--- a/.github/workflows/insiders-fast.yml
+++ b/.github/workflows/insiders-fast.yml
@@ -41,7 +41,7 @@ jobs:
     if: |
       always() &&
       (needs.changes.outputs.new == 'true' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.status != 'success')
-    uses: ./.github/workflows/publish.yml
+    uses: ./.github/workflows/publish-pmc.yml
     strategy:
       matrix:
         target:

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: ${{ inputs.buildForMachineConfiguration == 'false' && 'recursive' || '' }}
+          submodules: ${{ inputs.buildForMachineConfiguration == false && 'recursive' || '' }}
           clean: true
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -42,6 +42,10 @@ on:
         type: string
         required: false
         default: ${{ github.ref }}
+      buildForMachineConfiguration:
+        type: boolean
+        required: false
+        default: false
 
 env:
   BUILD_TYPE: Release
@@ -54,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
+          submodules: ${{ inputs.buildForMachineConfiguration == 'false' && 'recursive' || '' }}
           clean: true
           ref: ${{ inputs.ref }}
 
@@ -93,7 +97,11 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           working-directory: ${{ env.MOUNT }}/build
           cmd: |
-            cmake ../src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTWEAK_VERSION=${{ steps.version.outputs.tweak }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=OFF -DBUILD_MODULETEST=ON -DBUILD_SAMPLES=OFF -Duse_default_uuid=ON -DBUILD_ADAPTERS=ON
+            if [ "${{ inputs.buildForMachineConfiguration }}" = "true" ]; then
+              cmake ../src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+            else
+              cmake ../src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTWEAK_VERSION=${{ steps.version.outputs.tweak }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=OFF -DBUILD_MODULETEST=ON -DBUILD_SAMPLES=OFF -Duse_default_uuid=ON -DBUILD_ADAPTERS=ON
+            fi
 
       - name: Build azure-osconfig
         uses: ./.github/actions/container-exec
@@ -131,4 +139,6 @@ jobs:
         if: ${{ !inputs.test }}
         with:
           name: ${{ inputs.artifact }}
-          path: ./build/osconfig*
+          path: |
+            ./build/osconfig*
+            ./build/*.zip

--- a/.github/workflows/package-publish-pmc.yml
+++ b/.github/workflows/package-publish-pmc.yml
@@ -1,4 +1,4 @@
-name: Publish Package
+name: Publish Package PMC
 
 on:
   workflow_call:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     name: Publish
-    uses: ./.github/workflows/publish.yml
+    uses: ./.github/workflows/publish-pmc.yml
     strategy:
       matrix:
         target:

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -12,12 +12,6 @@ on:
       dist:
         type: string
         required: true
-      repo:
-        type: string
-        required: true
-      channel:
-        type: string
-        required: true
       package-type:
         type: string
         required: true
@@ -25,10 +19,18 @@ on:
         type: string
         description: The GitHub environment to use for the build.
         required: true
+      release-name:
+        type: string
+        description: The GitHub release name to update.
+        required: true
       container-tag:
         type: string
         required: false
         default: latest
+      buildForMachineConfiguration:
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   package:
@@ -39,6 +41,7 @@ jobs:
       artifact: ${{ inputs.target }}-${{ inputs.arch }}
       package-type: ${{ inputs.package-type }}
       container-tag: ${{ inputs.container-tag }}
+      buildForMachineConfiguration: ${{ inputs.buildForMachineConfiguration }}
       release: true
 
   sign:
@@ -48,14 +51,4 @@ jobs:
       artifact: ${{ inputs.target }}-${{ inputs.arch }}
       key-code: ${{ inputs.dist == 'azurelinux' && 'CP-459159-Pgp' || 'CP-450779-Pgp' }}
       package-type: ${{ inputs.package-type }}
-    secrets: inherit
-
-  publish:
-    uses: ./.github/workflows/package-publish.yml
-    needs: sign
-    with:
-      repo: ${{ inputs.repo }}
-      environment: ${{ inputs.environment }}
-      channel: ${{ inputs.channel }}
-      artifact: ${{ inputs.target }}-${{ inputs.arch }}-signed
     secrets: inherit

--- a/.github/workflows/publish-pmc.yml
+++ b/.github/workflows/publish-pmc.yml
@@ -1,0 +1,61 @@
+name: Publish
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        type: string
+        required: true
+      arch:
+        type: string
+        required: true
+      dist:
+        type: string
+        required: true
+      repo:
+        type: string
+        required: true
+      channel:
+        type: string
+        required: true
+      package-type:
+        type: string
+        required: true
+      environment:
+        type: string
+        description: The GitHub environment to use for the build.
+        required: true
+      container-tag:
+        type: string
+        required: false
+        default: latest
+
+jobs:
+  package:
+    uses: ./.github/workflows/package-build.yml
+    with:
+      target: ${{ inputs.target }}
+      arch: ${{ inputs.arch }}
+      artifact: ${{ inputs.target }}-${{ inputs.arch }}
+      package-type: ${{ inputs.package-type }}
+      container-tag: ${{ inputs.container-tag }}
+      release: true
+
+  sign:
+    uses: ./.github/workflows/package-sign.yml
+    needs: package
+    with:
+      artifact: ${{ inputs.target }}-${{ inputs.arch }}
+      key-code: ${{ inputs.dist == 'azurelinux' && 'CP-459159-Pgp' || 'CP-450779-Pgp' }}
+      package-type: ${{ inputs.package-type }}
+    secrets: inherit
+
+  publish:
+    uses: ./.github/workflows/package-publish-pmc.yml
+    needs: sign
+    with:
+      repo: ${{ inputs.repo }}
+      environment: ${{ inputs.environment }}
+      channel: ${{ inputs.channel }}
+      artifact: ${{ inputs.target }}-${{ inputs.arch }}-signed
+    secrets: inherit

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:trusty
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -y update && apt-get -y install software-properties-common
+RUN apt -y update && apt-get -y install \
+    apt-transport-https \
+    git \
+    cmake \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    uuid-dev \
+    ninja-build \
+    python3-jsonschema \
+    wget \
+    gcovr\
+    jq \
+    bc \
+    file
+
+WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
+
+# GTest
+RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
+RUN cd googletest && cmake . -G Ninja && cmake --build . --target install
+
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
+RUN cd rapidjson && cmake . && cmake --build . --parallel --target install && rm -rf /git/rapidjson


### PR DESCRIPTION
## Description

* Added Ubuntu 14.04 Trusty build support (GCC 4.8) for building Machine Configuration policy packages
* Added `Publish (GitHub)` workflow which doesn't publish just yet but currently builds the MC policy packages for Ubuntu 14.04 Trusty
* Fixed `Build Containers` workflow to build the specified containers when the `distro_list` input is provided
* Added a `buildForMachineConfiguration` input to the `package-build.yml` workflow to control whether to build the policy packages for MC or Debian/RPM packages
* Renamed the `publish.yml` workflow to `publish-pmc.yml` to reflect the the new GItHub publishing variant with PMC

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.