### PR TITLE
Ubuntu 22.04 prerequisite for fuzzer CI

### DIFF
--- a/devops/docker/ubuntu-22.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-22.04-amd64/Dockerfile
@@ -23,7 +23,8 @@ RUN apt -y update && apt-get -y install \
     bc \
     file \
     libasan8 \
-    libubsan1
+    libubsan1 \
+    clang
 
 WORKDIR /git
 


### PR DESCRIPTION
## Description

Add clang package installation which is required for implementing CI using fuzzer.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.