### PR TITLE
Small optimization for compiler check for platform and modules build

### DIFF
--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -4,8 +4,7 @@
 add_compile_options("-Wall;-Wextra;-Wunused;-Werror;-Wformat;-Wformat-security;-Wno-unused-result")
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     add_compile_options("-Wunused-const-variable=2")
-endif()
-if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
     add_compile_options("-Wunused-variable")
 endif()
 

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -4,8 +4,7 @@
 add_compile_options("-Wall;-Wextra;-Wunused;-Werror;-Wformat;-Wformat-security;-Wno-unused-result")
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
     add_compile_options("-Wunused-const-variable=2")
-endif()
-if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
     add_compile_options("-Wunused-variable")
 endif()
 


### PR DESCRIPTION
## Description

Small optimization for compiler check for platform and modules build. Using if-elseif-endif instead of 2x if-endif.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.