### PR TITLE
Add ASA scans running on CentOS 8

### DIFF
--- a/devops/scripts/asa/Dockerfile-centos8
+++ b/devops/scripts/asa/Dockerfile-centos8
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# centos:8 / 2024-11-20
+FROM mcr.microsoft.com/mirror/docker/library/centos@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
+
+# CentOS Linux 8 had reached the End Of Life (EOL) on December 31st, 2021.
+# It means that CentOS 8 will no longer receive development resources from
+# the official CentOS project. After Dec 31st, 2021, if you need to update
+# your CentOS, you need to change the mirrors to vault.centos.org where they
+# will be archived permanently
+
+# .NET / ASA / sarif-tools setup
+RUN rpm -Uv https://packages.microsoft.com/config/centos/8/packages-microsoft-prod.rpm \
+    && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && yum install -y \
+        wget-1.19.5-10.el8 \
+        libicu-60.3-2.el8_1 \
+        dotnet-sdk-8.0-8.0.301-1 \
+        python38-3.8.8 \
+        python38-pip-19.3.1 \
+   && dotnet tool install -g Microsoft.CST.AttackSurfaceAnalyzer.CLI --version 2.3.313+f3ddb94bf9 \
+   && pip3 install sarif-tools==2.0.0 \
+   && yum clean all \
+   && rm -rf /var/cache/yum
+
+ENV PATH="$PATH:/root/.dotnet/tools/" \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true
+
+# Setup MC
+RUN yum install -y  \
+    openssl \
+    powershell-7.4.6 \
+    && wget https://github.com/microsoft/omi/releases/download/v1.9.1-0/omi-1.9.1-0.ssl_110.ulinux.s.x64.rpm \
+    && echo "7287aad50de4a64655a1efc71fcbf8a6 ./omi-1.9.1-0.ssl_110.ulinux.s.x64.rpm" | md5sum -c \
+    && rpm -i ./omi-1.9.1-0.ssl_110.ulinux.s.x64.rpm \
+    && rm -f ./omi-1.9.1-0.ssl_110.ulinux.s.x64.rpm \
+    && pwsh --command "Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted" \
+    && pwsh --command "Install-Module -Name GuestConfiguration -RequiredVersion 4.6.0" \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/omi/lib/"
+
+# Working dir represents full github path to this place
+RUN mkdir -p /azure/azure-osconfig/devops/scripts/asa/
+WORKDIR /azure/azure-osconfig/devops/scripts/asa/
+# Copy setup script as a last step to do not require rebuilding the previous layers when the script is updated
+COPY ./scan.sh /azure/azure-osconfig/devops/scripts/asa/scan.sh
+
+ENTRYPOINT [ "/azure/azure-osconfig/devops/scripts/asa/scan.sh" ]

--- a/devops/scripts/asa/Dockerfile-ubuntu22
+++ b/devops/scripts/asa/Dockerfile-ubuntu22
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:22.04
+# ubuntu:22.04 / 2024-11-20
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97
 
 # .NET / ASA / sarif-tools setup
 RUN apt-get update \

--- a/devops/scripts/asa/README.md
+++ b/devops/scripts/asa/README.md
@@ -7,6 +7,8 @@ Scans are running in the container.
 `podman` or `docker` on host system is needed to run the script. 
 The Default is `docker`, can be configured in [run_asa.sh](run_asa.sh).
 
+Scans will run automatically in all supported distros, for now Ubuntu 22.04 and CentOS 8.
+
 ## How to run:
 
 `./run_asa.sh -p https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip`
@@ -16,10 +18,11 @@ Run `./run_asa.sh` without any options to see the possible options.
 Script will fail if ASA scan detect any findings with severity equal to error
 (by default, can be configured using `-fo` option)
 
-The `./report` directory will be created and following output files will be put there:
-* ./report/after_audit - ASA report after audit, together with related osconfig_nrp.log
-* ./report/after_remediation - ASA report after remediation, together with related osconfig_nrp.log
-* ./report/asa.log - output log from all of the ASA tool collect and report generation runs
+The `./report/${DISTRO}` directories for every distro the scans were run for will be created and following
+output files will be put there:
+* ./report/${DISTRO}/after_audit - ASA report after audit, together with related osconfig_nrp.log
+* ./report/${DISTRO}/after_remediation - ASA report after remediation, together with related osconfig_nrp.log
+* ./report/${DISTRO}/asa.log - output log from all of the ASA tool collect and report generation runs
 
 When running in the CI system `sha256` of policy package should be checked using `-c` option due to security concerns:
 
@@ -32,8 +35,7 @@ When running in the CI system `sha256` of policy package should be checked using
 ## Known constrains:
 * For now container image does not include systemd so the service related functionality and related ASA scans are omitted
 * ASA scan does not run TPM checks
-* Scans are now executed only on Ubuntu 22.04
+* Scans are now executed on Ubuntu 22.04 and CentOS 8
 
 ## Planned TODO:
-* Support for running ASA scans in the container with RPM based distro
 * Run as a part of the GitHub Actions workflow

--- a/devops/scripts/asa/run_asa.sh
+++ b/devops/scripts/asa/run_asa.sh
@@ -8,16 +8,33 @@ set -e
 # Tested and supported runtimes: podman, docker
 CONTAINER_RUNTIME="podman"
 
+DISTROS=("ubuntu22" "centos8")
+
+function echo_header {
+  echo ""
+  echo "============================================================="
+  echo ${1}
+  echo "============================================================="
+}
+
 if ! dpkg --list ${CONTAINER_RUNTIME} > /dev/null && ! rpm -q ${CONTAINER_RUNTIME} > /dev/null; then
     echo "Install prerequisites first: ${CONTAINER_RUNTIME}"
     exit 1
 fi
 
-${CONTAINER_RUNTIME} build -f ./Dockerfile-ubuntu22 -t osconfig-asa-ubuntu22 .
+for DISTRO in ${DISTROS[@]}; do
+    echo_header "RUNNING ${DISTRO} CONTAINER IMAGE BUILD"
 
-mkdir -p ./report
+    ${CONTAINER_RUNTIME} build -f ./Dockerfile-${DISTRO} -t osconfig-asa-${DISTRO} .
 
-${CONTAINER_RUNTIME} run -it \
-    -v ./scan.sh:/azure/azure-osconfig/devops/scripts/asa/scan.sh \
-    -v ./report:/azure/azure-osconfig/devops/scripts/asa/report \
-    osconfig-asa-ubuntu22 "$@"
+    echo_header "RUNNING ASA SCAN IN ${DISTRO} CONTAINER"
+    mkdir -p ./report/${DISTRO}
+
+    ${CONTAINER_RUNTIME} run -it \
+        -v ./scan.sh:/azure/azure-osconfig/devops/scripts/asa/scan.sh \
+        -v ./report/${DISTRO}:/azure/azure-osconfig/devops/scripts/asa/report \
+        osconfig-asa-${DISTRO} "$@"
+    echo_header "Finished for ${DISTRO}"
+done
+
+echo_header "No ASA problems detected. Scanned distros: ${DISTROS[@]}"

--- a/devops/scripts/asa/run_asa.sh
+++ b/devops/scripts/asa/run_asa.sh
@@ -6,14 +6,14 @@
 set -e
 
 # Tested and supported runtimes: podman, docker
-CONTAINER_RUNTIME="podman"
+CONTAINER_RUNTIME="docker"
 
 DISTROS=("ubuntu22" "centos8")
 
 function echo_header {
   echo ""
   echo "============================================================="
-  echo ${1}
+  echo "${1}"
   echo "============================================================="
 }
 
@@ -22,7 +22,7 @@ if ! dpkg --list ${CONTAINER_RUNTIME} > /dev/null && ! rpm -q ${CONTAINER_RUNTIM
     exit 1
 fi
 
-for DISTRO in ${DISTROS[@]}; do
+for DISTRO in "${DISTROS[@]}"; do
     echo_header "RUNNING ${DISTRO} CONTAINER IMAGE BUILD"
 
     ${CONTAINER_RUNTIME} build -f ./Dockerfile-${DISTRO} -t osconfig-asa-${DISTRO} .
@@ -37,4 +37,4 @@ for DISTRO in ${DISTROS[@]}; do
     echo_header "Finished for ${DISTRO}"
 done
 
-echo_header "No ASA problems detected. Scanned distros: ${DISTROS[@]}"
+echo_header "No ASA problems detected. Scanned distros: " "${DISTROS[@]}"


### PR DESCRIPTION
## Description

* ASA Scans running on CentOS 8 Added.
* Base container images locked by SHA256 to improve hermeticity.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.