### PR TITLE
New simple action to check policy package size

### DIFF
--- a/.github/actions/check-perf/action.yml
+++ b/.github/actions/check-perf/action.yml
@@ -33,8 +33,7 @@ runs:
             echo "Found no performance warnings in '$perflog'"
         fi
 
-        if [ "$failed" == true ]
-        then
+        if [ "$failed" == true ]; then
             echo "Check performance test failed"
             exit 1
         fi

--- a/.github/actions/check-size/action.yml
+++ b/.github/actions/check-size/action.yml
@@ -19,15 +19,22 @@ runs:
       run: |
         failed=false
 
+        echo "$package"
+        echo "$limit"
+        
         echo "Checking the size of '$package'"
         echo "Size of '$package':"
-        actual = wc -c $package | awk '{print $1}'
 
-        if (actual > limit)
-            echo "Size of '$package' of $actual kB is greater than the limit of $limit kB"
+        # command = f"wc -c $package | awk '{{print $1}}'"
+        # actual = int(subprocess.check_output(command, shell=True).strip())
+
+        actual = $(wc -c < "$package")
+
+        if [ "$actual" -gt "$limit" ]; then
+            echo "Size of '$package' of $actual bytes is greater than the limit of $limit bytes"
             failed=true
         else
-            echo "Size of '$package' of $actual kB is at or under the limit of $limit kB"
+            echo "Size of '$package' of $actual bytes is at or under the limit of $limit bytes"
         fi
 
         if [ "$failed" == true ]

--- a/.github/actions/check-size/action.yml
+++ b/.github/actions/check-size/action.yml
@@ -19,19 +19,13 @@ runs:
       run: |
         failed=false
 
-        echo "Package: $package"
-        echo "Limit: $limit kB"
-        
-        echo "Checking the size of '$package'"
-
         actual=$(du -k "$package" | cut -f1)
-        echo "Actual: $actual kB"
 
         if [ "$actual" -gt "$limit" ]; then
-            echo "Size of '$package' of $actual bytes is greater than the limit of $limit bytes"
+            echo "Size of '$package' of $actual kB is greater than the limit of $limit kB"
             failed=true
         else
-            echo "Size of '$package' of $actual bytes is at or under the limit of $limit bytes"
+            echo "Size of '$package' of $actual kB is at or under the limit of $limit kB"
         fi
 
         if [ "$failed" == true ]

--- a/.github/actions/check-size/action.yml
+++ b/.github/actions/check-size/action.yml
@@ -19,13 +19,13 @@ runs:
       run: |
         failed=false
 
-        echo "$package"
-        echo "$limit"
+        echo "Package: $package"
+        echo "Limit: $limit kB"
         
         echo "Checking the size of '$package'"
-        echo "Size of '$package':"
 
         actual=$(du -k "$package" | cut -f1)
+        echo "Actual: $actual kB"
 
         if [ "$actual" -gt "$limit" ]; then
             echo "Size of '$package' of $actual bytes is greater than the limit of $limit bytes"

--- a/.github/actions/check-size/action.yml
+++ b/.github/actions/check-size/action.yml
@@ -8,6 +8,7 @@ inputs:
   limit:
     description: the maximum size of the package in kB
     required: true
+    type: integer
 
 runs:
   using: composite
@@ -21,15 +22,14 @@ runs:
 
         actual=$(du -k "$package" | cut -f1)
 
-        if [ "$actual" -gt "$limit" ]; then
+        if [ "$actual" -gt $limit ]; then
             echo "Size of '$package' of $actual kB is greater than the limit of $limit kB"
             failed=true
         else
             echo "Size of '$package' of $actual kB is at or under the limit of $limit kB"
         fi
 
-        if [ "$failed" == true ]
-        then
+        if [ "$failed" == true ]; then
             echo "Check package size test failed"
             exit 1
         fi

--- a/.github/actions/check-size/action.yml
+++ b/.github/actions/check-size/action.yml
@@ -1,0 +1,38 @@
+name: Check size of a policy package
+description: Checks the disk size of a policy package
+
+inputs:
+  package:
+    description: the name of the package
+    required: true
+  limit:
+    description: the maximum size of the package in kB
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check policy package size
+      env:
+        package: ${{ inputs.package }}
+        limit: ${{ inputs.limit }}
+      run: |
+        failed=false
+
+        echo "Checking the size of '$package'"
+        echo "Size of '$package':"
+        actual = wc -c $package | awk '{print $1}'
+
+        if (actual > limit)
+            echo "Size of '$package' of $actual kB is greater than the limit of $limit kB"
+            failed=true
+        else
+            echo "Size of '$package' of $actual kB is at or under the limit of $limit kB"
+        fi
+
+        if [ "$failed" == true ]
+        then
+            echo "Check package size test failed"
+            exit 1
+        fi
+      shell: bash

--- a/.github/actions/check-size/action.yml
+++ b/.github/actions/check-size/action.yml
@@ -25,10 +25,7 @@ runs:
         echo "Checking the size of '$package'"
         echo "Size of '$package':"
 
-        # command = f"wc -c $package | awk '{{print $1}}'"
-        # actual = int(subprocess.check_output(command, shell=True).strip())
-
-        actual = $(wc -c < "$package")
+        actual=$(du -k "$package" | cut -f1)
 
         if [ "$actual" -gt "$limit" ]; then
             echo "Size of '$package' of $actual bytes is greater than the limit of $limit bytes"

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -188,7 +188,7 @@ jobs:
         if: success() || failure()
         uses: ./.github/actions/check-size
         with:
-          package: $name.zip
+          package: '${{ steps.normalize.outputs.path }}'
           limit: "290"
 
       - name: Run Guest Configuration Test

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -186,7 +186,6 @@ jobs:
       
       - name: Check package size
         if: success() || failure()
-        working-directory: ${{ steps.normalize.outputs.PolicyPackageDir }}
         uses: ./.github/actions/check-size
         with:
           package: $name.zip

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -184,6 +184,14 @@ jobs:
               Rename-Item -Path $_.Name -NewName "$name.zip"
           }
       
+      - name: Check package size
+        if: success() || failure()
+        working-directory: ${{ steps.normalize.outputs.PolicyPackageDir }}
+        uses: ./.github/actions/check-size
+        with:
+          package: $name.zip
+          limit: "290000"
+
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.normalize.outputs.PolicyPackageDir }}
         run: |

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -189,7 +189,7 @@ jobs:
         uses: ./.github/actions/check-size
         with:
           package: '${{ steps.normalize.outputs.path }}'
-          limit: "290"
+          limit: 290
 
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.normalize.outputs.PolicyPackageDir }}

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -189,7 +189,7 @@ jobs:
         uses: ./.github/actions/check-size
         with:
           package: $name.zip
-          limit: "290000"
+          limit: "290"
 
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.normalize.outputs.PolicyPackageDir }}


### PR DESCRIPTION
## Description

New GitHub action to check policy package size added to existing Universal NRP workflow. Today our two packages are ~ 280 kB each. The current limit is 290 kB. We'll see how this goes in CI and adjust (increase) later if justified (for example, for the future CIS baseline).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.