### PR TITLE
Temporarily disable EnsureCronServiceIsEnabled (audit and remediation) test cases for Module Test

### DIFF
--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -931,11 +931,6 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureCronServiceIsEnabled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
     "ObjectName": "initEnsurePermissionsOnEtcAnacronTab",
     "Payload": "600"
   },
@@ -2103,11 +2098,6 @@
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "auditEnsureZeroconfNetworkingIsDisabled"
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureCronServiceIsEnabled"
   },
   {
     "ObjectType": "Desired",


### PR DESCRIPTION

## Description

Temporarily disable EnsureCronServiceIsEnabled (audit and remediation) test cases for Module Test. These are unreliable and randomly fail on several distros during Module Test CI. For now they will remain in the MC CI tests.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
