### PR TITLE
Updating the reference custom test policy definitions

### DIFF
--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7"
+        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0"
       }
     },
     "parameters": {
@@ -341,7 +341,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7",
+                        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -358,7 +358,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7",
+                        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -375,7 +375,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "111174DFBE41B09E92D53E31677738D2A250EC672C6BD535A891E14F2503B2D7",
+                        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -1,923 +1,923 @@
 {
-    "properties": {
-        "displayName": "Configure SSH security posture for Linux (powered by OSConfig)",
-        "policyType": "Custom",
-        "mode": "Indexed",
-        "description": "This policy audits and configures SSH server security configuration on Linux machines (Azure VMs and Arc-enabled machines). For more information including pre-requisites, settings in scope, defaults, and customization, see https://aka.ms/SshPostureControlOverview",
-        "metadata": {
-            "category": "Guest Configuration",
-            "version": "1.0.1",
-            "requiredProviders": [
-                "Microsoft.GuestConfiguration"
-            ],
-            "guestConfiguration": {
-                "name": "LinuxSshServerSecurityBaseline",
-                "version": "1.0.0",
-                "contentType": "Custom",
-                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                "configurationParameter": {
-                    "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                    "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                    "logLevel": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                    "maxAuthTries": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                    "allowUsers": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                    "denyUsers": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                    "allowGroups": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                    "denyGroups": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                    "hostBasedAuthentication": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                    "permitRootLogin": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                    "permitEmptyPasswords": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                    "clientAliveCountMax": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                    "clientAliveInterval": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                    "loginGraceTime": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
-                    "messageAuthenticationCodeAlgorithms": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                    "banner": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                    "permitUserEnvironment": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                    "ciphers": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                    "port": "Ensure that the SSH port is configured;DesiredObjectValue"
-                }
-            }
-        },
-        "parameters": {
-            "includeArcMachines": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Include Arc connected machines",
-                    "description": "By selecting this option, you agree to be charged monthly per Arc connected machine.",
-                    "portalReview": "true"
-                },
-                "allowedValues": [
-                    "true",
-                    "false"
-                ],
-                "defaultValue": "false"
-            },
-            "effect": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Effect",
-                    "description": "Configures between remediation (DeployIfNotExists) or audit-only (AuditIfNotExists) policy execution mode. Default is AuditIfNotExists"
-                },
-                "allowedValues": [
-                    "DeployIfNotExists",
-                    "AuditIfNotExists"
-                ],
-                "defaultValue": "AuditIfNotExists"
-            },
-            "accessPermissionsForSshdConfig": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Access permissions for sshd_config",
-                    "description": "File access permissions for /etc/ssh/sshd_config. Default is '600'"
-                },
-                "defaultValue": "600"
-            },
-            "ignoreHosts": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Ignore rhosts and shosts",
-                    "description": "Whether to ignore per-user .rhosts and .shosts files during HostbasedAuthentication. Default is 'yes'"
-                },
-                "defaultValue": "yes"
-            },
-            "logLevel": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Log verbosity level",
-                    "description": "The verbosity level for the sshd logging. Default is 'INFO'"
-                },
-                "defaultValue": "INFO"
-            },
-            "maxAuthTries": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Maximum number of authentication attempts",
-                    "description": "The maximum number of authentication attempts permitted per connection. Default is '6'"
-                },
-                "defaultValue": "6"
-            },
-            "allowUsers": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Allowed users for SSH",
-                    "description": "List of users to be allowed to connect with SSH. Default is all authenticated users ('*@*')"
-                },
-                "defaultValue": "*@*"
-            },
-            "denyUsers": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Denied users for SSH",
-                    "description": "List of users to be denied to connect with SSH. Default is 'root'"
-                },
-                "defaultValue": "root"
-            },
-            "allowGroups": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Allowed groups for SSH",
-                    "description": "List of user groups to be allowed to connect with SSH. Default is all groups ('*')"
-                },
-                "defaultValue": "*"
-            },
-            "denyGroups": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Denied groups for SSH",
-                    "description": "List of user groups to be denied to connect with SSH. Default is 'root'"
-                },
-                "defaultValue": "root"
-            },
-            "hostBasedAuthentication": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Host-based authentication",
-                    "description": "Host-based authentication. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "permitRootLogin": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Whether root can log in using ssh",
-                    "description": "Whether root can log in using ssh. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "permitEmptyPasswords": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Whether the server allows login to accounts with empty password strings",
-                    "description": "Whether the server allows login to accounts with empty password strings. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "clientAliveCountMax": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The number of client alive messages which may be sent without sshd receiving any messages back from the client",
-                    "description": "The number of client alive messages which may be sent without sshd receiving any messages back from the client. Default is '0'"
-                },
-                "defaultValue": "0"
-            },
-            "clientAliveInterval": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response",
-                    "description": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response. Default is  1 hour ('3600')"
-                },
-                "defaultValue": "3600"
-            },
-            "loginGraceTime": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The time in seconds after which the server disconnects if the user has not successfully logged in",
-                    "description": "The time in seconds after which the server disconnects if the user has not successfully logged in. Default is 1 minute ('60')"
-                },
-                "defaultValue": "60"
-            },
-            "messageAuthenticationCodeAlgorithms": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The list of available message authentication code (MAC) algorithms",
-                    "description": "The list of available message authentication code (MAC) algorithms. Default is 'hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com'"
-                },
-                "defaultValue": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
-            },
-            "banner": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The contents of the banner file that is sent to the remote user before authentication is allowed",
-                    "description": "The contents of the banner file that is sent to the remote user before authentication is allowed. Default is '#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n'"
-                },
-                "defaultValue": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
-            },
-            "permitUserEnvironment": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd",
-                    "description": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "ciphers": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The list of allowed ciphers",
-                    "description": "The list of allowed ciphers. Default is 'aes128-ctr,aes192-ctr,aes256-ctr'"
-                },
-                "defaultValue": "aes128-ctr,aes192-ctr,aes256-ctr"
-            },
-            "port": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The SSH port",
-                    "description": "The SSH port. Default is '22'"
-                },
-                "defaultValue": "22"
-            }
-        },
-        "policyRule": {
-            "if": {
-                "anyOf": [
-                    {
-                        "allOf": [
-                            {
-                                "anyOf": [
-                                    {
-                                        "field": "type",
-                                        "equals": "Microsoft.Compute/virtualMachines"
-                                    },
-                                    {
-                                        "field": "type",
-                                        "equals": "Microsoft.Compute/virtualMachineScaleSets"
-                                    }
-                                ]
-                            },
-                            {
-                                "field": "tags['aks-managed-orchestrator']",
-                                "exists": "false"
-                            },
-                            {
-                                "field": "tags['aks-managed-poolName']",
-                                "exists": "false"
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "field": "Microsoft.Compute/imagePublisher",
-                                        "in": [
-                                            "microsoft-aks",
-                                            "qubole-inc",
-                                            "datastax",
-                                            "couchbase",
-                                            "scalegrid",
-                                            "checkpoint",
-                                            "paloaltonetworks",
-                                            "debian",
-                                            "credativ"
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "OpenLogic"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "Oracle"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "RedHat"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "center-for-internet-security-inc"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageOffer",
-                                                "notLike": "cis-windows*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "Suse"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "11*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "Canonical"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "12*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "microsoft-dsvm"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageOffer",
-                                                "notLike": "dsvm-win*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "cloudera"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "microsoft-ads"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageOffer",
-                                                "like": "linux*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "anyOf": [
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration",
-                                                        "exists": true
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
-                                                        "like": "Linux*"
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachineScaleSets/osProfile.linuxConfiguration",
-                                                        "exists": true
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.storageProfile.osDisk.osType",
-                                                        "like": "Linux*"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "anyOf": [
-                                                    {
-                                                        "field": "Microsoft.Compute/imagePublisher",
-                                                        "exists": false
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/imagePublisher",
-                                                        "notIn": [
-                                                            "OpenLogic",
-                                                            "RedHat",
-                                                            "credativ",
-                                                            "Suse",
-                                                            "Canonical",
-                                                            "microsoft-dsvm",
-                                                            "cloudera",
-                                                            "microsoft-ads",
-                                                            "center-for-internet-security-inc",
-                                                            "Oracle",
-                                                            "AzureDatabricks",
-                                                            "azureopenshift"
-                                                        ]
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "allOf": [
-                            {
-                                "value": "[parameters('IncludeArcMachines')]",
-                                "equals": true
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "type",
-                                                "equals": "Microsoft.HybridCompute/machines"
-                                            },
-                                            {
-                                                "field": "Microsoft.HybridCompute/imageOffer",
-                                                "like": "linux*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "type",
-                                                "equals": "Microsoft.ConnectedVMwarevSphere/virtualMachines"
-                                            },
-                                            {
-                                                "field": "Microsoft.ConnectedVMwarevSphere/virtualMachines/osProfile.osType",
-                                                "like": "linux*"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            },
-            "then": {
-                "effect": "[parameters('effect')]",
-                "details": {
-                    "roleDefinitionIds": [
-                        "/providers/Microsoft.Authorization/roleDefinitions/088ab73d-1256-47ae-bea9-9de8e7131f31"
-                    ],
-                    "type": "Microsoft.GuestConfiguration/guestConfigurationAssignments",
-                    "name": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]",
-                    "existenceCondition": {
-                        "allOf": [
-                            {
-                                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/complianceStatus",
-                                "equals": "Compliant"
-                            },
-                            {
-                                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/parameterHash",
-                                "equals": "[base64(concat('Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue', '=', parameters('accessPermissionsForSshdConfig'), ',', 'Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue', '=', parameters('ignoreHosts'), ',', 'Ensure that the SSH LogLevel is configured;DesiredObjectValue', '=', parameters('logLevel'), ',', 'Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue', '=', parameters('maxAuthTries'), ',', 'Ensure that the allowed users for SSH access are configured;DesiredObjectValue', '=', parameters('allowUsers'), ',', 'Ensure that the denied users for SSH are configured;DesiredObjectValue', '=', parameters('denyUsers'), ',', 'Ensure that the allowed groups for SSH are configured;DesiredObjectValue', '=', parameters('allowGroups'), ',', 'Ensure that the denied groups for SSH are configured;DesiredObjectValue', '=', parameters('denyGroups'), ',', 'Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue', '=', parameters('hostBasedAuthentication'), ',', 'Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue', '=', parameters('permitRootLogin'), ',', 'Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue', '=', parameters('permitEmptyPasswords'), ',', 'Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue', '=', parameters('clientAliveCountMax'), ',', 'Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue', '=', parameters('clientAliveInterval'), ',', 'Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue', '=', parameters('loginGraceTime'), ',', 'Ensure that only approved MAC algorithms are used;DesiredObjectValue', '=', parameters('messageAuthenticationCodeAlgorithms'), ',', 'Ensure that the SSH warning banner is configured;DesiredObjectValue', '=', parameters('banner'), ',', 'Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue', '=', parameters('permitUserEnvironment'), ',', 'Ensure that appropriate ciphers are used for SSH;DesiredObjectValue', '=', parameters('ciphers'), ',', 'Ensure that the SSH port is configured;DesiredObjectValue', '=', parameters('port')))]"
-                            }
-                        ]
-                    },
-                    "deployment": {
-                        "properties": {
-                            "mode": "incremental",
-                            "parameters": {
-                                "vmName": {
-                                    "value": "[field('name')]"
-                                },
-                                "location": {
-                                    "value": "[field('location')]"
-                                },
-                                "type": {
-                                    "value": "[field('type')]"
-                                },
-                                "assignmentName": {
-                                    "value": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]"
-                                },
-                                "accessPermissionsForSshdConfig": {
-                                    "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                },
-                                "ignoreHosts": {
-                                    "value": "[parameters('ignoreHosts')]"
-                                },
-                                "logLevel": {
-                                    "value": "[parameters('logLevel')]"
-                                },
-                                "maxAuthTries": {
-                                    "value": "[parameters('maxAuthTries')]"
-                                },
-                                "allowUsers": {
-                                    "value": "[parameters('allowUsers')]"
-                                },
-                                "denyUsers": {
-                                    "value": "[parameters('denyUsers')]"
-                                },
-                                "allowGroups": {
-                                    "value": "[parameters('allowGroups')]"
-                                },
-                                "denyGroups": {
-                                    "value": "[parameters('denyGroups')]"
-                                },
-                                "hostBasedAuthentication": {
-                                    "value": "[parameters('hostBasedAuthentication')]"
-                                },
-                                "permitRootLogin": {
-                                    "value": "[parameters('permitRootLogin')]"
-                                },
-                                "permitEmptyPasswords": {
-                                    "value": "[parameters('permitEmptyPasswords')]"
-                                },
-                                "clientAliveCountMax": {
-                                    "value": "[parameters('clientAliveCountMax')]"
-                                },
-                                "clientAliveInterval": {
-                                    "value": "[parameters('clientAliveInterval')]"
-                                },
-                                "loginGraceTime": {
-                                    "value": "[parameters('loginGraceTime')]"
-                                },
-                                "messageAuthenticationCodeAlgorithms": {
-                                    "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                },
-                                "banner": {
-                                    "value": "[parameters('banner')]"
-                                },
-                                "permitUserEnvironment": {
-                                    "value": "[parameters('permitUserEnvironment')]"
-                                },
-                                "ciphers": {
-                                    "value": "[parameters('ciphers')]"
-                                },
-                                "port": {
-                                    "value": "[parameters('port')]"
-                                }
-                            },
-                            "template": {
-                                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                                "contentVersion": "1.0.0.0",
-                                "parameters": {
-                                    "vmName": {
-                                        "type": "string"
-                                    },
-                                    "location": {
-                                        "type": "string"
-                                    },
-                                    "type": {
-                                        "type": "string"
-                                    },
-                                    "assignmentName": {
-                                        "type": "string"
-                                    },
-                                    "accessPermissionsForSshdConfig": {
-                                        "type": "string"
-                                    },
-                                    "ignoreHosts": {
-                                        "type": "string"
-                                    },
-                                    "logLevel": {
-                                        "type": "string"
-                                    },
-                                    "maxAuthTries": {
-                                        "type": "string"
-                                    },
-                                    "allowUsers": {
-                                        "type": "string"
-                                    },
-                                    "denyUsers": {
-                                        "type": "string"
-                                    },
-                                    "allowGroups": {
-                                        "type": "string"
-                                    },
-                                    "denyGroups": {
-                                        "type": "string"
-                                    },
-                                    "hostBasedAuthentication": {
-                                        "type": "string"
-                                    },
-                                    "permitRootLogin": {
-                                        "type": "string"
-                                    },
-                                    "permitEmptyPasswords": {
-                                        "type": "string"
-                                    },
-                                    "clientAliveCountMax": {
-                                        "type": "string"
-                                    },
-                                    "clientAliveInterval": {
-                                        "type": "string"
-                                    },
-                                    "loginGraceTime": {
-                                        "type": "string"
-                                    },
-                                    "messageAuthenticationCodeAlgorithms": {
-                                        "type": "string"
-                                    },
-                                    "banner": {
-                                        "type": "string"
-                                    },
-                                    "permitUserEnvironment": {
-                                        "type": "string"
-                                    },
-                                    "ciphers": {
-                                        "type": "string"
-                                    },
-                                    "port": {
-                                        "type": "string"
-                                    }
-                                },
-                                "resources": [
-                                    {
-                                        "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachines'))]",
-                                        "apiVersion": "2018-11-20",
-                                        "type": "Microsoft.Compute/virtualMachines/providers/guestConfigurationAssignments",
-                                        "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
-                                        "location": "[parameters('location')]",
-                                        "properties": {
-                                            "guestConfiguration": {
-                                                "name": "LinuxSshServerSecurityBaseline",
-                                                "version": "1.0.0",
-                                                "contentType": "Custom",
-                                                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                                                "assignmentType": "ApplyAndAutoCorrect",
-                                                "configurationParameter": [
-                                                    {
-                                                        "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                                                        "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                                                        "value": "[parameters('ignoreHosts')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                                                        "value": "[parameters('logLevel')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                                                        "value": "[parameters('maxAuthTries')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                                                        "value": "[parameters('hostBasedAuthentication')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitRootLogin')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitEmptyPasswords')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveCountMax')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveInterval')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
-                                                        "value": "[parameters('loginGraceTime')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                                                        "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                                                        "value": "[parameters('banner')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitUserEnvironment')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                                                        "value": "[parameters('ciphers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH port is configured;DesiredObjectValue",
-                                                        "value": "[parameters('port')]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.HybridCompute/machines'))]",
-                                        "apiVersion": "2018-11-20",
-                                        "type": "Microsoft.HybridCompute/machines/providers/guestConfigurationAssignments",
-                                        "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
-                                        "location": "[parameters('location')]",
-                                        "properties": {
-                                            "guestConfiguration": {
-                                                "name": "LinuxSshServerSecurityBaseline",
-                                                "version": "1.0.0",
-                                                "contentType": "Custom",
-                                                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                                                "assignmentType": "ApplyAndAutoCorrect",
-                                                "configurationParameter": [
-                                                    {
-                                                        "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                                                        "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                                                        "value": "[parameters('ignoreHosts')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                                                        "value": "[parameters('logLevel')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                                                        "value": "[parameters('maxAuthTries')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                                                        "value": "[parameters('hostBasedAuthentication')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitRootLogin')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitEmptyPasswords')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveCountMax')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveInterval')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
-                                                        "value": "[parameters('loginGraceTime')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                                                        "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                                                        "value": "[parameters('banner')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitUserEnvironment')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                                                        "value": "[parameters('ciphers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH port is configured;DesiredObjectValue",
-                                                        "value": "[parameters('port')]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachineScaleSets'))]",
-                                        "apiVersion": "2018-11-20",
-                                        "type": "Microsoft.Compute/virtualMachineScaleSets/providers/guestConfigurationAssignments",
-                                        "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
-                                        "location": "[parameters('location')]",
-                                        "properties": {
-                                            "guestConfiguration": {
-                                                "name": "LinuxSshServerSecurityBaseline",
-                                                "version": "1.0.0",
-                                                "contentType": "Custom",
-                                                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                                                "assignmentType": "ApplyAndAutoCorrect",
-                                                "configurationParameter": [
-                                                    {
-                                                        "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                                                        "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                                                        "value": "[parameters('ignoreHosts')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                                                        "value": "[parameters('logLevel')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                                                        "value": "[parameters('maxAuthTries')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                                                        "value": "[parameters('hostBasedAuthentication')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitRootLogin')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitEmptyPasswords')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveCountMax')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveInterval')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
-                                                        "value": "[parameters('loginGraceTime')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                                                        "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                                                        "value": "[parameters('banner')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitUserEnvironment')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                                                        "value": "[parameters('ciphers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH port is configured;DesiredObjectValue",
-                                                        "value": "[parameters('port')]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
+  "properties": {
+    "displayName": "Configure SSH security posture for Linux (powered by OSConfig)",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "description": "This policy audits and configures SSH server security configuration on Linux machines (Azure VMs and Arc-enabled machines). For more information including pre-requisites, settings in scope, defaults, and customization, see https://aka.ms/SshPostureControlOverview",
+    "metadata": {
+      "category": "Guest Configuration",
+      "version": "1.0.1",
+      "requiredProviders": [
+        "Microsoft.GuestConfiguration"
+      ],
+      "guestConfiguration": {
+        "name": "LinuxSshServerSecurityBaseline",
+        "version": "1.0.0",
+        "contentType": "Custom",
+        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+        "configurationParameter": {
+          "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+          "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+          "logLevel": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+          "maxAuthTries": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+          "allowUsers": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+          "denyUsers": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+          "allowGroups": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+          "denyGroups": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+          "hostBasedAuthentication": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+          "permitRootLogin": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+          "permitEmptyPasswords": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+          "clientAliveCountMax": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+          "clientAliveInterval": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+          "loginGraceTime": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
+          "messageAuthenticationCodeAlgorithms": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+          "banner": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+          "permitUserEnvironment": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+          "ciphers": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+          "port": "Ensure that the SSH port is configured;DesiredObjectValue"
         }
+      }
+    },
+    "parameters": {
+      "includeArcMachines": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Include Arc connected machines",
+          "description": "By selecting this option, you agree to be charged monthly per Arc connected machine.",
+          "portalReview": "true"
+        },
+        "allowedValues": [
+          "true",
+          "false"
+        ],
+        "defaultValue": "false"
+      },
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Configures between remediation (DeployIfNotExists) or audit-only (AuditIfNotExists) policy execution mode. Default is AuditIfNotExists"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      },
+      "accessPermissionsForSshdConfig": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Access permissions for sshd_config",
+          "description": "File access permissions for /etc/ssh/sshd_config. Default is '600'"
+        },
+        "defaultValue": "600"
+      },
+      "ignoreHosts": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Ignore rhosts and shosts",
+          "description": "Whether to ignore per-user .rhosts and .shosts files during HostbasedAuthentication. Default is 'yes'"
+        },
+        "defaultValue": "yes"
+      },
+      "logLevel": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Log verbosity level",
+          "description": "The verbosity level for the sshd logging. Default is 'INFO'"
+        },
+        "defaultValue": "INFO"
+      },
+      "maxAuthTries": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Maximum number of authentication attempts",
+          "description": "The maximum number of authentication attempts permitted per connection. Default is '6'"
+        },
+        "defaultValue": "6"
+      },
+      "allowUsers": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Allowed users for SSH",
+          "description": "List of users to be allowed to connect with SSH. Default is all authenticated users ('*@*')"
+        },
+        "defaultValue": "*@*"
+      },
+      "denyUsers": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Denied users for SSH",
+          "description": "List of users to be denied to connect with SSH. Default is 'root'"
+        },
+        "defaultValue": "root"
+      },
+      "allowGroups": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Allowed groups for SSH",
+          "description": "List of user groups to be allowed to connect with SSH. Default is all groups ('*')"
+        },
+        "defaultValue": "*"
+      },
+      "denyGroups": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Denied groups for SSH",
+          "description": "List of user groups to be denied to connect with SSH. Default is 'root'"
+        },
+        "defaultValue": "root"
+      },
+      "hostBasedAuthentication": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Host-based authentication",
+          "description": "Host-based authentication. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "permitRootLogin": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Whether root can log in using ssh",
+          "description": "Whether root can log in using ssh. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "permitEmptyPasswords": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Whether the server allows login to accounts with empty password strings",
+          "description": "Whether the server allows login to accounts with empty password strings. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "clientAliveCountMax": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The number of client alive messages which may be sent without sshd receiving any messages back from the client",
+          "description": "The number of client alive messages which may be sent without sshd receiving any messages back from the client. Default is '0'"
+        },
+        "defaultValue": "0"
+      },
+      "clientAliveInterval": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response",
+          "description": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response. Default is  1 hour ('3600')"
+        },
+        "defaultValue": "3600"
+      },
+      "loginGraceTime": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The time in seconds after which the server disconnects if the user has not successfully logged in",
+          "description": "The time in seconds after which the server disconnects if the user has not successfully logged in. Default is 1 minute ('60')"
+        },
+        "defaultValue": "60"
+      },
+      "messageAuthenticationCodeAlgorithms": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The list of available message authentication code (MAC) algorithms",
+          "description": "The list of available message authentication code (MAC) algorithms. Default is 'hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com'"
+        },
+        "defaultValue": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
+      },
+      "banner": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The contents of the banner file that is sent to the remote user before authentication is allowed",
+          "description": "The contents of the banner file that is sent to the remote user before authentication is allowed. Default is '#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n'"
+        },
+        "defaultValue": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
+      },
+      "permitUserEnvironment": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd",
+          "description": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "ciphers": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The list of allowed ciphers",
+          "description": "The list of allowed ciphers. Default is 'aes128-ctr,aes192-ctr,aes256-ctr'"
+        },
+        "defaultValue": "aes128-ctr,aes192-ctr,aes256-ctr"
+      },
+      "port": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The SSH port",
+          "description": "The SSH port. Default is '22'"
+        },
+        "defaultValue": "22"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "anyOf": [
+          {
+            "allOf": [
+              {
+                "anyOf": [
+                  {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachines"
+                  },
+                  {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachineScaleSets"
+                  }
+                ]
+              },
+              {
+                "field": "tags['aks-managed-orchestrator']",
+                "exists": "false"
+              },
+              {
+                "field": "tags['aks-managed-poolName']",
+                "exists": "false"
+              },
+              {
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "in": [
+                      "microsoft-aks",
+                      "qubole-inc",
+                      "datastax",
+                      "couchbase",
+                      "scalegrid",
+                      "checkpoint",
+                      "paloaltonetworks",
+                      "debian",
+                      "credativ"
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "OpenLogic"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "Oracle"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "RedHat"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "center-for-internet-security-inc"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "notLike": "cis-windows*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "Suse"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "11*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "Canonical"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "12*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "microsoft-dsvm"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "notLike": "dsvm-win*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "cloudera"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "microsoft-ads"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "linux*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration",
+                            "exists": true
+                          },
+                          {
+                            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+                            "like": "Linux*"
+                          },
+                          {
+                            "field": "Microsoft.Compute/virtualMachineScaleSets/osProfile.linuxConfiguration",
+                            "exists": true
+                          },
+                          {
+                            "field": "Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.storageProfile.osDisk.osType",
+                            "like": "Linux*"
+                          }
+                        ]
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "exists": false
+                          },
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "notIn": [
+                              "OpenLogic",
+                              "RedHat",
+                              "credativ",
+                              "Suse",
+                              "Canonical",
+                              "microsoft-dsvm",
+                              "cloudera",
+                              "microsoft-ads",
+                              "center-for-internet-security-inc",
+                              "Oracle",
+                              "AzureDatabricks",
+                              "azureopenshift"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "value": "[parameters('IncludeArcMachines')]",
+                "equals": true
+              },
+              {
+                "anyOf": [
+                  {
+                    "allOf": [
+                      {
+                        "field": "type",
+                        "equals": "Microsoft.HybridCompute/machines"
+                      },
+                      {
+                        "field": "Microsoft.HybridCompute/imageOffer",
+                        "like": "linux*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "type",
+                        "equals": "Microsoft.ConnectedVMwarevSphere/virtualMachines"
+                      },
+                      {
+                        "field": "Microsoft.ConnectedVMwarevSphere/virtualMachines/osProfile.osType",
+                        "like": "linux*"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/088ab73d-1256-47ae-bea9-9de8e7131f31"
+          ],
+          "type": "Microsoft.GuestConfiguration/guestConfigurationAssignments",
+          "name": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]",
+          "existenceCondition": {
+            "allOf": [
+              {
+                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/complianceStatus",
+                "equals": "Compliant"
+              },
+              {
+                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/parameterHash",
+                "equals": "[base64(concat('Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue', '=', parameters('accessPermissionsForSshdConfig'), ',', 'Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue', '=', parameters('ignoreHosts'), ',', 'Ensure that the SSH LogLevel is configured;DesiredObjectValue', '=', parameters('logLevel'), ',', 'Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue', '=', parameters('maxAuthTries'), ',', 'Ensure that the allowed users for SSH access are configured;DesiredObjectValue', '=', parameters('allowUsers'), ',', 'Ensure that the denied users for SSH are configured;DesiredObjectValue', '=', parameters('denyUsers'), ',', 'Ensure that the allowed groups for SSH are configured;DesiredObjectValue', '=', parameters('allowGroups'), ',', 'Ensure that the denied groups for SSH are configured;DesiredObjectValue', '=', parameters('denyGroups'), ',', 'Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue', '=', parameters('hostBasedAuthentication'), ',', 'Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue', '=', parameters('permitRootLogin'), ',', 'Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue', '=', parameters('permitEmptyPasswords'), ',', 'Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue', '=', parameters('clientAliveCountMax'), ',', 'Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue', '=', parameters('clientAliveInterval'), ',', 'Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue', '=', parameters('loginGraceTime'), ',', 'Ensure that only approved MAC algorithms are used;DesiredObjectValue', '=', parameters('messageAuthenticationCodeAlgorithms'), ',', 'Ensure that the SSH warning banner is configured;DesiredObjectValue', '=', parameters('banner'), ',', 'Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue', '=', parameters('permitUserEnvironment'), ',', 'Ensure that appropriate ciphers are used for SSH;DesiredObjectValue', '=', parameters('ciphers'), ',', 'Ensure that the SSH port is configured;DesiredObjectValue', '=', parameters('port')))]"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "vmName": {
+                  "value": "[field('name')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "type": {
+                  "value": "[field('type')]"
+                },
+                "assignmentName": {
+                  "value": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]"
+                },
+                "accessPermissionsForSshdConfig": {
+                  "value": "[parameters('accessPermissionsForSshdConfig')]"
+                },
+                "ignoreHosts": {
+                  "value": "[parameters('ignoreHosts')]"
+                },
+                "logLevel": {
+                  "value": "[parameters('logLevel')]"
+                },
+                "maxAuthTries": {
+                  "value": "[parameters('maxAuthTries')]"
+                },
+                "allowUsers": {
+                  "value": "[parameters('allowUsers')]"
+                },
+                "denyUsers": {
+                  "value": "[parameters('denyUsers')]"
+                },
+                "allowGroups": {
+                  "value": "[parameters('allowGroups')]"
+                },
+                "denyGroups": {
+                  "value": "[parameters('denyGroups')]"
+                },
+                "hostBasedAuthentication": {
+                  "value": "[parameters('hostBasedAuthentication')]"
+                },
+                "permitRootLogin": {
+                  "value": "[parameters('permitRootLogin')]"
+                },
+                "permitEmptyPasswords": {
+                  "value": "[parameters('permitEmptyPasswords')]"
+                },
+                "clientAliveCountMax": {
+                  "value": "[parameters('clientAliveCountMax')]"
+                },
+                "clientAliveInterval": {
+                  "value": "[parameters('clientAliveInterval')]"
+                },
+                "loginGraceTime": {
+                  "value": "[parameters('loginGraceTime')]"
+                },
+                "messageAuthenticationCodeAlgorithms": {
+                  "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                },
+                "banner": {
+                  "value": "[parameters('banner')]"
+                },
+                "permitUserEnvironment": {
+                  "value": "[parameters('permitUserEnvironment')]"
+                },
+                "ciphers": {
+                  "value": "[parameters('ciphers')]"
+                },
+                "port": {
+                  "value": "[parameters('port')]"
+                }
+              },
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.0.0",
+                "parameters": {
+                  "vmName": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "assignmentName": {
+                    "type": "string"
+                  },
+                  "accessPermissionsForSshdConfig": {
+                    "type": "string"
+                  },
+                  "ignoreHosts": {
+                    "type": "string"
+                  },
+                  "logLevel": {
+                    "type": "string"
+                  },
+                  "maxAuthTries": {
+                    "type": "string"
+                  },
+                  "allowUsers": {
+                    "type": "string"
+                  },
+                  "denyUsers": {
+                    "type": "string"
+                  },
+                  "allowGroups": {
+                    "type": "string"
+                  },
+                  "denyGroups": {
+                    "type": "string"
+                  },
+                  "hostBasedAuthentication": {
+                    "type": "string"
+                  },
+                  "permitRootLogin": {
+                    "type": "string"
+                  },
+                  "permitEmptyPasswords": {
+                    "type": "string"
+                  },
+                  "clientAliveCountMax": {
+                    "type": "string"
+                  },
+                  "clientAliveInterval": {
+                    "type": "string"
+                  },
+                  "loginGraceTime": {
+                    "type": "string"
+                  },
+                  "messageAuthenticationCodeAlgorithms": {
+                    "type": "string"
+                  },
+                  "banner": {
+                    "type": "string"
+                  },
+                  "permitUserEnvironment": {
+                    "type": "string"
+                  },
+                  "ciphers": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachines'))]",
+                    "apiVersion": "2018-11-20",
+                    "type": "Microsoft.Compute/virtualMachines/providers/guestConfigurationAssignments",
+                    "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "guestConfiguration": {
+                        "name": "LinuxSshServerSecurityBaseline",
+                        "version": "1.0.0",
+                        "contentType": "Custom",
+                        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "assignmentType": "ApplyAndAutoCorrect",
+                        "configurationParameter": [
+                          {
+                            "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+                            "value": "[parameters('accessPermissionsForSshdConfig')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+                            "value": "[parameters('ignoreHosts')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+                            "value": "[parameters('logLevel')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+                            "value": "[parameters('maxAuthTries')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+                            "value": "[parameters('allowUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('allowGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+                            "value": "[parameters('hostBasedAuthentication')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+                            "value": "[parameters('permitRootLogin')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+                            "value": "[parameters('permitEmptyPasswords')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveCountMax')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveInterval')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
+                            "value": "[parameters('loginGraceTime')]"
+                          },
+                          {
+                            "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+                            "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+                            "value": "[parameters('banner')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+                            "value": "[parameters('permitUserEnvironment')]"
+                          },
+                          {
+                            "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+                            "value": "[parameters('ciphers')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH port is configured;DesiredObjectValue",
+                            "value": "[parameters('port')]"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.HybridCompute/machines'))]",
+                    "apiVersion": "2018-11-20",
+                    "type": "Microsoft.HybridCompute/machines/providers/guestConfigurationAssignments",
+                    "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "guestConfiguration": {
+                        "name": "LinuxSshServerSecurityBaseline",
+                        "version": "1.0.0",
+                        "contentType": "Custom",
+                        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "assignmentType": "ApplyAndAutoCorrect",
+                        "configurationParameter": [
+                          {
+                            "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+                            "value": "[parameters('accessPermissionsForSshdConfig')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+                            "value": "[parameters('ignoreHosts')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+                            "value": "[parameters('logLevel')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+                            "value": "[parameters('maxAuthTries')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+                            "value": "[parameters('allowUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('allowGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+                            "value": "[parameters('hostBasedAuthentication')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+                            "value": "[parameters('permitRootLogin')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+                            "value": "[parameters('permitEmptyPasswords')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveCountMax')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveInterval')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
+                            "value": "[parameters('loginGraceTime')]"
+                          },
+                          {
+                            "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+                            "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+                            "value": "[parameters('banner')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+                            "value": "[parameters('permitUserEnvironment')]"
+                          },
+                          {
+                            "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+                            "value": "[parameters('ciphers')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH port is configured;DesiredObjectValue",
+                            "value": "[parameters('port')]"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachineScaleSets'))]",
+                    "apiVersion": "2018-11-20",
+                    "type": "Microsoft.Compute/virtualMachineScaleSets/providers/guestConfigurationAssignments",
+                    "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "guestConfiguration": {
+                        "name": "LinuxSshServerSecurityBaseline",
+                        "version": "1.0.0",
+                        "contentType": "Custom",
+                        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "assignmentType": "ApplyAndAutoCorrect",
+                        "configurationParameter": [
+                          {
+                            "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+                            "value": "[parameters('accessPermissionsForSshdConfig')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+                            "value": "[parameters('ignoreHosts')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+                            "value": "[parameters('logLevel')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+                            "value": "[parameters('maxAuthTries')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+                            "value": "[parameters('allowUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('allowGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+                            "value": "[parameters('hostBasedAuthentication')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+                            "value": "[parameters('permitRootLogin')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+                            "value": "[parameters('permitEmptyPasswords')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveCountMax')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveInterval')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LoginGraceTime is configured;DesiredObjectValue",
+                            "value": "[parameters('loginGraceTime')]"
+                          },
+                          {
+                            "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+                            "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+                            "value": "[parameters('banner')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+                            "value": "[parameters('permitUserEnvironment')]"
+                          },
+                          {
+                            "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+                            "value": "[parameters('ciphers')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH port is configured;DesiredObjectValue",
+                            "value": "[parameters('port')]"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -1,896 +1,896 @@
 {
-    "properties": {
-        "displayName": "Audit and configure SSH security posture for Linux (powered by OSConfig)",
-        "policyType": "Custom",
-        "mode": "Indexed",
-        "description": "This policy audits and configures the SSH server security configuration on Linux machines (Azure VMs and Arc-enabled machines). For more information including pre-requisites, settings in scope, defaults, and customization, see https://aka.ms/SshPostureControlOverview",
-        "metadata": {
-            "category": "Guest Configuration",
-            "version": "1.0.1",
-            "requiredProviders": [
-                "Microsoft.GuestConfiguration"
-            ],
-            "guestConfiguration": {
-                "name": "LinuxSshServerSecurityBaseline",
-                "version": "1.0.0",
-                "contentType": "Custom",
-                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                "configurationParameter": {
-                    "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                    "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                    "logLevel": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                    "maxAuthTries": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                    "allowUsers": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                    "denyUsers": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                    "allowGroups": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                    "denyGroups": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                    "hostBasedAuthentication": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                    "permitRootLogin": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                    "permitEmptyPasswords": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                    "clientAliveCountMax": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                    "clientAliveInterval": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                    "messageAuthenticationCodeAlgorithms": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                    "banner": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                    "permitUserEnvironment": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                    "ciphers": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                    "port": "Ensure that the SSH port is configured;DesiredObjectValue"
-                }
-            }
-        },
-        "parameters": {
-            "includeArcMachines": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Include Arc connected machines",
-                    "description": "By selecting this option, you agree to be charged monthly per Arc connected machine.",
-                    "portalReview": "true"
-                },
-                "allowedValues": [
-                    "true",
-                    "false"
-                ],
-                "defaultValue": "false"
-            },
-            "effect": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Effect",
-                    "description": "Configures between remediation (DeployIfNotExists) or audit-only (AuditIfNotExists) policy execution mode. Default is AuditIfNotExists"
-                },
-                "allowedValues": [
-                    "DeployIfNotExists",
-                    "AuditIfNotExists"
-                ],
-                "defaultValue": "AuditIfNotExists"
-            },
-            "accessPermissionsForSshdConfig": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Access permissions for sshd_config",
-                    "description": "File access permissions for /etc/ssh/sshd_config. Default is '600'"
-                },
-                "defaultValue": "600"
-            },
-            "ignoreHosts": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Ignore rhosts and shosts",
-                    "description": "Whether to ignore per-user .rhosts and .shosts files during HostbasedAuthentication. Default is 'yes'"
-                },
-                "defaultValue": "yes"
-            },
-            "logLevel": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Log verbosity level",
-                    "description": "The verbosity level for the sshd logging. Default is 'INFO'"
-                },
-                "defaultValue": "INFO"
-            },
-            "maxAuthTries": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Maximum number of authentication attempts",
-                    "description": "The maximum number of authentication attempts permitted per connection. Default is '6'"
-                },
-                "defaultValue": "6"
-            },
-            "allowUsers": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Allowed users for SSH",
-                    "description": "List of users to be allowed to connect with SSH. Default is all authenticated users ('*@*')"
-                },
-                "defaultValue": "*@*"
-            },
-            "denyUsers": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Denied users for SSH",
-                    "description": "List of users to be denied to connect with SSH. Default is 'root'"
-                },
-                "defaultValue": "root"
-            },
-            "allowGroups": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Allowed groups for SSH",
-                    "description": "List of user groups to be allowed to connect with SSH. Default is all groups ('*')"
-                },
-                "defaultValue": "*"
-            },
-            "denyGroups": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Denied groups for SSH",
-                    "description": "List of user groups to be denied to connect with SSH. Default is 'root'"
-                },
-                "defaultValue": "root"
-            },
-            "hostBasedAuthentication": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Host-based authentication",
-                    "description": "Host-based authentication. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "permitRootLogin": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Whether root can log in using ssh",
-                    "description": "Whether root can log in using ssh. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "permitEmptyPasswords": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Whether the server allows login to accounts with empty password strings",
-                    "description": "Whether the server allows login to accounts with empty password strings. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "clientAliveCountMax": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The number of client alive messages which may be sent without sshd receiving any messages back from the client",
-                    "description": "The number of client alive messages which may be sent without sshd receiving any messages back from the client. Default is '0'"
-                },
-                "defaultValue": "0"
-            },
-            "clientAliveInterval": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response",
-                    "description": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response. Default is  1 hour ('3600')"
-                },
-                "defaultValue": "3600"
-            },
-            "messageAuthenticationCodeAlgorithms": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The list of available message authentication code (MAC) algorithms",
-                    "description": "The list of available message authentication code (MAC) algorithms. Default is 'hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com'"
-                },
-                "defaultValue": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
-            },
-            "banner": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The contents of the banner file that is sent to the remote user before authentication is allowed",
-                    "description": "The contents of the banner file that is sent to the remote user before authentication is allowed. Default is '#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n'"
-                },
-                "defaultValue": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
-            },
-            "permitUserEnvironment": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd",
-                    "description": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. Default is 'no'"
-                },
-                "defaultValue": "no"
-            },
-            "ciphers": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The list of allowed ciphers",
-                    "description": "The list of allowed ciphers. Default is 'aes128-ctr,aes192-ctr,aes256-ctr'"
-                },
-                "defaultValue": "aes128-ctr,aes192-ctr,aes256-ctr"
-            },
-            "port": {
-                "type": "string",
-                "metadata": {
-                    "displayName": "The SSH port",
-                    "description": "The SSH port. Default is '22'"
-                },
-                "defaultValue": "22"
-            }
-        },
-        "policyRule": {
-            "if": {
-                "anyOf": [
-                    {
-                        "allOf": [
-                            {
-                                "anyOf": [
-                                    {
-                                        "field": "type",
-                                        "equals": "Microsoft.Compute/virtualMachines"
-                                    },
-                                    {
-                                        "field": "type",
-                                        "equals": "Microsoft.Compute/virtualMachineScaleSets"
-                                    }
-                                ]
-                            },
-                            {
-                                "field": "tags['aks-managed-orchestrator']",
-                                "exists": "false"
-                            },
-                            {
-                                "field": "tags['aks-managed-poolName']",
-                                "exists": "false"
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "field": "Microsoft.Compute/imagePublisher",
-                                        "in": [
-                                            "microsoft-aks",
-                                            "qubole-inc",
-                                            "datastax",
-                                            "couchbase",
-                                            "scalegrid",
-                                            "checkpoint",
-                                            "paloaltonetworks",
-                                            "debian",
-                                            "credativ"
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "OpenLogic"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "Oracle"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "RedHat"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "center-for-internet-security-inc"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageOffer",
-                                                "notLike": "cis-windows*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "Suse"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "11*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "Canonical"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "12*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "microsoft-dsvm"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageOffer",
-                                                "notLike": "dsvm-win*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "cloudera"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageSKU",
-                                                "notLike": "6*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "Microsoft.Compute/imagePublisher",
-                                                "equals": "microsoft-ads"
-                                            },
-                                            {
-                                                "field": "Microsoft.Compute/imageOffer",
-                                                "like": "linux*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "anyOf": [
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration",
-                                                        "exists": true
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
-                                                        "like": "Linux*"
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachineScaleSets/osProfile.linuxConfiguration",
-                                                        "exists": true
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.storageProfile.osDisk.osType",
-                                                        "like": "Linux*"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "anyOf": [
-                                                    {
-                                                        "field": "Microsoft.Compute/imagePublisher",
-                                                        "exists": false
-                                                    },
-                                                    {
-                                                        "field": "Microsoft.Compute/imagePublisher",
-                                                        "notIn": [
-                                                            "OpenLogic",
-                                                            "RedHat",
-                                                            "credativ",
-                                                            "Suse",
-                                                            "Canonical",
-                                                            "microsoft-dsvm",
-                                                            "cloudera",
-                                                            "microsoft-ads",
-                                                            "center-for-internet-security-inc",
-                                                            "Oracle",
-                                                            "AzureDatabricks",
-                                                            "azureopenshift"
-                                                        ]
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "allOf": [
-                            {
-                                "value": "[parameters('IncludeArcMachines')]",
-                                "equals": true
-                            },
-                            {
-                                "anyOf": [
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "type",
-                                                "equals": "Microsoft.HybridCompute/machines"
-                                            },
-                                            {
-                                                "field": "Microsoft.HybridCompute/imageOffer",
-                                                "like": "linux*"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "allOf": [
-                                            {
-                                                "field": "type",
-                                                "equals": "Microsoft.ConnectedVMwarevSphere/virtualMachines"
-                                            },
-                                            {
-                                                "field": "Microsoft.ConnectedVMwarevSphere/virtualMachines/osProfile.osType",
-                                                "like": "linux*"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            },
-            "then": {
-                "effect": "[parameters('effect')]",
-                "details": {
-                    "roleDefinitionIds": [
-                        "/providers/Microsoft.Authorization/roleDefinitions/088ab73d-1256-47ae-bea9-9de8e7131f31"
-                    ],
-                    "type": "Microsoft.GuestConfiguration/guestConfigurationAssignments",
-                    "name": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]",
-                    "existenceCondition": {
-                        "allOf": [
-                            {
-                                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/complianceStatus",
-                                "equals": "Compliant"
-                            },
-                            {
-                                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/parameterHash",
-                                "equals": "[base64(concat('Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue', '=', parameters('accessPermissionsForSshdConfig'), ',', 'Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue', '=', parameters('ignoreHosts'), ',', 'Ensure that the SSH LogLevel is configured;DesiredObjectValue', '=', parameters('logLevel'), ',', 'Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue', '=', parameters('maxAuthTries'), ',', 'Ensure that the allowed users for SSH access are configured;DesiredObjectValue', '=', parameters('allowUsers'), ',', 'Ensure that the denied users for SSH are configured;DesiredObjectValue', '=', parameters('denyUsers'), ',', 'Ensure that the allowed groups for SSH are configured;DesiredObjectValue', '=', parameters('allowGroups'), ',', 'Ensure that the denied groups for SSH are configured;DesiredObjectValue', '=', parameters('denyGroups'), ',', 'Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue', '=', parameters('hostBasedAuthentication'), ',', 'Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue', '=', parameters('permitRootLogin'), ',', 'Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue', '=', parameters('permitEmptyPasswords'), ',', 'Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue', '=', parameters('clientAliveCountMax'), ',', 'Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue', '=', parameters('clientAliveInterval'), ',', ',', 'Ensure that only approved MAC algorithms are used;DesiredObjectValue', '=', parameters('messageAuthenticationCodeAlgorithms'), ',', 'Ensure that the SSH warning banner is configured;DesiredObjectValue', '=', parameters('banner'), ',', 'Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue', '=', parameters('permitUserEnvironment'), ',', 'Ensure that appropriate ciphers are used for SSH;DesiredObjectValue', '=', parameters('ciphers'), ',', 'Ensure that the SSH port is configured;DesiredObjectValue', '=', parameters('port')))]"
-                            }
-                        ]
-                    },
-                    "deployment": {
-                        "properties": {
-                            "mode": "incremental",
-                            "parameters": {
-                                "vmName": {
-                                    "value": "[field('name')]"
-                                },
-                                "location": {
-                                    "value": "[field('location')]"
-                                },
-                                "type": {
-                                    "value": "[field('type')]"
-                                },
-                                "assignmentName": {
-                                    "value": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]"
-                                },
-                                "accessPermissionsForSshdConfig": {
-                                    "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                },
-                                "ignoreHosts": {
-                                    "value": "[parameters('ignoreHosts')]"
-                                },
-                                "logLevel": {
-                                    "value": "[parameters('logLevel')]"
-                                },
-                                "maxAuthTries": {
-                                    "value": "[parameters('maxAuthTries')]"
-                                },
-                                "allowUsers": {
-                                    "value": "[parameters('allowUsers')]"
-                                },
-                                "denyUsers": {
-                                    "value": "[parameters('denyUsers')]"
-                                },
-                                "allowGroups": {
-                                    "value": "[parameters('allowGroups')]"
-                                },
-                                "denyGroups": {
-                                    "value": "[parameters('denyGroups')]"
-                                },
-                                "hostBasedAuthentication": {
-                                    "value": "[parameters('hostBasedAuthentication')]"
-                                },
-                                "permitRootLogin": {
-                                    "value": "[parameters('permitRootLogin')]"
-                                },
-                                "permitEmptyPasswords": {
-                                    "value": "[parameters('permitEmptyPasswords')]"
-                                },
-                                "clientAliveCountMax": {
-                                    "value": "[parameters('clientAliveCountMax')]"
-                                },
-                                "clientAliveInterval": {
-                                    "value": "[parameters('clientAliveInterval')]"
-                                },
-                                "messageAuthenticationCodeAlgorithms": {
-                                    "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                },
-                                "banner": {
-                                    "value": "[parameters('banner')]"
-                                },
-                                "permitUserEnvironment": {
-                                    "value": "[parameters('permitUserEnvironment')]"
-                                },
-                                "ciphers": {
-                                    "value": "[parameters('ciphers')]"
-                                },
-                                "port": {
-                                    "value": "[parameters('port')]"
-                                }
-                            },
-                            "template": {
-                                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                                "contentVersion": "1.0.1",
-                                "parameters": {
-                                    "vmName": {
-                                        "type": "string"
-                                    },
-                                    "location": {
-                                        "type": "string"
-                                    },
-                                    "type": {
-                                        "type": "string"
-                                    },
-                                    "assignmentName": {
-                                        "type": "string"
-                                    },
-                                    "accessPermissionsForSshdConfig": {
-                                        "type": "string"
-                                    },
-                                    "ignoreHosts": {
-                                        "type": "string"
-                                    },
-                                    "logLevel": {
-                                        "type": "string"
-                                    },
-                                    "maxAuthTries": {
-                                        "type": "string"
-                                    },
-                                    "allowUsers": {
-                                        "type": "string"
-                                    },
-                                    "denyUsers": {
-                                        "type": "string"
-                                    },
-                                    "allowGroups": {
-                                        "type": "string"
-                                    },
-                                    "denyGroups": {
-                                        "type": "string"
-                                    },
-                                    "hostBasedAuthentication": {
-                                        "type": "string"
-                                    },
-                                    "permitRootLogin": {
-                                        "type": "string"
-                                    },
-                                    "permitEmptyPasswords": {
-                                        "type": "string"
-                                    },
-                                    "clientAliveCountMax": {
-                                        "type": "string"
-                                    },
-                                    "clientAliveInterval": {
-                                        "type": "string"
-                                    },
-                                    "messageAuthenticationCodeAlgorithms": {
-                                        "type": "string"
-                                    },
-                                    "banner": {
-                                        "type": "string"
-                                    },
-                                    "permitUserEnvironment": {
-                                        "type": "string"
-                                    },
-                                    "ciphers": {
-                                        "type": "string"
-                                    },
-                                    "port": {
-                                        "type": "string"
-                                    }
-                                },
-                                "resources": [
-                                    {
-                                        "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachines'))]",
-                                        "apiVersion": "2018-11-20",
-                                        "type": "Microsoft.Compute/virtualMachines/providers/guestConfigurationAssignments",
-                                        "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
-                                        "location": "[parameters('location')]",
-                                        "properties": {
-                                            "guestConfiguration": {
-                                                "name": "LinuxSshServerSecurityBaseline",
-                                                "version": "1.0.0",
-                                                "contentType": "Custom",
-                                                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                                                "assignmentType": "ApplyAndAutoCorrect",
-                                                "configurationParameter": [
-                                                    {
-                                                        "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                                                        "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                                                        "value": "[parameters('ignoreHosts')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                                                        "value": "[parameters('logLevel')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                                                        "value": "[parameters('maxAuthTries')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                                                        "value": "[parameters('hostBasedAuthentication')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitRootLogin')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitEmptyPasswords')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveCountMax')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveInterval')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                                                        "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                                                        "value": "[parameters('banner')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitUserEnvironment')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                                                        "value": "[parameters('ciphers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH port is configured;DesiredObjectValue",
-                                                        "value": "[parameters('port')]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.HybridCompute/machines'))]",
-                                        "apiVersion": "2018-11-20",
-                                        "type": "Microsoft.HybridCompute/machines/providers/guestConfigurationAssignments",
-                                        "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
-                                        "location": "[parameters('location')]",
-                                        "properties": {
-                                            "guestConfiguration": {
-                                                "name": "LinuxSshServerSecurityBaseline",
-                                                "version": "1.0.0",
-                                                "contentType": "Custom",
-                                                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                                                "assignmentType": "ApplyAndAutoCorrect",
-                                                "configurationParameter": [
-                                                    {
-                                                        "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                                                        "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                                                        "value": "[parameters('ignoreHosts')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                                                        "value": "[parameters('logLevel')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                                                        "value": "[parameters('maxAuthTries')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                                                        "value": "[parameters('hostBasedAuthentication')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitRootLogin')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitEmptyPasswords')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveCountMax')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveInterval')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                                                        "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                                                        "value": "[parameters('banner')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitUserEnvironment')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                                                        "value": "[parameters('ciphers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH port is configured;DesiredObjectValue",
-                                                        "value": "[parameters('port')]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachineScaleSets'))]",
-                                        "apiVersion": "2018-11-20",
-                                        "type": "Microsoft.Compute/virtualMachineScaleSets/providers/guestConfigurationAssignments",
-                                        "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
-                                        "location": "[parameters('location')]",
-                                        "properties": {
-                                            "guestConfiguration": {
-                                                "name": "LinuxSshServerSecurityBaseline",
-                                                "version": "1.0.0",
-                                                "contentType": "Custom",
-                                                "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                                                "contentHash": "F9CCC8589686F8BB6E0516A89DC8F7C4A09824A2FD0EA076597E6AB9AB436531",
-                                                "assignmentType": "ApplyAndAutoCorrect",
-                                                "configurationParameter": [
-                                                    {
-                                                        "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
-                                                        "value": "[parameters('accessPermissionsForSshdConfig')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
-                                                        "value": "[parameters('ignoreHosts')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
-                                                        "value": "[parameters('logLevel')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
-                                                        "value": "[parameters('maxAuthTries')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyUsers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('allowGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
-                                                        "value": "[parameters('denyGroups')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
-                                                        "value": "[parameters('hostBasedAuthentication')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitRootLogin')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitEmptyPasswords')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveCountMax')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
-                                                        "value": "[parameters('clientAliveInterval')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
-                                                        "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
-                                                        "value": "[parameters('banner')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
-                                                        "value": "[parameters('permitUserEnvironment')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
-                                                        "value": "[parameters('ciphers')]"
-                                                    },
-                                                    {
-                                                        "name": "Ensure that the SSH port is configured;DesiredObjectValue",
-                                                        "value": "[parameters('port')]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
+  "properties": {
+    "displayName": "Audit and configure SSH security posture for Linux (powered by OSConfig)",
+    "policyType": "Custom",
+    "mode": "Indexed",
+    "description": "This policy audits and configures the SSH server security configuration on Linux machines (Azure VMs and Arc-enabled machines). For more information including pre-requisites, settings in scope, defaults, and customization, see https://aka.ms/SshPostureControlOverview",
+    "metadata": {
+      "category": "Guest Configuration",
+      "version": "1.0.1",
+      "requiredProviders": [
+        "Microsoft.GuestConfiguration"
+      ],
+      "guestConfiguration": {
+        "name": "LinuxSshServerSecurityBaseline",
+        "version": "1.0.0",
+        "contentType": "Custom",
+        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+        "configurationParameter": {
+          "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+          "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+          "logLevel": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+          "maxAuthTries": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+          "allowUsers": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+          "denyUsers": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+          "allowGroups": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+          "denyGroups": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+          "hostBasedAuthentication": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+          "permitRootLogin": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+          "permitEmptyPasswords": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+          "clientAliveCountMax": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+          "clientAliveInterval": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+          "messageAuthenticationCodeAlgorithms": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+          "banner": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+          "permitUserEnvironment": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+          "ciphers": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+          "port": "Ensure that the SSH port is configured;DesiredObjectValue"
         }
+      }
+    },
+    "parameters": {
+      "includeArcMachines": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Include Arc connected machines",
+          "description": "By selecting this option, you agree to be charged monthly per Arc connected machine.",
+          "portalReview": "true"
+        },
+        "allowedValues": [
+          "true",
+          "false"
+        ],
+        "defaultValue": "false"
+      },
+      "effect": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Configures between remediation (DeployIfNotExists) or audit-only (AuditIfNotExists) policy execution mode. Default is AuditIfNotExists"
+        },
+        "allowedValues": [
+          "DeployIfNotExists",
+          "AuditIfNotExists"
+        ],
+        "defaultValue": "AuditIfNotExists"
+      },
+      "accessPermissionsForSshdConfig": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Access permissions for sshd_config",
+          "description": "File access permissions for /etc/ssh/sshd_config. Default is '600'"
+        },
+        "defaultValue": "600"
+      },
+      "ignoreHosts": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Ignore rhosts and shosts",
+          "description": "Whether to ignore per-user .rhosts and .shosts files during HostbasedAuthentication. Default is 'yes'"
+        },
+        "defaultValue": "yes"
+      },
+      "logLevel": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Log verbosity level",
+          "description": "The verbosity level for the sshd logging. Default is 'INFO'"
+        },
+        "defaultValue": "INFO"
+      },
+      "maxAuthTries": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Maximum number of authentication attempts",
+          "description": "The maximum number of authentication attempts permitted per connection. Default is '6'"
+        },
+        "defaultValue": "6"
+      },
+      "allowUsers": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Allowed users for SSH",
+          "description": "List of users to be allowed to connect with SSH. Default is all authenticated users ('*@*')"
+        },
+        "defaultValue": "*@*"
+      },
+      "denyUsers": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Denied users for SSH",
+          "description": "List of users to be denied to connect with SSH. Default is 'root'"
+        },
+        "defaultValue": "root"
+      },
+      "allowGroups": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Allowed groups for SSH",
+          "description": "List of user groups to be allowed to connect with SSH. Default is all groups ('*')"
+        },
+        "defaultValue": "*"
+      },
+      "denyGroups": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Denied groups for SSH",
+          "description": "List of user groups to be denied to connect with SSH. Default is 'root'"
+        },
+        "defaultValue": "root"
+      },
+      "hostBasedAuthentication": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Host-based authentication",
+          "description": "Host-based authentication. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "permitRootLogin": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Whether root can log in using ssh",
+          "description": "Whether root can log in using ssh. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "permitEmptyPasswords": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Whether the server allows login to accounts with empty password strings",
+          "description": "Whether the server allows login to accounts with empty password strings. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "clientAliveCountMax": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The number of client alive messages which may be sent without sshd receiving any messages back from the client",
+          "description": "The number of client alive messages which may be sent without sshd receiving any messages back from the client. Default is '0'"
+        },
+        "defaultValue": "0"
+      },
+      "clientAliveInterval": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response",
+          "description": "Timeout interval in seconds after which if no data has been received from the client, sshd will send a message to request a response. Default is  1 hour ('3600')"
+        },
+        "defaultValue": "3600"
+      },
+      "messageAuthenticationCodeAlgorithms": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The list of available message authentication code (MAC) algorithms",
+          "description": "The list of available message authentication code (MAC) algorithms. Default is 'hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com'"
+        },
+        "defaultValue": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
+      },
+      "banner": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The contents of the banner file that is sent to the remote user before authentication is allowed",
+          "description": "The contents of the banner file that is sent to the remote user before authentication is allowed. Default is '#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n'"
+        },
+        "defaultValue": "#######################################################################\n\nAuthorized access only!\n\nIf you are not authorized to access or use this system, disconnect now!\n\n#######################################################################\n"
+      },
+      "permitUserEnvironment": {
+        "type": "string",
+        "metadata": {
+          "displayName": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd",
+          "description": "Whether ~/.ssh/environment and environment= options in ~/.ssh/authorized_keys are processed by sshd. Default is 'no'"
+        },
+        "defaultValue": "no"
+      },
+      "ciphers": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The list of allowed ciphers",
+          "description": "The list of allowed ciphers. Default is 'aes128-ctr,aes192-ctr,aes256-ctr'"
+        },
+        "defaultValue": "aes128-ctr,aes192-ctr,aes256-ctr"
+      },
+      "port": {
+        "type": "string",
+        "metadata": {
+          "displayName": "The SSH port",
+          "description": "The SSH port. Default is '22'"
+        },
+        "defaultValue": "22"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "anyOf": [
+          {
+            "allOf": [
+              {
+                "anyOf": [
+                  {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachines"
+                  },
+                  {
+                    "field": "type",
+                    "equals": "Microsoft.Compute/virtualMachineScaleSets"
+                  }
+                ]
+              },
+              {
+                "field": "tags['aks-managed-orchestrator']",
+                "exists": "false"
+              },
+              {
+                "field": "tags['aks-managed-poolName']",
+                "exists": "false"
+              },
+              {
+                "anyOf": [
+                  {
+                    "field": "Microsoft.Compute/imagePublisher",
+                    "in": [
+                      "microsoft-aks",
+                      "qubole-inc",
+                      "datastax",
+                      "couchbase",
+                      "scalegrid",
+                      "checkpoint",
+                      "paloaltonetworks",
+                      "debian",
+                      "credativ"
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "OpenLogic"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "Oracle"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "RedHat"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "center-for-internet-security-inc"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "notLike": "cis-windows*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "Suse"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "11*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "Canonical"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "12*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "microsoft-dsvm"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "notLike": "dsvm-win*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "cloudera"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageSKU",
+                        "notLike": "6*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "Microsoft.Compute/imagePublisher",
+                        "equals": "microsoft-ads"
+                      },
+                      {
+                        "field": "Microsoft.Compute/imageOffer",
+                        "like": "linux*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "field": "Microsoft.Compute/virtualMachines/osProfile.linuxConfiguration",
+                            "exists": true
+                          },
+                          {
+                            "field": "Microsoft.Compute/virtualMachines/storageProfile.osDisk.osType",
+                            "like": "Linux*"
+                          },
+                          {
+                            "field": "Microsoft.Compute/virtualMachineScaleSets/osProfile.linuxConfiguration",
+                            "exists": true
+                          },
+                          {
+                            "field": "Microsoft.Compute/virtualMachineScaleSets/virtualMachineProfile.storageProfile.osDisk.osType",
+                            "like": "Linux*"
+                          }
+                        ]
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "exists": false
+                          },
+                          {
+                            "field": "Microsoft.Compute/imagePublisher",
+                            "notIn": [
+                              "OpenLogic",
+                              "RedHat",
+                              "credativ",
+                              "Suse",
+                              "Canonical",
+                              "microsoft-dsvm",
+                              "cloudera",
+                              "microsoft-ads",
+                              "center-for-internet-security-inc",
+                              "Oracle",
+                              "AzureDatabricks",
+                              "azureopenshift"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "value": "[parameters('IncludeArcMachines')]",
+                "equals": true
+              },
+              {
+                "anyOf": [
+                  {
+                    "allOf": [
+                      {
+                        "field": "type",
+                        "equals": "Microsoft.HybridCompute/machines"
+                      },
+                      {
+                        "field": "Microsoft.HybridCompute/imageOffer",
+                        "like": "linux*"
+                      }
+                    ]
+                  },
+                  {
+                    "allOf": [
+                      {
+                        "field": "type",
+                        "equals": "Microsoft.ConnectedVMwarevSphere/virtualMachines"
+                      },
+                      {
+                        "field": "Microsoft.ConnectedVMwarevSphere/virtualMachines/osProfile.osType",
+                        "like": "linux*"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "then": {
+        "effect": "[parameters('effect')]",
+        "details": {
+          "roleDefinitionIds": [
+            "/providers/Microsoft.Authorization/roleDefinitions/088ab73d-1256-47ae-bea9-9de8e7131f31"
+          ],
+          "type": "Microsoft.GuestConfiguration/guestConfigurationAssignments",
+          "name": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]",
+          "existenceCondition": {
+            "allOf": [
+              {
+                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/complianceStatus",
+                "equals": "Compliant"
+              },
+              {
+                "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/parameterHash",
+                "equals": "[base64(concat('Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue', '=', parameters('accessPermissionsForSshdConfig'), ',', 'Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue', '=', parameters('ignoreHosts'), ',', 'Ensure that the SSH LogLevel is configured;DesiredObjectValue', '=', parameters('logLevel'), ',', 'Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue', '=', parameters('maxAuthTries'), ',', 'Ensure that the allowed users for SSH access are configured;DesiredObjectValue', '=', parameters('allowUsers'), ',', 'Ensure that the denied users for SSH are configured;DesiredObjectValue', '=', parameters('denyUsers'), ',', 'Ensure that the allowed groups for SSH are configured;DesiredObjectValue', '=', parameters('allowGroups'), ',', 'Ensure that the denied groups for SSH are configured;DesiredObjectValue', '=', parameters('denyGroups'), ',', 'Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue', '=', parameters('hostBasedAuthentication'), ',', 'Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue', '=', parameters('permitRootLogin'), ',', 'Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue', '=', parameters('permitEmptyPasswords'), ',', 'Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue', '=', parameters('clientAliveCountMax'), ',', 'Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue', '=', parameters('clientAliveInterval'), ',', ',', 'Ensure that only approved MAC algorithms are used;DesiredObjectValue', '=', parameters('messageAuthenticationCodeAlgorithms'), ',', 'Ensure that the SSH warning banner is configured;DesiredObjectValue', '=', parameters('banner'), ',', 'Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue', '=', parameters('permitUserEnvironment'), ',', 'Ensure that appropriate ciphers are used for SSH;DesiredObjectValue', '=', parameters('ciphers'), ',', 'Ensure that the SSH port is configured;DesiredObjectValue', '=', parameters('port')))]"
+              }
+            ]
+          },
+          "deployment": {
+            "properties": {
+              "mode": "incremental",
+              "parameters": {
+                "vmName": {
+                  "value": "[field('name')]"
+                },
+                "location": {
+                  "value": "[field('location')]"
+                },
+                "type": {
+                  "value": "[field('type')]"
+                },
+                "assignmentName": {
+                  "value": "[concat('LinuxSshServerSecurityBaseline$pid', uniqueString(policy().assignmentId, policy().definitionReferenceId))]"
+                },
+                "accessPermissionsForSshdConfig": {
+                  "value": "[parameters('accessPermissionsForSshdConfig')]"
+                },
+                "ignoreHosts": {
+                  "value": "[parameters('ignoreHosts')]"
+                },
+                "logLevel": {
+                  "value": "[parameters('logLevel')]"
+                },
+                "maxAuthTries": {
+                  "value": "[parameters('maxAuthTries')]"
+                },
+                "allowUsers": {
+                  "value": "[parameters('allowUsers')]"
+                },
+                "denyUsers": {
+                  "value": "[parameters('denyUsers')]"
+                },
+                "allowGroups": {
+                  "value": "[parameters('allowGroups')]"
+                },
+                "denyGroups": {
+                  "value": "[parameters('denyGroups')]"
+                },
+                "hostBasedAuthentication": {
+                  "value": "[parameters('hostBasedAuthentication')]"
+                },
+                "permitRootLogin": {
+                  "value": "[parameters('permitRootLogin')]"
+                },
+                "permitEmptyPasswords": {
+                  "value": "[parameters('permitEmptyPasswords')]"
+                },
+                "clientAliveCountMax": {
+                  "value": "[parameters('clientAliveCountMax')]"
+                },
+                "clientAliveInterval": {
+                  "value": "[parameters('clientAliveInterval')]"
+                },
+                "messageAuthenticationCodeAlgorithms": {
+                  "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                },
+                "banner": {
+                  "value": "[parameters('banner')]"
+                },
+                "permitUserEnvironment": {
+                  "value": "[parameters('permitUserEnvironment')]"
+                },
+                "ciphers": {
+                  "value": "[parameters('ciphers')]"
+                },
+                "port": {
+                  "value": "[parameters('port')]"
+                }
+              },
+              "template": {
+                "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                "contentVersion": "1.0.1",
+                "parameters": {
+                  "vmName": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "assignmentName": {
+                    "type": "string"
+                  },
+                  "accessPermissionsForSshdConfig": {
+                    "type": "string"
+                  },
+                  "ignoreHosts": {
+                    "type": "string"
+                  },
+                  "logLevel": {
+                    "type": "string"
+                  },
+                  "maxAuthTries": {
+                    "type": "string"
+                  },
+                  "allowUsers": {
+                    "type": "string"
+                  },
+                  "denyUsers": {
+                    "type": "string"
+                  },
+                  "allowGroups": {
+                    "type": "string"
+                  },
+                  "denyGroups": {
+                    "type": "string"
+                  },
+                  "hostBasedAuthentication": {
+                    "type": "string"
+                  },
+                  "permitRootLogin": {
+                    "type": "string"
+                  },
+                  "permitEmptyPasswords": {
+                    "type": "string"
+                  },
+                  "clientAliveCountMax": {
+                    "type": "string"
+                  },
+                  "clientAliveInterval": {
+                    "type": "string"
+                  },
+                  "messageAuthenticationCodeAlgorithms": {
+                    "type": "string"
+                  },
+                  "banner": {
+                    "type": "string"
+                  },
+                  "permitUserEnvironment": {
+                    "type": "string"
+                  },
+                  "ciphers": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "string"
+                  }
+                },
+                "resources": [
+                  {
+                    "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachines'))]",
+                    "apiVersion": "2018-11-20",
+                    "type": "Microsoft.Compute/virtualMachines/providers/guestConfigurationAssignments",
+                    "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "guestConfiguration": {
+                        "name": "LinuxSshServerSecurityBaseline",
+                        "version": "1.0.0",
+                        "contentType": "Custom",
+                        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "assignmentType": "ApplyAndAutoCorrect",
+                        "configurationParameter": [
+                          {
+                            "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+                            "value": "[parameters('accessPermissionsForSshdConfig')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+                            "value": "[parameters('ignoreHosts')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+                            "value": "[parameters('logLevel')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+                            "value": "[parameters('maxAuthTries')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+                            "value": "[parameters('allowUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('allowGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+                            "value": "[parameters('hostBasedAuthentication')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+                            "value": "[parameters('permitRootLogin')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+                            "value": "[parameters('permitEmptyPasswords')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveCountMax')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveInterval')]"
+                          },
+                          {
+                            "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+                            "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+                            "value": "[parameters('banner')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+                            "value": "[parameters('permitUserEnvironment')]"
+                          },
+                          {
+                            "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+                            "value": "[parameters('ciphers')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH port is configured;DesiredObjectValue",
+                            "value": "[parameters('port')]"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.HybridCompute/machines'))]",
+                    "apiVersion": "2018-11-20",
+                    "type": "Microsoft.HybridCompute/machines/providers/guestConfigurationAssignments",
+                    "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "guestConfiguration": {
+                        "name": "LinuxSshServerSecurityBaseline",
+                        "version": "1.0.0",
+                        "contentType": "Custom",
+                        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "assignmentType": "ApplyAndAutoCorrect",
+                        "configurationParameter": [
+                          {
+                            "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+                            "value": "[parameters('accessPermissionsForSshdConfig')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+                            "value": "[parameters('ignoreHosts')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+                            "value": "[parameters('logLevel')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+                            "value": "[parameters('maxAuthTries')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+                            "value": "[parameters('allowUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('allowGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+                            "value": "[parameters('hostBasedAuthentication')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+                            "value": "[parameters('permitRootLogin')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+                            "value": "[parameters('permitEmptyPasswords')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveCountMax')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveInterval')]"
+                          },
+                          {
+                            "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+                            "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+                            "value": "[parameters('banner')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+                            "value": "[parameters('permitUserEnvironment')]"
+                          },
+                          {
+                            "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+                            "value": "[parameters('ciphers')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH port is configured;DesiredObjectValue",
+                            "value": "[parameters('port')]"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "condition": "[equals(toLower(parameters('type')), toLower('Microsoft.Compute/virtualMachineScaleSets'))]",
+                    "apiVersion": "2018-11-20",
+                    "type": "Microsoft.Compute/virtualMachineScaleSets/providers/guestConfigurationAssignments",
+                    "name": "[concat(parameters('vmName'), '/Microsoft.GuestConfiguration/', parameters('assignmentName'))]",
+                    "location": "[parameters('location')]",
+                    "properties": {
+                      "guestConfiguration": {
+                        "name": "LinuxSshServerSecurityBaseline",
+                        "version": "1.0.0",
+                        "contentType": "Custom",
+                        "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
+                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "assignmentType": "ApplyAndAutoCorrect",
+                        "configurationParameter": [
+                          {
+                            "name": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
+                            "value": "[parameters('accessPermissionsForSshdConfig')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
+                            "value": "[parameters('ignoreHosts')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH LogLevel is configured;DesiredObjectValue",
+                            "value": "[parameters('logLevel')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH MaxAuthTries is configured;DesiredObjectValue",
+                            "value": "[parameters('maxAuthTries')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed users for SSH access are configured;DesiredObjectValue",
+                            "value": "[parameters('allowUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the denied users for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyUsers')]"
+                          },
+                          {
+                            "name": "Ensure that the allowed groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('allowGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the denied groups for SSH are configured;DesiredObjectValue",
+                            "value": "[parameters('denyGroups')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH HostBasedAuthentication is configured;DesiredObjectValue",
+                            "value": "[parameters('hostBasedAuthentication')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitRootLogin is configured;DesiredObjectValue",
+                            "value": "[parameters('permitRootLogin')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitEmptyPasswords is configured;DesiredObjectValue",
+                            "value": "[parameters('permitEmptyPasswords')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveCountMax is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveCountMax')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH ClientAliveInterval is configured;DesiredObjectValue",
+                            "value": "[parameters('clientAliveInterval')]"
+                          },
+                          {
+                            "name": "Ensure that only approved MAC algorithms are used;DesiredObjectValue",
+                            "value": "[parameters('messageAuthenticationCodeAlgorithms')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH warning banner is configured;DesiredObjectValue",
+                            "value": "[parameters('banner')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH PermitUserEnvironment is configured;DesiredObjectValue",
+                            "value": "[parameters('permitUserEnvironment')]"
+                          },
+                          {
+                            "name": "Ensure that appropriate ciphers are used for SSH;DesiredObjectValue",
+                            "value": "[parameters('ciphers')]"
+                          },
+                          {
+                            "name": "Ensure that the SSH port is configured;DesiredObjectValue",
+                            "value": "[parameters('port')]"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }


### PR DESCRIPTION
## Description

Updating the reference custom test policy definitions in the existing locations, where our partners expect them to be found:
- Updating the policy package hashes to point to current securely built test policy packages.
- Correcting formatting for the 2 SSH definitions to expand tabs to 2 spaces instead of 4 spaces per tab.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.