### PR TITLE
Cutting unnecessary dependencies for NRP and policy packages build on Ubuntu 14 workflow

### DIFF
--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -1,7 +1,9 @@
 name: CI with sanitizers enabled
 
 on:
-  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 20 * * *' # Every day at 12pm PST (UTC-8)
 
 env:
   BUILD_TYPE: Debug
@@ -21,6 +23,21 @@ jobs:
         run: |
           matrix="$(cat <<'EOL'
           [
+            { "name": "almalinux-9", "arch": "amd64", "tag": "latest" },
+            { "name": "amazonlinux-2", "arch": "amd64", "tag": "latest" },
+            { "name": "centos-7", "arch": "amd64", "tag": "latest" },
+            { "name": "centos-8", "arch": "amd64", "tag": "latest" },
+            { "name": "debian-10", "arch": "amd64", "tag": "latest" },
+            { "name": "debian-11", "arch": "amd64", "tag": "latest" },
+            { "name": "debian-12", "arch": "amd64", "tag": "latest" },
+            { "name": "mariner-2", "arch": "amd64", "tag": "latest" },
+            { "name": "oraclelinux-7", "arch": "amd64", "tag": "latest" },
+            { "name": "oraclelinux-8", "arch": "amd64", "tag": "latest" },
+            { "name": "rhel-7", "arch": "amd64", "tag": "latest" },
+            { "name": "rhel-8", "arch": "amd64", "tag": "latest" },
+            { "name": "rhel-9", "arch": "amd64", "tag": "latest" },
+            { "name": "sles-15", "arch": "amd64", "tag": "latest" },
+            { "name": "ubuntu-20.04", "arch": "amd64", "tag": "latest" },
             { "name": "ubuntu-22.04", "arch": "amd64", "tag": "latest" }
           ]
           EOL

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -23,21 +23,6 @@ jobs:
         run: |
           matrix="$(cat <<'EOL'
           [
-            # { "name": "almalinux-9", "arch": "amd64", "tag": "latest" },
-            # { "name": "amazonlinux-2", "arch": "amd64", "tag": "latest" },
-            # { "name": "centos-7", "arch": "amd64", "tag": "latest" },
-            # { "name": "centos-8", "arch": "amd64", "tag": "latest" },
-            # { "name": "debian-10", "arch": "amd64", "tag": "latest" },
-            # { "name": "debian-11", "arch": "amd64", "tag": "latest" },
-            # { "name": "debian-12", "arch": "amd64", "tag": "latest" },
-            # { "name": "mariner-2", "arch": "amd64", "tag": "latest" },
-            # { "name": "oraclelinux-7", "arch": "amd64", "tag": "latest" },
-            # { "name": "oraclelinux-8", "arch": "amd64", "tag": "latest" },
-            # { "name": "rhel-7", "arch": "amd64", "tag": "latest" },
-            # { "name": "rhel-8", "arch": "amd64", "tag": "latest" },
-            # { "name": "rhel-9", "arch": "amd64", "tag": "latest" },
-            # { "name": "sles-15", "arch": "amd64", "tag": "latest" },
-            # { "name": "ubuntu-20.04", "arch": "amd64", "tag": "latest" },
             { "name": "ubuntu-22.04", "arch": "amd64", "tag": "latest" }
           ]
           EOL

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -68,7 +68,7 @@ jobs:
             mkdir build && cd build
             cmake ../src -DCMAKE_C_FLAGS="${{ env.SANITIZER_FLAGS }}" -DCMAKE_CXX_FLAGS="${{ env.SANITIZER_FLAGS }}" -DCMAKE_build-type=${{ env.BUILD_TYPE }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_ADAPTERS=ON -Duse_default_uuid=ON
 
-      - name: Build azure-osconfig
+      - name: Build Azure OSConfig
         uses: ./.github/actions/container-exec
         with:
           container: ${{ steps.container.outputs.id }}

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -23,21 +23,21 @@ jobs:
         run: |
           matrix="$(cat <<'EOL'
           [
-            { "name": "almalinux-9", "arch": "amd64", "tag": "latest" },
-            { "name": "amazonlinux-2", "arch": "amd64", "tag": "latest" },
-            { "name": "centos-7", "arch": "amd64", "tag": "latest" },
-            { "name": "centos-8", "arch": "amd64", "tag": "latest" },
-            { "name": "debian-10", "arch": "amd64", "tag": "latest" },
-            { "name": "debian-11", "arch": "amd64", "tag": "latest" },
-            { "name": "debian-12", "arch": "amd64", "tag": "latest" },
-            { "name": "mariner-2", "arch": "amd64", "tag": "latest" },
-            { "name": "oraclelinux-7", "arch": "amd64", "tag": "latest" },
-            { "name": "oraclelinux-8", "arch": "amd64", "tag": "latest" },
-            { "name": "rhel-7", "arch": "amd64", "tag": "latest" },
-            { "name": "rhel-8", "arch": "amd64", "tag": "latest" },
-            { "name": "rhel-9", "arch": "amd64", "tag": "latest" },
-            { "name": "sles-15", "arch": "amd64", "tag": "latest" },
-            { "name": "ubuntu-20.04", "arch": "amd64", "tag": "latest" },
+            # { "name": "almalinux-9", "arch": "amd64", "tag": "latest" },
+            # { "name": "amazonlinux-2", "arch": "amd64", "tag": "latest" },
+            # { "name": "centos-7", "arch": "amd64", "tag": "latest" },
+            # { "name": "centos-8", "arch": "amd64", "tag": "latest" },
+            # { "name": "debian-10", "arch": "amd64", "tag": "latest" },
+            # { "name": "debian-11", "arch": "amd64", "tag": "latest" },
+            # { "name": "debian-12", "arch": "amd64", "tag": "latest" },
+            # { "name": "mariner-2", "arch": "amd64", "tag": "latest" },
+            # { "name": "oraclelinux-7", "arch": "amd64", "tag": "latest" },
+            # { "name": "oraclelinux-8", "arch": "amd64", "tag": "latest" },
+            # { "name": "rhel-7", "arch": "amd64", "tag": "latest" },
+            # { "name": "rhel-8", "arch": "amd64", "tag": "latest" },
+            # { "name": "rhel-9", "arch": "amd64", "tag": "latest" },
+            # { "name": "sles-15", "arch": "amd64", "tag": "latest" },
+            # { "name": "ubuntu-20.04", "arch": "amd64", "tag": "latest" },
             { "name": "ubuntu-22.04", "arch": "amd64", "tag": "latest" }
           ]
           EOL

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,4 +1,4 @@
-name: Publish (GitHub)
+name: Build 'OSConfig for MC' (NRP and policy packages)
 
 on:
   workflow_dispatch:
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     name: Publish
-    uses: ./.github/workflows/publish-github.yml
+    uses: ./.github/workflows/nrp-build.yml
     strategy:
       matrix:
         target:
@@ -29,5 +29,5 @@ jobs:
       dist: ${{ matrix.target.dist }}
       environment: prod
       package-type: ${{ matrix.target.package-type }}
-      buildForMachineConfiguration: true
+      buildOsConfigForMc: true
     secrets: inherit

--- a/.github/workflows/nrp-build.yml
+++ b/.github/workflows/nrp-build.yml
@@ -27,7 +27,7 @@ on:
         type: string
         required: false
         default: latest
-      buildForMachineConfiguration:
+      buildOsConfigForMc:
         type: boolean
         required: false
         default: false
@@ -41,7 +41,7 @@ jobs:
       artifact: ${{ inputs.target }}-${{ inputs.arch }}
       package-type: ${{ inputs.package-type }}
       container-tag: ${{ inputs.container-tag }}
-      buildForMachineConfiguration: ${{ inputs.buildForMachineConfiguration }}
+      buildOsConfigForMc: ${{ inputs.buildOsConfigForMc }}
       release: true
 
   sign:

--- a/.github/workflows/nrp-build.yml
+++ b/.github/workflows/nrp-build.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Build 'OSConfig for MC' (NRP and policy packages)
 
 on:
   workflow_call:
@@ -43,12 +43,3 @@ jobs:
       container-tag: ${{ inputs.container-tag }}
       buildOsConfigForMc: ${{ inputs.buildOsConfigForMc }}
       release: true
-
-  sign:
-    uses: ./.github/workflows/package-sign.yml
-    needs: package
-    with:
-      artifact: ${{ inputs.target }}-${{ inputs.arch }}
-      key-code: ${{ inputs.dist == 'azurelinux' && 'CP-459159-Pgp' || 'CP-450779-Pgp' }}
-      package-type: ${{ inputs.package-type }}
-    secrets: inherit

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -1,4 +1,4 @@
-name: Build Package
+name: Build Azure OSConfig Package
 
 on:
   workflow_call:
@@ -42,7 +42,7 @@ on:
         type: string
         required: false
         default: ${{ github.ref }}
-      buildForMachineConfiguration:
+      buildOsConfigForMc:
         type: boolean
         required: false
         default: false
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: ${{ inputs.buildForMachineConfiguration == false && 'recursive' || '' }}
+          submodules: ${{ inputs.buildOsConfigForMc == false && 'recursive' || '' }}
           clean: true
           ref: ${{ inputs.ref }}
 
@@ -97,13 +97,13 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           working-directory: ${{ env.MOUNT }}/build
           cmd: |
-            if [ "${{ inputs.buildForMachineConfiguration }}" = "true" ]; then
+            if [ "${{ inputs.buildOsConfigForMc }}" = "true" ]; then
               cmake ../src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
             else
               cmake ../src -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTWEAK_VERSION=${{ steps.version.outputs.tweak }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=OFF -DBUILD_MODULETEST=ON -DBUILD_SAMPLES=OFF -Duse_default_uuid=ON -DBUILD_ADAPTERS=ON
             fi
 
-      - name: Build azure-osconfig
+      - name: Build Azure OSConfig
         uses: ./.github/actions/container-exec
         with:
           container: ${{ steps.container.outputs.id }}

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update && apt-get -y install 
+RUN apt-get -y update && apt-get -y install \ 
     gcc \
     git \
     cmake \

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -7,7 +7,8 @@ RUN apt -y update && apt-get -y install \
     gcc \
     git \
     cmake \
-    build-essential
+    build-essential \
+    libcurl4-openssl-dev \
 
 WORKDIR /git
 

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -4,32 +4,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
-    apt-transport-https \
+    gcc \
     git \
     cmake \
-    build-essential \
-    curl \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    uuid-dev \
-    ninja-build \
-    python3-jsonschema \
-    wget \
-    gcovr\
-    jq \
-    bc \
-    file
+    build-essential
 
 WORKDIR /git
 
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
-
-# GTest
-RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
-RUN cd googletest && cmake . -G Ninja && cmake --build . --target install
-
-# rapidjson
-RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
-RUN cd rapidjson && cmake . && cmake --build . --parallel --target install && rm -rf /git/rapidjson

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -11,7 +11,3 @@ RUN apt -y update && apt-get -y install \
     file
 
 WORKDIR /git
-                                                                                                                         
-# CMake
-RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
-RUN cd CMake && ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -8,10 +8,10 @@ RUN apt -y update && apt-get -y install \
     git \
     cmake \
     build-essential \
-    libcurl4-openssl-dev \
+    file
 
 WORKDIR /git
-
+                                                                                                                         
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
-RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
+RUN cd CMake && ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -2,8 +2,7 @@ FROM ubuntu:trusty
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt -y update && apt-get -y install software-properties-common
-RUN apt -y update && apt-get -y install \
+RUN apt-get -y update && apt-get -y install 
     gcc \
     git \
     cmake \

--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1"
+        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C"
       }
     },
     "parameters": {
@@ -341,7 +341,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1",
+                        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -358,7 +358,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1",
+                        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -375,7 +375,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "33090ABF6B3F28A4E53EE933489348F16880FB5C35099F32B0A1361D64A70AA1",
+                        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }

--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C"
+        "contentHash": "4D8808C3AB72CA78E1BB14D4BF72A71D481E235C985C976EE7311E2EDA1EC12F"
       }
     },
     "parameters": {
@@ -341,7 +341,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C",
+                        "contentHash": "4D8808C3AB72CA78E1BB14D4BF72A71D481E235C985C976EE7311E2EDA1EC12F",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -358,7 +358,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C",
+                        "contentHash": "4D8808C3AB72CA78E1BB14D4BF72A71D481E235C985C976EE7311E2EDA1EC12F",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -375,7 +375,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "7CB23CD4CB6A7F3364B0544F469380F1D0AC8A5991733D0FD699F5563BBDBC7C",
+                        "contentHash": "4D8808C3AB72CA78E1BB14D4BF72A71D481E235C985C976EE7311E2EDA1EC12F",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                                                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                                                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                                                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                                                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                                                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "5295AB027251DE7B36018CD38220E1463C0C3D76F74895B11A3CF7FA0FC67A76",
+                                                "contentHash": "EB2F6BC3326670F82A6B10884783B1E8B5F00BB8C783C8755F658BA8C7C39FAA",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {


### PR DESCRIPTION
## Description

This PR cuts unnecessary dependencies for NRP and policy packages build on Ubuntu 14 workflow. As fewer dependencies we have to install there, as safer we are on such an old distribution. With this occasion also adjusting some of the names (as the workflow is for building 'OSConfig for MC' aka NRP and policy packages, not publishing it), cutting unnecessary steps (building CMake 3, signing off the policy package, etc.), enabling for PRs and nightly runs the new sanitizers CI, and also used to run our full CI validation on the new policy packages stored at https://github.com/Azure/azure-osconfig/releases/tag/test_policy_package.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.