### PR TITLE
Narrow file permissions used when creating text files

### DIFF
--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -87,8 +87,8 @@ void __attribute__((destructor)) Destroy()
     CloseLog(&g_log);
 
     // When the NRP is done, allow others read-only (no write, search or execute) access to the NRP logs
-    SetFileAccess(LOG_FILE, 0, 0, 06774, NULL);
-    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 06774, NULL);
+    SetFileAccess(LOG_FILE, 0, 0, 0644, NULL);
+    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 0644, NULL);
 }
 
 static void LogOsConfigVersion(MI_Context* context)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1022,8 +1022,8 @@ void AsbShutdown(void* log)
     CloseLog(&g_perfLog);
 
     // When done, allow others access to read the performance log
-    SetFileAccess(PERF_LOG_FILE, 0, 0, 06774, NULL);
-    SetFileAccess(ROLLED_PERF_LOG_FILE, 0, 0, 06774, NULL);
+    SetFileAccess(PERF_LOG_FILE, 0, 0, 0644, NULL);
+    SetFileAccess(ROLLED_PERF_LOG_FILE, 0, 0, 0644, NULL);
 }
 
 static char* AuditEnsurePermissionsOnEtcIssue(void* log)

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -382,7 +382,7 @@ int RestrictFileAccessToCurrentAccountOnly(const char* fileName)
     // S_IXUSR (0100): Execute/search permission, owner
     // S_IXGRP (0010): Execute/search permission, group
 
-    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP);
+    return chmod(fileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 }
 
 static bool IsATrueFileOrDirectory(bool directory, const char* name, void* log)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -36,7 +36,7 @@ bool IsFullLoggingEnabled()
 
 static int RestrictFileAccessToCurrentAccountOnly(const char* fileName)
 {
-    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP);
+    return chmod(fileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 }
 
 OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName)


### PR DESCRIPTION
## Description

Previously the default used for various text files (config, log, temporary) as well as unix sockets was 06774. This has more permissions than necessary and also some bits set that are unexpected for text files:
- x77x makes the log files owner/group executable
- 6xxx means set user id + set group id. These bits are for privilege elevation.

Change the default permissions to 0660 for `RestrictFileAccessToCurrentAccountOnly` and 0644 for NRP. This maintains the intended access to these files.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
