### PR TITLE
Re-adding building from source CMake 3 for Ubuntu 14 build of the NRP and the policy packages

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -113,6 +113,6 @@ jobs:
         with:
           context: ${{ steps.image.outputs.path }}
           # Only push the image when a pull request is merged to main
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -113,6 +113,6 @@ jobs:
         with:
           context: ${{ steps.image.outputs.path }}
           # Only push the image when a pull request is merged to main
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y install \ 
     gcc \
     git \
-    cmake \
     build-essential \
     file
 

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -10,3 +10,7 @@ RUN apt-get -y update && apt-get -y install \
     file
 
 WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake


### PR DESCRIPTION
## Description

Re-adding building from source CMake 3 for Ubuntu 14 build of the NRP and the policy packages to the Ubuntu 14 Docker container. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.