### PR TITLE
Update RHEL7/Centos7/OracleLinux7 dockerfiles

### DIFF
--- a/devops/docker/centos-7-amd64/Dockerfile
+++ b/devops/docker/centos-7-amd64/Dockerfile
@@ -1,6 +1,9 @@
 # TODO: Add mcr.io retagged images
 FROM centos:7
 
+RUN rm /etc/yum.repos.d/*.repo
+COPY centos.repo /etc/yum.repos.d/centos.repo
+
 RUN yum install -y \
     autoconf \
     gcc \
@@ -19,10 +22,10 @@ WORKDIR /git
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
 
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
+RUN cd rapidjson && cmake -DRAPIDJSON_BUILD_TESTS=0 . && cmake --build . --parallel --target install && rm -rf /git/rapidjson
+
 # GTest
 RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
 RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest
-
-# rapidjson
-RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
-RUN cd rapidjson && cmake . && cmake --build . --parallel --target install && rm -rf /git/rapidjson

--- a/devops/docker/centos-7-amd64/centos.repo
+++ b/devops/docker/centos-7-amd64/centos.repo
@@ -1,0 +1,22 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=https://vault.centos.org/7.9.2009/os/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=https://vault.centos.org/7.9.2009/updates/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=https://vault.centos.org/7.9.2009/extras/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/devops/docker/oraclelinux-7-amd64/Dockerfile
+++ b/devops/docker/oraclelinux-7-amd64/Dockerfile
@@ -19,10 +19,10 @@ WORKDIR /git
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
 
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
+RUN cd rapidjson && cmake -DRAPIDJSON_BUILD_TESTS=0 . && cmake --build . --parallel --target install && rm -rf /git/rapidjson
+
 # GTest
 RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
 RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest
-
-# rapidjson
-RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
-RUN cd rapidjson && cmake . && cmake --build . --parallel --target install && rm -rf /git/rapidjson

--- a/devops/docker/rhel-7-amd64/Dockerfile
+++ b/devops/docker/rhel-7-amd64/Dockerfile
@@ -1,6 +1,13 @@
 # ubi7 images are missing RPM devtools, copy from centos7
 FROM centos:centos7 as centos
-RUN yum update -y && yumdownloader rpm-build && yumdownloader elfutils
+RUN rm /etc/yum.repos.d/*.repo
+COPY centos.repo /etc/yum.repos.d/centos.repo
+
+RUN yum update -y
+RUN rm /etc/yum.repos.d/*.repo
+COPY centos.repo /etc/yum.repos.d/centos.repo
+
+RUN yumdownloader rpm-build && yumdownloader elfutils
 
 # TODO: Add mcr.io retagged images
 FROM registry.access.redhat.com/ubi7/ubi
@@ -27,13 +34,13 @@ RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm 
 RUN git clone https://github.com/stedolan/jq.git --recursive
 RUN cd jq && autoreconf -i && ./configure && make -j$(nproc) && make install && rm -rf /git/jq
 
+# rapidjson
+RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
+RUN cd rapidjson && cmake -DRAPIDJSON_BUILD_TESTS=0 . && cmake --build . --parallel --target install && rm -rf /git/rapidjson
+
 # GTest
 RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
 RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest
-
-# rapidjson
-RUN git clone https://github.com/Tencent/rapidjson --recursive -b v1.1.0
-RUN cd rapidjson && cmake . && cmake --build . --parallel --target install && rm -rf /git/rapidjson
 
 # elfutils
 RUN yum install -y /elfutils.rpm && rm -f /elfutils.rpm

--- a/devops/docker/rhel-7-amd64/centos.repo
+++ b/devops/docker/rhel-7-amd64/centos.repo
@@ -1,0 +1,22 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=https://vault.centos.org/7.9.2009/os/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=https://vault.centos.org/7.9.2009/updates/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=https://vault.centos.org/7.9.2009/extras/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile.2
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile.2
@@ -1,0 +1,8 @@
+FROM ghcr.io/azure/azure-osconfig/ubuntu-14.04-amd64:latest
+
+RUN apt-get install -y ninja-build
+
+WORKDIR /git
+
+RUN git clone https://github.com/google/googletest --recursive -b release-1.10.0
+RUN cd googletest && cmake . -G Ninja && cmake --build . --target install && rm -rf /git/googletest


### PR DESCRIPTION
## Description

Update build container dockerfiles for Centos 7 (and derivative) to fix an issue preventing `commandrunner` and `samples/cpp` from building.

Rapidjson has a google test submodule that it installs. This module has a version of google test that does not match the one we expect and overwrites the version that we clone ourselves. Disable installation of rapidjson's googletest by setting a cmake variable and order the gtest installation after rapidjson to ensure google test is installed correctly.

Centos 7 mirror lists have been decomissioned but we can still access a snapshot of the repo - we just have to overwrite the repo definitions. This is necessary to get the containers to build at all.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.