### PR TITLE
Updating CONTRIBUTING.md to use 'dev' branch instead of 'main'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,5 @@
 
 - [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
 - [ ] I added unit-tests to validate my changes. All unit tests are passing.
-- [ ] I have merged the latest `main` branch prior to this PR submission.
-- [ ] I submitted this PR against the `main` branch.
+- [ ] I have merged the latest `dev` branch prior to this PR submission.
+- [ ] I submitted this PR against the `dev` branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ Most contributions require you to agree to a Contributor License Agreement (CLA)
 
 1. Create a GitHub account if you do not have one yet: [Join GitHub](https://github.com/join).
 2. Fork the public GitHub repo: [https://github.com/Azure/azure-osconfig](https://github.com/Azure/azure-osconfig). [Learn more about forking a repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo).
-3. Clone the forked repo. Optionally create a new branch to keep your changes isolated from the `main` branch. By forking and cloning the public GitHub repo, a copy of repo will be created in your GitHub account and a local copy will be locally created in your clone. Use this local copy to make modifications.
+3. Clone the forked repo. Optionally create a new branch to keep your changes isolated from the `dev` branch. By forking and cloning the public GitHub repo, a copy of repo will be created in your GitHub account and a local copy will be locally created in your clone. Use this local copy to make modifications.
 4. Commit the changes locally and push to your fork.
-6. From your fork, create a PR that targets the `main` branch. [Learn more about pull request](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/creating-an-issue-or-pull-request#creating-a-pull-request).
+6. From your fork, create a PR that targets the `dev` branch. [Learn more about pull request](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/creating-an-issue-or-pull-request#creating-a-pull-request).
 7. The PR triggers a series of GitHub actions that will validate the new submitted changes.
 
 The OSConfig Core team will respond to a PR that passes all checks in 3 business days.


### PR DESCRIPTION
## Description

Updating CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md to refer to 'dev' branch instead of 'main'.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I submitted this PR against the `main` branch.