### PR TITLE
Temporarily removing auditd related tests from Module Test pass

### DIFF
--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -1219,16 +1219,6 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAuditdInstalled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAuditdServiceIsRunning"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
     "ObjectName": "remediateEnsureSnmpServerIsDisabled"
   },
   {
@@ -2387,16 +2377,6 @@
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "auditEnsureUnnecessaryAccountsAreRemoved"
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAuditdInstalled"
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAuditdServiceIsRunning"
   },
   {
     "ObjectType": "Reported",


### PR DESCRIPTION
## Description

Temporarily removing 'auditd' related tests from Module Test pass as they do not give reliable results. Keeping them only in MC test pass for now.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
