### PR TITLE
Only install aziot config if the directory exists

### DIFF
--- a/src/adapters/pnp/CMakeLists.txt
+++ b/src/adapters/pnp/CMakeLists.txt
@@ -96,9 +96,4 @@ install(FILES daemon/${target_name}.json DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}
 install(FILES daemon/${target_name}.conn DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/osconfig)
 install(FILES daemon/${target_name}.toml DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/osconfig)
 install(FILES daemon/${target_name}.service DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/systemd/system)
-
-add_custom_command(
-    TARGET ${target_name}
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/daemon/${target_name}.toml /etc/aziot/identityd/config.d/${target_name}.toml
-)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/daemon/${target_name}.toml DESTINATION /etc/aziot/identityd/config.d/)


### PR DESCRIPTION
## Description

Check if `/etc/aziot` exists before trying to install it during build. This change fixes a build failure on machines when the build is running as non-root. We should never be writing files to /etc/ during building and no one should be building as root.

Ideally this custom command would be removed or moved behind a cmake `option()`.


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.