### PR TITLE
Removed EOL distros rhel-7 debian-10

### DIFF
--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -16,7 +16,6 @@ jobs:
         target:
           [
             { os: centos, version: 8, package-type: RPM },
-            { os: debian, version: 10, package-type: DEB },
             { os: debian, version: 11, package-type: DEB },
             { os: debian, version: 12, package-type: DEB },
             { os: mariner, version: 2, package-type: RPM },

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -63,13 +63,15 @@ jobs:
               { "os": "ubuntu", "version": "20.04" },
               { "os": "ubuntu", "version": "22.04" }
             ]
-          # { "os": "amazonlinux", "version": "2" },
+          # { "os": "amazonlinux", "version": "2" }, [TODO: Onboard]
+          # { "os": "azurelinux", "version": "3" }, [TODO: Onboard]
           # { "os": "centos", "version": "7" }, [EOL June 30, 2024]
           # { "os": "debian", "version": "10" }, [EOL June 30, 2024]
+          # { "os": "mariner", "version": "1" }, [EOL July 31, 2023]
           # { "os": "oraclelinux", "version": "7" }, [EOL December 31, 2024]
           # { "os": "rhel", "version": "7" }, [EOL June 30, 2024]
           # { "os": "sles", "version": "12" }, [EOL October 31, 2024]
-          # { "os": "ubuntu", "version": "16.04" }, [EOL April 21, 2021]
+          # { "os": "ubuntu", "version": "16.04" }, [TODO: Onboard EOL April 21, 2021]
           # { "os": "ubuntu", "version": "18.04" }, [EOL May 31, 2023]
         run: |
           # If no explicit packages defined, use the default packages

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -52,12 +52,10 @@ jobs:
             [
               { "os": "almalinux", "version": "9" },
               { "os": "centos", "version": "8" },
-              { "os": "debian", "version": "10" },
               { "os": "debian", "version": "11" },
               { "os": "debian", "version": "12" },
               { "os": "mariner", "version": "2" },
               { "os": "oraclelinux", "version": "8" },
-              { "os": "rhel", "version": "7" },
               { "os": "rhel", "version": "8" },
               { "os": "rhel", "version": "9" },
               { "os": "rockylinux", "version": "9" },
@@ -66,11 +64,13 @@ jobs:
               { "os": "ubuntu", "version": "22.04" }
             ]
           # { "os": "amazonlinux", "version": "2" },
-          # { "os": "centos", "version": "7" },
-          # { "os": "oraclelinux", "version": "7" },
-          # { "os": "sles", "version": "12" },
-          # { "os": "ubuntu", "version": "16.04" },
-          # { "os": "ubuntu", "version": "18.04" },
+          # { "os": "centos", "version": "7" }, [EOL June 30, 2024]
+          # { "os": "debian", "version": "10" }, [EOL June 30, 2024]
+          # { "os": "oraclelinux", "version": "7" }, [EOL December 31, 2024]
+          # { "os": "rhel", "version": "7" }, [EOL June 30, 2024]
+          # { "os": "sles", "version": "12" }, [EOL October 31, 2024]
+          # { "os": "ubuntu", "version": "16.04" }, [EOL April 21, 2021]
+          # { "os": "ubuntu", "version": "18.04" }, [EOL May 31, 2023]
         run: |
           # If no explicit packages defined, use the default packages
           if [[ '${{ inputs.policy_packages }}' == '[]' || '${{ inputs.policy_packages }}' == '' ]]; then

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -65,14 +65,6 @@ jobs:
             ]
           # { "os": "amazonlinux", "version": "2" }, [TODO: Onboard]
           # { "os": "azurelinux", "version": "3" }, [TODO: Onboard]
-          # { "os": "centos", "version": "7" }, [EOL June 30, 2024]
-          # { "os": "debian", "version": "10" }, [EOL June 30, 2024]
-          # { "os": "mariner", "version": "1" }, [EOL July 31, 2023]
-          # { "os": "oraclelinux", "version": "7" }, [EOL December 31, 2024]
-          # { "os": "rhel", "version": "7" }, [EOL June 30, 2024]
-          # { "os": "sles", "version": "12" }, [EOL October 31, 2024]
-          # { "os": "ubuntu", "version": "16.04" }, [TODO: Onboard EOL April 21, 2021]
-          # { "os": "ubuntu", "version": "18.04" }, [EOL May 31, 2023]
         run: |
           # If no explicit packages defined, use the default packages
           if [[ '${{ inputs.policy_packages }}' == '[]' || '${{ inputs.policy_packages }}' == '' ]]; then


### PR DESCRIPTION
## Description

* Removed EOL distros rhel-7 and debian-10 (EOL June 30, 2024) from e2e automation (Module and UniversalNRP Tests)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.