### PR TITLE
First set of bug fixes resulting from fuzzing (work in progress)

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3773,12 +3773,19 @@ static int RemediateEnsurePostfixNetworkListeningIsDisabled(char* value, void* l
     return DisablePostfixNetworkListening(log);
 }
 
+static int CheckAndFreeReason(char *reason)
+{
+    int ret = (0 == strncmp(g_pass, reason, strlen(g_pass))) ? 0 : ENOENT;
+    FREE_MEMORY(reason);
+    return ret;
+}
+
 static int RemediateEnsureRpcgssdServiceIsDisabled(char* value, void* log)
 {
     UNUSED(value);
     StopAndDisableDaemon(g_rpcgssd, log);
     StopAndDisableDaemon(g_rpcGssd, log);
-    return (0 == strncmp(g_pass, AuditEnsureRpcgssdServiceIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckAndFreeReason(AuditEnsureRpcgssdServiceIsDisabled(log));
 }
 
 static int RemediateEnsureRpcidmapdServiceIsDisabled(char* value, void* log)
@@ -3786,7 +3793,7 @@ static int RemediateEnsureRpcidmapdServiceIsDisabled(char* value, void* log)
     UNUSED(value);
     StopAndDisableDaemon(g_rpcidmapd, log);
     StopAndDisableDaemon(g_nfsIdmapd, log);
-    return (0 == strncmp(g_pass, AuditEnsureRpcidmapdServiceIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckAndFreeReason(AuditEnsureRpcidmapdServiceIsDisabled(log));
 }
 
 static int RemediateEnsurePortmapServiceIsDisabled(char* value, void* log)
@@ -3813,7 +3820,7 @@ static int RemediateEnsureNetworkFileSystemServiceIsDisabled(char* value, void* 
 {
     UNUSED(value);
     StopAndDisableDaemon(g_nfsServer, log);
-    return (0 == strncmp(g_pass, AuditEnsureNetworkFileSystemServiceIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckAndFreeReason(AuditEnsureNetworkFileSystemServiceIsDisabled(log));
 }
 
 static int RemediateEnsureRpcsvcgssdServiceIsDisabled(char* value, void* log)
@@ -3832,21 +3839,21 @@ static int RemediateEnsureSnmpServerIsDisabled(char* value, void* log)
 {
     UNUSED(value);
     StopAndDisableDaemon(g_snmpd, log);
-    return (0 == strncmp(g_pass, AuditEnsureSnmpServerIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckAndFreeReason(AuditEnsureSnmpServerIsDisabled(log));
 }
 
 static int RemediateEnsureRsynServiceIsDisabled(char* value, void* log)
 {
     UNUSED(value);
     StopAndDisableDaemon(g_rsync, log);
-    return (0 == strncmp(g_pass, AuditEnsureRsynServiceIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckAndFreeReason(AuditEnsureRsynServiceIsDisabled(log));
 }
 
 static int RemediateEnsureNisServerIsDisabled(char* value, void* log)
 {
     UNUSED(value);
     StopAndDisableDaemon(g_ypserv, log);
-    return (0 == strncmp(g_pass, AuditEnsureNisServerIsDisabled(log), strlen(g_pass))) ? 0 : ENOENT;
+    return CheckAndFreeReason(AuditEnsureNisServerIsDisabled(log));
 }
 
 static int RemediateEnsureRshClientNotInstalled(char* value, void* log)

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -800,6 +800,7 @@ int SetPasswordCreationRequirements(int retry, int minlen, int minclass, int dcr
 
         FREE_MEMORY(pamModulePath);
         FREE_MEMORY(pamModulePath2);
+        FREE_MEMORY(pamModulePath3);
     }
 
     if (0 == CheckFileExists(g_etcSecurityPwQualityConf, NULL, log))


### PR DESCRIPTION
## Description

First set of bugfixes found through fuzzing:
* fix leaks in some remediation paths. These remediation functions call audit functions that return an allocated reason string, but the string was not being free'd.
* fix leak of pamModulePath3 in SetPasswordCreationRequirements()

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.