### PR TITLE
Add missing stdio.h include

### DIFF
--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -5,6 +5,7 @@
 #define LOGGING_H
 
 #include <string.h>
+#include <stdio.h>
 
 // Maximum log size (1,024,000 is 1MB aka 1024 * 1000), increase or decrease as needed
 #define MAX_LOG_SIZE 1024000


### PR DESCRIPTION
## Description

Logging.h file uses types from stdio and is missing inclusion.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
