### PR TITLE
Updating the reference custom test policy definitions

### DIFF
--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0"
+        "contentHash": "2EE557B1F9843F2FDD4ACF29563B51A9D1D7EF7721C73D920AEF2C412A1E2499"
       }
     },
     "parameters": {
@@ -341,7 +341,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0",
+                        "contentHash": "2EE557B1F9843F2FDD4ACF29563B51A9D1D7EF7721C73D920AEF2C412A1E2499",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -358,7 +358,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0",
+                        "contentHash": "2EE557B1F9843F2FDD4ACF29563B51A9D1D7EF7721C73D920AEF2C412A1E2499",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }
@@ -375,7 +375,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "84E75D967A8C674EA140BC842EB44001BA86A12D721112634DBA77F17B25F1D0",
+                        "contentHash": "2EE557B1F9843F2FDD4ACF29563B51A9D1D7EF7721C73D920AEF2C412A1E2499",
                         "assignmentType": "ApplyAndAutoCorrect"
                       }
                     }

--- a/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/19params/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
         "configurationParameter": {
           "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
           "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -639,7 +639,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {
@@ -734,7 +734,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {
@@ -829,7 +829,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {

--- a/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/ssh/LinuxSshServerSecurityBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
         "configurationParameter": {
           "accessPermissionsForSshdConfig": "Ensure that permissions on /etc/ssh/sshd_config are configured;DesiredObjectValue",
           "ignoreHosts": "Ensure that the SSH IgnoreRhosts is configured;DesiredObjectValue",
@@ -624,7 +624,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {
@@ -715,7 +715,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {
@@ -806,7 +806,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/LinuxSshServerSecurityBaseline.zip",
-                        "contentHash": "51C9C20D6AB94947A69B6C4154593579957F8990FF545C49A38FCEB9A0D3E404",
+                        "contentHash": "88B900762F29AF01A059573D17036D4B970308413B987C6AE1B9F74CEC250D3B",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {


### PR DESCRIPTION
## Description

Updating the reference custom test policy definitions (the policy package hashes that point to current securely built test policy packages) in the existing locations, where our partners expect them to be found. These definitions are currently deployed in our manual validation pass and found to be correctly working.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.