### PR TITLE
Fix crashes in MC adapter for SecurityBaseline when AsbMmiGet fails

### DIFF
--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -468,6 +468,10 @@ static MI_Result GetReportedObjectValueFromDevice(const char* who, MI_Context* c
             FREE_MEMORY(objectValue);
         }
     }
+    else
+    {
+        miResult = MI_RESULT_FAILED;
+    }
 
     g_reportedMpiResult = mpiResult;
 
@@ -927,7 +931,7 @@ void MI_CALL OsConfigResource_Invoke_TestTargetResource(
     MI_UNREFERENCED_PARAMETER(methodName);
     MI_UNREFERENCED_PARAMETER(instanceName);
 
-    OsConfigResource_TestTargetResource test_result_object;
+    OsConfigResource_TestTargetResource test_result_object = {{0},{0},{0},{0},{0},{0}};
 
     MI_Result miResult = MI_RESULT_OK;
     MI_Result miCleanup = MI_RESULT_OK;


### PR DESCRIPTION
## Description
Fix crashes in MC adapter for SecurityBaseline when AsbMmiGet fails:
 - set proper MI_RESULT when AsbMmiGet failed
 - initialize OsConfigResource_TestTargetResource so that we won't try to destroy based on undefined memory

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.