### PR TITLE
Fixing memory leaks in moduletest

### DIFF
--- a/src/modules/test/Module.c
+++ b/src/modules/test/Module.c
@@ -341,7 +341,8 @@ MANAGEMENT_MODULE* LoadModule(const char* client, const char* path)
         UnloadModule(module);
         module = NULL;
     }
-
+    json_value_free(value);
+    FREE_MEMORY(payload);
     return module;
 }
 

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -95,7 +95,7 @@ static bool g_verbose = false;
 
 void FreeStep(STEP* step)
 {
-    if (step)
+    if (NULL == step)
     {
         return;
     }
@@ -505,6 +505,7 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
         json_value_free(expectedJsonValue);
         json_value_free(actualJsonValue);
         FREE_MEMORY(payloadString);
+        FREE_MEMORY(payload);
     }
     else if (test->type == DESIRED)
     {
@@ -669,7 +670,7 @@ int InvokeRecipe(const char* client, const char* path, const char* bin)
                             if (step->data.module.action == UNLOAD)
                             {
                                 UnloadModule(module);
-                                module = NULL;
+                                FREE_MEMORY(module);
                             }
                             else
                             {
@@ -697,6 +698,7 @@ int InvokeRecipe(const char* client, const char* path, const char* bin)
             {
                 LOG_INFO("Warning: module is still loaded, unloading...");
                 UnloadModule(module);
+                FREE_MEMORY(module);
                 module = NULL;
             }
 
@@ -709,6 +711,7 @@ int InvokeRecipe(const char* client, const char* path, const char* bin)
             for (int i = 0; i < failed; i++)
             {
                 LOG_TRACE("  %*d %s", (int)log10(total) + 1, failures[i].index + 1, failures[i].name);
+                FREE_MEMORY(failures[i].name);
             }
 
             LOG_TRACE(LINE_SEPARATOR_THICK);
@@ -726,6 +729,10 @@ int InvokeRecipe(const char* client, const char* path, const char* bin)
         status = 1;
     }
 
+    for (int i = 0; i < total; i++)
+    {
+        FreeStep(&steps[i]);
+    }
     FREE_MEMORY(failures);
     FREE_MEMORY(steps);
 


### PR DESCRIPTION
## Description

`moduletest` has memory leaks in the test runnner itself that can be seen when running it from a build-tree that has sanitizer enabled (or `-DBUILD_FUZZER=1`). By fixing these leaks in the test runner itself, we won't miss leaks happening inside the tested libraries.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.