### PR TITLE
Fix module tests failures caused by apt-get race conditions

### DIFF
--- a/.github/actions/defer-tests/action.yml
+++ b/.github/actions/defer-tests/action.yml
@@ -1,0 +1,34 @@
+name: Defer test execution
+description: Wait for background services to avoid module tests races
+
+runs:
+  using: composite
+  steps:
+    - name: Stop apt-daily
+      run: |
+        source /etc/os-release
+        if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
+          sudo systemctl stop apt-daily.service || true
+          sudo systemctl stop apt-daily.timer || true
+          sudo systemctl stop apt-daily-upgrade.service || true
+          sudo systemctl stop apt-daily-upgrade.timer || true
+        fi
+
+    - name: Wait for packages installed by azsec
+      run: |
+        source /etc/os-release
+        if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
+          until dpkg -l azsec-bpftrace 2>/dev/null | grep -q '^ii'; do
+            echo "Waiting for azsec-bpftrace to be installed..."
+            sleep 5
+          done
+        elif [[ "$ID" == "mariner" ]]; then
+          until rpm -q azsec-bpftrace &>/dev/null; do
+            echo "Waiting for azsec-bpftrace to be installed..."
+            sleep 5
+          done
+          until rpm -q KeysInUse-OpenSSL &>/dev/null; do
+            echo "Waiting for azsec-bpftrace to be installed..."
+            sleep 5
+          done
+        fi

--- a/.github/actions/defer-tests/action.yml
+++ b/.github/actions/defer-tests/action.yml
@@ -13,6 +13,7 @@ runs:
           sudo systemctl stop apt-daily-upgrade.service || true
           sudo systemctl stop apt-daily-upgrade.timer || true
         fi
+      shell: bash
 
     - name: Wait for packages installed by azsec
       run: |
@@ -32,3 +33,4 @@ runs:
             sleep 5
           done
         fi
+      shell: bash

--- a/.github/workflows/module-test-run.yml
+++ b/.github/workflows/module-test-run.yml
@@ -43,34 +43,8 @@ jobs:
           sudo mkdir -p /etc/osconfig
           sudo cp -r ./src/adapters/pnp/daemon/osconfig.json /etc/osconfig/osconfig.json
 
-      - name: Stop apt-daily
-        run: |
-          source /etc/os-release
-          if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
-            sudo systemctl stop apt-daily.service || true
-            sudo systemctl stop apt-daily.timer || true
-            sudo systemctl stop apt-daily-upgrade.service || true
-            sudo systemctl stop apt-daily-upgrade.timer || true
-          fi
-
-      - name: Wait for packages installed by azsec
-        run: |
-          source /etc/os-release
-          if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
-            until dpkg -l azsec-bpftrace 2>/dev/null | grep -q '^ii'; do
-              echo "Waiting for azsec-bpftrace to be installed..."
-              sleep 5
-            done
-          elif [[ "$ID" == "mariner" ]]; then
-            until rpm -q azsec-bpftrace &>/dev/null; do
-              echo "Waiting for azsec-bpftrace to be installed..."
-              sleep 5
-            done
-            until rpm -q KeysInUse-OpenSSL &>/dev/null; do
-              echo "Waiting for azsec-bpftrace to be installed..."
-              sleep 5
-            done
-          fi
+      - name: Defer test execution
+        uses: ./.github/actions/defer-tests
 
       - name: Run moduletest
         working-directory: ${{ steps.download.outputs.download-path }}/modules/test

--- a/.github/workflows/module-test-run.yml
+++ b/.github/workflows/module-test-run.yml
@@ -43,6 +43,35 @@ jobs:
           sudo mkdir -p /etc/osconfig
           sudo cp -r ./src/adapters/pnp/daemon/osconfig.json /etc/osconfig/osconfig.json
 
+      - name: Stop apt-daily
+        run: |
+          source /etc/os-release
+          if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
+            sudo systemctl stop apt-daily.service || true
+            sudo systemctl stop apt-daily.timer || true
+            sudo systemctl stop apt-daily-upgrade.service || true
+            sudo systemctl stop apt-daily-upgrade.timer || true
+          fi
+
+      - name: Wait for packages installed by azsec
+        run: |
+          source /etc/os-release
+          if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
+            until dpkg -l azsec-bpftrace 2>/dev/null | grep -q '^ii'; do
+              echo "Waiting for azsec-bpftrace to be installed..."
+              sleep 5
+            done
+          elif [[ "$ID" == "mariner" ]]; then
+            until rpm -q azsec-bpftrace &>/dev/null; do
+              echo "Waiting for azsec-bpftrace to be installed..."
+              sleep 5
+            done
+            until rpm -q KeysInUse-OpenSSL &>/dev/null; do
+              echo "Waiting for azsec-bpftrace to be installed..."
+              sleep 5
+            done
+          fi
+
       - name: Run moduletest
         working-directory: ${{ steps.download.outputs.download-path }}/modules/test
         run: |

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -279,6 +279,9 @@ jobs:
           sudo mkdir -p /etc/osconfig
           sudo cp -r ${{ steps.download.outputs.download-path }}/modules/test/osconfig.json /etc/osconfig/osconfig.json
 
+      - name: Defer test execution
+        uses: ./.github/actions/defer-tests
+
       - name: Run moduletest
         working-directory: ${{ steps.download.outputs.download-path }}/modules/test
         run: |

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -931,6 +931,11 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureCronServiceIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
     "ObjectName": "initEnsurePermissionsOnEtcAnacronTab",
     "Payload": "600"
   },
@@ -2108,6 +2113,11 @@
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "auditEnsureZeroconfNetworkingIsDisabled"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "auditEnsureCronServiceIsEnabled"
   },
   {
     "ObjectType": "Desired",

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -1214,6 +1214,16 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAuditdInstalled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAuditdServiceIsRunning"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
     "ObjectName": "remediateEnsureSnmpServerIsDisabled"
   },
   {
@@ -2367,6 +2377,16 @@
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "auditEnsureUnnecessaryAccountsAreRemoved"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "auditEnsureAuditdInstalled"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "auditEnsureAuditdServiceIsRunning"
   },
   {
     "ObjectType": "Reported",


### PR DESCRIPTION
## Description

This PR adds some waits and disables daily jobs on debian-based systems. The tests were failing due to races between module tests which use apt for package management and other system services: azsecd and daily update jobs.

We add 2 additional stages to the module test:
- disablement of daily jobs
- waiting for packages that are automatically installed on specific distros, mainly azsec-bpftrace

We revert temporarily disabled module tests.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
