### PR TITLE
Add scripts to run microsoft/AttackSurfaceAnalyzer for the azure-osconfig

### DIFF
--- a/devops/scripts/asa/Dockerfile-ubuntu22
+++ b/devops/scripts/asa/Dockerfile-ubuntu22
@@ -1,0 +1,55 @@
+#FROM localhost/ubuntu-22.04-amd64:latest
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
+
+# .NET / ASA / sarif-tools setup
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends  \
+        wget=1.21.2-2ubuntu1.1 \
+        software-properties-common=0.99.22.9 \
+        apt-transport-https=2.4.13 \
+    && wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && echo "b8713c36d3e6f6b2520830180cf6b5779e48410ad5d5e1b192635b0c7359fcc6 ./packages-microsoft-prod.deb" | sha256sum -c \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libc6=2.35-0ubuntu3.8 \
+        libgcc1=1:12.3.0-1ubuntu1~22.04 \
+        libgssapi-krb5-2=1.19.2-2ubuntu0.4 \
+        libicu70=70.1-2 \
+        libssl3=3.0.2-0ubuntu1.18 \
+        libstdc++6=12.3.0-1ubuntu1~22.04 \
+        zlib1g=1:1.2.11.dfsg-2ubuntu9.2 \
+        tzdata=2024a-0ubuntu0.22.04.1 \
+        unzip=6.0-26ubuntu3.2 \
+        dotnet-sdk-8.0=8.0.403-1 \
+        python3=3.10.6-1~22.04.1 \
+        python3-pip=22.0.2+dfsg-1ubuntu0.5 \
+   && dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI --version 2.3.313+f3ddb94bf9 \
+   && pip3 install sarif-tools==2.0.0 \
+   && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="$PATH:/root/.dotnet/tools/" \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Setup MC
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends powershell=7.4.6-1.deb \
+    && wget https://github.com/microsoft/omi/releases/download/v1.9.1-0/omi-1.9.1-0.ssl_300.ulinux.s.x64.deb \
+    && echo "e9aa619f50386b105c23de91f2f835cb ./omi-1.9.1-0.ssl_300.ulinux.s.x64.deb" | md5sum -c \
+    && dpkg -i ./omi-1.9.1-0.ssl_300.ulinux.s.x64.deb \
+    && rm -f ./omi-1.9.1-0.ssl_300.ulinux.s.x64.deb \
+    && pwsh --command "Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted" \
+    && pwsh --command "Install-Module -Name GuestConfiguration -RequiredVersion 4.6.0" \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/omi/lib/"
+
+# Working dir represents full github path to this place
+RUN mkdir -p /azure/azure-osconfig/devops/scripts/asa/
+WORKDIR /azure/azure-osconfig/devops/scripts/asa/
+# Copy setup script as a last step to do not require rebuilding the previous layers when the script is updated
+COPY ./scan.sh /azure/azure-osconfig/devops/scripts/asa/scan.sh
+
+ENTRYPOINT [ "/azure/azure-osconfig/devops/scripts/asa/scan.sh" ]

--- a/devops/scripts/asa/Dockerfile-ubuntu22
+++ b/devops/scripts/asa/Dockerfile-ubuntu22
@@ -1,4 +1,6 @@
-#FROM localhost/ubuntu-22.04-amd64:latest
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
 
 # .NET / ASA / sarif-tools setup

--- a/devops/scripts/asa/README.md
+++ b/devops/scripts/asa/README.md
@@ -1,0 +1,39 @@
+Scripts in this directory allows to run 
+[microsoft/AttackSurfaceAnalyzer](https://github.com/microsoft/AttackSurfaceAnalyzer) 
+scans for
+[Azure/azure-osconfig](https://github.com/Azure/azure-osconfig)
+
+Scans are running in the container.
+`podman` or `docker` on host system is needed to run the script. 
+The Default is `docker`, can be configured in [run_asa.sh](run_asa.sh).
+
+## How to run:
+
+`./run_asa.sh -p https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip`
+
+Run `./run_asa.sh` without any options to see the possible options.
+
+Script will fail if ASA scan detect any findings with severity equal to error
+(by default, can be configured using `-fo` option)
+
+The `./report` directory will be created and following output files will be put there:
+* ./report/after_audit - ASA report after audit, together with related osconfig_nrp.log
+* ./report/after_remediation - ASA report after remediation, together with related osconfig_nrp.log
+* ./report/asa.log - output log from all of the ASA tool collect and report generation runs
+
+When running in the CI system `sha256` of policy package should be checked using `-c` option due to security concerns:
+
+```
+./run_asa.sh \
+-p https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip \
+-c 2ad11f6869459f2f6412428172ee167cb0b77f1e397b0fc549dc47339840fd85
+```
+
+## Known constrains:
+* For now container image does not include systemd so the service related functionality and related ASA scans are omitted
+* ASA scan does not run TPM checks
+* Scans are now executed only on Ubuntu 22.04
+
+## Planned TODO:
+* Support for running ASA scans in the container with RPM based distro
+* Run as a part of the GHA pipeline

--- a/devops/scripts/asa/README.md
+++ b/devops/scripts/asa/README.md
@@ -36,4 +36,4 @@ When running in the CI system `sha256` of policy package should be checked using
 
 ## Planned TODO:
 * Support for running ASA scans in the container with RPM based distro
-* Run as a part of the GHA pipeline
+* Run as a part of the GitHub Actions workflow

--- a/devops/scripts/asa/run_asa.sh
+++ b/devops/scripts/asa/run_asa.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Tested and supported runtimes: podman, docker
+CONTAINER_RUNTIME="podman"
+
+if ! dpkg --list ${CONTAINER_RUNTIME} > /dev/null && ! rpm -q ${CONTAINER_RUNTIME} > /dev/null; then
+    echo "Install prerequisites first: ${CONTAINER_RUNTIME}"
+    exit 1
+fi
+
+${CONTAINER_RUNTIME} build -f ./Dockerfile-ubuntu22 -t osconfig-asa-ubuntu22 .
+
+mkdir -p ./report
+
+${CONTAINER_RUNTIME} run -it \
+    -v ./scan.sh:/azure/azure-osconfig/devops/scripts/asa/scan.sh \
+    -v ./report:/azure/azure-osconfig/devops/scripts/asa/report \
+    osconfig-asa-ubuntu22 "$@"

--- a/devops/scripts/asa/run_asa.sh
+++ b/devops/scripts/asa/run_asa.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 set -e
 
 # Tested and supported runtimes: podman, docker

--- a/devops/scripts/asa/scan.sh
+++ b/devops/scripts/asa/scan.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -e
+
+ASA_FAIL_ON="error"
+OUTPUT_DIR="report"
+AFTER_AUDIT_REPORT_DIR=${OUTPUT_DIR}/after_audit
+AFTER_REMEDIATION_REPORT_DIR=${OUTPUT_DIR}/after_remediation
+OSCONFIG_LOG_FILE="/var/log/osconfig_nrp.log"
+ASA_LOG_FILENAME="asa.log"
+
+function clear_osconfig_logs {
+  echo "" > ${OSCONFIG_LOG_FILE}
+}
+
+function log {
+    local msg=$1
+    local level=$2
+
+    echo "[$(date +%H:%M:%S) ${level}] ${msg}"
+}
+
+function print_usage {
+    echo -e ""
+    echo -e "Usage: $(basename ${0}) [OPTIONS]"
+    echo -e ""
+    echo -e "\t-p, --package\t\tURL to policy package ZIP file"
+    echo -e "\t-c, --checksum\t\tPolicy package file SHA256 check sum to verify before executing anything"
+    echo -e "\t-fo, --failon\t\tFail if there were findings in ASA scan with given severity level or above: error, warning, note"
+    echo -e ""
+    echo -e "Example:"
+    echo -e "\t$(basename ${0}) -p https://host/AzureLinuxBaseline.zip -fo error"
+    echo -e ""
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -p|--package) POLICY_PACKAGE_FILE="$2"; shift ;;
+        -c|--checksum) POLICY_PACKAGE_SHA256="$2"; shift ;;
+        -fo|--failon) ASA_FAIL_ON="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; print_usage; exit 1 ;;
+    esac
+    shift
+done
+
+POLICY_NAME=$(basename "$POLICY_PACKAGE_FILE")
+
+if [ -n "${POLICY_PACKAGE_FILE}" ]; then
+  log "Downloading package policy file..." "INFO"
+  wget "${POLICY_PACKAGE_FILE}" -O "${POLICY_NAME}"
+  log "Package policy file downloaded." "INFO"
+else
+  log "Policy package file URL not provided." "ERROR"
+  print_usage
+  exit 1
+fi
+
+if [ -n "${POLICY_PACKAGE_SHA256}" ]; then
+  log "Checksum provided, checking policy package SHA256..." "INFO"
+  if echo "${POLICY_PACKAGE_SHA256} ./${POLICY_NAME}" | sha256sum --check --status; then
+    log "Wrong policy package checksum." "ERROR"
+    exit 1
+  fi
+else
+  log "Policy package checksum wasn't provided. The check was omitted." "WARNING"
+fi
+
+if [ ! -s "./${POLICY_NAME}" ]; then
+  log "Policy file (./${POLICY_NAME}) does not exists or empty." "ERROR"
+  exit 2
+fi
+
+log "Creating report directories..." "INFO"
+mkdir -p ${AFTER_AUDIT_REPORT_DIR}
+mkdir -p ${AFTER_REMEDIATION_REPORT_DIR}
+
+log "Running ASA collection before GC audit..." "INFO"
+echo "ASA COLLECT BEFORE GC AUDIT" > ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+asa collect -a >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+
+log "Running Get-GuestConfigurationPackageComplianceStatus..." "INFO"
+clear_osconfig_logs
+pwsh --command "Get-GuestConfigurationPackageComplianceStatus -Path ./${POLICY_NAME}"
+cp ${OSCONFIG_LOG_FILE} ${AFTER_AUDIT_REPORT_DIR}
+
+log "Running ASA collection after GC audit..." "INFO"
+echo ""; echo "ASA COLLECT AFTER GC AUDIT" >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+asa collect -a >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+asa export-collect --outputsarif --outputpath ${AFTER_AUDIT_REPORT_DIR} >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+
+log "Running Start-GuestConfigurationPackageRemediation..." "INFO"
+clear_osconfig_logs
+pwsh --command "Start-GuestConfigurationPackageRemediation -Path ./${POLICY_NAME}"
+cp ${OSCONFIG_LOG_FILE} ${AFTER_REMEDIATION_REPORT_DIR}
+
+log "Running ASA collection after GC remediation..." "INFO"
+echo ""; echo "ASA COLLECT AFTER GC REMEDIATION" >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+asa collect -a >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+asa export-collect --outputsarif --outputpath ${AFTER_REMEDIATION_REPORT_DIR} >> ${OUTPUT_DIR}/${ASA_LOG_FILENAME}
+
+# Another run just to check compliance status after remediation
+log "Running Get-GuestConfigurationPackageComplianceStatus..." "INFO"
+pwsh --command "Get-GuestConfigurationPackageComplianceStatus -Path ./${POLICY_NAME}"
+
+AFTER_AUDIT_SARIF=$(ls -Art ${AFTER_AUDIT_REPORT_DIR}/*.Sarif | tail -n 1)
+AFTER_REMEDIATION_SARIF=$(ls -Art ${AFTER_REMEDIATION_REPORT_DIR}/*.Sarif | tail -n 1)
+
+log "Checking after audit ASA report..." "INFO"
+sarif --check ${ASA_FAIL_ON} summary ${AFTER_AUDIT_SARIF}
+log "Checking after remediation ASA report..." "INFO"
+sarif --check ${ASA_FAIL_ON} summary ${AFTER_REMEDIATION_SARIF}
+log "All good! Finishing..." "INFO"

--- a/devops/scripts/asa/scan.sh
+++ b/devops/scripts/asa/scan.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 set -e
 
 ASA_FAIL_ON="error"


### PR DESCRIPTION
## Description

Scans are running in the container.
`podman` or `docker` on host system is needed to run the script. 
The Default is `docker`, can be configured in [run_asa.sh](run_asa.sh).

Using instructions are included in the README.md file in this PR.

### Known constrains:
* For now container image does not include systemd so the service related functionality and related ASA scans are omitted
* ASA scan does not run TPM checks
* Scans are now executed only on Ubuntu 22.04

### Planned TODO:
* Support for running ASA scans in the container with RPM based distro
* Run as a part of the GHA pipeline

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.