### PR TITLE
Added bc to build-infra image

### DIFF
--- a/devops/e2e/cloudtest/build-infra.json
+++ b/devops/e2e/cloudtest/build-infra.json
@@ -13,13 +13,19 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "apt list --installed"
+                "command": "sudo apt update && sudo apt upgrade -y"
+            }
+        },
+        {
+            "name": "linux-install-packages",
+            "parameters": {
+                "packages": "bc"
             }
         },
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo apt update && sudo apt upgrade -y"
+                "command": "apt list --installed"
             }
         }
     ]

--- a/devops/e2e/cloudtest/build-infra.json
+++ b/devops/e2e/cloudtest/build-infra.json
@@ -11,12 +11,6 @@
             }
         },
         {
-            "name": "linux-bash-command",
-            "parameters": {
-                "command": "sudo apt update && sudo apt upgrade -y"
-            }
-        },
-        {
             "name": "linux-install-packages",
             "parameters": {
                 "packages": "bc"


### PR DESCRIPTION
## Description

* Universal NRP Tests failed because the `build-infra` image did not have the `bc` package installed. It seems the base image regressed (1ES PT - Ubuntu 22.04 - vNext) so explicitly added `bc` package.
* Image has already been tested and works (https://github.com/Azure/azure-osconfig/actions/runs/12658469701)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.