### PR TITLE
Updating the custom test policy reference definitions

### DIFF
--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "832539A6E9167E356B1CA99F090E20B6C94673FAB6E6714881798C56D8EBD44E"
+        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7"
       }
     },
     "parameters": {
@@ -341,7 +341,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "832539A6E9167E356B1CA99F090E20B6C94673FAB6E6714881798C56D8EBD44E",
+                        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -358,7 +358,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "832539A6E9167E356B1CA99F090E20B6C94673FAB6E6714881798C56D8EBD44E",
+                        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -375,7 +375,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "832539A6E9167E356B1CA99F090E20B6C94673FAB6E6714881798C56D8EBD44E",
+                        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -734,7 +734,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -829,7 +829,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
                 "version": "1.0.0",
                 "contentType": "Custom",
                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                 "configurationParameter": {
                     "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
                     "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -715,7 +715,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {
@@ -806,7 +806,7 @@
                                                 "version": "1.0.0",
                                                 "contentType": "Custom",
                                                 "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "1ADA673657D30BC454919EB74AC05785ED946FC948AD64CFFFF436BC229567C6",
+                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
                                                 "assignmentType": "ApplyAndAutoCorrect",
                                                 "configurationParameter": [
                                                     {


### PR DESCRIPTION
## Description

Updating the custom test policy reference definitions to point them to policy packages for 12/24 manual validation. We are keeping these for now in here and with manual updates because of partners that are already using these definitions from these locations. In the future we may replace this process with an automated one or else, tbd.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.