### PR TITLE
Fix cleanup of SecurityBaseline module test recipe

### DIFF
--- a/src/modules/test/CMakeLists.txt
+++ b/src/modules/test/CMakeLists.txt
@@ -32,11 +32,11 @@ set(MOFS
 )
 
 add_custom_command(
-    OUTPUT ${SRC}/SecurityBaselineTests.json
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/SecurityBaselineTests.json.stamp
     DEPENDS ${SRC}/create-asb-json.sh ${SRC}/mof-to-json.awk ${SRC}/SecurityBaselineTests.json-header ${SRC}/SecurityBaselineTests.json-mid ${SRC}/SecurityBaselineTests.json-footer ${MOFS}
-    COMMAND ./create-asb-json.sh ${MOFS} >${SRC}/SecurityBaselineTests.json
+    COMMAND ./create-asb-json.sh ${MOFS} >${SRC}/SecurityBaselineTests.json && touch ${CMAKE_CURRENT_BINARY_DIR}/SecurityBaselineTests.json.stamp
     WORKING_DIRECTORY ${SRC}
 )
 add_custom_target(generate-asb-test-json
-    DEPENDS ${SRC}/SecurityBaselineTests.json
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/SecurityBaselineTests.json.stamp
 )


### PR DESCRIPTION
## Description

Currently when invoking 'make clean' command, SecurityBaselineTest.json module test recipe is removed. Fix this behavior by attaching to a stamp file output. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
