### PR TITLE
Remove centos-8 from e2e automated tests

### DIFF
--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         target:
           [
-            { os: centos, version: 8, package-type: RPM },
             { os: debian, version: 11, package-type: DEB },
             { os: debian, version: 12, package-type: DEB },
             { os: mariner, version: 2, package-type: RPM },

--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -26,6 +26,8 @@ jobs:
             { os: ubuntu, version: 20.04, package-type: DEB },
             { os: ubuntu, version: 22.04, package-type: DEB },
           ]
+          # { os: amazonlinux, version: 2, package-type: RPM }, [TODO: Onboard]
+          # { os: azurelinux, version: 3, package-type: RPM }, [TODO: Onboard]
         arch: [amd64]
     with:
       target: ${{ matrix.target.os }}-${{ matrix.target.version }}

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -51,7 +51,6 @@ jobs:
           TARGETS: |
             [
               { "os": "almalinux", "version": "9" },
-              { "os": "centos", "version": "8" },
               { "os": "debian", "version": "11" },
               { "os": "debian", "version": "12" },
               { "os": "mariner", "version": "2" },


### PR DESCRIPTION
## Description

* Removed CentOS8 from automated e2e tests (MC + nrp tests)

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `main` branch prior to this PR submission.
- [X] I submitted this PR against the `main` branch.