### PR TITLE
Adding manifest for component governance

### DIFF
--- a/src/common/parson/cgmanifest.json
+++ b/src/common/parson/cgmanifest.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1,
+    "registrations":[
+        {
+            "component": {
+                "type": "git",
+                "git": {
+                    "RepositoryUrl": "https://github.com/kgabis/parson",
+                    "CommitHash": "8beeb5ea4da5eedff8d3221307ef04855804a920"
+                }
+            },
+            "developmentDependency" : false
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Adding component governance manifest for parson.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.