### PR TITLE
Fix SshUtilsUT build on GCC 4.8 distros

### DIFF
--- a/src/common/tests/CMakeLists.txt
+++ b/src/common/tests/CMakeLists.txt
@@ -10,14 +10,9 @@ find_package(GTest REQUIRED)
 
 add_executable(commontests
     CommonUtilsUT.cpp
+    SshUtilsUT.cpp
+    Helper.c
 )
-
-if (CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER "4.9")
-    target_sources(commontests PRIVATE
-        SshUtilsUT.cpp
-        Helper.c
-    )
-endif()
 
 target_link_libraries(commontests
     gtest

--- a/src/common/tests/SshUtilsUT.cpp
+++ b/src/common/tests/SshUtilsUT.cpp
@@ -3,6 +3,7 @@
 
 #include <fcntl.h>
 #include <fstream>
+#include <system_error>
 #include <gtest/gtest.h>
 #include "Helper.h"
 


### PR DESCRIPTION
## Description

The file was missing an `#include <system_error>` statement. With this change `commontests` builds on centos 7/rhel 7/oracle linux 7 and ubuntu 14.04 again, so there is no reason to make the include of these files conditional.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.