### PR TITLE
Add missing 'log' argument in BackupSshdConfig

### DIFF
--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -1022,7 +1022,7 @@ static int SaveRemediationToConfFile(void* log)
     return status;
 }
 
-static int BackupSshdConfig(const char* configuration)
+static int BackupSshdConfig(const char* configuration, void* log)
 {
     size_t configurationSize = 0;
     int status = 0;
@@ -1064,7 +1064,7 @@ static int SaveRemediationToSshdConfig(void* log)
         OsConfigLogError(log, "SaveRemediationToSshdConfig: failed to read from '%s'", g_sshServerConfiguration);
         status = EEXIST;
     }
-    else if (0 != (status = BackupSshdConfig(originalConfiguration)))
+    else if (0 != (status = BackupSshdConfig(originalConfiguration, log)))
     {
         OsConfigLogInfo(log, "SaveRemediationToSshdConfig: failed to make a backup copy of '%s'", g_sshServerConfiguration);
     }

--- a/src/common/tests/CMakeLists.txt
+++ b/src/common/tests/CMakeLists.txt
@@ -9,7 +9,10 @@ include(CTest)
 find_package(GTest REQUIRED)
 
 add_executable(commontests
-    CommonUtilsUT.cpp)
+    CommonUtilsUT.cpp
+    SshUtilsUT.cpp
+    Helper.c
+)
 
 target_link_libraries(commontests
     gtest
@@ -19,6 +22,8 @@ target_link_libraries(commontests
     pthread
     logging
     commonutils
-    asb)
+    asb
+    parsonlib
+)
 
 gtest_discover_tests(commontests XML_OUTPUT_DIR ${GTEST_OUTPUT_DIR})

--- a/src/common/tests/Helper.c
+++ b/src/common/tests/Helper.c
@@ -1,0 +1,19 @@
+#include "../commonutils/SshUtils.c"
+
+int BackupSshdConfigTest(char const* c)
+{
+    return BackupSshdConfig(c, NULL);
+}
+
+void SwapGlobalSshServerConfigs(const char** config, const char** backup, const char** remediation)
+{
+    const char* temp = g_sshServerConfiguration;
+    g_sshServerConfiguration = *config;
+    *config = temp;
+    temp = g_sshServerConfigurationBackup;
+    g_sshServerConfigurationBackup = *backup;
+    *backup = temp;
+    temp = g_osconfigRemediationConf;
+    g_osconfigRemediationConf = *remediation;
+    *remediation = temp;
+}

--- a/src/common/tests/Helper.h
+++ b/src/common/tests/Helper.h
@@ -1,0 +1,14 @@
+#ifndef HELPER_H
+#define HELPER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+int BackupSshdConfigTest(char const* c);
+void SwapGlobalSshServerConfigs(const char** config, const char** backup, const char** remediation);
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // HELPER_H

--- a/src/common/tests/SshUtilsUT.cpp
+++ b/src/common/tests/SshUtilsUT.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <fcntl.h>
+#include <fstream>
+#include <gtest/gtest.h>
+#include "Helper.h"
+
+class SshTest : public testing::Test
+{
+protected:
+    SshTest()
+    {
+        char tmpl[] = "/tmp/sshXXXXXX";
+        char* dir = ::mkdtemp(tmpl);
+        if (dir == NULL)
+        {
+            throw std::system_error(errno, std::generic_category(), "mkdtemp failed");
+        }
+        tmpdir = dir;
+        sshdir = tmpdir + "/ssh";
+        ::mkdir(sshdir.c_str(), 0755);
+        sshd_config = sshdir + "/sshd_config";
+        sshd_config_backup = sshdir + "/sshd_config.bak";
+        sshd_config_remediation = sshdir + "/osconfig_remediation.conf";
+        g_sshServerConfiguration_original = sshd_config.c_str();
+        g_sshServerConfigurationBackup_original = sshd_config_backup.c_str();
+        g_osconfigRemediationConf_original = sshd_config_remediation.c_str();
+        SwapGlobalSshServerConfigs(&g_sshServerConfiguration_original, &g_sshServerConfigurationBackup_original, &g_osconfigRemediationConf_original);
+    }
+
+    ~SshTest()
+    {
+        SwapGlobalSshServerConfigs(&g_sshServerConfiguration_original, &g_sshServerConfigurationBackup_original, &g_osconfigRemediationConf_original);
+        ClearDirs();
+        ::rmdir(tmpdir.c_str());
+    }
+
+    void ClearDirs() const
+    {
+        ::remove(sshd_config.c_str());
+        ::remove(sshd_config_backup.c_str());
+        ::remove(sshd_config_remediation.c_str());
+        ::rmdir(sshdir.c_str());
+    }
+
+    std::string tmpdir;
+    std::string sshdir;
+    std::string sshd_config;
+    std::string sshd_config_backup;
+    std::string sshd_config_remediation;
+    const char* g_sshServerConfiguration_original;
+    const char* g_sshServerConfigurationBackup_original;
+    const char* g_osconfigRemediationConf_original;
+};
+
+static std::string getFileContents(const std::string& filename)
+{
+    std::ifstream file(filename);
+    std::stringstream ss;
+    ss << file.rdbuf();
+    return ss.str();
+}
+
+TEST_F(SshTest, BackupSshdSuccess)
+{
+    std::string success = "success\n";
+    int result = BackupSshdConfigTest(success.c_str());
+
+    EXPECT_EQ(0, result);
+    EXPECT_EQ(success, getFileContents(sshd_config_backup));
+}
+
+TEST_F(SshTest, BackupSshdFail)
+{
+    // Force an error by removing an intermediate directory
+    ClearDirs();
+    int result = BackupSshdConfigTest("fail");
+
+    EXPECT_NE(0, result);
+}


### PR DESCRIPTION
## Description

`BackupSshdConfig()` passes `log` to `SavePayloadToFile()`, but it doesn't take a `log` parameter. This is picking up the function pointer to the log(arithm) function instead. If there is any error in `SavePayloadToFile`, logging segfaults. Add the missing parameter.

To ensure this doesn't regress, added unit tests for internals of `SshUtils`. These will be extended with new test cases.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.