### PR TITLE
Fix possible NULL dereference when lscpu command fails

### DIFF
--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -328,7 +328,7 @@ bool CheckCpuFlagSupported(const char* cpuFlag, char** reason, void* log)
     bool result = false;
     char* cpuFlags = GetCpuFlags(log);
 
-    if ((NULL != cpuFlag) && (NULL != strstr(cpuFlags, cpuFlag)))
+    if ((NULL != cpuFlag) && (NULL != cpuFlags) && (NULL != strstr(cpuFlags, cpuFlag)))
     {
         OsConfigLogInfo(log, "CPU flag '%s' is supported", cpuFlag);
         OsConfigCaptureSuccessReason(reason, "The device's CPU supports '%s'", cpuFlag);


### PR DESCRIPTION
## Description

In case the lscpu command fails or is not present on a system, the rule called auditEnsureKernelSupportForCpuNx will trigger 
GetCpuFlags function call which returns NULL in this case. This commit adds additional NULL check for the cpuFlags variable to avoid passing NULL pointer to strstr function.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.