### PR TITLE
Fix building Compliance MC adapter with fuzzer enabled

### DIFF
--- a/src/adapters/mc/compliance/CMakeLists.txt
+++ b/src/adapters/mc/compliance/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 # Compliance module for Linux
 project(OsConfigResourceCompliance)
-add_link_options("LINKER:-z,defs")
+if (BUILD_FUZZER)
+    add_link_options("LINKER:-z,defs -shared-libasan")
+else (BUILD_FUZZER)
+    add_link_options("LINKER:-z,defs")
+endif (BUILD_FUZZER)
 add_library(OsConfigResourceCompliance
     SHARED
         ../module.c

--- a/src/tests/fuzzer/CMakeLists.txt
+++ b/src/tests/fuzzer/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer")
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/common/commonutils
-    ${parson_SOURCE_DIR}
     )
 add_executable(osconfig-fuzzer target.cpp)
 target_link_libraries(osconfig-fuzzer PRIVATE
@@ -19,4 +18,5 @@ target_link_libraries(osconfig-fuzzer PRIVATE
     pthread
     securitybaselinelib
     compliancelib
+    parsonlib
 )


### PR DESCRIPTION
## Description

At the moment builds with fuzzer enabled fail due to rigorous link-time checks. This commit fixes the issue.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
