### PR TITLE
github: Run fuzzing nightly

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -2,6 +2,8 @@ name: Fuzzer execution
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *' # Every day at 7pm PST/4am CET
 
 jobs:
   fuzzer-execution:


### PR DESCRIPTION
## Description

Add a trigger to the fuzzing workflow that runs it nightly. The fuzzing runs will need to be periodically reviewed to see if there are any failures.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.