### PR TITLE
Fix stdio inclusion regression

### DIFF
--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -5,6 +5,7 @@
 #define LOGGING_H
 
 #include <string.h>
+#include <stdio.h>
 
 // Maximum log size (1,024,000 is 1MB aka 1024 * 1000), increase or decrease as needed
 #define MAX_LOG_SIZE 1024000

--- a/src/modules/compliance/src/lib/Engine.h
+++ b/src/modules/compliance/src/lib/Engine.h
@@ -5,7 +5,6 @@
 #define COMPLIANCE_ENGINE_H
 
 #include <Mmi.h>
-#include <cstdio>
 #include "Logging.h"
 
 #include "Result.h"


### PR DESCRIPTION
## Description

This commit fixes a small regression introduced by merging PRs #872 #863.

Thie #872 fixed missing inclusion of stdio, but I did not handle the merge of #863 properly and the change from #872 got reverted unintentionally.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
