### PR TITLE
Fix memory leak in parson's parse_object_value()

### DIFF
--- a/src/common/parson/parson.c
+++ b/src/common/parson/parson.c
@@ -742,6 +742,9 @@ static JSON_Value * parse_object_value(const char **string, size_t nesting) {
         new_key = get_quoted_string(string, &key_len);
         /* We do not support key names with embedded \0 chars */
         if (new_key == NULL || key_len != strlen(new_key)) {
+            if (new_key) {
+                parson_free(new_key);
+            }
             json_value_free(output_value);
             return NULL;
         }


### PR DESCRIPTION
## Description

Fix a memory leak in parson by adding a missing free in parson's `parse_object_value` implementation. The leak is triggerable from our code through fuzzing and we bundle parson so we're responsible for fixing issues in it.

`get_quoted_string` returns an allocated string and all other branches in the loop contain the call to `parson_free` (which is `free` by default). This fix is based on how upstream parson implemented the bugfix: https://github.com/kgabis/parson/commit/ab7f5e5401d45462f517f204e5ce52d80d7dbcd6.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.