### PR TITLE
Added pre-commit to devcontainer, removed postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,9 @@
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
+		"ghcr.io/devcontainers-extra/features/pre-commit:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
-	"postCreateCommand": "git submodule update --init",
 	"customizations": {
 		"vscode": {
 			"extensions": [


### PR DESCRIPTION
## Description

* Added pre-commit to devcontainer
* Removed `postCreateCommand` from the devcontainer as the `submodule update --init` should be done on the host when initially cloning

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.
