### PR TITLE
Add ProcedureObjectName and ProcedureObjectValue to OsConfig Schema

### DIFF
--- a/src/adapters/mc/OsConfig.schema.mof
+++ b/src/adapters/mc/OsConfig.schema.mof
@@ -28,6 +28,12 @@ class OsConfigResource : OMI_BaseResource
   [write, Description("Initialization MIM Object (for audit and remediation)")]
   string InitObjectName;
 
+  [write, Description("Procedure MIM Object (for audit and remediation)")]
+  string ProcedureObjectName;
+
+  [write, Description("Procedure MIM Value (for audit and remediation)")]
+  string ProcedureObjectValue;
+
   [write, Description("Reported MIM Object (for audit)")]
   string ReportedObjectName;
 

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -21,7 +21,9 @@ static char* g_ruleId = NULL;
 static char* g_payloadKey = NULL;
 static char* g_componentName = NULL;
 static char* g_initObjectName = NULL;
-static char* g_reportedObjectName = NULL;
+static char *g_procedureObjectName = NULL;
+static char *g_procedureObjectValue = NULL;
+static char *g_reportedObjectName = NULL;
 static char* g_expectedObjectValue = NULL;
 static char* g_desiredObjectName = NULL;
 static char* g_desiredObjectValue = NULL;
@@ -54,6 +56,8 @@ void __attribute__((constructor)) Initialize()
     g_payloadKey = DuplicateString(g_defaultValue);
     g_componentName = DuplicateString(g_defaultValue);
     g_initObjectName = DuplicateString(g_defaultValue);
+    g_procedureObjectName = DuplicateString(g_defaultValue);
+    g_procedureObjectValue = DuplicateString(g_defaultValue);
     g_reportedObjectName = DuplicateString(g_defaultValue);
     g_expectedObjectValue = DuplicateString(g_passValue);
     g_desiredObjectName = DuplicateString(g_defaultValue);
@@ -69,6 +73,8 @@ void __attribute__((destructor)) Destroy()
     FREE_MEMORY(g_payloadKey);
     FREE_MEMORY(g_componentName);
     FREE_MEMORY(g_initObjectName);
+    FREE_MEMORY(g_procedureObjectName);
+    FREE_MEMORY(g_procedureObjectValue);
     FREE_MEMORY(g_reportedObjectName);
     FREE_MEMORY(g_expectedObjectValue);
     FREE_MEMORY(g_desiredObjectName);
@@ -611,6 +617,25 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
         FREE_MEMORY(g_initObjectName);
     }
 
+    // Read the MIM procedure object name from the input resource values
+    if ((MI_TRUE == in->InputResource.value->ProcedureObjectName.exists) && (NULL != in->InputResource.value->ProcedureObjectName.value))
+    {
+        FREE_MEMORY(g_procedureObjectName);
+        if (NULL == (g_procedureObjectName = DuplicateString(in->InputResource.value->ProcedureObjectName.value)))
+        {
+            LogError(context, miResult, GetLog(), "[OsConfigResource.Get] DuplicateString(%s) failed", in->InputResource.value->ProcedureObjectName.value);
+            g_procedureObjectName = DuplicateString(g_defaultValue);
+            miResult = MI_RESULT_FAILED;
+            goto Exit;
+        }
+    }
+    else
+    {
+        // Not an error
+        LogInfo(context, GetLog(), "[OsConfigResource.Get] No ProcedureObjectName");
+        FREE_MEMORY(g_procedureObjectName);
+    }
+
     // Read the MIM reported object name from the input resource values
     if ((MI_TRUE == in->InputResource.value->ReportedObjectName.exists) && (NULL != in->InputResource.value->ReportedObjectName.value))
     {
@@ -653,6 +678,17 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
         {
             LogError(context, miResult, GetLog(), "[OsConfigResource.Get] DuplicateString(%s) failed", in->InputResource.value->DesiredObjectValue.value);
             g_desiredObjectValue = DuplicateString(g_failValue);
+        }
+    }
+
+    // Read the procedure MIM object value from the input resource values
+    if ((in->InputResource.value->ProcedureObjectValue.exists == MI_TRUE) && (in->InputResource.value->ProcedureObjectValue.value != NULL))
+    {
+        FREE_MEMORY(g_procedureObjectValue);
+        if (NULL == (g_procedureObjectValue = DuplicateString(in->InputResource.value->ProcedureObjectValue.value)))
+        {
+            LogError(context, miResult, GetLog(), "[OsConfigResource.Get] DuplicateString(%s) failed", in->InputResource.value->ProcedureObjectValue.value);
+            g_procedureObjectValue = DuplicateString(g_defaultValue);
         }
     }
 
@@ -1023,6 +1059,25 @@ void MI_CALL OsConfigResource_Invoke_TestTargetResource(
         FREE_MEMORY(g_initObjectName);
     }
 
+    // Read the MIM procedure object name from the input resource values
+    if ((MI_TRUE == in->InputResource.value->ProcedureObjectName.exists) && (NULL != in->InputResource.value->ProcedureObjectName.value))
+    {
+        FREE_MEMORY(g_procedureObjectName);
+        if (NULL == (g_procedureObjectName = DuplicateString(in->InputResource.value->ProcedureObjectName.value)))
+        {
+            LogError(context, miResult, GetLog(), "[OsConfigResource.Test] DuplicateString(%s) failed", in->InputResource.value->ProcedureObjectName.value);
+            g_procedureObjectName = DuplicateString(g_defaultValue);
+            miResult = MI_RESULT_FAILED;
+            goto Exit;
+        }
+    }
+    else
+    {
+        // Not an error
+        LogInfo(context, GetLog(), "[OsConfigResource.Test] No ProcedureObjectName");
+        FREE_MEMORY(g_procedureObjectName);
+    }
+
     // Read the MIM reported object name from the input resource values
     if ((MI_TRUE == in->InputResource.value->ReportedObjectName.exists) && (NULL != in->InputResource.value->ReportedObjectName.value))
     {
@@ -1050,6 +1105,17 @@ void MI_CALL OsConfigResource_Invoke_TestTargetResource(
         {
             LogError(context, miResult, GetLog(), "[OsConfigResource.Test] DuplicateString(%s) failed", in->InputResource.value->DesiredObjectValue.value);
             g_desiredObjectValue = DuplicateString(g_failValue);
+        }
+    }
+
+    // Read the procedure MIM object value from the input resource values
+    if ((in->InputResource.value->ProcedureObjectValue.exists == MI_TRUE) && (in->InputResource.value->ProcedureObjectValue.value != NULL))
+    {
+        FREE_MEMORY(g_procedureObjectValue);
+        if (NULL == (g_procedureObjectValue = DuplicateString(in->InputResource.value->ProcedureObjectValue.value)))
+        {
+            LogError(context, miResult, GetLog(), "[OsConfigResource.Get] DuplicateString(%s) failed", in->InputResource.value->ProcedureObjectValue.value);
+            g_procedureObjectValue = DuplicateString(g_defaultValue);
         }
     }
 

--- a/src/adapters/mc/OsConfigResource.h
+++ b/src/adapters/mc/OsConfigResource.h
@@ -41,6 +41,8 @@ typedef struct _OsConfigResource /* extends OMI_BaseResource */
     MI_ConstStringField PayloadKey;
     MI_ConstStringField ComponentName;
     MI_ConstStringField InitObjectName;
+    MI_ConstStringField ProcedureObjectName;
+    MI_ConstStringField ProcedureObjectValue;
     MI_ConstStringField ReportedObjectName;
     MI_ConstStringField ReportedObjectValue;
     MI_ConstStringField ExpectedObjectValue;
@@ -499,13 +501,77 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_InitObjectName(
         10);
 }
 
-MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ReportedObjectName(
+MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ProcedureObjectName(
     OsConfigResource* self,
     const MI_Char* str)
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
         11,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_ProcedureObjectName(
+    OsConfigResource* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        11,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ProcedureObjectName(
+    OsConfigResource* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        11);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ProcedureObjectValue(
+    OsConfigResource* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        12,
+        (MI_Value*)&str,
+        MI_STRING,
+        0);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_ProcedureObjectValue(
+    OsConfigResource* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        12,
+        (MI_Value*)&str,
+        MI_STRING,
+        MI_FLAG_BORROW);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ProcedureObjectValue(
+    OsConfigResource* self)
+{
+    return self->__instance.ft->ClearElementAt(
+        (MI_Instance*)&self->__instance,
+        12);
+}
+
+MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ReportedObjectName(
+    OsConfigResource* self,
+    const MI_Char* str)
+{
+    return self->__instance.ft->SetElementAt(
+        (MI_Instance*)&self->__instance,
+        13,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -517,7 +583,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_ReportedObjectName(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        11,
+        13,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -528,7 +594,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ReportedObjectName(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        11);
+        13);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ReportedObjectValue(
@@ -537,7 +603,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ReportedObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        12,
+        14,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -549,7 +615,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_ReportedObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        12,
+        14,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -560,7 +626,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ReportedObjectValue(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        12);
+        14);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ExpectedObjectValue(
@@ -569,7 +635,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ExpectedObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        13,
+        15,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -581,7 +647,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_ExpectedObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        13,
+        15,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -592,7 +658,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_ExpectedObjectValue(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        13);
+        15);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectName(
@@ -601,7 +667,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectName(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        14,
+        16,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -613,7 +679,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_DesiredObjectName(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        14,
+        16,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -624,7 +690,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_DesiredObjectName(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        14);
+        16);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectValue(
@@ -633,7 +699,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_DesiredObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        15,
+        17,
         (MI_Value*)&str,
         MI_STRING,
         0);
@@ -645,7 +711,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_DesiredObjectValue(
 {
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        15,
+        17,
         (MI_Value*)&str,
         MI_STRING,
         MI_FLAG_BORROW);
@@ -656,7 +722,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_DesiredObjectValue(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        15);
+        17);
 }
 
 MI_INLINE MI_Result MI_CALL OsConfigResource_Set_ReportedMpiResult(
@@ -685,7 +751,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Set_Reasons(
     arr.size = size;
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        17,
+        19,
         (MI_Value*)&arr,
         MI_INSTANCEA,
         0);
@@ -701,7 +767,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_SetPtr_Reasons(
     arr.size = size;
     return self->__instance.ft->SetElementAt(
         (MI_Instance*)&self->__instance,
-        17,
+        19,
         (MI_Value*)&arr,
         MI_INSTANCEA,
         MI_FLAG_BORROW);
@@ -712,7 +778,7 @@ MI_INLINE MI_Result MI_CALL OsConfigResource_Clear_Reasons(
 {
     return self->__instance.ft->ClearElementAt(
         (MI_Instance*)&self->__instance,
-        17);
+        19);
 }
 
 /*

--- a/src/adapters/mc/schema.c
+++ b/src/adapters/mc/schema.c
@@ -1697,6 +1697,92 @@ static MI_CONST MI_PropertyDecl OsConfigResource_InitObjectName_prop =
     NULL,
 };
 
+static MI_CONST MI_Boolean OsConfigResource_ProcedureObjectName_Write_qual_value = 1;
+
+static MI_CONST MI_Qualifier OsConfigResource_ProcedureObjectName_Write_qual =
+{
+    MI_T("Write"),
+    MI_BOOLEAN,
+    MI_FLAG_ENABLEOVERRIDE | MI_FLAG_TOSUBCLASS,
+    &OsConfigResource_ProcedureObjectName_Write_qual_value
+};
+
+static MI_CONST MI_Char* OsConfigResource_ProcedureObjectName_Description_qual_value = MI_T("28");
+
+static MI_CONST MI_Qualifier OsConfigResource_ProcedureObjectName_Description_qual =
+{
+    MI_T("Description"),
+    MI_STRING,
+    MI_FLAG_ENABLEOVERRIDE | MI_FLAG_TOSUBCLASS | MI_FLAG_TRANSLATABLE,
+    &OsConfigResource_ProcedureObjectName_Description_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST OsConfigResource_ProcedureObjectName_quals[] =
+{
+    &OsConfigResource_ProcedureObjectName_Write_qual,
+    &OsConfigResource_ProcedureObjectName_Description_qual,
+};
+
+/* property OsConfigResource.ProcedureObjectName */
+static MI_CONST MI_PropertyDecl OsConfigResource_ProcedureObjectName_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00706513, /* code */
+    MI_T("ProcedureObjectName"), /* name */
+    OsConfigResource_ProcedureObjectName_quals, /* qualifiers */
+    MI_COUNT(OsConfigResource_ProcedureObjectName_quals), /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(OsConfigResource, ProcedureObjectName), /* offset */
+    MI_T("OsConfigResource"), /* origin */
+    MI_T("OsConfigResource"), /* propagator */
+    NULL,
+};
+
+static MI_CONST MI_Boolean OsConfigResource_ProcedureObjectValue_Write_qual_value = 1;
+
+static MI_CONST MI_Qualifier OsConfigResource_ProcedureObjectValue_Write_qual =
+{
+    MI_T("Write"),
+    MI_BOOLEAN,
+    MI_FLAG_ENABLEOVERRIDE | MI_FLAG_TOSUBCLASS,
+    &OsConfigResource_ProcedureObjectValue_Write_qual_value
+};
+
+static MI_CONST MI_Char* OsConfigResource_ProcedureObjectValue_Description_qual_value = MI_T("29");
+
+static MI_CONST MI_Qualifier OsConfigResource_ProcedureObjectValue_Description_qual =
+{
+    MI_T("Description"),
+    MI_STRING,
+    MI_FLAG_ENABLEOVERRIDE | MI_FLAG_TOSUBCLASS | MI_FLAG_TRANSLATABLE,
+    &OsConfigResource_ProcedureObjectValue_Description_qual_value
+};
+
+static MI_Qualifier MI_CONST* MI_CONST OsConfigResource_ProcedureObjectValue_quals[] =
+{
+    &OsConfigResource_ProcedureObjectValue_Write_qual,
+    &OsConfigResource_ProcedureObjectValue_Description_qual,
+};
+
+/* property OsConfigResource.ProcedureObjectValue */
+static MI_CONST MI_PropertyDecl OsConfigResource_ProcedureObjectValue_prop =
+{
+    MI_FLAG_PROPERTY, /* flags */
+    0x00706514, /* code */
+    MI_T("ProcedureObjectValue"), /* name */
+    OsConfigResource_ProcedureObjectValue_quals, /* qualifiers */
+    MI_COUNT(OsConfigResource_ProcedureObjectValue_quals), /* numQualifiers */
+    MI_STRING, /* type */
+    NULL, /* className */
+    0, /* subscript */
+    offsetof(OsConfigResource, ProcedureObjectValue), /* offset */
+    MI_T("OsConfigResource"), /* origin */
+    MI_T("OsConfigResource"), /* propagator */
+    NULL,
+};
+
 static MI_CONST MI_Boolean OsConfigResource_ReportedObjectName_Write_qual_value = 1;
 
 static MI_CONST MI_Qualifier OsConfigResource_ReportedObjectName_Write_qual =
@@ -2011,6 +2097,8 @@ static MI_PropertyDecl MI_CONST* MI_CONST OsConfigResource_props[] =
     &OsConfigResource_PayloadKey_prop,
     &OsConfigResource_ComponentName_prop,
     &OsConfigResource_InitObjectName_prop,
+    &OsConfigResource_ProcedureObjectName_prop,
+    &OsConfigResource_ProcedureObjectValue_prop,
     &OsConfigResource_ReportedObjectName_prop,
     &OsConfigResource_ReportedObjectValue_prop,
     &OsConfigResource_ExpectedObjectValue_prop,
@@ -2776,7 +2864,7 @@ static MI_CONST MI_Qualifier OsConfigResource_Description_qual =
     &OsConfigResource_Description_qual_value
 };
 
-static MI_CONST MI_Char* OsConfigResource_ClassVersion_qual_value = MI_T("3.0.0");
+static MI_CONST MI_Char* OsConfigResource_ClassVersion_qual_value = MI_T("4.0.0");
 
 static MI_CONST MI_Qualifier OsConfigResource_ClassVersion_qual =
 {


### PR DESCRIPTION
## Description

Add ProcedureObjectName and ProcedureObjectValue fields to OsConfig schema and OsConfigResource
Add support for multiple Components in OsConfigResource.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.
