### PR TITLE
Fix module test failure on Debian 12

### DIFF
--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -17,6 +17,7 @@ static bool g_tdnfIsPresent = false;
 static bool g_dnfIsPresent = false;
 static bool g_yumIsPresent = false;
 static bool g_zypperIsPresent = false;
+static bool g_aptGetUpdateExecuted = false;
 
 int IsPresent(const char* what, void* log)
 {
@@ -178,6 +179,26 @@ int CheckPackageNotInstalled(const char* packageName, char** reason, void* log)
     return result;
 }
 
+void AptGetUpdateOnce(void* log)
+{
+    const char* command = "apt-get update";
+    int status = 0;
+    if (g_aptGetUpdateExecuted)
+    {
+        return;
+    }
+
+    if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+    {
+        OsConfigLogInfo(log, "AptGetUpdateOnce: '%s' was successful", command);
+        g_aptGetUpdateExecuted = true;
+    }
+    else
+    {
+        OsConfigLogError(log, "AptGetUpdateOnce: '%s' failed with %d", command, status);
+    }
+}
+
 int InstallOrUpdatePackage(const char* packageName, void* log)
 {
     const char* commandTemplate = "%s install -y %s";
@@ -187,6 +208,7 @@ int InstallOrUpdatePackage(const char* packageName, void* log)
     
     if (g_aptGetIsPresent)
     {
+        AptGetUpdateOnce(log);
         status = CheckOrInstallPackage(commandTemplate, g_aptGet, packageName, log);
     }
     else if (g_tdnfIsPresent)


### PR DESCRIPTION
## Description

Two issues:
### apt-cache
On a freshly configured system (VM/container/server) the apt cache may not be populated initially.  This causes any remediation task that requires package installation to happen to fail. Ensure we update the package cache on the first invocation of a function that attempts to install a package.

With this change `apt-get update` is done once and only on demand. Some remediation functions need to be revised to better interact with this, for example `RemediateEnsureAuditdServiceIsRunning`. `RemediateEnsureAuditdServiceIsRunning` attempts to install 4 different package candidates, some of which may not be available in a distro version at all. Each such probe could trigger an `apt-get update`, even if a later package in the list is already installed. This scenario is not critical because:
- for MC there is a `Test()` call that would never invoke `apt-get upate` and that would suppress the call to `Set()`
- for standalone Osconfig we would have one `apt-get update` per lifetime of `osconfig-platform` daemon which is acceptable.

### cronie

~The order of remediate tasks differs between moduletest and MC policy. The remediation tasks that modify permissions of cron files in `/etc/` do nothing until these files are created by installing crond. Subsequent audit tasks related to these cron files can fail. Move the `remediateEnsureCronServiceIsEnabled` task in moduletest earlier, so that the files are created before the permission remediation tasks run.~
dropped, because it's superseded by #821 which has the correct ordering.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.