### PR TITLE
Restore Debian 12 to moduletest workflow

### DIFF
--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -18,6 +18,7 @@ jobs:
             { os: centos, version: 8, package-type: RPM },
             { os: debian, version: 10, package-type: DEB },
             { os: debian, version: 11, package-type: DEB },
+            { os: debian, version: 12, package-type: DEB },
             { os: mariner, version: 2, package-type: RPM },
             { os: oraclelinux, version: 8, package-type: RPM },
             { os: rhel, version: 8, package-type: RPM },


### PR DESCRIPTION
## Description

Restore missing target to the moduletest workflow.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.