### PR TITLE
Disabling atomic reference counting for Security Baseline module only when compiler is gcc 4.8

### DIFF
--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -5,12 +5,15 @@
 #include <stdarg.h>
 #include <version.h>
 #include <ctype.h>
-// Not supported with gcc 4.8
-// #include <stdatomic.h>
 #include <errno.h>
+
+#if (defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))))
+#include <stdatomic.h>
+#endif
+
 #include <CommonUtils.h>
-#include <Asb.h>
 #include <Logging.h>
+#include <Asb.h>
 #include <Mmi.h>
 
 #include "SecurityBaseline.h"
@@ -32,8 +35,12 @@ static const char* g_securityBaselineModuleInfo = "{\"Name\": \"SecurityBaseline
 
 static OSCONFIG_LOG_HANDLE g_log = NULL;
 
-// atomic_int not supported with gcc 4.8, using plain int
+#if (defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))))
+static atomic_int g_referenceCount = 0;
+#else
 static int g_referenceCount = 0;
+#endif
+
 static unsigned int g_maxPayloadSizeBytes = 0;
 
 static OSCONFIG_LOG_HANDLE SecurityBaselineGetLog(void)

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -7,7 +7,7 @@
 #include <ctype.h>
 #include <errno.h>
 
-#if (defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))))
+#if ((defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)))) || defined(__clang__))
 #include <stdatomic.h>
 #endif
 
@@ -35,7 +35,7 @@ static const char* g_securityBaselineModuleInfo = "{\"Name\": \"SecurityBaseline
 
 static OSCONFIG_LOG_HANDLE g_log = NULL;
 
-#if (defined(__GNUC__) && !defined(__clang__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))))
+#if ((defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)))) || defined(__clang__))
 static atomic_int g_referenceCount = 0;
 #else
 static int g_referenceCount = 0;


### PR DESCRIPTION
… or earlier

## Description

Disabling atomic reference counting for Security Baseline module only when compiler is gcc 4.8 or earlier, in order to not disable in production builds but only in test builds done with gcc 4.8 (and not with clang or newer gcc).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.