### PR TITLE
Removing EOL .NET 6 SDK

### DIFF
--- a/devops/e2e/cloudtest/debian-10.json
+++ b/devops/e2e/cloudtest/debian-10.json
@@ -34,7 +34,7 @@
         {
             "name": "linux-install-packages",
             "parameters": {
-                "packages": "dotnet-sdk-6.0 jq powershell omi"
+                "packages": "jq powershell omi"
             }
         },
         {

--- a/devops/e2e/cloudtest/debian-12.json
+++ b/devops/e2e/cloudtest/debian-12.json
@@ -28,7 +28,7 @@
         {
             "name": "linux-bash-command",
             "parameters": {
-                "command": "sudo apt update && sudo apt install -y dotnet-sdk-6.0 jq omi"
+                "command": "sudo apt update && sudo apt install -y jq omi"
             }
         },
         {
@@ -38,6 +38,12 @@
             "name": "linux-bash-command",
             "parameters": {
                 "command": "wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.1/powershell_7.4.1-1.deb_amd64.deb -O powershell.deb && sudo dpkg -i powershell.deb && sudo apt-get install -f"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "apt list --installed"
             }
         }
     ]

--- a/devops/e2e/cloudtest/ubuntu-20_04.json
+++ b/devops/e2e/cloudtest/ubuntu-20_04.json
@@ -28,16 +28,16 @@
         {
             "name": "linux-install-packages",
             "parameters": {
-                "packages": "aziot-identity-service jq omi powershell"
+                "packages": "jq omi powershell"
             }
         },
         {
             "name": "linux-azcli"
         },
         {
-            "name": "linux-dotnet-sdk",
+            "name": "linux-bash-command",
             "parameters": {
-                "version": "6.0"
+                "command": "apt list --installed"
             }
         }
     ]

--- a/devops/e2e/cloudtest/ubuntu-22_04.json
+++ b/devops/e2e/cloudtest/ubuntu-22_04.json
@@ -16,17 +16,11 @@
         {
             "name": "linux-install-packages",
             "parameters": {
-                "packages": "aziot-identity-service jq omi powershell libgsl-dev libgsl27 libgslcblas0"
+                "packages": "jq omi powershell"
             }
         },
         {
             "name": "linux-azcli"
-        },
-        {
-            "name": "linux-dotnet-sdk",
-            "parameters": {
-                "version": "6.0"
-            }
         },
         {
             "name": "linux-bash-command",


### PR DESCRIPTION
## Description

* Removed .NET 6.0 SDK. from images this was a previous requirement for the dotnet e2e tests but they are no longer being used.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.