### PR TITLE
Stabilization for the execution speed performance automation

### DIFF
--- a/.github/actions/check-perf/action.yml
+++ b/.github/actions/check-perf/action.yml
@@ -19,8 +19,7 @@ runs:
       run: |
         failed=false
 
-        echo "Checking '$perflog' for any performance wanings"
-        ls -l "$perflog"
+        echo "Checking '$perflog' for any performance warnings"
         echo "Contents of '$perflog':"
         cat "$perflog"        
 

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -110,11 +110,11 @@ void LogPerfClock(PERF_CLOCK* clock, const char* componentName, const char* obje
     }
     else
     {
-        OsConfigLogInfo(log, "%s completed in %f seconds (%ld microseconds)", componentName, microseconds / 1000000.0, microseconds);
+        OsConfigLogInfo(log, "%s completed in %.2f seconds (%ld microseconds)", componentName, microseconds / 1000000.0, microseconds);
 
         if (microseconds > limit)
         {
-            OsConfigLogError(log, "%s completion time of %ld microseconds is longer than %f minutes (%ld microseconds)",
+            OsConfigLogError(log, "%s completion time of %ld microseconds is longer than %.2f minutes (%ld microseconds)",
                 componentName, microseconds, limit / 60000000.0, limit);
         }
     }

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -55,8 +55,8 @@ int StopPerfClock(PERF_CLOCK* clock, void* log)
 
 long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 {
-    long seconds = 0;
-    long nanoseconds = 0;
+    //long seconds = 0;
+    //long nanoseconds = 0;
     long microseconds = -1;
 
     if ((NULL == clock) || (0 == clock->stop.tv_sec))

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -110,12 +110,12 @@ void LogPerfClock(PERF_CLOCK* clock, const char* componentName, const char* obje
     }
     else
     {
-        OsConfigLogInfo(log, "%s completed in %ld seconds (%ld microseconds)", componentName, microseconds / 1000000, microseconds);
+        OsConfigLogInfo(log, "%s completed in %f seconds (%ld microseconds)", componentName, microseconds / 1000000.0, microseconds);
 
         if (microseconds > limit)
         {
-            OsConfigLogError(log, "%s completion time of %ld microseconds is longer than %ld minutes (%ld microseconds)",
-                componentName, microseconds, limit / 60000000, limit);
+            OsConfigLogError(log, "%s completion time of %ld microseconds is longer than %f minutes (%ld microseconds)",
+                componentName, microseconds, limit / 60000000.0, limit);
         }
     }
 }

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -55,8 +55,8 @@ int StopPerfClock(PERF_CLOCK* clock, void* log)
 
 long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 {
-    //long seconds = 0;
-    //long nanoseconds = 0;
+    long seconds = 0;
+    long nanoseconds = 0;
     long microseconds = -1;
 
     if ((NULL == clock) || (0 == clock->stop.tv_sec))
@@ -65,19 +65,16 @@ long GetPerfClockTime(PERF_CLOCK* clock, void* log)
         return microseconds;
     }
 
-   /*if ((nanoseconds = clock->stop.tv_nsec - clock->start.tv_nsec) < 0)
+    seconds = clock->stop.tv_sec - clock->start.tv_sec;
+    nanoseconds = clock->stop.tv_nsec - clock->start.tv_nsec;
+
+    if (nanoseconds < 0)
     {
-        if ((seconds = clock->stop.tv_sec - clock->start.tv_sec) > 0)
-        {
-            seconds -= 1;
-        }
-        
+        seconds -= 1;
         nanoseconds += 1000000000;
     }
 
-    microseconds = (seconds * 1000000) + (long)(((float)nanoseconds / 1000.0) + 0.5);*/
-
-    microseconds = ((clock->stop.tv_sec - clock->start.tv_sec) * ((long)(1000000000) + (clock->stop.tv_nsec - clock->start.tv_nsec))) / 1000;
+    microseconds = (seconds * 1000000) + (long)(((float)nanoseconds / 1000.0) + 0.5);
 
     return microseconds;
 }

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -55,8 +55,8 @@ int StopPerfClock(PERF_CLOCK* clock, void* log)
 
 long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 {
-    long seconds = 0;
-    long nanoseconds = 0;
+    //long seconds = 0;
+    //long nanoseconds = 0;
     long microseconds = -1;
 
     if ((NULL == clock) || (0 == clock->stop.tv_sec))
@@ -65,7 +65,7 @@ long GetPerfClockTime(PERF_CLOCK* clock, void* log)
         return microseconds;
     }
 
-    if ((nanoseconds = clock->stop.tv_nsec - clock->start.tv_nsec) < 0)
+    /*if ((nanoseconds = clock->stop.tv_nsec - clock->start.tv_nsec) < 0)
     {
         if ((seconds = clock->stop.tv_sec - clock->start.tv_sec) > 0)
         {
@@ -75,7 +75,9 @@ long GetPerfClockTime(PERF_CLOCK* clock, void* log)
         nanoseconds += 1000000000;
     }
 
-    microseconds = (seconds * 1000000) + (long)(((float)nanoseconds / 1000.0) + 0.5);
+    microseconds = (seconds * 1000000) + (long)(((float)nanoseconds / 1000.0) + 0.5);*/
+
+    microseconds = (clock->stop.tv_sec - clock->stop.tv_sec) + ((clock->stop.tv_nsec - clock->stop.tv_nsec) / 1000000000.0);
 
     return microseconds;
 }

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -55,8 +55,8 @@ int StopPerfClock(PERF_CLOCK* clock, void* log)
 
 long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 {
-    //long seconds = 0;
-    //long nanoseconds = 0;
+    long seconds = 0;
+    long nanoseconds = 0;
     long microseconds = -1;
 
     if ((NULL == clock) || (0 == clock->stop.tv_sec))
@@ -77,9 +77,7 @@ long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 
     microseconds = (seconds * 1000000) + (long)(((float)nanoseconds / 1000.0) + 0.5);*/
 
-    //nenoseconds = (clock->stop.tv_sec - tp_old.tv_sec) * (long)(1000000000) + (clock->stop.tv_nsec - tp_old.tv_nsec);
-
-    microseconds = (clock->stop.tv_sec - clock->start.tv_sec) + ((clock->stop.tv_nsec - clock->start.tv_nsec) / 1000000000.0);
+    microseconds = ((clock->stop.tv_sec - clock->start.tv_sec) * ((long)(1000000000) + (clock->stop.tv_nsec - clock->start.tv_nsec))) / 1000;
 
     return microseconds;
 }

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -55,8 +55,9 @@ int StopPerfClock(PERF_CLOCK* clock, void* log)
 
 long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 {
-    //long seconds = 0;
-    //long nanoseconds = 0;
+    long const billion = 1000000000;
+    long seconds = 0;
+    long nanoseconds = 0;
     long microseconds = -1;
 
     if ((NULL == clock) || (0 == clock->stop.tv_sec))
@@ -65,7 +66,7 @@ long GetPerfClockTime(PERF_CLOCK* clock, void* log)
         return microseconds;
     }
 
-    /*if ((nanoseconds = clock->stop.tv_nsec - clock->start.tv_nsec) < 0)
+   /*if ((nanoseconds = clock->stop.tv_nsec - clock->start.tv_nsec) < 0)
     {
         if ((seconds = clock->stop.tv_sec - clock->start.tv_sec) > 0)
         {
@@ -77,7 +78,9 @@ long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 
     microseconds = (seconds * 1000000) + (long)(((float)nanoseconds / 1000.0) + 0.5);*/
 
-    microseconds = (clock->stop.tv_sec - clock->stop.tv_sec) + ((clock->stop.tv_nsec - clock->stop.tv_nsec) / 1000000000.0);
+    //nenoseconds = (clock->stop.tv_sec - tp_old.tv_sec) * (long)(1000000000) + (clock->stop.tv_nsec - tp_old.tv_nsec);
+
+    microseconds = (clock->stop.tv_sec - clock->start.tv_sec) + ((clock->stop.tv_nsec - clock->start.tv_nsec) / 1000000000.0);
 
     return microseconds;
 }

--- a/src/common/commonutils/PerfUtils.c
+++ b/src/common/commonutils/PerfUtils.c
@@ -55,9 +55,8 @@ int StopPerfClock(PERF_CLOCK* clock, void* log)
 
 long GetPerfClockTime(PERF_CLOCK* clock, void* log)
 {
-    long const billion = 1000000000;
-    long seconds = 0;
-    long nanoseconds = 0;
+    //long seconds = 0;
+    //long nanoseconds = 0;
     long microseconds = -1;
 
     if ((NULL == clock) || (0 == clock->stop.tv_sec))


### PR DESCRIPTION
## Description

- Fixing one corner case bug in GetPerfClockTime() where elapsed times won't be properly recorded.
- Small improvement to LogPerfClock() to log decimals for minutes and seconds.
- Typo fix in the 'Check performance' GitHub action YML.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.