### PR TITLE
Compliance module and MC adapter skeleton

### DIFF
--- a/src/adapters/mc/CMakeLists.txt
+++ b/src/adapters/mc/CMakeLists.txt
@@ -5,3 +5,4 @@ add_compile_options("-Wall;-Wextra;-Wunused;-Werror;-Wformat;-Wformat-security;-
 
 add_subdirectory(ssh)
 add_subdirectory(asb)
+add_subdirectory(compliance)

--- a/src/adapters/mc/compliance/Baseline.c
+++ b/src/adapters/mc/compliance/Baseline.c
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "../Common.h"
+#include "ComplianceInterface.h"
+
+static MMI_HANDLE gCompliance = NULL;
+
+static const char gComponentName[] = "Compliance";
+
+int BaselineIsValidResourceIdRuleId(const char* resourceId, const char* ruleId, const char* payloadKey, void* log)
+{
+    UNUSED(resourceId);
+    UNUSED(ruleId);
+    UNUSED(payloadKey);
+    UNUSED(log);
+    return 0;
+}
+
+void BaselineInitialize(void* log)
+{
+    ComplianceInitialize(log);
+    gCompliance = ComplianceMmiOpen(gComponentName, -1);
+}
+
+void BaselineShutdown(void* log)
+{
+    UNUSED(log);
+    if(NULL == gCompliance)
+    {
+        return;
+    }
+
+    ComplianceMmiClose(gCompliance);
+    ComplianceShutdown();
+    gCompliance = NULL;
+}
+
+int BaselineMmiGet(const char* componentName, const char* objectName, char** payload, int* payloadSizeBytes, unsigned int maxPayloadSizeBytes, void* log)
+{
+    UNUSED(log);
+    UNUSED(maxPayloadSizeBytes);
+
+    if (0 != strcmp(componentName, gComponentName))
+    {
+        return EINVAL;
+    }
+
+    if (NULL == gCompliance)
+    {
+        return EINVAL;
+    }
+
+    return ComplianceMmiGet(gCompliance, componentName, objectName, payload, payloadSizeBytes);
+}
+
+int BaselineMmiSet(const char* componentName, const char* objectName, const char* payload, const int payloadSizeBytes, void* log)
+{
+    UNUSED(log);
+
+    if (0 != strcmp(componentName, gComponentName))
+    {
+        return EINVAL;
+    }
+
+    return ComplianceMmiSet(gCompliance, componentName, objectName, payload, payloadSizeBytes);
+}

--- a/src/adapters/mc/compliance/CMakeLists.txt
+++ b/src/adapters/mc/compliance/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Compliance module for Linux
+project(OsConfigResourceCompliance)
+add_link_options("LINKER:-z,defs")
+add_library(OsConfigResourceCompliance
+    SHARED
+        ../module.c
+        ../schema.c
+        ../OsConfigResource.c
+        Baseline.c)
+
+target_link_libraries(OsConfigResourceCompliance
+    PRIVATE
+        commonutils
+        logging
+        mpiclient
+        parsonlib
+        compliancelib)

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 add_module(securitybaseline)
 add_module(configuration)
 add_module(deviceinfo)
+add_module(compliance)
 
 if (BUILD_MODULETEST)
     add_subdirectory(test)

--- a/src/modules/compliance/CMakeLists.txt
+++ b/src/modules/compliance/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+add_subdirectory(src)
+if (BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/modules/compliance/src/CMakeLists.txt
+++ b/src/modules/compliance/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+add_subdirectory(lib)
+add_subdirectory(so)

--- a/src/modules/compliance/src/lib/CMakeLists.txt
+++ b/src/modules/compliance/src/lib/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+project(compliancelib)
+
+add_library(compliancelib STATIC
+    ComplianceInterface.cpp
+    ${PROCEDURES}
+    )
+
+target_link_libraries(compliancelib
+    PRIVATE
+        commonutils
+        logging
+)
+
+set_property(TARGET compliancelib PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(compliancelib PUBLIC
+    ${MODULES_INC_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/modules/compliance/src/lib/ComplianceInterface.cpp
+++ b/src/modules/compliance/src/lib/ComplianceInterface.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "ComplianceInterface.h"
+#include "CommonUtils.h"
+
+void ComplianceInitialize(void* log)
+{
+    UNUSED(log);
+}
+
+void ComplianceShutdown(void)
+{
+}
+
+MMI_HANDLE ComplianceMmiOpen(const char* clientName, const unsigned int maxPayloadSizeBytes)
+{
+    UNUSED(clientName);
+    UNUSED(maxPayloadSizeBytes);
+    return nullptr;
+}
+
+void ComplianceMmiClose(MMI_HANDLE clientSession)
+{
+    UNUSED(clientSession);
+}
+
+int ComplianceMmiGetInfo(const char* clientName, char** payload, int* payloadSizeBytes)
+{
+    UNUSED(clientName);
+    UNUSED(payload);
+    UNUSED(payloadSizeBytes);
+    return -1;
+}
+
+int ComplianceMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* objectName, char** payload, int* payloadSizeBytes)
+{
+    UNUSED(clientSession);
+    UNUSED(componentName);
+    UNUSED(objectName);
+    UNUSED(payload);
+    UNUSED(payloadSizeBytes);
+    return -1;
+}
+
+int ComplianceMmiSet(MMI_HANDLE clientSession, const char* componentName, const char* objectName, const char* payload, const int payloadSizeBytes)
+{
+    UNUSED(clientSession);
+    UNUSED(componentName);
+    UNUSED(objectName);
+    UNUSED(payload);
+    UNUSED(payloadSizeBytes);
+    return -1;
+}
+
+void ComplianceMmiFree(char* payload)
+{
+    UNUSED(payload);
+}

--- a/src/modules/compliance/src/lib/ComplianceInterface.h
+++ b/src/modules/compliance/src/lib/ComplianceInterface.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCE_INTERFACE_H
+#define COMPLIANCE_INTERFACE_H
+
+#include "../inc/Mmi.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void ComplianceInitialize(void*);
+void ComplianceShutdown();
+
+MMI_HANDLE ComplianceMmiOpen(const char* clientName, const unsigned int maxPayloadSizeBytes);
+void ComplianceMmiClose(MMI_HANDLE clientSession);
+int ComplianceMmiGetInfo(const char* clientName, char** payload, int* payloadSizeBytes);
+int ComplianceMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* objectName, char** payload, int* payloadSizeBytes);
+int ComplianceMmiSet(MMI_HANDLE clientSession, const char* componentName, const char* objectName, const char* payload, const int payloadSizeBytes);
+void ComplianceMmiFree(char* payload);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // COMPLIANCE_INTERFACE_H

--- a/src/modules/compliance/src/so/CMakeLists.txt
+++ b/src/modules/compliance/src/so/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+project(compliance)
+
+add_library(compliance SHARED ComplianceModule.c)
+target_link_libraries(compliance
+    PRIVATE
+        commonutils
+        logging
+    PUBLIC
+        compliancelib
+)
+target_include_directories(compliance
+    PUBLIC
+        ${MODULES_INC_DIR}
+)
+set_target_properties(compliance
+    PROPERTIES
+        PREFIX ""
+        POSITION_INDEPENDENT_CODE ON
+)
+install(TARGETS compliance DESTINATION ${MODULES_INSTALL_DIR})

--- a/src/modules/compliance/src/so/ComplianceModule.c
+++ b/src/modules/compliance/src/so/ComplianceModule.c
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <Mmi.h>
+#include "ComplianceInterface.h"
+#include <stddef.h>
+
+void __attribute__((constructor)) InitModule(void)
+{
+    ComplianceInitialize(NULL);
+}
+
+void __attribute__((destructor)) DestroyModule(void)
+{
+    ComplianceShutdown(NULL);
+}
+
+int MmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloadSizeBytes)
+{
+    return ComplianceMmiGetInfo(clientName, payload, payloadSizeBytes);
+}
+
+MMI_HANDLE MmiOpen(const char* clientName, const unsigned int maxPayloadSizeBytes)
+{
+    return ComplianceMmiOpen(clientName, maxPayloadSizeBytes);
+}
+
+void MmiClose(MMI_HANDLE clientSession)
+{
+    return ComplianceMmiClose(clientSession);
+}
+
+int MmiSet(MMI_HANDLE clientSession, const char* componentName, const char* objectName, const MMI_JSON_STRING payload, const int payloadSizeBytes)
+{
+    return ComplianceMmiSet(clientSession, componentName, objectName, payload, payloadSizeBytes);
+}
+
+int MmiGet(MMI_HANDLE clientSession, const char* componentName, const char* objectName, MMI_JSON_STRING* payload, int* payloadSizeBytes)
+{
+    return ComplianceMmiGet(clientSession, componentName, objectName, payload, payloadSizeBytes);
+}
+
+void MmiFree(MMI_JSON_STRING payload)
+{
+    return ComplianceMmiFree(payload);
+}

--- a/src/modules/compliance/tests/CMakeLists.txt
+++ b/src/modules/compliance/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+project(compliancetests)
+
+include(CTest)
+find_package(GTest REQUIRED)
+
+add_executable(compliancetests ComplianceTests.cpp)
+target_link_libraries(compliancetests gtest gtest_main pthread compliancelib logging commonutils)
+
+gtest_discover_tests(compliancetests XML_OUTPUT_DIR ${GTEST_OUTPUT_DIR})

--- a/src/modules/compliance/tests/ComplianceTests.cpp
+++ b/src/modules/compliance/tests/ComplianceTests.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <gtest/gtest.h>
+#include <version.h>
+#include <Mmi.h>
+#include <CommonUtils.h>
+#include "ComplianceInterface.h"
+
+using namespace std;
+
+class ComplianceTest : public ::testing::Test
+{
+    protected:
+        void SetUp()
+        {
+            ComplianceInitialize(nullptr);
+        }
+
+        void TearDown()
+        {
+            ComplianceShutdown();
+        }
+};
+
+TEST_F(ComplianceTest, ComplianceMmiOpen)
+{
+    auto handle = ComplianceMmiOpen("test", 100);
+    ASSERT_EQ(handle, nullptr);
+}


### PR DESCRIPTION
## Description

This PR introduces basic, mostly empty placeholders for the Compliance module and MC adapter. The goal is to have a clear starting point and separate the work done for POC into smaller, digestible bits.
This PR contains work done by @wupeka.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
