### PR TITLE
Stabilization fixes for hardening and optimization found during current manual Azure Policies validation for ASB v2

### DIFF
--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -21,7 +21,6 @@ jobs:
             { os: debian, version: 12, package-type: DEB },
             { os: mariner, version: 2, package-type: RPM },
             { os: oraclelinux, version: 8, package-type: RPM },
-            { os: rhel, version: 7, package-type: RPM },
             { os: rhel, version: 8, package-type: RPM },
             { os: rhel, version: 9, package-type: RPM },
             { os: rockylinux, version: 9, package-type: RPM },

--- a/src/common/asb/Asb.h
+++ b/src/common/asb/Asb.h
@@ -4,11 +4,9 @@
 #ifndef ASB_H
 #define ASB_H
 
-#define PRETTY_NAME_AZURE_LINUX_1 "CBL-Mariner/Linux"
-#define PRETTY_NAME_AZURE_LINUX_2 "CBL-Mariner/Linux"
+#define PRETTY_NAME_AZURE_LINUX "CBL-Mariner/Linux"
 #define PRODUCT_NAME_AZURE_COMMODORE "Azure Commodore"
-#define PRETTY_NAME_ALMA_LINUX_9 "AlmaLinux 9 (Beryllium)"
-#define PRETTY_NAME_ALMA_LINUX_9_3 "AlmaLinux 9.3 (Shamrock Pampas Cat)"
+#define PRETTY_NAME_ALMA_LINUX_9 "AlmaLinux 9"
 #define PRETTY_NAME_AMAZON_LINUX_2 "Amazon Linux 2"
 #define PRETTY_NAME_CENTOS_7 "CentOS Linux 7"
 #define PRETTY_NAME_CENTOS_8 "CentOS Stream 8"

--- a/src/common/asb/Asb.h
+++ b/src/common/asb/Asb.h
@@ -4,6 +4,7 @@
 #ifndef ASB_H
 #define ASB_H
 
+#define PRETTY_NAME_AZURE_LINUX_1 "CBL-Mariner/Linux"
 #define PRETTY_NAME_AZURE_LINUX_2 "CBL-Mariner/Linux"
 #define PRODUCT_NAME_AZURE_COMMODORE "Azure Commodore"
 #define PRETTY_NAME_ALMA_LINUX_9 "AlmaLinux 9 (Beryllium)"
@@ -20,6 +21,7 @@
 #define PRETTY_NAME_RHEL_8 "Red Hat Enterprise Linux 8"
 #define PRETTY_NAME_RHEL_9 "Red Hat Enterprise Linux 9"
 #define PRETTY_NAME_ROCKY_LINUX_9 "Rocky Linux 9"
+#define PRETTY_NAME_SLES_12 "SUSE Linux Enterprise Server 12"
 #define PRETTY_NAME_SLES_15 "SUSE Linux Enterprise Server 15"
 #define PRETTY_NAME_UBUNTU_16_04 "Ubuntu 16.04"
 #define PRETTY_NAME_UBUNTU_18_04 "Ubuntu 18.04"

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -932,7 +932,7 @@ bool IsCommodore(void* log)
     char* textResult = NULL;
     bool status = false;
 
-    if ((0 == ExecuteCommand(NULL, productNameCommand, true, true, 0, 0, &textResult, NULL, log)) && textResult)
+    if ((0 == ExecuteCommand(NULL, productNameCommand, true, false, 0, 0, &textResult, NULL, log)) && textResult)
     {
         RemovePrefixBlanks(textResult);
         RemoveTrailingBlanks(textResult);
@@ -958,6 +958,15 @@ bool IsSelinuxPresent(void)
 
 bool DetectSelinux(void* log)
 {
-    g_selinuxPresent = (0 == CheckTextIsFoundInFile("/sys/kernel/security/lsm", "selinux", NULL, log));
-    return IsSelinuxPresent();
+    const char* command = "cat /sys/kernel/security/lsm | grep selinux";
+    bool status = false;
+
+    if (0 == ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log))
+    {
+        status = true;
+    }
+
+    g_selinuxPresent = status;
+
+    return status;
 }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -502,7 +502,7 @@ int CheckFileExists(const char* fileName, char** reason, void* log)
     {
         OsConfigLogInfo(log, "CheckFileExists: file '%s' is not found", fileName);
         OsConfigCaptureReason(reason, "File  '%s' is not found", fileName);
-        status = EEXIST;
+        status = ENOENT;
     }
 
     return status;
@@ -521,7 +521,7 @@ int CheckFileNotFound(const char* fileName, char** reason, void* log)
     {
         OsConfigLogInfo(log, "CheckFileNotFound: file '%s' exists", fileName);
         OsConfigCaptureReason(reason, "File  '%s' exists", fileName);
-        status = EEXIST;
+        status = ENOENT;
     }
 
     return status;
@@ -1008,7 +1008,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     else if (false == FileExists(fileName))
     {
         OsConfigLogInfo(log, "ReplaceMarkedLinesInFile called for a file that does not exist: '%s'", fileName);
-        return EEXIST;
+        return ENOENT;
     }
     else if (NULL == (line = malloc(lineMax + 1)))
     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1008,7 +1008,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     else if (false == FileExists(fileName))
     {
         OsConfigLogInfo(log, "ReplaceMarkedLinesInFile called for a file that does not exist: '%s'", fileName);
-        return ENOENT;
+        return 0;
     }
     else if (NULL == (line = malloc(lineMax + 1)))
     {
@@ -1910,6 +1910,11 @@ int SetEtcConfValue(const char* file, const char* name, const char* value, void*
     {
         OsConfigLogError(log, "SetEtcConfValue: invalid argument");
         return EINVAL;
+    }
+    else if (false == FileExists(file))
+    {
+        OsConfigLogError(log, "SetEtcConfValue: file '%s' does not exist");
+        return ENOENT;
     }
     else if (NULL == (newline = FormatAllocateString(newlineTemplate, name, value)))
     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1008,7 +1008,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     else if (false == FileExists(fileName))
     {
         OsConfigLogInfo(log, "ReplaceMarkedLinesInFile called for a file that does not exist: '%s'", fileName);
-        return 0;
+        return EEXIST;
     }
     else if (NULL == (line = malloc(lineMax + 1)))
     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1913,7 +1913,7 @@ int SetEtcConfValue(const char* file, const char* name, const char* value, void*
     }
     else if (false == FileExists(file))
     {
-        OsConfigLogError(log, "SetEtcConfValue: file '%s' does not exist");
+        OsConfigLogError(log, "SetEtcConfValue: file '%s' does not exist", file);
         return ENOENT;
     }
     else if (NULL == (newline = FormatAllocateString(newlineTemplate, name, value)))

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -187,7 +187,7 @@ static int ExecuteAptGetUpdate(void* log)
     
     if (g_aptGetUpdateExecuted)
     {
-        return;
+        return status;
     }
 
     if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
@@ -210,7 +210,7 @@ static int ExecuteZypperRefresh(void* log)
 
     if (g_zypperRefreshExecuted)
     {
-        return;
+        return status;
     }
 
     if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -293,6 +293,7 @@ int InstallPackage(const char* packageName, void* log)
 int UninstallPackage(const char* packageName, void* log)
 {
     const char* commandTemplateAptGet = "%s remove -y --purge %s";
+    const char* commandTemplateZypper = "%s remove -y --force %s";
     const char* commandTemplateAllElse = "%s remove -y %s";
 
     int status = ENOENT;
@@ -322,7 +323,7 @@ int UninstallPackage(const char* packageName, void* log)
         {
             ExecuteZypperRefresh(log);
             ExecuteZypperRefreshServices(log);
-            status = CheckOrInstallPackage(commandTemplateAllElse, g_zypper, packageName, log);
+            status = CheckOrInstallPackage(commandTemplateZypper, g_zypper, packageName, log);
         }
 
         if ((0 == status) && (0 == IsPackageInstalled(packageName, log)))

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -19,6 +19,7 @@ static bool g_yumIsPresent = false;
 static bool g_zypperIsPresent = false;
 static bool g_aptGetUpdateExecuted = false;
 static bool g_zypperRefreshExecuted = false;
+static bool g_zypperRefreshServicesExecuted = false;
 
 int IsPresent(const char* what, void* log)
 {
@@ -216,7 +217,12 @@ static int ExecuteAptGetUpdate(void* log)
 
 static int ExecuteZypperRefresh(void* log)
 {
-    return ExecuteSimplePackageCommand("zypper --refresh", &g_zypperRefreshExecuted, log);
+    return ExecuteSimplePackageCommand("zypper refresh", &g_zypperRefreshExecuted, log);
+}
+
+static int ExecuteZypperRefreshServices(void* log)
+{
+    return ExecuteSimplePackageCommand("zypper refresh --services", &g_zypperRefreshServicesExecuted, log);
 }
 
 int InstallOrUpdatePackage(const char* packageName, void* log)
@@ -246,6 +252,7 @@ int InstallOrUpdatePackage(const char* packageName, void* log)
     else if (g_zypperIsPresent)
     {
         ExecuteZypperRefresh(log);
+        ExecuteZypperRefreshServices(log);
         status = CheckOrInstallPackage(commandTemplate, g_zypper, packageName, log);
     }
 
@@ -314,6 +321,7 @@ int UninstallPackage(const char* packageName, void* log)
         else if (g_zypperIsPresent)
         {
             ExecuteZypperRefresh(log);
+            ExecuteZypperRefreshServices(log);
             status = CheckOrInstallPackage(commandTemplateAllElse, g_zypper, packageName, log);
         }
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -180,50 +180,43 @@ int CheckPackageNotInstalled(const char* packageName, char** reason, void* log)
     return result;
 }
 
-static int ExecuteAptGetUpdate(void* log)
+static int ExecuteSimplePackageCommand(const char* command, bool* executed, void* log)
 {
-    const char* command = "apt-get update";
     int status = 0;
+
+    if ((NULL == command) || (NULL == executed))
+    {
+        OsConfigLogError(log, "ExecuteSimplePackageCommand called with invalid arguments");
+        return EINVAL;
+    }
     
-    if (g_aptGetUpdateExecuted)
+    if (true == *executed)
     {
         return status;
     }
 
     if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteAptGetUpdate: '%s' was successful", command);
-        g_aptGetUpdateExecuted = true;
+        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' was successful", command);
+        *executed = true;
     }
     else
     {
-        OsConfigLogError(log, "ExecuteAptGetUpdate: '%s' failed with %d (errno: %d)", command, status, errno);
+        OsConfigLogError(log, "ExecuteSimplePackageCommand: '%s' failed with %d (errno: %d)", command, status, errno);
+        *executed = false;
     }
 
     return status;
 }
 
+static int ExecuteAptGetUpdate(void* log)
+{
+    return ExecuteSimplePackageCommand("apt-get update", &g_aptGetUpdateExecuted, log);
+}
+
 static int ExecuteZypperRefresh(void* log)
 {
-    const char* command = "zypper --refresh";
-    int status = 0;
-
-    if (g_zypperRefreshExecuted)
-    {
-        return status;
-    }
-
-    if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
-    {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' was successful", command);
-        g_aptGetUpdateExecuted = true;
-    }
-    else
-    {
-        OsConfigLogError(log, "ExecuteZypperRefresh: '%s' failed with %d (errno: %d)", command, status, errno);
-    }
-
-    return status;
+    return ExecuteSimplePackageCommand("zypper --refresh", &g_zypperRefreshExecuted, log);
 }
 
 int InstallOrUpdatePackage(const char* packageName, void* log)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2249,6 +2249,8 @@ TEST_F(CommonUtilsTest, ReplaceMarkedLinesInFile)
     EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, nullptr, nullptr, '#', false, nullptr));
     EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(m_path, nullptr, nullptr, '#', false, nullptr));
 
+    EXPECT_EQ(EEXIST, ReplaceMarkedLinesInFile("does_not_exist", marker1, newline1, '#', true, nullptr));
+    
     EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker1, newline1, '#', true, nullptr));
     EXPECT_STREQ(outFile1, contents = LoadStringFromFile(m_path, false, nullptr));
     FREE_MEMORY(contents);

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -707,11 +707,11 @@ TEST_F(CommonUtilsTest, CheckFileExists)
 {
     EXPECT_TRUE(CreateTestFile(m_path, m_data));
     EXPECT_EQ(0, CheckFileExists(m_path, nullptr, nullptr));
-    EXPECT_EQ(EEXIST, CheckFileNotFound(m_path, nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckFileNotFound(m_path, nullptr, nullptr));
     EXPECT_TRUE(Cleanup(m_path));
-    EXPECT_EQ(EEXIST, CheckFileExists(m_path, nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckFileExists(m_path, nullptr, nullptr));
     EXPECT_EQ(0, CheckFileNotFound(m_path, nullptr, nullptr));
-    EXPECT_EQ(EEXIST, CheckFileExists("This file does not exist", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckFileExists("This file does not exist", nullptr, nullptr));
     EXPECT_EQ(0, CheckFileNotFound("This file does not exist", nullptr, nullptr));
 }
 
@@ -2249,7 +2249,7 @@ TEST_F(CommonUtilsTest, ReplaceMarkedLinesInFile)
     EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, nullptr, nullptr, '#', false, nullptr));
     EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(m_path, nullptr, nullptr, '#', false, nullptr));
 
-    EXPECT_EQ(EEXIST, ReplaceMarkedLinesInFile("does_not_exist", marker1, newline1, '#', true, nullptr));
+    EXPECT_EQ(ENOENT, ReplaceMarkedLinesInFile("does_not_exist", marker1, newline1, '#', true, nullptr));
     
     EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker1, newline1, '#', true, nullptr));
     EXPECT_STREQ(outFile1, contents = LoadStringFromFile(m_path, false, nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2249,7 +2249,7 @@ TEST_F(CommonUtilsTest, ReplaceMarkedLinesInFile)
     EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(nullptr, nullptr, nullptr, '#', false, nullptr));
     EXPECT_EQ(EINVAL, ReplaceMarkedLinesInFile(m_path, nullptr, nullptr, '#', false, nullptr));
 
-    EXPECT_EQ(ENOENT, ReplaceMarkedLinesInFile("does_not_exist", marker1, newline1, '#', true, nullptr));
+    EXPECT_EQ(0, ReplaceMarkedLinesInFile("does_not_exist", marker1, newline1, '#', true, nullptr));
     
     EXPECT_EQ(0, ReplaceMarkedLinesInFile(m_path, marker1, newline1, '#', true, nullptr));
     EXPECT_STREQ(outFile1, contents = LoadStringFromFile(m_path, false, nullptr));


### PR DESCRIPTION
## Description

Stabilization fixes during manual validation, including:
- Consolidation of the friendly distro name constants in Asb.h.
- Replaced Check* function with local ExecuteCommand for DetectSelinux() function in order to simplify and do not log extra.
- The ExecuteCommand call for IsCommodore does not need to format results for JSON.
- CheckFileExists, CheckFileNotFound need to return ENOENT instead EEXIST when file not found.
- Making  SetEtcConfValue fail with ENOENT in case of file not found instead of 0 and masking the remediation failure in logs.
- Added zypper refresh and forced uninstall functionality for Red Hat based distros (similar to apt-get update for Ubuntu/Debian).
- Temporarily removing RTHEL 7 from ModuleTest run: CommandRunner does not build there.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.