### PR TITLE
Add a runtime detection & selection of available container runtime

### DIFF
--- a/devops/scripts/asa/run_asa.sh
+++ b/devops/scripts/asa/run_asa.sh
@@ -5,8 +5,27 @@
 
 set -e
 
-# Tested and supported runtimes: podman, docker
-CONTAINER_RUNTIME="podman"
+SUPPORTED_RUNTIMES=("docker" "podman")
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Loop through the supported runtimes and select the first one that is present
+for RUNTIME in "${SUPPORTED_RUNTIMES[@]}"; do
+    if command_exists "${RUNTIME}"; then
+        CONTAINER_RUNTIME="${RUNTIME}"
+        break
+    fi
+done
+
+# Check if a container runtime was found
+if [ -z "$CONTAINER_RUNTIME" ]; then
+    echo "No supported container runtime found. One of the following is required: " "${SUPPORTED_RUNTIMES[@]}"
+    exit 1
+else
+    echo "Using container runtime: $CONTAINER_RUNTIME"
+fi
 
 if ! dpkg --list ${CONTAINER_RUNTIME} > /dev/null && ! rpm -q ${CONTAINER_RUNTIME} > /dev/null; then
     echo "Install prerequisites first: ${CONTAINER_RUNTIME}"


### PR DESCRIPTION
## Description

This is the follow up PR to this one: https://github.com/Azure/azure-osconfig/pull/814

It was suggested there to make container runtime detection in the runtime.

I will rebase/merge and resolve conflicts when https://github.com/Azure/azure-osconfig/pull/814 will be merged.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.