### PR TITLE
Fix workflow for building 'OSConfig for MC' on Ubuntu 14.04

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -108,7 +108,12 @@ jobs:
         with:
           container: ${{ steps.container.outputs.id }}
           working-directory: ${{ env.MOUNT }}/build
-          cmd: cmake --build . --config ${{ env.BUILD_TYPE }} --parallel
+          cmd: |
+            if [ "${{ inputs.buildOsConfigForMc }}" = "true" ]; then
+              cmake --build . --config ${{ env.BUILD_TYPE }}
+            else
+              cmake --build . --config ${{ env.BUILD_TYPE }} --parallel
+            fi
 
       - name: Run cpack
         uses: ./.github/actions/container-exec

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y install \ 
     gcc \
     git \
-    cmake \
+    cmake3 \
     build-essential \
     file
 


### PR DESCRIPTION
## Description

The workflow for building 'OSConfig for MC' was changed to no longer build CMake v3.21.7 from sources, which led to using the default `cmake` from the ubuntu 14.04 repository, which is v2.8. OSConfig doesn't allow building with cmake version less than v3.2. Switch to installing the `cmake3` package, which provides cmake v3.5, to meet the minimum cmake version requirement, and adjust the 'Build Azure OSConfig' step to account for that cmake version not supporting the `--parallel` argument.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.