### PR TITLE
Making auto-validation for rule UUIDs case insensitive to allow future easy changes between lowercase and uppercase UUIDs in ASB MOF

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -829,7 +829,7 @@ int AsbIsValidResourceIdRuleId(const char* resourceId, const char* ruleId, const
                 OsConfigLogError(log, "AsbIsValidRuleIdAndName: resourceId for rule '%s' of '%s' (instead of '%s') is invalid", payloadKey, resourceId, g_rules[i].resourceId);
                 result = ENOENT;
             }
-            else if ((NULL != ruleId) && (0 != strncmp(ruleId, g_rules[i].ruleId, strlen(g_rules[i].ruleId))))
+            else if ((NULL != ruleId) && (0 != strncasecmp(ruleId, g_rules[i].ruleId, strlen(g_rules[i].ruleId))))
             {
                 OsConfigLogError(log, "AsbIsValidRuleIdAndName: ruleId for rule '%s' of '%s' (instead of '%s') is invalid", payloadKey, ruleId, g_rules[i].ruleId);
                 result = ENOENT;

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -814,9 +814,9 @@ int AsbIsValidResourceIdRuleId(const char* resourceId, const char* ruleId, const
     int i = 0;
     int result = 0;
 
-    if (NULL == payloadKey)
+    if ((NULL == payloadKey) || ((NULL == resourceId) && (NULL == ruleId)))
     {
-        OsConfigLogError(log, "AsbIsValidRuleIdAndName: invalid payloadKey argument");
+        OsConfigLogError(log, "AsbIsValidRuleIdAndName called with invalid arguments");
         return EINVAL;
     }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2405,7 +2405,7 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, nullptr, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, miscasedGoodRuleId, payloadKey, nullptr));
-    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, miscasedRuleId, payloadKey, nullptr));
+    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, miscasedGoodRuleId, payloadKey, nullptr));
 }
 
 TEST_F(CommonUtilsTest, IsValidDaemonName)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2380,12 +2380,13 @@ TEST_F(CommonUtilsTest, RemoveEscapeSequencesFromFile)
 TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
 {
     const char* goodResourceId = "Ensure SMB V1 with Samba is disabled (CIS: L1 - Server - 2.2.12)";
+    const char* differentCaseResourceId = "ensure SMB V1 with Samba is disabled (CIS: L1 - Server - 2.2.12)";
     const char* goodRuleId = "7624efb0-3026-4c72-8920-48d5be78a50e";
+    const char* differentCaseGoodRuleId = "7624EFB0-3026-4C72-8920-48D5BE78A50E";
     const char* badResourceId = "Ensure the rsh client is not installed (CIS: L1 - Server - 2.3.2)";
     const char* badRuleId = "6d441f31-f888-4f4f-b1da-7cfc26263e3f";
-    const char* miscasedResourceId = "ensure the rsh client is not installed (CIS: L1 - Server - 2.3.2)";
-    const char* miscasedBadRuleId = "6D441F31-F888-4F4F-B1DA-7CFC26263E3F";
-    const char* miscasedGoodRuleId = "7624EFB0-3026-4C72-8920-48D5BE78A50A"; 
+    const char* differentCaseBadRuleId = "6D441F31-F888-4F4F-B1DA-7CFC26263E3F";
+    
     const char* payloadKey = "EnsureSmbWithSambaIsDisabled";
     
     EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(nullptr, nullptr, nullptr, nullptr));
@@ -2395,17 +2396,17 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(badResourceId, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(goodResourceId, badRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(badResourceId, badRuleId, payloadKey, nullptr));
-    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, goodRuleId, payloadKey, nullptr));
-    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, miscasedGoodRuleId, payloadKey, nullptr));
-    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, miscasedBadRuleId, payloadKey, nullptr));
-    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(nullptr, miscasedBadRuleId, payloadKey, nullptr));
-    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, nullptr, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(differentCaseResourceId, goodRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(differentCaseResourceId, differentCaseGoodRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(differentCaseResourceId, differentCaseBadRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(nullptr, differentCaseBadRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(differentCaseResourceId, nullptr, payloadKey, nullptr));
 
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, nullptr, payloadKey, nullptr));
-    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, miscasedGoodRuleId, payloadKey, nullptr));
-    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, miscasedGoodRuleId, payloadKey, nullptr));
+    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, differentCaseGoodRuleId, payloadKey, nullptr));
+    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, differentCaseGoodRuleId, payloadKey, nullptr));
 }
 
 TEST_F(CommonUtilsTest, IsValidDaemonName)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2383,6 +2383,8 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     const char* goodRuleId = "7624efb0-3026-4c72-8920-48d5be78a50e";
     const char* badResourceId = "Ensure the rsh client is not installed (CIS: L1 - Server - 2.3.2)";
     const char* badRuleId = "6d441f31-f888-4f4f-b1da-7cfc26263e3f";
+    const char* miscasedResourceId = "ensure the rsh client is not installed (CIS: L1 - Server - 2.3.2)";
+    const char* miscasedRuleId = "6D441F31-F888-4F4F-B1DA-7CFC26263E3F";
     const char* payloadKey = "EnsureSmbWithSambaIsDisabled";
     
     EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(nullptr, nullptr, nullptr, nullptr));
@@ -2392,10 +2394,15 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(badResourceId, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(goodResourceId, badRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(badResourceId, badRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, goodRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, miscasedRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, nullptr, payloadKey, nullptr));
 
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, nullptr, payloadKey, nullptr));
+    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, miscasedRuleId, payloadKey, nullptr));
+    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, miscasedRuleId, payloadKey, nullptr));
 }
 
 TEST_F(CommonUtilsTest, IsValidDaemonName)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2384,7 +2384,8 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     const char* badResourceId = "Ensure the rsh client is not installed (CIS: L1 - Server - 2.3.2)";
     const char* badRuleId = "6d441f31-f888-4f4f-b1da-7cfc26263e3f";
     const char* miscasedResourceId = "ensure the rsh client is not installed (CIS: L1 - Server - 2.3.2)";
-    const char* miscasedRuleId = "6D441F31-F888-4F4F-B1DA-7CFC26263E3F";
+    const char* miscasedBadRuleId = "6D441F31-F888-4F4F-B1DA-7CFC26263E3F";
+    const char* miscasedGoodRuleId = "7624EFB0-3026-4C72-8920-48D5BE78A50A"; 
     const char* payloadKey = "EnsureSmbWithSambaIsDisabled";
     
     EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(nullptr, nullptr, nullptr, nullptr));
@@ -2395,13 +2396,15 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(goodResourceId, badRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(badResourceId, badRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, goodRuleId, payloadKey, nullptr));
-    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, miscasedRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, miscasedGoodRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, miscasedBadRuleId, payloadKey, nullptr));
+    EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(nullptr, miscasedBadRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(miscasedResourceId, nullptr, payloadKey, nullptr));
 
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, nullptr, payloadKey, nullptr));
-    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, miscasedRuleId, payloadKey, nullptr));
+    EXPECT_EQ(0, AsbIsValidResourceIdRuleId(goodResourceId, miscasedGoodRuleId, payloadKey, nullptr));
     EXPECT_EQ(0, AsbIsValidResourceIdRuleId(nullptr, miscasedRuleId, payloadKey, nullptr));
 }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2392,6 +2392,7 @@ TEST_F(CommonUtilsTest, AsbIsValidResourceIdRuleId)
     EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(nullptr, nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(goodResourceId, nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(goodResourceId, goodRuleId, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, AsbIsValidResourceIdRuleId(nullptr, nullptr, payloadKey, nullptr));
 
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(badResourceId, goodRuleId, payloadKey, nullptr));
     EXPECT_EQ(ENOENT, AsbIsValidResourceIdRuleId(goodResourceId, badRuleId, payloadKey, nullptr));


### PR DESCRIPTION
## Description

Making auto-validation for rule UUIDs case insensitive to allow future easy changes between lowercase and uppercase UUIDs in ASB MOF. Keeping case sensitive comparison for rule names. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.