### PR TITLE
Fix slow execution of CheckTextNotFoundInEnvironmentVariable function

### DIFF
--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1331,6 +1331,7 @@ int CheckTextNotFoundInEnvironmentVariable(const char* variableName, const char*
                         OsConfigCaptureReason(reason, "'%s' found in '%s' ('%s')", text, variableName, found);
                         foundText = true;
                         status = EEXIST;
+                        break;
                     }
                 } 
             


### PR DESCRIPTION
## Description

Break text search loop when pattern is found. This fix avoids long running executions by repetitively scanning list of environment variables if pattern occurs frequently in the searched string.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.