### PR TITLE
Second phase of improvements for 'OSConfig for MC' logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,37 +146,21 @@ OSConfig periodically reports device data at a default time period of 30 seconds
 
 This interval is used for RC/DC, GitOps DC, and IoT Hub processing.
 
-### Enabling logging of system commands executed by OSConfig for debugging purposes
+### Enabling full debug logging
 
-Command logging means that OSConfig will log all input and output from system commands executed by Agent, Platform and Modules.
+Full debug logging means that OSConfig will log all input and output from and to all management authority channels, as well as all input and output from system commands executed by Agent, Platform and Modules.
 
-Generally it is not recommended to run OSConfig with command logging enabled.
+Generally it is not recommended to run OSConfig with full debug logging enabled.
 
-To enable command logging for debugging purposes, edit the OSConfig general configuration file `/etc/osconfig/osconfig.json` and set there (or add if needed) an integer value named "CommandLogging" to a non-zero value:
-
-```json
-{
-    "CommandLogging": 1
-}
-```
-
-To disable command logging, set "CommandLogging" to 0.
-
-### Enabling full logging for debugging purposes
-
-Full logging means that OSConfig will log all input and output from and to IoT Hub, AIS, RC/DC, GitOps DC, etc.
-
-Generally it is not recommended to run OSConfig with full logging enabled.
-
-To enable full logging for debugging purposes, edit the OSConfig general configuration file `/etc/osconfig/osconfig.json` and set there (or add if needed) an integer value named "FullLogging" to a non-zero value:
+To enable full debug logging, edit the OSConfig general configuration file `/etc/osconfig/osconfig.json` and set there (or add if needed) an integer value named "DebugLogging" to a non-zero value:
 
 ```json
 {
-    "FullLogging": 1
+    "DebugLogging": 1
 }
 ```
 
-To disable full logging, set "FullLogging" to 0.
+To disable full debug logging, set "DebugLogging" to 0.
 
 ## Local Management over RC/DC
 

--- a/src/adapters/pnp/AisUtils.c
+++ b/src/adapters/pnp/AisUtils.c
@@ -277,7 +277,7 @@ static int SendAisRequest(const char* udsSocketPath, const char* apiUriPath, con
         }
 
         OsConfigLogInfo(GetLog(), "SendAisRequest: %s %s to %s, %d long", (HTTP_CLIENT_REQUEST_POST == clientRequestType) ? "POST" : "GET", apiUriPath, udsSocketPath, (int)payloadLen);
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(GetLog(), "SendAisRequest payload: %s", payload);
         }
@@ -333,7 +333,7 @@ static int SendAisRequest(const char* udsSocketPath, const char* apiUriPath, con
                 (*response)[responseLen] = 0;
                 result = AIS_SUCCESS;
                 OsConfigLogInfo(GetLog(), "SendAisRequest: ok");
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(GetLog(), "SendAisRequest response: %s", *response);
                 }
@@ -688,7 +688,7 @@ char* RequestConnectionStringFromAis(char** x509Certificate, char** x509PrivateK
         connectAs = useModuleId ? "module" : "device";
         connectTo = useGatewayHost ? "Edge gateway" : "IoT Hub";
         OsConfigLogInfo(GetLog(), "RequestConnectionStringFromAis: connected to %s as %s (%d)", connectTo, connectAs, result);
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(GetLog(), "Connection string: %s", connectionString);
         }

--- a/src/adapters/pnp/AisUtils.c
+++ b/src/adapters/pnp/AisUtils.c
@@ -277,10 +277,7 @@ static int SendAisRequest(const char* udsSocketPath, const char* apiUriPath, con
         }
 
         OsConfigLogInfo(GetLog(), "SendAisRequest: %s %s to %s, %d long", (HTTP_CLIENT_REQUEST_POST == clientRequestType) ? "POST" : "GET", apiUriPath, udsSocketPath, (int)payloadLen);
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(GetLog(), "SendAisRequest payload: %s", payload);
-        }
+        OsConfigLogDebug(GetLog(), "SendAisRequest payload: %s", payload);
 
         if (HTTP_CLIENT_OK != (httpResult = uhttp_client_execute_request(clientHandle, clientRequestType, apiUriPath, httpHeadersHandle, (const unsigned char*)payload, payloadLen, HttpReceiveCallback, &context)))
         {
@@ -333,10 +330,7 @@ static int SendAisRequest(const char* udsSocketPath, const char* apiUriPath, con
                 (*response)[responseLen] = 0;
                 result = AIS_SUCCESS;
                 OsConfigLogInfo(GetLog(), "SendAisRequest: ok");
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(GetLog(), "SendAisRequest response: %s", *response);
-                }
+                OsConfigLogDebug(GetLog(), "SendAisRequest response: %s", *response);
             }
             else
             {
@@ -688,10 +682,7 @@ char* RequestConnectionStringFromAis(char** x509Certificate, char** x509PrivateK
         connectAs = useModuleId ? "module" : "device";
         connectTo = useGatewayHost ? "Edge gateway" : "IoT Hub";
         OsConfigLogInfo(GetLog(), "RequestConnectionStringFromAis: connected to %s as %s (%d)", connectTo, connectAs, result);
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(GetLog(), "Connection string: %s", connectionString);
-        }
+        OsConfigLogDebug(GetLog(), "Connection string: %s", connectionString);
     }
     else
     {

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -516,8 +516,7 @@ int main(int argc, char *argv[])
     jsonConfiguration = LoadStringFromFile(CONFIG_FILE, false, GetLog());
     if (NULL != jsonConfiguration)
     {
-        SetCommandLogging(IsCommandLoggingEnabledInJsonConfig(jsonConfiguration));
-        SetFullLogging(IsFullLoggingEnabledInJsonConfig(jsonConfiguration));
+        SetDebugLogging(IsDebugLoggingEnabledInJsonConfig(jsonConfiguration));
         FREE_MEMORY(jsonConfiguration);
     }
 
@@ -537,9 +536,9 @@ int main(int argc, char *argv[])
     OsConfigLogInfo(GetLog(), "OSConfig Agent starting (PID: %d, PPID: %d)", pid = getpid(), getppid());
     OsConfigLogInfo(GetLog(), "OSConfig version: %s", OSCONFIG_VERSION);
 
-    if (IsCommandLoggingEnabled() || IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(GetLog(), "WARNING: verbose logging (command and/or full) is enabled. To disable verbose logging edit %s and restart OSConfig", CONFIG_FILE);
+        OsConfigLogInfo(GetLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
     }
 
     // Load remaining configuration
@@ -589,7 +588,7 @@ int main(int argc, char *argv[])
         memcpy(g_productInfo, encodedProductInfo, sizeof(g_productInfo) - 1);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(GetLog(), "Product info: '%s' (%d bytes)", g_productInfo, (int)strlen(g_productInfo));
     }

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -536,10 +536,7 @@ int main(int argc, char *argv[])
     OsConfigLogInfo(GetLog(), "OSConfig Agent starting (PID: %d, PPID: %d)", pid = getpid(), getppid());
     OsConfigLogInfo(GetLog(), "OSConfig version: %s", OSCONFIG_VERSION);
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(GetLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
-    }
+    OsConfigLogDebug(GetLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
 
     // Load remaining configuration
     jsonConfiguration = LoadStringFromFile(CONFIG_FILE, false, GetLog());
@@ -588,10 +585,7 @@ int main(int argc, char *argv[])
         memcpy(g_productInfo, encodedProductInfo, sizeof(g_productInfo) - 1);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(GetLog(), "Product info: '%s' (%d bytes)", g_productInfo, (int)strlen(g_productInfo));
-    }
+    OsConfigLogDebug(GetLog(), "Product info: '%s' (%d bytes)", g_productInfo, (int)strlen(g_productInfo));
 
     FREE_MEMORY(osName);
     FREE_MEMORY(osVersion);

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -536,7 +536,10 @@ int main(int argc, char *argv[])
     OsConfigLogInfo(GetLog(), "OSConfig Agent starting (PID: %d, PPID: %d)", pid = getpid(), getppid());
     OsConfigLogInfo(GetLog(), "OSConfig version: %s", OSCONFIG_VERSION);
 
-    OsConfigLogDebug(GetLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
+    if (IsDebugLoggingEnabled())
+    {
+        OsConfigLogInfo(GetLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
+    }
 
     // Load remaining configuration
     jsonConfiguration = LoadStringFromFile(CONFIG_FILE, false, GetLog());

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -538,7 +538,7 @@ int main(int argc, char *argv[])
 
     if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(GetLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
+        OsConfigLogInfo(GetLog(), "WARNING: debug logging is enabled. To disable debug logging, edit '%s' and restart OSConfig", CONFIG_FILE);
     }
 
     // Load remaining configuration

--- a/src/adapters/pnp/PnpUtils.c
+++ b/src/adapters/pnp/PnpUtils.c
@@ -391,7 +391,7 @@ static void ModuleTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsig
 
     if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(GetLog(), "ModuleTwinCallback: received %.*s (%d bytes)", (int)size, payload, (int)size);
+        OsConfigLogDebug(GetLog(), "ModuleTwinCallback: received %.*s (%d bytes)", (int)size, payload, (int)size);
     }
     else
     {
@@ -521,10 +521,7 @@ void IotHubDoWork(void)
 
 static void ReadReportedStateCallback(int statusCode, void* userContextCallback)
 {
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(GetLog(), "Report for %s complete with status %u", userContextCallback ? (char*)userContextCallback : "all properties", statusCode);
-    }
+    OsConfigLogDebug(GetLog(), "Report for %s complete with status %u", userContextCallback ? (char*)userContextCallback : "all properties", statusCode);
 }
 
 IOTHUB_CLIENT_RESULT ReportPropertyToIotHub(const char* componentName, const char* propertyName, size_t* lastPayloadHash)
@@ -584,10 +581,7 @@ IOTHUB_CLIENT_RESULT ReportPropertyToIotHub(const char* componentName, const cha
             {
                 result = IoTHubDeviceClient_LL_SendReportedState(g_moduleHandle, (const unsigned char*)decoratedPayload, decoratedLength, ReadReportedStateCallback, (void*)propertyName);
 
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(GetLog(), "%s.%s: reported %.*s (%d bytes), result: %d", componentName, propertyName, decoratedLength, decoratedPayload, decoratedLength, result);
-                }
+                OsConfigLogDebug(GetLog(), "%s.%s: reported %.*s (%d bytes), result: %d", componentName, propertyName, decoratedLength, decoratedPayload, decoratedLength, result);
 
                 if (IOTHUB_CLIENT_OK != result)
                 {
@@ -646,10 +640,7 @@ IOTHUB_CLIENT_RESULT UpdatePropertyFromIotHub(const char* componentName, const c
     {
         valueLength = strlen(serializedValue);
 
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(GetLog(), "%s.%s: received %.*s (%d bytes)", componentName, propertyName, valueLength, serializedValue, valueLength);
-        }
+        OsConfigLogDebug(GetLog(), "%s.%s: received %.*s (%d bytes)", componentName, propertyName, valueLength, serializedValue, valueLength);
 
         mpiResult = CallMpiSet(componentName, propertyName, serializedValue, valueLength, GetLog());
         if ((MPI_OK != mpiResult) && RefreshMpiClientSession(&platformAlreadyRunning) && (false == platformAlreadyRunning))
@@ -680,10 +671,7 @@ IOTHUB_CLIENT_RESULT UpdatePropertyFromIotHub(const char* componentName, const c
 
 static void AckReportedStateCallback(int statusCode, void* userContextCallback)
 {
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(GetLog(), "Property update acknowledgement complete with status %u", statusCode);
-    }
+    OsConfigLogDebug(GetLog(), "Property update acknowledgement complete with status %u", statusCode);
     UNUSED(userContextCallback);
 }
 
@@ -712,10 +700,7 @@ IOTHUB_CLIENT_RESULT AckPropertyUpdateToIotHub(const char* componentName, const 
 
         result = IoTHubDeviceClient_LL_SendReportedState(g_moduleHandle, (const unsigned char*)ackBuffer, ackValueLength, AckReportedStateCallback, NULL);
 
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(GetLog(), "%s.%s: acknowledged %.*s (%d bytes), result: %d", componentName, propertyName, ackValueLength, ackBuffer, ackValueLength, result);
-        }
+        OsConfigLogDebug(GetLog(), "%s.%s: acknowledged %.*s (%d bytes), result: %d", componentName, propertyName, ackValueLength, ackBuffer, ackValueLength, result);
 
         if (IOTHUB_CLIENT_OK != result)
         {

--- a/src/adapters/pnp/PnpUtils.c
+++ b/src/adapters/pnp/PnpUtils.c
@@ -389,7 +389,7 @@ static void ModuleTwinCallback(DEVICE_TWIN_UPDATE_STATE updateState, const unsig
     LogAssert(GetLog(), NULL != payload);
     LogAssert(GetLog(), 0 < size);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(GetLog(), "ModuleTwinCallback: received %.*s (%d bytes)", (int)size, payload, (int)size);
     }
@@ -521,7 +521,7 @@ void IotHubDoWork(void)
 
 static void ReadReportedStateCallback(int statusCode, void* userContextCallback)
 {
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(GetLog(), "Report for %s complete with status %u", userContextCallback ? (char*)userContextCallback : "all properties", statusCode);
     }
@@ -584,7 +584,7 @@ IOTHUB_CLIENT_RESULT ReportPropertyToIotHub(const char* componentName, const cha
             {
                 result = IoTHubDeviceClient_LL_SendReportedState(g_moduleHandle, (const unsigned char*)decoratedPayload, decoratedLength, ReadReportedStateCallback, (void*)propertyName);
 
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(GetLog(), "%s.%s: reported %.*s (%d bytes), result: %d", componentName, propertyName, decoratedLength, decoratedPayload, decoratedLength, result);
                 }
@@ -603,7 +603,7 @@ IOTHUB_CLIENT_RESULT ReportPropertyToIotHub(const char* componentName, const cha
     else
     {
         // Avoid log abuse when a component specified in configuration is not active
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MPI_OK == mpiResult)
             {
@@ -646,7 +646,7 @@ IOTHUB_CLIENT_RESULT UpdatePropertyFromIotHub(const char* componentName, const c
     {
         valueLength = strlen(serializedValue);
 
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(GetLog(), "%s.%s: received %.*s (%d bytes)", componentName, propertyName, valueLength, serializedValue, valueLength);
         }
@@ -680,7 +680,7 @@ IOTHUB_CLIENT_RESULT UpdatePropertyFromIotHub(const char* componentName, const c
 
 static void AckReportedStateCallback(int statusCode, void* userContextCallback)
 {
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(GetLog(), "Property update acknowledgement complete with status %u", statusCode);
     }
@@ -712,7 +712,7 @@ IOTHUB_CLIENT_RESULT AckPropertyUpdateToIotHub(const char* componentName, const 
 
         result = IoTHubDeviceClient_LL_SendReportedState(g_moduleHandle, (const unsigned char*)ackBuffer, ackValueLength, AckReportedStateCallback, NULL);
 
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(GetLog(), "%s.%s: acknowledged %.*s (%d bytes), result: %d", componentName, propertyName, ackValueLength, ackBuffer, ackValueLength, result);
         }

--- a/src/adapters/pnp/Watcher.c
+++ b/src/adapters/pnp/Watcher.c
@@ -240,9 +240,9 @@ static int RefreshGitClone(const char* gitBranch, const char* gitClonePath, cons
     FREE_MEMORY(checkoutFileCommand);
     FREE_MEMORY(currentDirectory);
 
-    if ((0 == error) && (IsDebugLoggingEnabled()))
+    if (0 == error)
     {
-        OsConfigLogInfo(log, "Watcher: successfully refreshed the Git clone at %s for branch %s", gitClonePath, gitBranch);
+        OsConfigLogDebug(log, "Watcher: successfully refreshed the Git clone at %s for branch %s", gitClonePath, gitBranch);
     }
 
     return error;

--- a/src/adapters/pnp/Watcher.c
+++ b/src/adapters/pnp/Watcher.c
@@ -240,7 +240,7 @@ static int RefreshGitClone(const char* gitBranch, const char* gitClonePath, cons
     FREE_MEMORY(checkoutFileCommand);
     FREE_MEMORY(currentDirectory);
 
-    if ((0 == error) && (IsFullLoggingEnabled()))
+    if ((0 == error) && (IsDebugLoggingEnabled()))
     {
         OsConfigLogInfo(log, "Watcher: successfully refreshed the Git clone at %s for branch %s", gitClonePath, gitBranch);
     }

--- a/src/adapters/pnp/daemon/osconfig.json
+++ b/src/adapters/pnp/daemon/osconfig.json
@@ -1,6 +1,5 @@
 {
-  "CommandLogging": 0,
-  "FullLogging": 0,
+  "DebugLogging": 0,
   "GitManagement": 0,
   "GitRepositoryUrl": " ",
   "GitBranch": " ",
@@ -15,11 +14,7 @@
     },
     {
       "ComponentName": "Configuration",
-      "ObjectName": "commandLoggingEnabled"
-    },
-    {
-      "ComponentName": "Configuration",
-      "ObjectName": "fullLoggingEnabled"
+      "ObjectName": "debugLoggingEnabled"
     },
     {
       "ComponentName": "Configuration",

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -881,8 +881,6 @@ void AsbInitialize(OSCONFIG_LOG_HANDLE log)
 
     StartPerfClock(&g_perfClock, GetPerfLog());
 
-    SetDebugLogging(true); //////////////////
-
     OsConfigLogInfo(log, "AsbInitialize: %s", g_asbName);
 
     if (NULL != (cpuModel = GetCpuModel(GetPerfLog())))

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -881,6 +881,8 @@ void AsbInitialize(OSCONFIG_LOG_HANDLE log)
 
     StartPerfClock(&g_perfClock, GetPerfLog());
 
+    SetDebugLogging(true); //////////////////
+
     OsConfigLogInfo(log, "AsbInitialize: %s", g_asbName);
 
     if (NULL != (cpuModel = GetCpuModel(GetPerfLog())))

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -941,7 +941,7 @@ void AsbInitialize(OSCONFIG_LOG_HANDLE log)
     {
         if (false == MakeFileBackupCopy(g_etcFstab, g_etcFstabCopy, false, log))
         {
-            OsConfigLogInfo(log, "AsbInitialize: failed to make a local backup copy of '%s'", g_etcFstab);
+            OsConfigLogInfo(log, "AsbInitialize: cannot make a local backup copy of '%s' (%d)", g_etcFstab, errno);
         }
     }
 

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -127,7 +127,7 @@ static int SystemCommand(void* context, const char* command, int timeoutSeconds,
             status = NormalizeStatus(status);
             if (childProcess == workerProcess)
             {
-                OsConfigLogDebug(log, "Command execution complete with status %d", status);
+                OsConfigLogDebug(log, "Command execution returning %d", status);
                 KillProcess(timerProcess);
             }
             else
@@ -175,7 +175,7 @@ static int SystemCommand(void* context, const char* command, int timeoutSeconds,
     }
 
     status = NormalizeStatus(status);
-    OsConfigLogDebug(log, "SystemCommand: command '%s' completed with %d", command, status);
+    OsConfigLogDebug(log, "SystemCommand: command '%s' returning %d", command, status);
 
     return status;
 }

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -222,7 +222,6 @@ typedef struct REPORTED_PROPERTY
     size_t lastPayloadHash;
 } REPORTED_PROPERTY;
 
-bool IsCommandLoggingEnabledInJsonConfig(const char* jsonString);
 bool IsDebugLoggingEnabledInJsonConfig(const char* jsonString);
 bool IsIotHubManagementEnabledInJsonConfig(const char* jsonString);
 int GetReportingIntervalFromJsonConfig(const char* jsonString, OSCONFIG_LOG_HANDLE log);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -52,9 +52,6 @@ bool AppendToFile(const char* fileName, const char* payload, const int payloadSi
 bool ConcatenateFiles(const char* firstFileName, const char* secondFileName, bool preserveAccess, OSCONFIG_LOG_HANDLE log);
 int RenameFile(const char* original, const char* target, OSCONFIG_LOG_HANDLE log);
 
-void SetCommandLogging(bool commandLogging);
-bool IsCommandLoggingEnabled(void);
-
 typedef int(*CommandCallback)(void* context);
 
 // If called from the main process thread the timeoutSeconds and callback arguments are ignored
@@ -226,7 +223,7 @@ typedef struct REPORTED_PROPERTY
 } REPORTED_PROPERTY;
 
 bool IsCommandLoggingEnabledInJsonConfig(const char* jsonString);
-bool IsFullLoggingEnabledInJsonConfig(const char* jsonString);
+bool IsDebugLoggingEnabledInJsonConfig(const char* jsonString);
 bool IsIotHubManagementEnabledInJsonConfig(const char* jsonString);
 int GetReportingIntervalFromJsonConfig(const char* jsonString, OSCONFIG_LOG_HANDLE log);
 int GetModelVersionFromJsonConfig(const char* jsonString, OSCONFIG_LOG_HANDLE log);

--- a/src/common/commonutils/ConfigUtils.c
+++ b/src/common/commonutils/ConfigUtils.c
@@ -68,19 +68,13 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
 
     if (NULL == valueName)
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogError(log, "GetIntegerFromJsonConfig: no value name, using the specified default (%d)", defaultValue);
-        }
+        OsConfigLogDebug(log, "GetIntegerFromJsonConfig: no value name, using the specified default (%d)", defaultValue);
         return valueToReturn;
     }
 
     if (minValue >= maxValue)
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogError(log, "GetIntegerFromJsonConfig: bad min (%d) and/or max (%d) values for %s, using default (%d)", minValue, maxValue, valueName, defaultValue);
-        }
+        OsConfigLogDebug(log, "GetIntegerFromJsonConfig: bad min (%d) and/or max (%d) values for %s, using default (%d)", minValue, maxValue, valueName, defaultValue);
         return valueToReturn;
     }
 
@@ -94,46 +88,37 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
                 if (0 == valueToReturn)
                 {
                     valueToReturn = defaultValue;
-                    if (IsDebugLoggingEnabled())
-                    {
-                        OsConfigLogInfo(log, "GetIntegerFromJsonConfig: %s value not found or 0, using default (%d)", valueName, defaultValue);
-                    }
+                    OsConfigLogDebug(log, "GetIntegerFromJsonConfig: %s value not found or 0, using default (%d)", valueName, defaultValue);
                 }
                 else if (valueToReturn < minValue)
                 {
-                    if (IsDebugLoggingEnabled())
-                    {
-                        OsConfigLogError(log, "GetIntegerFromJsonConfig: %s value %d too small, using minimum (%d)", valueName, valueToReturn, minValue);
-                    }
+                    OsConfigLogDebug(log, "GetIntegerFromJsonConfig: %s value %d too small, using minimum (%d)", valueName, valueToReturn, minValue);
                     valueToReturn = minValue;
                 }
                 else if (valueToReturn > maxValue)
                 {
-                    if (IsDebugLoggingEnabled())
-                    {
-                        OsConfigLogError(log, "GetIntegerFromJsonConfig: %s value %d too big, using maximum (%d)", valueName, valueToReturn, maxValue);
-                    }
+                    OsConfigLogDebug(log, "GetIntegerFromJsonConfig: %s value %d too big, using maximum (%d)", valueName, valueToReturn, maxValue);
                     valueToReturn = maxValue;
                 }
-                else if (IsDebugLoggingEnabled())
+                else
                 {
-                    OsConfigLogInfo(log, "GetIntegerFromJsonConfig: %s: %d", valueName, valueToReturn);
+                    OsConfigLogDebug(log, "GetIntegerFromJsonConfig: %s: %d", valueName, valueToReturn);
                 }
             }
-            else if (IsDebugLoggingEnabled())
+            else
             {
-                OsConfigLogError(log, "GetIntegerFromJsonConfig: json_value_get_object(root) failed, using default (%d) for %s", defaultValue, valueName);
+                OsConfigLogDebug(log, "GetIntegerFromJsonConfig: json_value_get_object(root) failed, using default (%d) for %s", defaultValue, valueName);
             }
             json_value_free(rootValue);
         }
-        else if (IsDebugLoggingEnabled())
+        else
         {
-            OsConfigLogError(log, "GetIntegerFromJsonConfig: json_parse_string failed, using default (%d) for %s", defaultValue, valueName);
+            OsConfigLogDebug(log, "GetIntegerFromJsonConfig: json_parse_string failed, using default (%d) for %s", defaultValue, valueName);
         }
     }
-    else if (IsDebugLoggingEnabled())
+    else
     {
-        OsConfigLogError(log, "GetIntegerFromJsonConfig: no configuration data, using default (%d) for %s", defaultValue, valueName);
+        OsConfigLogDebug(log, "GetIntegerFromJsonConfig: no configuration data, using default (%d) for %s", defaultValue, valueName);
     }
 
     return valueToReturn;
@@ -272,10 +257,7 @@ static char* GetStringFromJsonConfig(const char* valueName, const char* jsonStri
 
     if (NULL == valueName)
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogError(log, "GetStringFromJsonConfig: no value name");
-        }
+        OsConfigLogDebug(log, "GetStringFromJsonConfig: no value name");
         return value;
     }
 
@@ -288,10 +270,7 @@ static char* GetStringFromJsonConfig(const char* valueName, const char* jsonStri
                 value = (char*)json_object_get_string(rootObject, valueName);
                 if (NULL == value)
                 {
-                    if (IsDebugLoggingEnabled())
-                    {
-                        OsConfigLogInfo(log, "GetStringFromJsonConfig: %s value not found or empty", valueName);
-                    }
+                    OsConfigLogDebug(log, "GetStringFromJsonConfig: %s value not found or empty", valueName);
                 }
                 else
                 {
@@ -302,32 +281,29 @@ static char* GetStringFromJsonConfig(const char* valueName, const char* jsonStri
                         memcpy(buffer, value, valueLength);
                         buffer[valueLength] = 0;
                     }
-                    else if (IsDebugLoggingEnabled())
+                    else
                     {
                         OsConfigLogError(log, "GetStringFromJsonConfig: failed to allocate %d bytes for %s", (int)(valueLength + 1), valueName);
                     }
                 }
             }
-            else if (IsDebugLoggingEnabled())
+            else
             {
-                OsConfigLogError(log, "GetStringFromJsonConfig: json_value_get_object(root) failed for %s", valueName);
+                OsConfigLogDebug(log, "GetStringFromJsonConfig: json_value_get_object(root) failed for %s", valueName);
             }
             json_value_free(rootValue);
         }
-        else if (IsDebugLoggingEnabled())
+        else
         {
-            OsConfigLogError(log, "GetStringFromJsonConfig: json_parse_string failed for %s", valueName);
+            OsConfigLogDebug(log, "GetStringFromJsonConfig: json_parse_string failed for %s", valueName);
         }
     }
-    else if (IsDebugLoggingEnabled())
+    else
     {
-        OsConfigLogError(log, "GetStringFromJsonConfig: no configuration data for %s", valueName);
+        OsConfigLogDebug(log, "GetStringFromJsonConfig: no configuration data for %s", valueName);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "GetStringFromJsonConfig(%s): %s", valueName, buffer);
-    }
+    OsConfigLogDebug(log, "GetStringFromJsonConfig(%s): %s", valueName, buffer);
 
     return buffer;
 }

--- a/src/common/commonutils/ConfigUtils.c
+++ b/src/common/commonutils/ConfigUtils.c
@@ -18,8 +18,7 @@
 #define IOT_HUB_MANAGEMENT "IotHubManagement"
 #define LOCAL_MANAGEMENT "LocalManagement"
 
-#define COMMAND_LOGGING "CommandLogging"
-#define FULL_LOGGING "FullLogging"
+#define DEBUG_LOGGING "DebugLogging"
 
 #define PROTOCOL "IotHubProtocol"
 
@@ -51,14 +50,9 @@ static bool IsOptionEnabledInJsonConfig(const char* jsonString, const char* sett
     return result;
 }
 
-bool IsCommandLoggingEnabledInJsonConfig(const char* jsonString)
+bool IsDebugLoggingEnabledInJsonConfig(const char* jsonString)
 {
-    return IsOptionEnabledInJsonConfig(jsonString, COMMAND_LOGGING);
-}
-
-bool IsFullLoggingEnabledInJsonConfig(const char* jsonString)
-{
-    return IsOptionEnabledInJsonConfig(jsonString, FULL_LOGGING);
+    return IsOptionEnabledInJsonConfig(jsonString, DEBUG_LOGGING);
 }
 
 bool IsIotHubManagementEnabledInJsonConfig(const char* jsonString)
@@ -74,7 +68,7 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
 
     if (NULL == valueName)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(log, "GetIntegerFromJsonConfig: no value name, using the specified default (%d)", defaultValue);
         }
@@ -83,7 +77,7 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
 
     if (minValue >= maxValue)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(log, "GetIntegerFromJsonConfig: bad min (%d) and/or max (%d) values for %s, using default (%d)", minValue, maxValue, valueName, defaultValue);
         }
@@ -100,14 +94,14 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
                 if (0 == valueToReturn)
                 {
                     valueToReturn = defaultValue;
-                    if (IsFullLoggingEnabled())
+                    if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogInfo(log, "GetIntegerFromJsonConfig: %s value not found or 0, using default (%d)", valueName, defaultValue);
                     }
                 }
                 else if (valueToReturn < minValue)
                 {
-                    if (IsFullLoggingEnabled())
+                    if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogError(log, "GetIntegerFromJsonConfig: %s value %d too small, using minimum (%d)", valueName, valueToReturn, minValue);
                     }
@@ -115,29 +109,29 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
                 }
                 else if (valueToReturn > maxValue)
                 {
-                    if (IsFullLoggingEnabled())
+                    if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogError(log, "GetIntegerFromJsonConfig: %s value %d too big, using maximum (%d)", valueName, valueToReturn, maxValue);
                     }
                     valueToReturn = maxValue;
                 }
-                else if (IsFullLoggingEnabled())
+                else if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(log, "GetIntegerFromJsonConfig: %s: %d", valueName, valueToReturn);
                 }
             }
-            else if (IsFullLoggingEnabled())
+            else if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(log, "GetIntegerFromJsonConfig: json_value_get_object(root) failed, using default (%d) for %s", defaultValue, valueName);
             }
             json_value_free(rootValue);
         }
-        else if (IsFullLoggingEnabled())
+        else if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(log, "GetIntegerFromJsonConfig: json_parse_string failed, using default (%d) for %s", defaultValue, valueName);
         }
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogError(log, "GetIntegerFromJsonConfig: no configuration data, using default (%d) for %s", defaultValue, valueName);
     }
@@ -278,7 +272,7 @@ static char* GetStringFromJsonConfig(const char* valueName, const char* jsonStri
 
     if (NULL == valueName)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(log, "GetStringFromJsonConfig: no value name");
         }
@@ -294,7 +288,7 @@ static char* GetStringFromJsonConfig(const char* valueName, const char* jsonStri
                 value = (char*)json_object_get_string(rootObject, valueName);
                 if (NULL == value)
                 {
-                    if (IsFullLoggingEnabled())
+                    if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogInfo(log, "GetStringFromJsonConfig: %s value not found or empty", valueName);
                     }
@@ -308,29 +302,29 @@ static char* GetStringFromJsonConfig(const char* valueName, const char* jsonStri
                         memcpy(buffer, value, valueLength);
                         buffer[valueLength] = 0;
                     }
-                    else if (IsFullLoggingEnabled())
+                    else if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogError(log, "GetStringFromJsonConfig: failed to allocate %d bytes for %s", (int)(valueLength + 1), valueName);
                     }
                 }
             }
-            else if (IsFullLoggingEnabled())
+            else if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(log, "GetStringFromJsonConfig: json_value_get_object(root) failed for %s", valueName);
             }
             json_value_free(rootValue);
         }
-        else if (IsFullLoggingEnabled())
+        else if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(log, "GetStringFromJsonConfig: json_parse_string failed for %s", valueName);
         }
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogError(log, "GetStringFromJsonConfig: no configuration data for %s", valueName);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "GetStringFromJsonConfig(%s): %s", valueName, buffer);
     }

--- a/src/common/commonutils/DaemonUtils.c
+++ b/src/common/commonutils/DaemonUtils.c
@@ -121,7 +121,7 @@ static bool CommandDaemon(const char* command, const char* daemonName, OSCONFIG_
     }
     else
     {
-        OsConfigLogInfo(log, "Failed to %s service '%s' (%d)", command, daemonName, result);
+        OsConfigLogInfo(log, "Cannot %s service '%s' (%d, errno: %d)", command, daemonName, result, errno);
         status = false;
     }
 

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -112,7 +112,7 @@ char* GetOsPrettyName(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "OS pretty name: '%s'", textResult);
     }
@@ -147,7 +147,7 @@ char* GetOsName(OSCONFIG_LOG_HANDLE log)
         }
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "OS name: '%s'", textResult);
     }
@@ -173,7 +173,7 @@ char* GetOsVersion(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "OS version: '%s'", textResult);
     }
@@ -235,7 +235,7 @@ char* GetOsKernelName(OSCONFIG_LOG_HANDLE log)
     static char* osKernelNameCommand = "uname -s";
     char* textResult = GetAnotherOsProperty(osKernelNameCommand, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Kernel name: '%s'", textResult);
     }
@@ -248,7 +248,7 @@ char* GetOsKernelRelease(OSCONFIG_LOG_HANDLE log)
     static char* osKernelReleaseCommand = "uname -r";
     char* textResult = GetAnotherOsProperty(osKernelReleaseCommand, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Kernel release: '%s'", textResult);
     }
@@ -261,7 +261,7 @@ char* GetOsKernelVersion(OSCONFIG_LOG_HANDLE log)
     static char* osKernelVersionCommand = "uname -v";
     char* textResult = GetAnotherOsProperty(osKernelVersionCommand, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Kernel version: '%s'", textResult);
     }
@@ -274,7 +274,7 @@ char* GetCpuType(OSCONFIG_LOG_HANDLE log)
     const char* osCpuTypeCommand = "lscpu | grep Architecture:";
     char* textResult = GetHardwareProperty(osCpuTypeCommand, false, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CPU type: '%s'", textResult);
     }
@@ -287,7 +287,7 @@ char* GetCpuVendor(OSCONFIG_LOG_HANDLE log)
     const char* osCpuVendorCommand = "grep 'vendor_id' /proc/cpuinfo | uniq";
     char* textResult = GetHardwareProperty(osCpuVendorCommand, false, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CPU vendor id: '%s'", textResult);
     }
@@ -300,7 +300,7 @@ char* GetCpuModel(OSCONFIG_LOG_HANDLE log)
     const char* osCpuModelCommand = "grep 'model name' /proc/cpuinfo | uniq";
     char* textResult = GetHardwareProperty(osCpuModelCommand, false, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CPU model: '%s'", textResult);
     }
@@ -319,7 +319,7 @@ unsigned int GetNumberOfCpuCores(OSCONFIG_LOG_HANDLE log)
         numberOfCores = atoi(textResult);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Number of CPU cores: %u ('%s')", numberOfCores, textResult);
     }
@@ -334,7 +334,7 @@ char* GetCpuFlags(OSCONFIG_LOG_HANDLE log)
     const char* osCpuFlagsCommand = "lscpu | grep \"Flags:\"";
     char* textResult = GetHardwareProperty(osCpuFlagsCommand, false, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CPU flags: '%s'", textResult);
     }
@@ -376,7 +376,7 @@ long GetTotalMemory(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Total memory: %lu kB", totalMemory);
     }
@@ -396,7 +396,7 @@ long GetFreeMemory(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Free memory: %lu kB", freeMemory);
     }
@@ -416,7 +416,7 @@ char* GetProductName(OSCONFIG_LOG_HANDLE log)
         textResult = GetHardwareProperty(osProductNameAlternateCommand, false, log);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Product name: '%s'", textResult);
     }
@@ -436,7 +436,7 @@ char* GetProductVendor(OSCONFIG_LOG_HANDLE log)
         textResult = GetHardwareProperty(osProductVendorAlternateCommand, false, log);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Product vendor: '%s'", textResult);
     }
@@ -456,7 +456,7 @@ char* GetProductVersion(OSCONFIG_LOG_HANDLE log)
         textResult = GetHardwareProperty(osProductVersionAlternateCommand, false, log);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Product version: '%s'", textResult);
     }
@@ -469,7 +469,7 @@ char* GetSystemCapabilities(OSCONFIG_LOG_HANDLE log)
     const char* osSystemCapabilitiesCommand = "lshw -c system | grep -m 1 \"capabilities:\"";
     char* textResult = GetHardwareProperty(osSystemCapabilitiesCommand, false, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Product capabilities: '%s'", textResult);
     }
@@ -482,7 +482,7 @@ char* GetSystemConfiguration(OSCONFIG_LOG_HANDLE log)
     const char* osSystemConfigurationCommand = "lshw -c system | grep -m 1 \"configuration:\"";
     char* textResult = GetHardwareProperty(osSystemConfigurationCommand, false, log);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "Product configuration: '%s'", textResult);
     }
@@ -544,7 +544,7 @@ static char* GetOsReleaseEntry(const char* commandTemplate, const char* name, ch
         result = DuplicateString("<null>");
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "'%s': '%s'", name, result);
     }
@@ -685,7 +685,7 @@ char* GetLoginUmask(char** reason, OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(result);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "UMASK: '%s'", result);
     }
@@ -769,7 +769,7 @@ static long GetPasswordDays(const char* name, OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(command);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "%s: %ld", name, days);
     }
@@ -939,7 +939,7 @@ int EnableVirtualMemoryRandomization(OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "EnableVirtualMemoryRandomization: failed writing '%s' to '%s' (%d)", fullRandomization, procSysKernelRandomizeVaSpace, errno);
+            OsConfigLogInfo(log, "EnableVirtualMemoryRandomization: cannot write '%s' to '%s' (%d)", fullRandomization, procSysKernelRandomizeVaSpace, errno);
             status = ENOENT;
         }
     }

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -112,10 +112,7 @@ char* GetOsPrettyName(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "OS pretty name: '%s'", textResult);
-    }
+    OsConfigLogDebug(log, "OS pretty name: '%s'", textResult);
 
     return textResult;
 }
@@ -147,10 +144,7 @@ char* GetOsName(OSCONFIG_LOG_HANDLE log)
         }
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "OS name: '%s'", textResult);
-    }
+    OsConfigLogDebug(log, "OS name: '%s'", textResult);
 
     return textResult;
 }
@@ -173,10 +167,7 @@ char* GetOsVersion(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "OS version: '%s'", textResult);
-    }
+    OsConfigLogDebug(log, "OS version: '%s'", textResult);
 
     return textResult;
 }
@@ -234,12 +225,7 @@ char* GetOsKernelName(OSCONFIG_LOG_HANDLE log)
 {
     static char* osKernelNameCommand = "uname -s";
     char* textResult = GetAnotherOsProperty(osKernelNameCommand, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Kernel name: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "Kernel name: '%s'", textResult);
     return textResult;
 }
 
@@ -247,12 +233,7 @@ char* GetOsKernelRelease(OSCONFIG_LOG_HANDLE log)
 {
     static char* osKernelReleaseCommand = "uname -r";
     char* textResult = GetAnotherOsProperty(osKernelReleaseCommand, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Kernel release: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "Kernel release: '%s'", textResult);
     return textResult;
 }
 
@@ -260,12 +241,7 @@ char* GetOsKernelVersion(OSCONFIG_LOG_HANDLE log)
 {
     static char* osKernelVersionCommand = "uname -v";
     char* textResult = GetAnotherOsProperty(osKernelVersionCommand, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Kernel version: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "Kernel version: '%s'", textResult);
     return textResult;
 }
 
@@ -273,12 +249,7 @@ char* GetCpuType(OSCONFIG_LOG_HANDLE log)
 {
     const char* osCpuTypeCommand = "lscpu | grep Architecture:";
     char* textResult = GetHardwareProperty(osCpuTypeCommand, false, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CPU type: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "CPU type: '%s'", textResult);
     return textResult;
 }
 
@@ -286,12 +257,7 @@ char* GetCpuVendor(OSCONFIG_LOG_HANDLE log)
 {
     const char* osCpuVendorCommand = "grep 'vendor_id' /proc/cpuinfo | uniq";
     char* textResult = GetHardwareProperty(osCpuVendorCommand, false, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CPU vendor id: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "CPU vendor id: '%s'", textResult);
     return textResult;
 }
 
@@ -299,12 +265,7 @@ char* GetCpuModel(OSCONFIG_LOG_HANDLE log)
 {
     const char* osCpuModelCommand = "grep 'model name' /proc/cpuinfo | uniq";
     char* textResult = GetHardwareProperty(osCpuModelCommand, false, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CPU model: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "CPU model: '%s'", textResult);
     return textResult;
 }
 
@@ -319,10 +280,7 @@ unsigned int GetNumberOfCpuCores(OSCONFIG_LOG_HANDLE log)
         numberOfCores = atoi(textResult);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Number of CPU cores: %u ('%s')", numberOfCores, textResult);
-    }
+    OsConfigLogDebug(log, "Number of CPU cores: %u ('%s')", numberOfCores, textResult);
 
     FREE_MEMORY(textResult);
 
@@ -333,12 +291,7 @@ char* GetCpuFlags(OSCONFIG_LOG_HANDLE log)
 {
     const char* osCpuFlagsCommand = "lscpu | grep \"Flags:\"";
     char* textResult = GetHardwareProperty(osCpuFlagsCommand, false, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CPU flags: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "CPU flags: '%s'", textResult);
     return textResult;
 }
 
@@ -376,10 +329,7 @@ long GetTotalMemory(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Total memory: %lu kB", totalMemory);
-    }
+    OsConfigLogDebug(log, "Total memory: %lu kB", totalMemory);
 
     return totalMemory;
 }
@@ -396,10 +346,7 @@ long GetFreeMemory(OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(textResult);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Free memory: %lu kB", freeMemory);
-    }
+    OsConfigLogDebug(log, "Free memory: %lu kB", freeMemory);
 
     return freeMemory;
 }
@@ -416,10 +363,7 @@ char* GetProductName(OSCONFIG_LOG_HANDLE log)
         textResult = GetHardwareProperty(osProductNameAlternateCommand, false, log);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Product name: '%s'", textResult);
-    }
+    OsConfigLogDebug(log, "Product name: '%s'", textResult);
 
     return textResult;
 }
@@ -436,10 +380,7 @@ char* GetProductVendor(OSCONFIG_LOG_HANDLE log)
         textResult = GetHardwareProperty(osProductVendorAlternateCommand, false, log);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Product vendor: '%s'", textResult);
-    }
+    OsConfigLogDebug(log, "Product vendor: '%s'", textResult);
 
     return textResult;
 }
@@ -456,10 +397,7 @@ char* GetProductVersion(OSCONFIG_LOG_HANDLE log)
         textResult = GetHardwareProperty(osProductVersionAlternateCommand, false, log);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Product version: '%s'", textResult);
-    }
+    OsConfigLogDebug(log, "Product version: '%s'", textResult);
 
     return textResult;
 }
@@ -468,12 +406,7 @@ char* GetSystemCapabilities(OSCONFIG_LOG_HANDLE log)
 {
     const char* osSystemCapabilitiesCommand = "lshw -c system | grep -m 1 \"capabilities:\"";
     char* textResult = GetHardwareProperty(osSystemCapabilitiesCommand, false, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Product capabilities: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "Product capabilities: '%s'", textResult);
     return textResult;
 }
 
@@ -481,12 +414,7 @@ char* GetSystemConfiguration(OSCONFIG_LOG_HANDLE log)
 {
     const char* osSystemConfigurationCommand = "lshw -c system | grep -m 1 \"configuration:\"";
     char* textResult = GetHardwareProperty(osSystemConfigurationCommand, false, log);
-
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "Product configuration: '%s'", textResult);
-    }
-
+    OsConfigLogDebug(log, "Product configuration: '%s'", textResult);
     return textResult;
 }
 
@@ -544,10 +472,7 @@ static char* GetOsReleaseEntry(const char* commandTemplate, const char* name, ch
         result = DuplicateString("<null>");
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "'%s': '%s'", name, result);
-    }
+    OsConfigLogDebug(log, "'%s': '%s'", name, result);
 
     return result;
 }
@@ -685,10 +610,7 @@ char* GetLoginUmask(char** reason, OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(result);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "UMASK: '%s'", result);
-    }
+    OsConfigLogDebug(log, "UMASK: '%s'", result);
 
     return result;
 }
@@ -769,10 +691,7 @@ static long GetPasswordDays(const char* name, OSCONFIG_LOG_HANDLE log)
         FREE_MEMORY(command);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "%s: %ld", name, days);
-    }
+    OsConfigLogDebug(log, "%s: %ld", name, days);
 
     return days;
 }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -84,7 +84,7 @@ static bool SaveToFile(const char* fileName, const char* mode, const char* paylo
                     if (payload[i] != (char)fputc(payload[i], file))
                     {
                         result = false;
-                        OsConfigLogInfo(log, "SaveToFile: failed saving '%c' to '%s' (%d)", payload[i], fileName, errno);
+                        OsConfigLogInfo(log, "SaveToFile: cannot save '%c' to '%s' (%d)", payload[i], fileName, errno);
                     }
                 }
 
@@ -147,13 +147,13 @@ bool FileEndsInEol(const char* fileName, OSCONFIG_LOG_HANDLE log)
             }
             else
             {
-                OsConfigLogInfo(log, "FileEndsInEol: failed to open '%s' for reading", fileName);
+                OsConfigLogInfo(log, "FileEndsInEol: cannot open '%s' for reading", fileName);
             }
         }
     }
     else
     {
-        OsConfigLogInfo(log, "FileEndsInEol: stat('%s') failed with %d (errno: %d)", fileName, status, errno);
+        OsConfigLogInfo(log, "FileEndsInEol: stat('%s') completed with %d (errno: %d)", fileName, status, errno);
     }
 
     return result;
@@ -174,13 +174,13 @@ bool AppendPayloadToFile(const char* fileName, const char* payload, const int pa
     {
         if (false == SaveToFile(fileName, "a", "\n", 1, log))
         {
-            OsConfigLogInfo(log, "AppendPayloadToFile: failed to append EOL to '%s'", fileName);
+            OsConfigLogInfo(log, "AppendPayloadToFile: cannot append EOL to '%s'", fileName);
         }
     }
 
     if (false == (result = SaveToFile(fileName, "a", payload, payloadSizeBytes, log)))
     {
-        OsConfigLogInfo(log, "AppendPayloadToFile: failed to append '%.*s' to '%s'", payloadSizeBytes, payload, fileName);
+        OsConfigLogInfo(log, "AppendPayloadToFile: cannot append '%.*s' to '%s'", payloadSizeBytes, payload, fileName);
     }
 
     return result;
@@ -245,7 +245,7 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
             }
             else
             {
-                OsConfigLogInfo(log, "InternalSecureSaveToFile: failed to read from '%s'", fileName);
+                OsConfigLogInfo(log, "InternalSecureSaveToFile: cannot read from '%s' (%d)", fileName, errno);
                 result = false;
             }
         }
@@ -262,7 +262,7 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
 
     if (result && (false == FileExists(tempFileName)))
     {
-        OsConfigLogInfo(log, "InternalSecureSaveToFile: failed to create temporary file");
+        OsConfigLogInfo(log, "InternalSecureSaveToFile: cannot create temporary file (%d)", errno);
         result = false;
     }
 
@@ -270,7 +270,7 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
     {
         if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, fileName, log)))
         {
-            OsConfigLogInfo(log, "InternalSecureSaveToFile: RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", tempFileName, fileName, status);
+            OsConfigLogInfo(log, "InternalSecureSaveToFile: RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d", tempFileName, fileName, status);
             result = false;
         }
 
@@ -317,7 +317,7 @@ bool MakeFileBackupCopy(const char* fileName, const char* backupName, bool prese
             else
             {
                 result = false;
-                OsConfigLogInfo(log, "MakeFileBackupCopy: failed to make a file copy of '%s'", fileName);
+                OsConfigLogInfo(log, "MakeFileBackupCopy: cannot make a file copy of '%s' (%d)", fileName, errno);
             }
         }
         else
@@ -454,7 +454,7 @@ static bool IsATrueFileOrDirectory(bool directory, const char* name, OSCONFIG_LO
     }
     else
     {
-        OsConfigLogInfo(log, "IsATrueFileOrDirectory: stat('%s') failed with %d (errno: %d)", name, status, errno);
+        OsConfigLogInfo(log, "IsATrueFileOrDirectory: stat('%s') completed with %d (errno: %d)", name, status, errno);
     }
 
     return result;
@@ -920,7 +920,7 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, OSCON
         {
             OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' without restored original owner and access mode", original, target);
         }
-        else if (IsFullLoggingEnabled())
+        else if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' with restored original owner %u, group %u and access mode %u",
                 original, target, ownerId, groupId, mode);
@@ -1021,7 +1021,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
                             if (EOF == fputs(line, tempHandle))
                             {
                                 status = (0 == errno) ? EPERM : errno;
-                                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: failed writing to temporary file '%s' (%d)", tempFileName, status);
+                                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: cannot write to temporary file '%s' (%d)", tempFileName, status);
                             }
                         }
 
@@ -1035,13 +1035,13 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
                 {
                     close(tempDescriptor);
 
-                    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: failed to open temporary file '%s', fdopen() failed (%d)", tempFileName, errno);
+                    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: cannot open temporary file '%s', fdopen() failed (%d)", tempFileName, errno);
                     status = EACCES;
                 }
             }
             else
             {
-                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: failed to open temporary file '%s', open() failed (%d)", tempFileName, errno);
+                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: cannot open temporary file '%s', open() failed (%d)", tempFileName, errno);
                 status = EACCES;
             }
 
@@ -1068,7 +1068,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
 
         if (false == AppendPayloadToFile(tempFileName, newline, strlen(newline), log))
         {
-            OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: failed to append line '%s' at end of '%s'", newline, fileName);
+            OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: cannot append line '%s' at end of '%s'", newline, fileName);
         }
     }
 
@@ -1078,14 +1078,14 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         {
             if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, fileName, log)))
             {
-                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", tempFileName, fileName, status);
+                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d", tempFileName, fileName, status);
             }
         }
         else
         {
             if (0 != (status = RenameFile(tempFileName, fileName, log)))
             {
-                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFile('%s' to '%s') failed with %d", tempFileName, fileName, status);
+                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFile('%s' to '%s') completed with %d", tempFileName, fileName, status);
             }
         }
 
@@ -1924,7 +1924,7 @@ int DisablePostfixNetworkListening(OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "DisablePostfixNetworkListening: failed creating directory '%s' with %d access", etcPostfix, mode);
+            OsConfigLogInfo(log, "DisablePostfixNetworkListening: cannot create directory '%s' with %d access (%d)", etcPostfix, mode, errno);
         }
     }
 
@@ -1936,7 +1936,7 @@ int DisablePostfixNetworkListening(OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "DisablePostfixNetworkListening: failed writing '%s' to '%s' (%d)", inetInterfacesLocalhost, etcPostfixMainCf, errno);
+            OsConfigLogInfo(log, "DisablePostfixNetworkListening: cannot write '%s' to '%s' (%d)", inetInterfacesLocalhost, etcPostfixMainCf, errno);
             status = ENOENT;
         }
     }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -920,9 +920,9 @@ int RenameFileWithOwnerAndAccess(const char* original, const char* target, OSCON
         {
             OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' without restored original owner and access mode", original, target);
         }
-        else if (IsDebugLoggingEnabled())
+        else
         {
-            OsConfigLogInfo(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' with restored original owner %u, group %u and access mode %u",
+            OsConfigLogDebug(log, "RenameFileWithOwnerAndAccess: '%s' renamed to '%s' with restored original owner %u, group %u and access mode %u",
                 original, target, ownerId, groupId, mode);
         }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -153,7 +153,7 @@ bool FileEndsInEol(const char* fileName, OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "FileEndsInEol: stat('%s') completed with %d (errno: %d)", fileName, status, errno);
+        OsConfigLogInfo(log, "FileEndsInEol: stat('%s') returned %d (errno: %d)", fileName, status, errno);
     }
 
     return result;
@@ -270,7 +270,7 @@ static bool InternalSecureSaveToFile(const char* fileName, const char* mode, con
     {
         if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, fileName, log)))
         {
-            OsConfigLogInfo(log, "InternalSecureSaveToFile: RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d", tempFileName, fileName, status);
+            OsConfigLogInfo(log, "InternalSecureSaveToFile: RenameFileWithOwnerAndAccess('%s' to '%s') returned %d", tempFileName, fileName, status);
             result = false;
         }
 
@@ -454,7 +454,7 @@ static bool IsATrueFileOrDirectory(bool directory, const char* name, OSCONFIG_LO
     }
     else
     {
-        OsConfigLogInfo(log, "IsATrueFileOrDirectory: stat('%s') completed with %d (errno: %d)", name, status, errno);
+        OsConfigLogInfo(log, "IsATrueFileOrDirectory: stat('%s') returned %d (errno: %d)", name, status, errno);
     }
 
     return result;
@@ -1078,14 +1078,14 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
         {
             if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, fileName, log)))
             {
-                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d", tempFileName, fileName, status);
+                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFileWithOwnerAndAccess('%s' to '%s') returned %d", tempFileName, fileName, status);
             }
         }
         else
         {
             if (0 != (status = RenameFile(tempFileName, fileName, log)))
             {
-                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFile('%s' to '%s') completed with %d", tempFileName, fileName, status);
+                OsConfigLogInfo(log, "ReplaceMarkedLinesInFile: RenameFile('%s' to '%s') returned %d", tempFileName, fileName, status);
             }
         }
 
@@ -1095,7 +1095,7 @@ int ReplaceMarkedLinesInFile(const char* fileName, const char* marker, const cha
     FREE_MEMORY(tempFileName);
     FREE_MEMORY(fileNameCopy);
 
-    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s', '%s') complete with %d", fileName, marker, status);
+    OsConfigLogInfo(log, "ReplaceMarkedLinesInFile('%s', '%s') returning %d", fileName, marker, status);
 
     return status;
 }

--- a/src/common/commonutils/Internal.h
+++ b/src/common/commonutils/Internal.h
@@ -37,8 +37,6 @@
 #define gettid() syscall(SYS_gettid)
 #endif
 
-#define PLAIN_STATUS_FROM_ERRNO(a) ((0 == a) ? "passed" : "failed")
-
 #define INT_ENOENT -999
 
 #define MAX_STRING_LENGTH 512

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -431,7 +431,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                 }
                 else
                 {
-                    OsConfigLogInfo(log, "SetFileSystemMountingOption:  RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d", tempFileNameTwo, fsMountTable, status);
+                    OsConfigLogInfo(log, "SetFileSystemMountingOption:  RenameFileWithOwnerAndAccess('%s' to '%s') returned %d", tempFileNameTwo, fsMountTable, status);
                 }
             }
         }

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -76,12 +76,9 @@ int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDi
                     }
                 }
 
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(log, "CheckFileSystemMountingOption, line %d in '%s': mnt_fsname '%s', mnt_dir '%s', mnt_type '%s', mnt_opts '%s', mnt_freq %d, mnt_passno %d",
-                        lineNumber, mountFileName, mountStruct->mnt_fsname, mountStruct->mnt_dir, mountStruct->mnt_type, mountStruct->mnt_opts,
-                        mountStruct->mnt_freq, mountStruct->mnt_passno);
-                }
+                OsConfigLogDebug(log, "CheckFileSystemMountingOption, line %d in '%s': mnt_fsname '%s', mnt_dir '%s', mnt_type '%s', mnt_opts '%s', mnt_freq %d, mnt_passno %d",
+                    lineNumber, mountFileName, mountStruct->mnt_fsname, mountStruct->mnt_dir, mountStruct->mnt_type, mountStruct->mnt_opts,
+                    mountStruct->mnt_freq, mountStruct->mnt_passno);
             }
 
             lineNumber += 1;

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -76,7 +76,7 @@ int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDi
                     }
                 }
 
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(log, "CheckFileSystemMountingOption, line %d in '%s': mnt_fsname '%s', mnt_dir '%s', mnt_type '%s', mnt_opts '%s', mnt_freq %d, mnt_passno %d",
                         lineNumber, mountFileName, mountStruct->mnt_fsname, mountStruct->mnt_dir, mountStruct->mnt_type, mountStruct->mnt_opts,
@@ -109,7 +109,7 @@ int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDi
     else
     {
         status = (0 == errno) ? ENOENT : errno;
-        OsConfigLogInfo(log, "CheckFileSystemMountingOption: could not open file '%s', setmntent() failed (%d)", mountFileName, status);
+        OsConfigLogInfo(log, "CheckFileSystemMountingOption: cannot open file '%s', setmntent() failed (%d, errno: %d)", mountFileName, status, errno);
         OsConfigCaptureReason(reason, "Cannot access '%s', setmntent() failed (%d)", mountFileName, status);
     }
 
@@ -280,7 +280,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                         {
                             if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                             {
-                                OsConfigLogInfo(log, "SetFileSystemMountingOption: failed collecting entries from '%s'", fsMountTable);
+                                OsConfigLogInfo(log, "SetFileSystemMountingOption: cannot collect entries from '%s'", fsMountTable);
                                 break;
                             }
                         }
@@ -303,7 +303,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                         {
                             if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                             {
-                                OsConfigLogInfo(log, "SetFileSystemMountingOption: failed copying existing entries from '%s'", fsMountTable);
+                                OsConfigLogInfo(log, "SetFileSystemMountingOption: cannot copy existing entries from '%s'", fsMountTable);
                                 break;
                             }
                         }
@@ -369,7 +369,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                                     {
                                         if (0 != (status = AppendPayloadToFile(tempFileNameOne, newLine, (const int)strlen(newLine), log) ? 0 : ENOENT))
                                         {
-                                            OsConfigLogInfo(log, "SetFileSystemMountingOption: failed collecting entry from '%s'", mountTable);
+                                            OsConfigLogInfo(log, "SetFileSystemMountingOption: cannot collect entry from '%s'", mountTable);
                                             break;
                                         }
                                     }
@@ -390,7 +390,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                     else
                     {
                         status = (0 == errno) ? ENOENT : errno;
-                        OsConfigLogInfo(log, "SetFileSystemMountingOption: could not open '%s', setmntent() failed (%d)", mountTable, status);
+                        OsConfigLogInfo(log, "SetFileSystemMountingOption: cannot open '%s', setmntent() failed (%d)", mountTable, status);
                     }
                 }
             }
@@ -404,7 +404,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
         else
         {
             status = (0 == errno) ? ENOENT : errno;
-            OsConfigLogInfo(log, "SetFileSystemMountingOption: could not open '%s', setmntent() failed (%d)", fsMountTable, status);
+            OsConfigLogInfo(log, "SetFileSystemMountingOption: cannot open '%s', setmntent() failed (%d)", fsMountTable, status);
         }
 
         if (matchFound && (0 == status))
@@ -434,7 +434,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                 }
                 else
                 {
-                    OsConfigLogInfo(log, "SetFileSystemMountingOption:  RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d", tempFileNameTwo, fsMountTable, status);
+                    OsConfigLogInfo(log, "SetFileSystemMountingOption:  RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d", tempFileNameTwo, fsMountTable, status);
                 }
             }
         }

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -609,13 +609,13 @@ int RemoveEscapeSequencesFromFile(const char* fileName, const char* escapes, uns
     {
         if (false == SecureSaveToFile(fileName, newFileContents, strlen(newFileContents), log))
         {
-            OsConfigLogInfo(log, "ReplaceEscapesFromFile: failed saving '%s'", fileName);
+            OsConfigLogInfo(log, "ReplaceEscapesFromFile: cannot save '%s' (%d)", fileName, errno);
             status = ENOENT;
         }
     }
     else
     {
-        OsConfigLogInfo(log, "ReplaceEscapesFromFile: failed to replace desired characters in '%s'", fileName);
+        OsConfigLogInfo(log, "ReplaceEscapesFromFile: cannot replace desired characters in '%s'", fileName);
         status = ENOENT;
     }
 

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -337,7 +337,7 @@ int DisableAllWirelessInterfaces(OSCONFIG_LOG_HANDLE log)
         }
     }
 
-    OsConfigLogInfo(log, "DisableAllWirelessInterfaces completed with %d", status);
+    OsConfigLogInfo(log, "DisableAllWirelessInterfaces returned %d", status);
 
     return status;
 }
@@ -383,7 +383,7 @@ int SetDefaultDenyFirewallPolicy(OSCONFIG_LOG_HANDLE log)
         }
     }
 
-    OsConfigLogInfo(log, "SetDefaultDenyFirewallPolicy completed with %d", status);
+    OsConfigLogInfo(log, "SetDefaultDenyFirewallPolicy returned %d", status);
 
     return 0;
 }

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -84,7 +84,7 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
 
     status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log);
 
-    OsConfigLogInfo(log, "Package manager '%s' command '%s' complete with %d (errno: %d)", packageManager, command, status, errno);
+    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning %d (errno: %d)", packageManager, command, status, errno);
 
     FREE_MEMORY(command);
 
@@ -203,7 +203,7 @@ static int ExecuteSimplePackageCommand(const char* command, bool* executed, OSCO
     }
     else
     {
-        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' completed with %d (errno: %d)", command, status, errno);
+        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' returned %d (errno: %d)", command, status, errno);
         *executed = false;
     }
 
@@ -267,7 +267,7 @@ int InstallOrUpdatePackage(const char* packageName, OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "InstallOrUpdatePackage: installation or update of package '%s' completed with %d (errno: %d)", packageName, status, errno);
+        OsConfigLogInfo(log, "InstallOrUpdatePackage: installation or update of package '%s' returned %d (errno: %d)", packageName, status, errno);
     }
 
     return status;
@@ -337,7 +337,7 @@ int UninstallPackage(const char* packageName, OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "UninstallPackage: uninstallation of package '%s' completed with %d (errno: %d)", packageName, status, errno);
+            OsConfigLogInfo(log, "UninstallPackage: uninstallation of package '%s' returned %d (errno: %d)", packageName, status, errno);
         }
     }
     else if (EINVAL != status)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -203,7 +203,7 @@ static int ExecuteSimplePackageCommand(const char* command, bool* executed, OSCO
     }
     else
     {
-        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' failed with %d (errno: %d)", command, status, errno);
+        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' completed with %d (errno: %d)", command, status, errno);
         *executed = false;
     }
 
@@ -267,7 +267,7 @@ int InstallOrUpdatePackage(const char* packageName, OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "InstallOrUpdatePackage: installation or update of package '%s' failed with %d (errno: %d)", packageName, status, errno);
+        OsConfigLogInfo(log, "InstallOrUpdatePackage: installation or update of package '%s' completed with %d (errno: %d)", packageName, status, errno);
     }
 
     return status;
@@ -337,7 +337,7 @@ int UninstallPackage(const char* packageName, OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "UninstallPackage: uninstallation of package '%s' failed with %d (errno: %d)", packageName, status, errno);
+            OsConfigLogInfo(log, "UninstallPackage: uninstallation of package '%s' completed with %d (errno: %d)", packageName, status, errno);
         }
     }
     else if (EINVAL != status)

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -164,7 +164,7 @@ int SetEnsurePasswordReuseIsLimited(int remember, OSCONFIG_LOG_HANDLE log)
     FREE_MEMORY(newline);
     FREE_MEMORY(pamModulePath);
 
-    OsConfigLogInfo(log, "SetEnsurePasswordReuseIsLimited(%d) complete with %d", remember, status);
+    OsConfigLogInfo(log, "SetEnsurePasswordReuseIsLimited(%d) returning %d", remember, status);
 
     return status;
 }

--- a/src/common/commonutils/ProxyUtils.c
+++ b/src/common/commonutils/ProxyUtils.c
@@ -325,7 +325,7 @@ bool ParseHttpProxyData(const char* proxyData, char** proxyHostAddress, int* pro
             OsConfigLogInfo(log, "HTTP proxy host|address: %s (%d)", *proxyHostAddress, hostAddressLength);
             OsConfigLogInfo(log, "HTTP proxy port: %d", *proxyPort);
 
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(log, "HTTP proxy username: %s (%d)", *proxyUsername, usernameLength);
                 OsConfigLogInfo(log, "HTTP proxy password: %s (%d)", *proxyPassword, passwordLength);

--- a/src/common/commonutils/ProxyUtils.c
+++ b/src/common/commonutils/ProxyUtils.c
@@ -325,11 +325,8 @@ bool ParseHttpProxyData(const char* proxyData, char** proxyHostAddress, int* pro
             OsConfigLogInfo(log, "HTTP proxy host|address: %s (%d)", *proxyHostAddress, hostAddressLength);
             OsConfigLogInfo(log, "HTTP proxy port: %d", *proxyPort);
 
-            if (IsDebugLoggingEnabled())
-            {
-                OsConfigLogInfo(log, "HTTP proxy username: %s (%d)", *proxyUsername, usernameLength);
-                OsConfigLogInfo(log, "HTTP proxy password: %s (%d)", *proxyPassword, passwordLength);
-            }
+            OsConfigLogDebug(log, "HTTP proxy username: %s (%d)", *proxyUsername, usernameLength);
+            OsConfigLogDebug(log, "HTTP proxy password: %s (%d)", *proxyPassword, passwordLength);
 
             FREE_MEMORY(port);
 

--- a/src/common/commonutils/SocketUtils.c
+++ b/src/common/commonutils/SocketUtils.c
@@ -104,7 +104,7 @@ char* ReadUriFromSocket(int socketHandle, OSCONFIG_LOG_HANDLE log)
         memset(returnUri, 0, uriLength + 1);
         strncpy(returnUri, bufferUri, uriLength);
 
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(log, "ReadUriFromSocket: %s", returnUri);
         }
@@ -144,7 +144,7 @@ int ReadHttpStatusFromSocket(int socketHandle, OSCONFIG_LOG_HANDLE log)
     {
         httpStatus = atoi(status);
 
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(log, "ReadHttpStatusFromSocket: %d ('%s')", httpStatus, status);
         }
@@ -196,7 +196,7 @@ int ReadHttpContentLengthFromSocket(int socketHandle, OSCONFIG_LOG_HANDLE log)
             {
                 httpContentLength = atoi(isolatedContentLength);
 
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(log, "ReadHttpContentLengthFromSocket: %d ('%s')", httpContentLength, isolatedContentLength);
                 }

--- a/src/common/commonutils/SocketUtils.c
+++ b/src/common/commonutils/SocketUtils.c
@@ -103,11 +103,7 @@ char* ReadUriFromSocket(int socketHandle, OSCONFIG_LOG_HANDLE log)
     {
         memset(returnUri, 0, uriLength + 1);
         strncpy(returnUri, bufferUri, uriLength);
-
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(log, "ReadUriFromSocket: %s", returnUri);
-        }
+        OsConfigLogDebug(log, "ReadUriFromSocket: %s", returnUri);
     }
     else
     {
@@ -143,11 +139,7 @@ int ReadHttpStatusFromSocket(int socketHandle, OSCONFIG_LOG_HANDLE log)
         (3 == read(socketHandle, status, 3)) && (isdigit(status[0]) && (status[0] >= '1') && (status[0] <= '5') && isdigit(status[1]) && isdigit(status[2])))
     {
         httpStatus = atoi(status);
-
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(log, "ReadHttpStatusFromSocket: %d ('%s')", httpStatus, status);
-        }
+        OsConfigLogDebug(log, "ReadHttpStatusFromSocket: %d ('%s')", httpStatus, status);
     }
 
     FREE_MEMORY(buffer);
@@ -195,11 +187,7 @@ int ReadHttpContentLengthFromSocket(int socketHandle, OSCONFIG_LOG_HANDLE log)
             if (isdigit(isolatedContentLength[0]))
             {
                 httpContentLength = atoi(isolatedContentLength);
-
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(log, "ReadHttpContentLengthFromSocket: %d ('%s')", httpContentLength, isolatedContentLength);
-                }
+                OsConfigLogDebug(log, "ReadHttpContentLengthFromSocket: %d ('%s')", httpContentLength, isolatedContentLength);
             }
         }
 

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -341,7 +341,7 @@ static int CheckOnlyApprovedMacAlgorithmsAreUsed(const char* macs, char** reason
     FREE_MEMORY(macsValue);
     FREE_MEMORY(sshMacs);
 
-    OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed complete with %d", status);
 
     return status;
 }
@@ -443,7 +443,7 @@ static int CheckAppropriateCiphersForSsh(const char* ciphers, char** reason, OSC
     FREE_MEMORY(ciphersValue);
     FREE_MEMORY(sshCiphers);
 
-    OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh complete with %d", status);
 
     return status;
 }
@@ -493,7 +493,7 @@ static int CheckSshOptionIsSet(const char* option, const char* expectedValue, ch
         status = ENOENT;
     }
 
-    OsConfigLogInfo(log, "CheckSshOptionIsSet: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckSshOptionIsSet complete with %d", status);
 
     return status;
 }
@@ -542,7 +542,7 @@ static int CheckSshClientAliveInterval(char** reason, OSCONFIG_LOG_HANDLE log)
 
     FREE_MEMORY(clientAliveInterval);
 
-    OsConfigLogInfo(log, "CheckSshClientAliveInterval: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckSshClientAliveInterval complete with %d", status);
 
     return status;
 }
@@ -575,7 +575,7 @@ static int CheckSshLoginGraceTime(const char* value, char** reason, OSCONFIG_LOG
 
     FREE_MEMORY(loginGraceTime);
 
-    OsConfigLogInfo(log, "CheckSshLoginGraceTime: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckSshLoginGraceTime complete with %d", status);
 
     return status;
 }
@@ -623,7 +623,7 @@ static int CheckSshWarningBanner(const char* bannerFile, const char* bannerText,
 
     FREE_MEMORY(banner);
 
-    OsConfigLogInfo(log, "CheckSshWarningBanner: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckSshWarningBanner complete with %d", status);
 
     return status;
 }
@@ -717,7 +717,7 @@ int CheckSshProtocol(char** reason, OSCONFIG_LOG_HANDLE log)
 
     FREE_MEMORY(protocol);
 
-    OsConfigLogInfo(log, "CheckSshProtocol: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckSshProtocol complete with %d", status);
 
     return status;
 }
@@ -795,7 +795,7 @@ static int CheckAllowDenyUsersGroups(const char* lowercase, const char* expected
         OsConfigCaptureReason(reason, "'%s' is not set to '%s' in SSH Server response", lowercase, expectedValue);
     }
 
-    OsConfigLogInfo(log, "CheckAllowDenyUsersGroups: %s (%d)", PLAIN_STATUS_FROM_ERRNO(status), status);
+    OsConfigLogInfo(log, "CheckAllowDenyUsersGroups complete with %d", status);
 
     return status;
 }

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -341,7 +341,7 @@ static int CheckOnlyApprovedMacAlgorithmsAreUsed(const char* macs, char** reason
     FREE_MEMORY(macsValue);
     FREE_MEMORY(sshMacs);
 
-    OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed complete with %d", status);
+    OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed returning %d", status);
 
     return status;
 }
@@ -443,7 +443,7 @@ static int CheckAppropriateCiphersForSsh(const char* ciphers, char** reason, OSC
     FREE_MEMORY(ciphersValue);
     FREE_MEMORY(sshCiphers);
 
-    OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh complete with %d", status);
+    OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh returning %d", status);
 
     return status;
 }
@@ -493,7 +493,7 @@ static int CheckSshOptionIsSet(const char* option, const char* expectedValue, ch
         status = ENOENT;
     }
 
-    OsConfigLogInfo(log, "CheckSshOptionIsSet complete with %d", status);
+    OsConfigLogInfo(log, "CheckSshOptionIsSet returning %d", status);
 
     return status;
 }
@@ -542,7 +542,7 @@ static int CheckSshClientAliveInterval(char** reason, OSCONFIG_LOG_HANDLE log)
 
     FREE_MEMORY(clientAliveInterval);
 
-    OsConfigLogInfo(log, "CheckSshClientAliveInterval complete with %d", status);
+    OsConfigLogInfo(log, "CheckSshClientAliveInterval returning %d", status);
 
     return status;
 }
@@ -575,7 +575,7 @@ static int CheckSshLoginGraceTime(const char* value, char** reason, OSCONFIG_LOG
 
     FREE_MEMORY(loginGraceTime);
 
-    OsConfigLogInfo(log, "CheckSshLoginGraceTime complete with %d", status);
+    OsConfigLogInfo(log, "CheckSshLoginGraceTime returning %d", status);
 
     return status;
 }
@@ -623,7 +623,7 @@ static int CheckSshWarningBanner(const char* bannerFile, const char* bannerText,
 
     FREE_MEMORY(banner);
 
-    OsConfigLogInfo(log, "CheckSshWarningBanner complete with %d", status);
+    OsConfigLogInfo(log, "CheckSshWarningBanner returning %d", status);
 
     return status;
 }
@@ -717,7 +717,7 @@ int CheckSshProtocol(char** reason, OSCONFIG_LOG_HANDLE log)
 
     FREE_MEMORY(protocol);
 
-    OsConfigLogInfo(log, "CheckSshProtocol complete with %d", status);
+    OsConfigLogInfo(log, "CheckSshProtocol returning %d", status);
 
     return status;
 }
@@ -795,7 +795,7 @@ static int CheckAllowDenyUsersGroups(const char* lowercase, const char* expected
         OsConfigCaptureReason(reason, "'%s' is not set to '%s' in SSH Server response", lowercase, expectedValue);
     }
 
-    OsConfigLogInfo(log, "CheckAllowDenyUsersGroups complete with %d", status);
+    OsConfigLogInfo(log, "CheckAllowDenyUsersGroups returning %d", status);
 
     return status;
 }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1248,7 +1248,7 @@ int RepairRootGroup(OSCONFIG_LOG_HANDLE log)
                                 // In a single atomic operation move edited contents from temporary file to /etc/group
                                 if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, etcGroup, log)))
                                 {
-                                    OsConfigLogInfo(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d",
+                                    OsConfigLogInfo(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') returned %d",
                                         tempFileName, etcGroup, status);
                                 }
                             }
@@ -3164,7 +3164,7 @@ int RemoveUserAccounts(const char* names, bool removeHomeDirs, OSCONFIG_LOG_HAND
     }
     else if (EEXIST != status)
     {
-        OsConfigLogInfo(log, "RemoveUserAccounts: CheckUserAccountsNotFound('%s') completed with %d", names, status);
+        OsConfigLogInfo(log, "RemoveUserAccounts: CheckUserAccountsNotFound('%s') returned %d", names, status);
         return status;
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -377,7 +377,7 @@ int EnumerateUsers(SIMPLIFIED_USER** userList, unsigned int* size, char** reason
                 }
                 else if (0 != (status = CheckIfUserHasPassword(&((*userList)[i]), log)))
                 {
-                    OsConfigLogInfo(log, "EnumerateUsers: failed checking user's login and password (%d)", status);
+                    OsConfigLogInfo(log, "EnumerateUsers: cannot check user's login and password (%d)", status);
                     break;
                 }
 
@@ -405,7 +405,7 @@ int EnumerateUsers(SIMPLIFIED_USER** userList, unsigned int* size, char** reason
         OsConfigLogInfo(log, "EnumerateUsers failed with %d", status);
         OsConfigCaptureReason(reason, "Failed to enumerate users (%d). User database may be corrupt. Automatic remediation is not possible", status);
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "EnumerateUsers: %u users found", *size);
 
@@ -466,7 +466,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
     }
     else if (-1 == (getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups)))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(log, "EnumerateUserGroups: first call to getgrouplist for user '%s' (%u) returned %d and %d",
                 user->username, user->groupId, getGroupListResult, numberOfGroups);
@@ -480,7 +480,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
             {
                 getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups);
 
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(log, "EnumerateUserGroups: second call to getgrouplist for user '%s' (%u) returned %d and %d",
                         user->username, user->groupId, getGroupListResult, numberOfGroups);
@@ -495,7 +495,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
         }
         else
         {
-            OsConfigLogInfo(log, "EnumerateUserGroups: first call to getgrouplist for user '%s' (%u) failed with -1 and returned %d groups",
+            OsConfigLogInfo(log, "EnumerateUserGroups: first call to getgrouplist for user '%s' (%u) returned -1 and %d groups",
                 user->username, user->groupId, numberOfGroups);
             status = ENOENT;
         }
@@ -503,7 +503,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
 
     if ((0 == status) && (0 < numberOfGroups))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(log, "EnumerateUserGroups: user '%s' (%u) is in %d group%s", user->username, user->groupId, numberOfGroups, (1 == numberOfGroups) ? "" : "s");
         }
@@ -537,7 +537,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
                         memset((*groupList)[i].groupName, 0, groupNameLength + 1);
                         memcpy((*groupList)[i].groupName, groupEntry->gr_name, groupNameLength);
 
-                        if (IsFullLoggingEnabled())
+                        if (IsDebugLoggingEnabled())
                         {
                             OsConfigLogInfo(log, "EnumerateUserGroups: user '%s' (%u) is in group '%s' (%u)",
                                 user->username, user->groupId, (*groupList)[i].groupName, (*groupList)[i].groupId);
@@ -604,7 +604,7 @@ int EnumerateAllGroups(SIMPLIFIED_GROUP** groupList, unsigned int* size, char** 
                         memset((*groupList)[i].groupName, 0, groupNameLength + 1);
                         memcpy((*groupList)[i].groupName, groupEntry->gr_name, groupNameLength);
 
-                        if (IsFullLoggingEnabled())
+                        if (IsDebugLoggingEnabled())
                         {
                             OsConfigLogInfo(log, "EnumerateAllGroups(group %d): group name '%s', gid %u, %s", i,
                                 (*groupList)[i].groupName, (*groupList)[i].groupId, (*groupList)[i].hasUsers ? "has users" : "empty");
@@ -623,7 +623,7 @@ int EnumerateAllGroups(SIMPLIFIED_GROUP** groupList, unsigned int* size, char** 
 
             endgrent();
 
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(log, "EnumerateAllGroups: found %u groups (expected %u)", i, *size);
             }
@@ -677,7 +677,7 @@ int CheckAllEtcPasswdGroupsExistInEtcGroup(char** reason, OSCONFIG_LOG_HANDLE lo
                     {
                         if (userGroupList[j].groupId == groupList[k].groupId)
                         {
-                            if (IsFullLoggingEnabled())
+                            if (IsDebugLoggingEnabled())
                             {
                                 OsConfigLogInfo(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group '%s' (%u) of user '%s' (%u) found in '/etc/group'",
                                     userList[i].username, userList[i].userId, userGroupList[j].groupName, userGroupList[j].groupId);
@@ -745,7 +745,7 @@ int SetAllEtcPasswdGroupsToExistInEtcGroup(OSCONFIG_LOG_HANDLE log)
                     {
                         if (userGroupList[j].groupId == groupList[k].groupId)
                         {
-                            if (IsFullLoggingEnabled())
+                            if (IsDebugLoggingEnabled())
                             {
                                 OsConfigLogInfo(log, "SetAllEtcPasswdGroupsToExistInEtcGroup: group '%s' (%u) of user '%s' (%u) found in '/etc/group'",
                                     userGroupList[j].groupName, userGroupList[j].groupId, userList[i].username, userList[i].userId);
@@ -882,7 +882,7 @@ int RemoveUser(SIMPLIFIED_USER* user, bool removeHome, OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "RemoveUser: failed to remove user '%s' (%u, %u) (%d)", user->username, user->userId, user->groupId, _status);
+            OsConfigLogInfo(log, "RemoveUser: cannot remove user '%s' (%u, %u) (%d)", user->username, user->userId, user->groupId, _status);
         }
 
         FREE_MEMORY(command);
@@ -988,7 +988,7 @@ int RemoveGroup(SIMPLIFIED_GROUP* group, bool removeHomeDirs, OSCONFIG_LOG_HANDL
         }
         else
         {
-            OsConfigLogInfo(log, "RemoveGroup: failed to remove group '%s' (%u) (%d)", group->groupName, group->groupId, status);
+            OsConfigLogInfo(log, "RemoveGroup: cannot remove group '%s' (%u) (%d)", group->groupName, group->groupId, status);
         }
 
         FREE_MEMORY(command);
@@ -1277,13 +1277,13 @@ int RepairRootGroup(OSCONFIG_LOG_HANDLE log)
                                 // In a single atomic operation move edited contents from temporary file to /etc/group
                                 if (0 != (status = RenameFileWithOwnerAndAccess(tempFileName, etcGroup, log)))
                                 {
-                                    OsConfigLogInfo(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') failed with %d",
+                                    OsConfigLogInfo(log, "RepairRootGroup:  RenameFileWithOwnerAndAccess('%s' to '%s') completed with %d",
                                         tempFileName, etcGroup, status);
                                 }
                             }
                             else
                             {
-                                OsConfigLogInfo(log, "RepairRootGroup: failed appending to to temp file '%s", tempFileName);
+                                OsConfigLogInfo(log, "RepairRootGroup: cannot append to to temp file '%s' (%d)", tempFileName, errno);
                                 status = ENOENT;
                             }
 
@@ -1292,18 +1292,18 @@ int RepairRootGroup(OSCONFIG_LOG_HANDLE log)
                     }
                     else
                     {
-                        OsConfigLogInfo(log, "RepairRootGroup: failed reading '%s", tempFileName);
+                        OsConfigLogInfo(log, "RepairRootGroup: cannot read from '%s' (%d)", tempFileName, errno);
                         status = EACCES;
                     }
                 }
                 else
                 {
-                    OsConfigLogInfo(log, "RepairRootGroup: failed removing potentially corrupted root entries from '%s' ", etcGroup);
+                    OsConfigLogInfo(log, "RepairRootGroup: cannot remove potentially corrupted root entries from '%s' (%d)", etcGroup, errno);
                 }
             }
             else
             {
-                OsConfigLogInfo(log, "RepairRootGroup: failed saving to temp file '%s", tempFileName);
+                OsConfigLogInfo(log, "RepairRootGroup: cannot save to temp file '%s' (%d)", tempFileName, errno);
                 status = EPERM;
             }
 
@@ -1311,7 +1311,7 @@ int RepairRootGroup(OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "RepairRootGroup: failed reading '%s", etcGroup);
+            OsConfigLogInfo(log, "RepairRootGroup: cannot read from '%s' (%d)", etcGroup, errno);
             status = EACCES;
         }
     }
@@ -1621,8 +1621,8 @@ int SetUserHomeDirectories(OSCONFIG_LOG_HANDLE log)
                 {
                     if (0 != (_status = SetDirectoryAccess(userList[i].home, userList[i].userId, userList[i].groupId, defaultHomeDirAccess, log)))
                     {
-                        OsConfigLogInfo(log, "SetUserHomeDirectories: failed to set access and ownership for home directory '%s' of user '%s' (%u, %u) (%d)",
-                            userList[i].home, userList[i].username, userList[i].userId, userList[i].groupId, _status);
+                        OsConfigLogInfo(log, "SetUserHomeDirectories: cannot set access and ownership for home directory '%s' of user '%s' (%u, %u) (%d, errno: %d)",
+                            userList[i].home, userList[i].username, userList[i].userId, userList[i].groupId, _status, errno);
                     }
                 }
 
@@ -1842,7 +1842,7 @@ int SetRestrictedUserHomeDirectories(unsigned int* modes, unsigned int numberOfM
                     }
                     else
                     {
-                        OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: failed to set restricted access (%u) for user '%s' (%u, %u) assigned home directory '%s' (%d)",
+                        OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: cannot set restricted access (%u) for user '%s' (%u, %u) assigned home directory '%s' (%d)",
                             userList[i].isRoot ? modeForRoot : modeForOthers, userList[i].username, userList[i].userId, userList[i].groupId, userList[i].home, _status);
 
                         if (0 == status)
@@ -1901,7 +1901,7 @@ int CheckPasswordHashingAlgorithm(unsigned int algorithm, char** reason, OSCONFI
             status = ENOENT;
         }
 
-        OsConfigLogInfo(log, "CheckPasswordHashingAlgorithm: failed to read 'ENCRYPT_METHOD' from '/etc/login.defs' (%d)", status);
+        OsConfigLogInfo(log, "CheckPasswordHashingAlgorithm: cannot read 'ENCRYPT_METHOD' from '/etc/login.defs' (%d)", status);
         OsConfigCaptureReason(reason, "Failed to read 'ENCRYPT_METHOD' from '/etc/login.defs' (%d)", status);
     }
 
@@ -1928,7 +1928,7 @@ int SetPasswordHashingAlgorithm(unsigned int algorithm, OSCONFIG_LOG_HANDLE log)
         }
         else
         {
-            OsConfigLogInfo(log, "SetPasswordHashingAlgorithm: failed to set 'ENCRYPT_METHOD' to '%s' in '/etc/login.defs' (%d)", encryption, status);
+            OsConfigLogInfo(log, "SetPasswordHashingAlgorithm: cannot set 'ENCRYPT_METHOD' to '%s' in '/etc/login.defs' (%d)", encryption, status);
         }
     }
 
@@ -2065,7 +2065,7 @@ int SetMinDaysBetweenPasswordChanges(long days, OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "SetMinDaysBetweenPasswordChanges: failed to set 'PASS_MIN_DAYS' to %ld days in '/etc/login.defs' (%d)", days, _status);
+        OsConfigLogInfo(log, "SetMinDaysBetweenPasswordChanges: cannot set 'PASS_MIN_DAYS' to %ld days in '/etc/login.defs' (%d)", days, _status);
     }
 
     if (_status && (0 == status))
@@ -2208,7 +2208,7 @@ int SetMaxDaysBetweenPasswordChanges(long days, OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "SetMaxDaysBetweenPasswordChanges: failed to set 'PASS_MAX_DAYS' to %ld days in '/etc/login.defs' (%d)", days, _status);
+        OsConfigLogInfo(log, "SetMaxDaysBetweenPasswordChanges: cannot set 'PASS_MAX_DAYS' to %ld days in '/etc/login.defs' (%d)", days, _status);
     }
 
     if (_status & (0 == status))
@@ -2481,7 +2481,7 @@ int SetPasswordExpirationWarning(long days, OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "SetPasswordExpirationWarning: failed to set 'PASS_WARN_AGE' to %ld days in '/etc/login.defs' (%d)", days, _status);
+        OsConfigLogInfo(log, "SetPasswordExpirationWarning: cannot set 'PASS_WARN_AGE' to %ld days in '/etc/login.defs' (%d)", days, _status);
     }
 
     if (_status && (0 == status))
@@ -3012,7 +3012,7 @@ int SetUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes, 
                             }
                             else
                             {
-                                OsConfigLogInfo(log, "SetUsersRestrictedDotFiles: failed to set restricted access (%u) for user '%s' (%u, %u) dot file '%s'",
+                                OsConfigLogInfo(log, "SetUsersRestrictedDotFiles: cannot set restricted access (%u) for user '%s' (%u, %u) dot file '%s'",
                                     mode, userList[i].username, userList[i].userId, userList[i].groupId, path);
 
                                 if (0 == status)
@@ -3193,7 +3193,7 @@ int RemoveUserAccounts(const char* names, bool removeHomeDirs, OSCONFIG_LOG_HAND
     }
     else if (EEXIST != status)
     {
-        OsConfigLogInfo(log, "RemoveUserAccounts: CheckUserAccountsNotFound('%s') failed with %d", names, status);
+        OsConfigLogInfo(log, "RemoveUserAccounts: CheckUserAccountsNotFound('%s') completed with %d", names, status);
         return status;
     }
 
@@ -3312,7 +3312,7 @@ int RestrictSuToRootGroup(OSCONFIG_LOG_HANDLE log)
     }
     else
     {
-        OsConfigLogInfo(log, "RestrictSuToRootGroup: failed writing '%s' to '%s' (%d)", suRestrictedToRootGroup, etcPamdSu, errno);
+        OsConfigLogInfo(log, "RestrictSuToRootGroup: cannot write '%s' to '%s' (%d)", suRestrictedToRootGroup, etcPamdSu, errno);
         status = ENOENT;
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -407,11 +407,11 @@ int EnumerateUsers(SIMPLIFIED_USER** userList, unsigned int* size, char** reason
     }
     else if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(log, "EnumerateUsers: %u users found", *size);
+        OsConfigLogDebug(log, "EnumerateUsers: %u users found", *size);
 
         for (i = 0; i < *size; i++)
         {
-            OsConfigLogInfo(log, "EnumerateUsers(user %u): name '%s', uid %d, gid %d, home '%s', shell '%s'", i,
+            OsConfigLogDebug(log, "EnumerateUsers(user %u): name '%s', uid %d, gid %d, home '%s', shell '%s'", i,
                 (*userList)[i].username, (*userList)[i].userId, (*userList)[i].groupId, (*userList)[i].home, (*userList)[i].shell);
         }
     }
@@ -466,12 +466,8 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
     }
     else if (-1 == (getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups)))
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(log, "EnumerateUserGroups: first call to getgrouplist for user '%s' (%u) returned %d and %d",
-                user->username, user->groupId, getGroupListResult, numberOfGroups);
-        }
-
+        OsConfigLogDebug(log, "EnumerateUserGroups: first call to getgrouplist for user '%s' (%u) returned %d and %d",
+            user->username, user->groupId, getGroupListResult, numberOfGroups);
         FREE_MEMORY(groupIds);
 
         if (0 < numberOfGroups)
@@ -479,12 +475,8 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
             if (NULL != (groupIds = malloc(numberOfGroups * sizeof(gid_t))))
             {
                 getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups);
-
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(log, "EnumerateUserGroups: second call to getgrouplist for user '%s' (%u) returned %d and %d",
-                        user->username, user->groupId, getGroupListResult, numberOfGroups);
-                }
+                OsConfigLogDebug(log, "EnumerateUserGroups: second call to getgrouplist for user '%s' (%u) returned %d and %d",
+                    user->username, user->groupId, getGroupListResult, numberOfGroups);
             }
             else
             {
@@ -503,10 +495,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
 
     if ((0 == status) && (0 < numberOfGroups))
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(log, "EnumerateUserGroups: user '%s' (%u) is in %d group%s", user->username, user->groupId, numberOfGroups, (1 == numberOfGroups) ? "" : "s");
-        }
+        OsConfigLogDebug(log, "EnumerateUserGroups: user '%s' (%u) is in %d group%s", user->username, user->groupId, numberOfGroups, (1 == numberOfGroups) ? "" : "s");
 
         if (NULL == (*groupList = malloc(sizeof(SIMPLIFIED_GROUP) * numberOfGroups)))
         {
@@ -537,11 +526,7 @@ int EnumerateUserGroups(SIMPLIFIED_USER* user, SIMPLIFIED_GROUP** groupList, uns
                         memset((*groupList)[i].groupName, 0, groupNameLength + 1);
                         memcpy((*groupList)[i].groupName, groupEntry->gr_name, groupNameLength);
 
-                        if (IsDebugLoggingEnabled())
-                        {
-                            OsConfigLogInfo(log, "EnumerateUserGroups: user '%s' (%u) is in group '%s' (%u)",
-                                user->username, user->groupId, (*groupList)[i].groupName, (*groupList)[i].groupId);
-                        }
+                        OsConfigLogDebug(log, "EnumerateUserGroups: user '%s' (%u) is in group '%s' (%u)", user->username, user->groupId, (*groupList)[i].groupName, (*groupList)[i].groupId);
                     }
                     else
                     {
@@ -604,11 +589,8 @@ int EnumerateAllGroups(SIMPLIFIED_GROUP** groupList, unsigned int* size, char** 
                         memset((*groupList)[i].groupName, 0, groupNameLength + 1);
                         memcpy((*groupList)[i].groupName, groupEntry->gr_name, groupNameLength);
 
-                        if (IsDebugLoggingEnabled())
-                        {
-                            OsConfigLogInfo(log, "EnumerateAllGroups(group %d): group name '%s', gid %u, %s", i,
-                                (*groupList)[i].groupName, (*groupList)[i].groupId, (*groupList)[i].hasUsers ? "has users" : "empty");
-                        }
+                        OsConfigLogDebug(log, "EnumerateAllGroups(group %d): group name '%s', gid %u, %s", i,
+                            (*groupList)[i].groupName, (*groupList)[i].groupId, (*groupList)[i].hasUsers ? "has users" : "empty");
                     }
                     else
                     {
@@ -623,10 +605,7 @@ int EnumerateAllGroups(SIMPLIFIED_GROUP** groupList, unsigned int* size, char** 
 
             endgrent();
 
-            if (IsDebugLoggingEnabled())
-            {
-                OsConfigLogInfo(log, "EnumerateAllGroups: found %u groups (expected %u)", i, *size);
-            }
+            OsConfigLogDebug(log, "EnumerateAllGroups: found %u groups (expected %u)", i, *size);
 
             *size = i;
         }
@@ -677,12 +656,8 @@ int CheckAllEtcPasswdGroupsExistInEtcGroup(char** reason, OSCONFIG_LOG_HANDLE lo
                     {
                         if (userGroupList[j].groupId == groupList[k].groupId)
                         {
-                            if (IsDebugLoggingEnabled())
-                            {
-                                OsConfigLogInfo(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group '%s' (%u) of user '%s' (%u) found in '/etc/group'",
-                                    userList[i].username, userList[i].userId, userGroupList[j].groupName, userGroupList[j].groupId);
-                            }
-
+                            OsConfigLogDebug(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group '%s' (%u) of user '%s' (%u) found in '/etc/group'",
+                                userList[i].username, userList[i].userId, userGroupList[j].groupName, userGroupList[j].groupId);
                             found = true;
                             break;
                         }
@@ -745,12 +720,8 @@ int SetAllEtcPasswdGroupsToExistInEtcGroup(OSCONFIG_LOG_HANDLE log)
                     {
                         if (userGroupList[j].groupId == groupList[k].groupId)
                         {
-                            if (IsDebugLoggingEnabled())
-                            {
-                                OsConfigLogInfo(log, "SetAllEtcPasswdGroupsToExistInEtcGroup: group '%s' (%u) of user '%s' (%u) found in '/etc/group'",
-                                    userGroupList[j].groupName, userGroupList[j].groupId, userList[i].username, userList[i].userId);
-                            }
-
+                            OsConfigLogDebug(log, "SetAllEtcPasswdGroupsToExistInEtcGroup: group '%s' (%u) of user '%s' (%u) found in '/etc/group'",
+                                userGroupList[j].groupName, userGroupList[j].groupId, userList[i].username, userList[i].userId);
                             found = true;
                             break;
                         }

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -14,7 +14,7 @@
 
 #define MAX_LOG_TRIM 1000
 
-static bool g_debugLoggingEnabled = false;
+static LoggingLevel g_loggingLevel = LoggingLevelInformational;
 
 struct OSCONFIG_LOG
 {
@@ -26,12 +26,12 @@ struct OSCONFIG_LOG
 
 void SetDebugLogging(bool fullLogging)
 {
-    g_debugLoggingEnabled = fullLogging;
+    g_loggingLevel = fullLogging ? LoggingLevelDebug : LoggingLevelInformational;
 }
 
 bool IsDebugLoggingEnabled(void)
 {
-    return g_debugLoggingEnabled;
+    return (LoggingLevelDebug == g_loggingLevel) ? true : false;
 }
 
 static int RestrictFileAccessToCurrentAccountOnly(const char* fileName)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -14,7 +14,7 @@
 
 #define MAX_LOG_TRIM 1000
 
-static bool g_fullLoggingEnabled = false;
+static bool g_debugLoggingEnabled = false;
 
 struct OSCONFIG_LOG
 {
@@ -24,14 +24,14 @@ struct OSCONFIG_LOG
     unsigned int trimLogCount;
 };
 
-void SetFullLogging(bool fullLogging)
+void SetDebugLogging(bool fullLogging)
 {
-    g_fullLoggingEnabled = fullLogging;
+    g_debugLoggingEnabled = fullLogging;
 }
 
-bool IsFullLoggingEnabled()
+bool IsDebugLoggingEnabled(void)
 {
-    return g_fullLoggingEnabled;
+    return g_debugLoggingEnabled;
 }
 
 static int RestrictFileAccessToCurrentAccountOnly(const char* fileName)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -94,7 +94,7 @@ FILE* GetLogFile(OSCONFIG_LOG_HANDLE log)
 static char g_logTime[TIME_FORMAT_STRING_LENGTH] = {0};
 
 // Returns the local date/time formatted as YYYY-MM-DD HH:MM:SS (for example: 2014-03-19 11:11:52)
-char* GetFormattedTime()
+char* GetFormattedTime(void)
 {
     time_t rawTime = {0};
     struct tm* timeInfo = NULL;

--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -26,8 +26,8 @@ extern "C"
 #endif
 
 // Matching the severity values in RFC 5424. Currently we only use 2 values from this enumeration:
-// - LoggingLevelInformational (6) is default and has [INFO] and [ERROR] labels
-// - LoggingLevelDebug (7) is optional, has the [DEBUG] label, and is managed via the 'DebugLogging' entry in osconfig.json configuration
+// - LoggingLevelInformational (6) uses [INFO] and [ERROR] labels and is always enabled by default
+// - LoggingLevelDebug (7) is optional, uses the [DEBUG] label, and is managed via the 'DebugLogging' entry in the osconfig.json configuration
 enum LoggingLevel
 {
     LoggingLevelEmergency = 0,
@@ -54,10 +54,10 @@ bool IsDaemon(void);
 
 #define __PREFIX_TEMPLATE__ "[%s][%s][%s:%d] "
 #define __SHORT_FILE__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define __LOG__(log, loglevel, format, ...) printf(__PREFIX_TEMPLATE__ format "\n", GetFormattedTime(), loglevel, __SHORT_FILE__, __LINE__, ## __VA_ARGS__)
-#define __LOG_TO_FILE__(log, loglevel, format, ...) {\
+#define __LOG__(log, label, format, ...) printf(__PREFIX_TEMPLATE__ format "\n", GetFormattedTime(), label, __SHORT_FILE__, __LINE__, ## __VA_ARGS__)
+#define __LOG_TO_FILE__(log, label, format, ...) {\
     TrimLog(log);\
-    fprintf(GetLogFile(log), __PREFIX_TEMPLATE__ format "\n", GetFormattedTime(), loglevel, __SHORT_FILE__, __LINE__, ## __VA_ARGS__); \
+    fprintf(GetLogFile(log), __PREFIX_TEMPLATE__ format "\n", GetFormattedTime(), label, __SHORT_FILE__, __LINE__, ## __VA_ARGS__); \
 }\
 
 #define __INFO__ "INFO"
@@ -98,7 +98,7 @@ bool IsDaemon(void);
             OSCONFIG_FILE_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
             fflush(GetLogFile(log));\
         }\
-        if ((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) {\
+        if (false == IsDaemon()) {\
             OSCONFIG_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
         }\
     }\

--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -48,7 +48,7 @@ bool IsDebugLoggingEnabled(void);
 void SetDebugLogging(bool fullLogging);
 
 FILE* GetLogFile(OSCONFIG_LOG_HANDLE log);
-char* GetFormattedTime();
+char* GetFormattedTime(void);
 void TrimLog(OSCONFIG_LOG_HANDLE log);
 bool IsDaemon(void);
 

--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -31,11 +31,11 @@ enum LoggingLevel
     LoggingLevelEmergency = 0,
     LoggingLevelAlert = 1,
     LoggingLevelCritical = 2,
-    LoggingLevelError = 3, //used for default error logging
+    LoggingLevelError = 3,
     LoggingLevelWarning = 4,
     LoggingLevelNotice = 5,
-    LoggingLevelInformational = 6, //used for default informational logging
-    LoggingLevelDebug = 7 //used for CommandLogging and DebugLogging
+    LoggingLevelInformational = 6,
+    LoggingLevelDebug = 7
 };
 typedef enum LoggingLevel LoggingLevel;
 

--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -25,7 +25,9 @@ extern "C"
 {
 #endif
 
-// Matching the severity values in RFC 5424 
+// Matching the severity values in RFC 5424. Currently we only use 2 values from this enumeration:
+// - LoggingLevelInformational (6) is default and has [INFO] and [ERROR] labels
+// - LoggingLevelDebug (7) is optional, has the [DEBUG] label, and is managed via the 'DebugLogging' entry in osconfig.json configuration
 enum LoggingLevel
 {
     LoggingLevelEmergency = 0,

--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -25,11 +25,25 @@ extern "C"
 {
 #endif
 
+// Matching the severity values in RFC 5424 
+enum LoggingLevel
+{
+    LoggingLevelEmergency = 0,
+    LoggingLevelAlert = 1,
+    LoggingLevelCritical = 2,
+    LoggingLevelError = 3, //used for default error logging
+    LoggingLevelWarning = 4,
+    LoggingLevelNotice = 5,
+    LoggingLevelInformational = 6, //used for default informational logging
+    LoggingLevelDebug = 7 //used for CommandLogging and DebugLogging
+};
+typedef enum LoggingLevel LoggingLevel;
+
 OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName);
 void CloseLog(OSCONFIG_LOG_HANDLE* log);
 
-void SetFullLogging(bool fullLogging);
-bool IsFullLoggingEnabled(void);
+bool IsDebugLoggingEnabled(void);
+void SetDebugLogging(bool fullLogging);
 
 FILE* GetLogFile(OSCONFIG_LOG_HANDLE log);
 char* GetFormattedTime();
@@ -61,7 +75,7 @@ bool IsDaemon(void);
         OSCONFIG_FILE_LOG_INFO(log, FORMAT, ##__VA_ARGS__);\
         fflush(GetLogFile(log));\
     }\
-    if ((false == IsDaemon()) || (false == IsFullLoggingEnabled())) {\
+    if ((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) {\
         OSCONFIG_LOG_INFO(log, FORMAT, ##__VA_ARGS__);\
     }\
 }\
@@ -71,18 +85,20 @@ bool IsDaemon(void);
         OSCONFIG_FILE_LOG_ERROR(log, FORMAT, ##__VA_ARGS__);\
         fflush(GetLogFile(log));\
     }\
-    if ((false == IsDaemon()) || (false == IsFullLoggingEnabled())) {\
+    if ((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) {\
         OSCONFIG_LOG_ERROR(log, FORMAT, ##__VA_ARGS__);\
     }\
 }\
 
 #define OsConfigLogDebug(log, FORMAT, ...) {\
-    if (NULL != GetLogFile(log)) {\
-        OSCONFIG_FILE_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
-        fflush(GetLogFile(log));\
-    }\
-    if ((false == IsDaemon()) || (false == IsFullLoggingEnabled())) {\
-        OSCONFIG_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
+    if (true == IsDebugLoggingEnabled()) {\
+        if (NULL != GetLogFile(log)) {\
+            OSCONFIG_FILE_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
+            fflush(GetLogFile(log));\
+        }\
+        if ((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) {\
+            OSCONFIG_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
+        }\
     }\
 }\
 

--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -112,9 +112,9 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
                 OsConfigLogError(log, "CallMpi(%s): failed to send request to socket '%s' of %d bytes (%d)", name, mpiSocket, actualDataSize, status);
             }
         }
-        else if (IsDebugLoggingEnabled())
+        else
         {
-            OsConfigLogInfo(log, "CallMpi(%s): sent to '%s' '%s' (%d bytes)", name, mpiSocket, data, actualDataSize);
+            OsConfigLogDebug(log, "CallMpi(%s): sent to '%s' '%s' (%d bytes)", name, mpiSocket, data, actualDataSize);
         }
     }
 
@@ -153,11 +153,7 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
         close(socketHandle);
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CallMpi(name: '%s', request: '%s', response: '%s', response size: %d bytes) to socket '%s' returned %d",
-            name, request, *response, *responseSize, mpiSocket, status);
-    }
+    OsConfigLogDebug(log, "CallMpi(name: '%s', request: '%s', response: '%s', response size: %d bytes) to socket '%s' returned %d", name, request, *response, *responseSize, mpiSocket, status);
 
     return status;
 }
@@ -332,7 +328,7 @@ int CallMpiSet(const char* componentName, const char* propertyName, const MPI_JS
 
     if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(log, "CallMpiSet(%p, %s, %s, %.*s, %d bytes) returned %d", g_mpiHandle, componentName, propertyName, payloadSizeBytes, payload, payloadSizeBytes, status);
+        OsConfigLogDebug(log, "CallMpiSet(%p, %s, %s, %.*s, %d bytes) returned %d", g_mpiHandle, componentName, propertyName, payloadSizeBytes, payload, payloadSizeBytes, status);
     }
     else
     {
@@ -411,10 +407,7 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
         *payloadSizeBytes = 0;
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CallMpiGet(%p, %s, %s, %.*s, %d bytes): %d", g_mpiHandle, componentName, propertyName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(log, "CallMpiGet(%p, %s, %s, %.*s, %d bytes): %d", g_mpiHandle, componentName, propertyName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     return status;
 };
@@ -470,7 +463,7 @@ int CallMpiSetDesired(const MPI_JSON_STRING payload, const int payloadSizeBytes,
 
     if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(log, "CallMpiSetDesired(%p, %.*s, %d bytes) returned %d", g_mpiHandle, payloadSizeBytes, payload, payloadSizeBytes, status);
+        OsConfigLogDebug(log, "CallMpiSetDesired(%p, %.*s, %d bytes) returned %d", g_mpiHandle, payloadSizeBytes, payload, payloadSizeBytes, status);
     }
     else
     {
@@ -550,10 +543,7 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes, OSCONFIG
         *payloadSizeBytes = 0;
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(log, "CallMpiGetReported(%p, %.*s, %d bytes): %d", g_mpiHandle, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(log, "CallMpiGetReported(%p, %.*s, %d bytes): %d", g_mpiHandle, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     return status;
 }

--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -47,9 +47,9 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
     *response = NULL;
     *responseSize = 0;
 
-    if (0 != (status = CheckFileAccess(mpiSocket, 0, 0, 06770, NULL, IsFullLoggingEnabled() ? log : NULL)))
+    if (0 != (status = CheckFileAccess(mpiSocket, 0, 0, 06770, NULL, IsDebugLoggingEnabled() ? log : NULL)))
     {
-        if (0 != (status = SetFileAccess(mpiSocket, 0, 0, 06770, IsFullLoggingEnabled() ? log : NULL)))
+        if (0 != (status = SetFileAccess(mpiSocket, 0, 0, 06770, IsDebugLoggingEnabled() ? log : NULL)))
         {
             OsConfigLogError(log, "CallMpi(%s): access to the MPI socket is not protected, cannot call the MPI (%d)", name, status);
             return status;
@@ -103,7 +103,7 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
         if (bytes != actualDataSize)
         {
             status = errno ? errno : EIO;
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(log, "CallMpi(%s): failed to send request '%s' (%d bytes) to socket '%s' (%d)", name, data, actualDataSize, mpiSocket, status);
             }
@@ -112,7 +112,7 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
                 OsConfigLogError(log, "CallMpi(%s): failed to send request to socket '%s' of %d bytes (%d)", name, mpiSocket, actualDataSize, status);
             }
         }
-        else if (IsFullLoggingEnabled())
+        else if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(log, "CallMpi(%s): sent to '%s' '%s' (%d bytes)", name, mpiSocket, data, actualDataSize);
         }
@@ -133,7 +133,7 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
 
             if (*responseSize != read(socketHandle, *response, *responseSize))
             {
-                if ((MPI_OK == status) || IsFullLoggingEnabled())
+                if ((MPI_OK == status) || IsDebugLoggingEnabled())
                 {
                     OsConfigLogError(log, "CallMpi(%s): failed to read %d bytes response from socket '%s' (%d)", name, *responseSize, mpiSocket, status);
                 }
@@ -153,7 +153,7 @@ static int CallMpi(const char* name, const char* request, char** response, int* 
         close(socketHandle);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CallMpi(name: '%s', request: '%s', response: '%s', response size: %d bytes) to socket '%s' returned %d",
             name, request, *response, *responseSize, mpiSocket, status);
@@ -330,7 +330,7 @@ int CallMpiSet(const char* componentName, const char* propertyName, const MPI_JS
         FREE_MEMORY(statusFromResponse);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CallMpiSet(%p, %s, %s, %.*s, %d bytes) returned %d", g_mpiHandle, componentName, propertyName, payloadSizeBytes, payload, payloadSizeBytes, status);
     }
@@ -411,7 +411,7 @@ int CallMpiGet(const char* componentName, const char* propertyName, MPI_JSON_STR
         *payloadSizeBytes = 0;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CallMpiGet(%p, %s, %s, %.*s, %d bytes): %d", g_mpiHandle, componentName, propertyName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
@@ -468,7 +468,7 @@ int CallMpiSetDesired(const MPI_JSON_STRING payload, const int payloadSizeBytes,
         FREE_MEMORY(statusFromResponse);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CallMpiSetDesired(%p, %.*s, %d bytes) returned %d", g_mpiHandle, payloadSizeBytes, payload, payloadSizeBytes, status);
     }
@@ -550,7 +550,7 @@ int CallMpiGetReported(MPI_JSON_STRING* payload, int* payloadSizeBytes, OSCONFIG
         *payloadSizeBytes = 0;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(log, "CallMpiGetReported(%p, %.*s, %d bytes): %d", g_mpiHandle, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1286,8 +1286,7 @@ TEST_F(CommonUtilsTest, LoadConfiguration)
 {
     const char* configuration =
         "{"
-          "\"CommandLogging\": 0,"
-          "\"FullLogging\": 1,"
+          "\"DebugLogging\": 1,"
           "\"GitManagement\": 1,"
           "\"GitRepositoryUrl\": \"https://USERNAME:PASSWORD@github.com/Azure/azure-osconfig\","
           "\"GitBranch\": \"foo/test\","
@@ -1311,8 +1310,7 @@ TEST_F(CommonUtilsTest, LoadConfiguration)
 
     char* value = nullptr;
 
-    EXPECT_FALSE(IsCommandLoggingEnabledInJsonConfig(configuration));
-    EXPECT_TRUE(IsFullLoggingEnabledInJsonConfig(configuration));
+    EXPECT_TRUE(IsDebugLoggingEnabledInJsonConfig(configuration));
     EXPECT_EQ(30, GetReportingIntervalFromJsonConfig(configuration, nullptr));
     EXPECT_EQ(11, GetModelVersionFromJsonConfig(configuration, nullptr));
     EXPECT_EQ(2, GetIotHubProtocolFromJsonConfig(configuration, nullptr));

--- a/src/modules/adhs/src/lib/Adhs.c
+++ b/src/modules/adhs/src/lib/Adhs.c
@@ -133,7 +133,7 @@ int AdhsMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloa
         status = ENOMEM;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(AdhsGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
@@ -208,7 +208,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
 
                     if (NULL == value)
                     {
-                        if (IsFullLoggingEnabled())
+                        if (IsDebugLoggingEnabled())
                         {
                             OsConfigLogError(AdhsGetLog(), "MmiGet failed to find valid TOML property '%s'", g_permissionConfigName);
                         }
@@ -217,7 +217,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
                 }
                 else
                 {
-                    if (IsFullLoggingEnabled())
+                    if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogError(AdhsGetLog(), "MmiGet failed to find TOML property '%s'", g_permissionConfigName);
                     }
@@ -234,7 +234,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(AdhsGetLog(), "MmiGet failed to read TOML file '%s'", g_adhsConfigFile);
             }
@@ -270,7 +270,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
         }
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(AdhsGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }

--- a/src/modules/adhs/src/lib/Adhs.c
+++ b/src/modules/adhs/src/lib/Adhs.c
@@ -133,10 +133,7 @@ int AdhsMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloa
         status = ENOMEM;
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(AdhsGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(AdhsGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     return status;
 }
@@ -270,10 +267,7 @@ int AdhsMmiGet(MMI_HANDLE clientSession, const char* componentName, const char* 
         }
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(AdhsGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(AdhsGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     FREE_MEMORY(fileContent);
 

--- a/src/modules/commandrunner/src/lib/CommandRunner.cpp
+++ b/src/modules/commandrunner/src/lib/CommandRunner.cpp
@@ -149,7 +149,7 @@ int CommandRunner::Set(const char* componentName, const char* objectName, const 
                     if ((m_commandMap.find(arguments.m_id) != m_commandMap.end()) && (m_commandMap[arguments.m_id]->GetId() == m_commandIdLoadedFromDisk))
                     {
                         OsConfigLogDebug(CommandRunnerLog::Get(), "Updating command (%s) loaded from disk, with complete payload", arguments.m_id.c_str());
- 
+
                         // Update the partial command loaded from the persisted cache
                         Command::Status currentStatus = m_commandMap[arguments.m_id]->GetStatus();
 

--- a/src/modules/commandrunner/src/lib/CommandRunner.cpp
+++ b/src/modules/commandrunner/src/lib/CommandRunner.cpp
@@ -148,7 +148,7 @@ int CommandRunner::Set(const char* componentName, const char* objectName, const 
                     std::lock_guard<std::mutex> lock(m_cacheMutex);
                     if ((m_commandMap.find(arguments.m_id) != m_commandMap.end()) && (m_commandMap[arguments.m_id]->GetId() == m_commandIdLoadedFromDisk))
                     {
-                        if (IsFullLoggingEnabled())
+                        if (IsDebugLoggingEnabled())
                         {
                             OsConfigLogInfo(CommandRunnerLog::Get(), "Updating command (%s) loaded from disk, with complete payload", arguments.m_id.c_str());
                         }
@@ -381,7 +381,7 @@ int CommandRunner::ScheduleCommand(std::shared_ptr<Command> command)
             status = EINVAL;
         }
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(CommandRunnerLog::Get(), "Command already recieved: %s (%s)", command->GetId().c_str(), command->m_arguments.c_str());
     }
@@ -464,7 +464,7 @@ void CommandRunner::WorkerThread(CommandRunner& instance)
     {
         int exitCode = command->Execute(instance.m_maxPayloadSizeBytes);
 
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(CommandRunnerLog::Get(), "Command '%s' (%s) completed with code: %d", command->GetId().c_str(), command->m_arguments.c_str(), exitCode);
         }
@@ -533,7 +533,7 @@ int CommandRunner::LoadPersistedCommandStatus(const std::string& clientName)
                 }
             }
         }
-        else if (IsFullLoggingEnabled())
+        else if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(CommandRunnerLog::Get(), "Cache file does not contain a status for client: %s", clientName.c_str());
         }

--- a/src/modules/commandrunner/src/lib/CommandRunner.cpp
+++ b/src/modules/commandrunner/src/lib/CommandRunner.cpp
@@ -148,11 +148,8 @@ int CommandRunner::Set(const char* componentName, const char* objectName, const 
                     std::lock_guard<std::mutex> lock(m_cacheMutex);
                     if ((m_commandMap.find(arguments.m_id) != m_commandMap.end()) && (m_commandMap[arguments.m_id]->GetId() == m_commandIdLoadedFromDisk))
                     {
-                        if (IsDebugLoggingEnabled())
-                        {
-                            OsConfigLogInfo(CommandRunnerLog::Get(), "Updating command (%s) loaded from disk, with complete payload", arguments.m_id.c_str());
-                        }
-
+                        OsConfigLogDebug(CommandRunnerLog::Get(), "Updating command (%s) loaded from disk, with complete payload", arguments.m_id.c_str());
+ 
                         // Update the partial command loaded from the persisted cache
                         Command::Status currentStatus = m_commandMap[arguments.m_id]->GetStatus();
 
@@ -381,9 +378,9 @@ int CommandRunner::ScheduleCommand(std::shared_ptr<Command> command)
             status = EINVAL;
         }
     }
-    else if (IsDebugLoggingEnabled())
+    else
     {
-        OsConfigLogInfo(CommandRunnerLog::Get(), "Command already recieved: %s (%s)", command->GetId().c_str(), command->m_arguments.c_str());
+        OsConfigLogDebug(CommandRunnerLog::Get(), "Command already recieved: %s (%s)", command->GetId().c_str(), command->m_arguments.c_str());
     }
 
     return status;
@@ -466,7 +463,7 @@ void CommandRunner::WorkerThread(CommandRunner& instance)
 
         if (IsDebugLoggingEnabled())
         {
-            OsConfigLogInfo(CommandRunnerLog::Get(), "Command '%s' (%s) completed with code: %d", command->GetId().c_str(), command->m_arguments.c_str(), exitCode);
+            OsConfigLogDebug(CommandRunnerLog::Get(), "Command '%s' (%s) completed with code: %d", command->GetId().c_str(), command->m_arguments.c_str(), exitCode);
         }
         else
         {
@@ -533,9 +530,9 @@ int CommandRunner::LoadPersistedCommandStatus(const std::string& clientName)
                 }
             }
         }
-        else if (IsDebugLoggingEnabled())
+        else
         {
-            OsConfigLogInfo(CommandRunnerLog::Get(), "Cache file does not contain a status for client: %s", clientName.c_str());
+            OsConfigLogDebug(CommandRunnerLog::Get(), "Cache file does not contain a status for client: %s", clientName.c_str());
         }
     }
 

--- a/src/modules/commandrunner/src/so/CommandRunnerModule.cpp
+++ b/src/modules/commandrunner/src/so/CommandRunnerModule.cpp
@@ -34,7 +34,7 @@ int MmiGetInfo(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(CommandRunnerLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -45,7 +45,7 @@ int MmiGetInfo(
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(CommandRunnerLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -125,14 +125,14 @@ int MmiSet(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(CommandRunnerLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(CommandRunnerLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
@@ -169,7 +169,7 @@ int MmiGet(
 
     ScopeGuard sg{[&]()
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {

--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -352,11 +352,8 @@ int ConfigurationMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, in
         status = ENOMEM;
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(ConfigurationGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
-
+    OsConfigLogDebug(ConfigurationGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
+ 
     return status;
 }
 
@@ -480,10 +477,7 @@ int ConfigurationMmiGet(MMI_HANDLE clientSession, const char* componentName, con
         }
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(ConfigurationGetLog(), "MmiGet(%p, %s, %s, '%.*s', %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(ConfigurationGetLog(), "MmiGet(%p, %s, %s, '%.*s', %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     if (NULL != serializedValue)
     {
@@ -635,7 +629,7 @@ int ConfigurationMmiSet(MMI_HANDLE clientSession, const char* componentName, con
 
     if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(ConfigurationGetLog(), "MmiSet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
+        OsConfigLogDebug(ConfigurationGetLog(), "MmiSet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
     }
     else
     {

--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -151,7 +151,6 @@ static int UpdateConfigurationFile(void)
     int refreshInterval = g_refreshInterval;
     bool localManagementEnabled = g_localManagementEnabled;
     bool debugLoggingEnabled = g_debugLoggingEnabled;
-    bool commandLoggingEnabled = g_commandLoggingEnabled;
     bool iotHubManagementEnabled = g_iotHubManagementEnabled;
     int iotHubProtocol = g_iotHubProtocol;
     bool gitManagementEnabled = g_gitManagementEnabled;
@@ -405,10 +404,6 @@ int ConfigurationMmiGet(MMI_HANDLE clientSession, const char* componentName, con
         else if (0 == strcmp(objectName, g_debugLoggingEnabledObject))
         {
             jsonValue = json_value_init_boolean(g_debugLoggingEnabled ? 1 : 0);
-        }
-        else if (0 == strcmp(objectName, g_commandLoggingEnabledObject))
-        {
-            jsonValue = json_value_init_boolean(g_commandLoggingEnabled ? 1 : 0);
         }
         else if (0 == strcmp(objectName, g_iotHubManagementEnabledObject))
         {

--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -21,8 +21,7 @@ static const char* g_configurationComponentName = "Configuration";
 static const char* g_modelVersionObject = "modelVersion";
 static const char* g_refreshIntervalObject = "refreshInterval";
 static const char* g_localManagementEnabledObject = "localManagementEnabled";
-static const char* g_fullLoggingEnabledObject = "fullLoggingEnabled";
-static const char* g_commandLoggingEnabledObject = "commandLoggingEnabled";
+static const char* g_debugLoggingEnabledObject = "debugLoggingEnabled";
 static const char* g_iotHubManagementEnabledObject = "iotHubManagementEnabled";
 static const char* g_iotHubProtocolObject = "iotHubProtocol";
 static const char* g_gitManagementEnabledObject = "gitManagementEnabled";
@@ -30,8 +29,7 @@ static const char* g_gitBranchObject = "gitBranch";
 
 static const char* g_desiredRefreshIntervalObject = "desiredRefreshInterval";
 static const char* g_desiredLocalManagementEnabledObject = "desiredLocalManagementEnabled";
-static const char* g_desiredFullLoggingEnabledObject = "desiredFullLoggingEnabled";
-static const char* g_desiredCommandLoggingEnabledObject = "desiredCommandLoggingEnabled";
+static const char* g_desiredDebugLoggingEnabledObject = "desiredDebugLoggingEnabled";
 static const char* g_desiredIotHubManagementEnabledObject = "desiredIotHubManagementEnabled";
 static const char* g_desiredIotHubProtocolObject = "desiredIotHubProtocol";
 static const char* g_desiredGitManagementEnabledObject = "desiredGitManagementEnabled";
@@ -64,8 +62,7 @@ static OSCONFIG_LOG_HANDLE g_log = NULL;
 static int g_modelVersion = DEFAULT_DEVICE_MODEL_ID;
 static int g_refreshInterval = DEFAULT_REPORTING_INTERVAL;
 static bool g_localManagementEnabled = false;
-static bool g_fullLoggingEnabled = false;
-static bool g_commandLoggingEnabled = false;
+static bool g_debugLoggingEnabled = false;
 static bool g_iotHubManagementEnabled = false;
 static int g_iotHubProtocol = 0;
 static bool g_gitManagementEnabled = false;
@@ -93,8 +90,7 @@ static char* LoadConfigurationFromFile(const char* fileName)
         g_modelVersion = GetModelVersionFromJsonConfig(jsonConfiguration, ConfigurationGetLog());
         g_refreshInterval = GetReportingIntervalFromJsonConfig(jsonConfiguration, ConfigurationGetLog());
         g_localManagementEnabled = (GetLocalManagementFromJsonConfig(jsonConfiguration, ConfigurationGetLog())) ? true : false;
-        g_fullLoggingEnabled = IsFullLoggingEnabledInJsonConfig(jsonConfiguration);
-        g_commandLoggingEnabled = IsCommandLoggingEnabledInJsonConfig(jsonConfiguration);
+        g_debugLoggingEnabled = IsDebugLoggingEnabledInJsonConfig(jsonConfiguration);
         g_iotHubManagementEnabled = IsIotHubManagementEnabledInJsonConfig(jsonConfiguration);
         g_iotHubProtocol = GetIotHubProtocolFromJsonConfig(jsonConfiguration, ConfigurationGetLog());
         g_gitManagementEnabled = GetGitManagementFromJsonConfig(jsonConfiguration, ConfigurationGetLog());
@@ -137,8 +133,7 @@ void ConfigurationShutdown(void)
 
 static int UpdateConfigurationFile(void)
 {
-    const char* commandLoggingEnabledName = "CommandLogging";
-    const char* fullLoggingEnabledName = "FullLogging";
+    const char* debugLoggingEnabledName = "DebugLogging";
     const char* localManagementEnabledName = "LocalManagement";
     const char* modelVersionName = "ModelVersion";
     const char* iotHubtManagementEnabledName = "IotHubManagement";
@@ -155,7 +150,7 @@ static int UpdateConfigurationFile(void)
     int modelVersion = g_modelVersion;
     int refreshInterval = g_refreshInterval;
     bool localManagementEnabled = g_localManagementEnabled;
-    bool fullLoggingEnabled = g_fullLoggingEnabled;
+    bool debugLoggingEnabled = g_debugLoggingEnabled;
     bool commandLoggingEnabled = g_commandLoggingEnabled;
     bool iotHubManagementEnabled = g_iotHubManagementEnabled;
     int iotHubProtocol = g_iotHubProtocol;
@@ -172,7 +167,7 @@ static int UpdateConfigurationFile(void)
     }
 
     if ((modelVersion != g_modelVersion) || (refreshInterval != g_refreshInterval) || (localManagementEnabled != g_localManagementEnabled) ||
-        (fullLoggingEnabled != g_fullLoggingEnabled) || (commandLoggingEnabled != g_commandLoggingEnabled) ||
+        (debugLoggingEnabled != g_debugLoggingEnabled) || (commandLoggingEnabled != g_commandLoggingEnabled) ||
         (iotHubManagementEnabled != g_iotHubManagementEnabled) || (iotHubProtocol != g_iotHubProtocol) ||
         (gitManagementEnabled != g_gitManagementEnabled) || strcmp(gitBranch, g_gitBranch))
     {
@@ -216,22 +211,13 @@ static int UpdateConfigurationFile(void)
                 OsConfigLogError(ConfigurationGetLog(), "json_object_set_boolean(%s, %s) failed", g_localManagementEnabledObject, localManagementEnabled ? "true" : "false");
             }
 
-            if (JSONSuccess == json_object_set_number(jsonObject, fullLoggingEnabledName, (double)(fullLoggingEnabled ? 1: 0)))
+            if (JSONSuccess == json_object_set_number(jsonObject, debugLoggingEnabledName, (double)(debugLoggingEnabled ? 1: 0)))
             {
-                g_fullLoggingEnabled = fullLoggingEnabled;
+                g_debugLoggingEnabled = debugLoggingEnabled;
             }
             else
             {
-                OsConfigLogError(ConfigurationGetLog(), "json_object_set_boolean(%s, %s) failed", g_fullLoggingEnabledObject, fullLoggingEnabled ? "true" : "false");
-            }
-
-            if (JSONSuccess == json_object_set_number(jsonObject, commandLoggingEnabledName, (double)(commandLoggingEnabled ? 1 : 0)))
-            {
-                g_commandLoggingEnabled = commandLoggingEnabled;
-            }
-            else
-            {
-                OsConfigLogError(ConfigurationGetLog(), "json_object_set_boolean(%s, %s) failed", g_commandLoggingEnabledObject, commandLoggingEnabled ? "true" : "false");
+                OsConfigLogError(ConfigurationGetLog(), "json_object_set_boolean(%s, %s) failed", g_debugLoggingEnabledObject, debugLoggingEnabled ? "true" : "false");
             }
 
             if (JSONSuccess == json_object_set_number(jsonObject, iotHubtManagementEnabledName, (double)(iotHubManagementEnabled ? 1 : 0)))
@@ -292,11 +278,11 @@ static int UpdateConfigurationFile(void)
 
     if (MMI_OK == status)
     {
-        OsConfigLogInfo(ConfigurationGetLog(), "New configuration successfully applied: %s", IsFullLoggingEnabled() ? newConfiguration : "-");
+        OsConfigLogInfo(ConfigurationGetLog(), "New configuration successfully applied: %s", IsDebugLoggingEnabled() ? newConfiguration : "-");
     }
     else
     {
-        OsConfigLogError(ConfigurationGetLog(), "Failed to apply new configuration: %s", IsFullLoggingEnabled() ? newConfiguration : "-");
+        OsConfigLogError(ConfigurationGetLog(), "Failed to apply new configuration: %s", IsDebugLoggingEnabled() ? newConfiguration : "-");
     }
 
     if (jsonValue)
@@ -368,7 +354,7 @@ int ConfigurationMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, in
         status = ENOMEM;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(ConfigurationGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
@@ -416,9 +402,9 @@ int ConfigurationMmiGet(MMI_HANDLE clientSession, const char* componentName, con
         {
             jsonValue = json_value_init_boolean(g_localManagementEnabled ? 1 : 0);
         }
-        else if (0 == strcmp(objectName, g_fullLoggingEnabledObject))
+        else if (0 == strcmp(objectName, g_debugLoggingEnabledObject))
         {
-            jsonValue = json_value_init_boolean(g_fullLoggingEnabled ? 1 : 0);
+            jsonValue = json_value_init_boolean(g_debugLoggingEnabled ? 1 : 0);
         }
         else if (0 == strcmp(objectName, g_commandLoggingEnabledObject))
         {
@@ -500,7 +486,7 @@ int ConfigurationMmiGet(MMI_HANDLE clientSession, const char* componentName, con
         }
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(ConfigurationGetLog(), "MmiGet(%p, %s, %s, '%.*s', %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
@@ -561,13 +547,9 @@ int ConfigurationMmiSet(MMI_HANDLE clientSession, const char* componentName, con
                 {
                     g_localManagementEnabled = (0 == json_value_get_boolean(jsonValue)) ? false : true;
                 }
-                else if (0 == strcmp(objectName, g_desiredFullLoggingEnabledObject))
+                else if (0 == strcmp(objectName, g_desiredDebugLoggingEnabledObject))
                 {
-                    g_fullLoggingEnabled = (0 == json_value_get_boolean(jsonValue)) ? false : true;
-                }
-                else if (0 == strcmp(objectName, g_desiredCommandLoggingEnabledObject))
-                {
-                    g_commandLoggingEnabled = (0 == json_value_get_boolean(jsonValue)) ? false : true;
+                    g_debugLoggingEnabled = (0 == json_value_get_boolean(jsonValue)) ? false : true;
                 }
                 else if (0 == strcmp(objectName, g_desiredIotHubManagementEnabledObject))
                 {
@@ -657,7 +639,7 @@ int ConfigurationMmiSet(MMI_HANDLE clientSession, const char* componentName, con
 
     FREE_MEMORY(payloadString);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(ConfigurationGetLog(), "MmiSet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
     }

--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -166,8 +166,7 @@ static int UpdateConfigurationFile(void)
     }
 
     if ((modelVersion != g_modelVersion) || (refreshInterval != g_refreshInterval) || (localManagementEnabled != g_localManagementEnabled) ||
-        (debugLoggingEnabled != g_debugLoggingEnabled) || (commandLoggingEnabled != g_commandLoggingEnabled) ||
-        (iotHubManagementEnabled != g_iotHubManagementEnabled) || (iotHubProtocol != g_iotHubProtocol) ||
+        (debugLoggingEnabled != g_debugLoggingEnabled) || (iotHubManagementEnabled != g_iotHubManagementEnabled) || (iotHubProtocol != g_iotHubProtocol) ||
         (gitManagementEnabled != g_gitManagementEnabled) || strcmp(gitBranch, g_gitBranch))
     {
         if (NULL == (jsonValue = json_parse_string(existingConfiguration)))

--- a/src/modules/configuration/src/lib/Configuration.c
+++ b/src/modules/configuration/src/lib/Configuration.c
@@ -353,7 +353,7 @@ int ConfigurationMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, in
     }
 
     OsConfigLogDebug(ConfigurationGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
- 
+
     return status;
 }
 

--- a/src/modules/configuration/tests/ConfigurationTests.cpp
+++ b/src/modules/configuration/tests/ConfigurationTests.cpp
@@ -28,7 +28,7 @@ class ConfigurationTest : public ::testing::Test
         const char* m_modelVersionObject = "modelVersion";
         const char* m_refreshIntervalObject = "refreshInterval";
         const char* m_localManagementEnabledObject = "localManagementEnabled";
-        const char* m_fullLoggingEnabledObject = "fullLoggingEnabled";
+        const char* m_debugLoggingEnabledObject = "debugLoggingEnabled";
         const char* m_commandLoggingEnabledObject = "commandLoggingEnabled";
         const char* m_iotHubManagementEnabledObject = "iotHubManagementEnabled";
         const char* m_iotHubProtocolObject = "iotHubProtocol";
@@ -37,7 +37,7 @@ class ConfigurationTest : public ::testing::Test
 
         const char* m_desiredRefreshIntervalObject = "desiredRefreshInterval";
         const char* m_desiredLocalManagementEnabledObject = "desiredLocalManagementEnabled";
-        const char* m_desiredFullLoggingEnabledObject = "desiredFullLoggingEnabled";
+        const char* m_desiredDebugLoggingEnabledObject = "desiredDebugLoggingEnabled";
         const char* m_desiredCommandLoggingEnabledObject = "desiredCommandLoggingEnabled";
         const char* m_desiredIotHubManagementEnabledObject = "desiredIotHubManagementEnabled";
         const char* m_desiredIotHubProtocolObject = "desiredIotHubProtocol";
@@ -46,8 +46,7 @@ class ConfigurationTest : public ::testing::Test
 
         const char* m_testConfiguration =
             "{"
-                "\"CommandLogging\": 0,"
-                "\"FullLogging\" : 0,"
+                "\"DebugLogging\" : 0,"
                 "\"LocalManagement\" : 0,"
                 "\"ModelVersion\" : 15,"
                 "\"IotHubManagement\" : 0,"
@@ -130,7 +129,7 @@ TEST_F(ConfigurationTest, MmiGet)
         m_modelVersionObject,
         m_refreshIntervalObject,
         m_localManagementEnabledObject,
-        m_fullLoggingEnabledObject,
+        m_debugLoggingEnabledObject,
         m_commandLoggingEnabledObject,
         m_iotHubManagementEnabledObject,
         m_iotHubProtocolObject,
@@ -167,7 +166,7 @@ TEST_F(ConfigurationTest, MmiGetTruncatedPayload)
         m_modelVersionObject,
         m_refreshIntervalObject,
         m_localManagementEnabledObject,
-        m_fullLoggingEnabledObject,
+        m_debugLoggingEnabledObject,
         m_commandLoggingEnabledObject,
         m_iotHubManagementEnabledObject,
         m_iotHubProtocolObject,
@@ -262,9 +261,9 @@ TEST_F(ConfigurationTest, MmiSet)
         { m_desiredLocalManagementEnabledObject, "true", 0, m_localManagementEnabledObject, "true" },
         { m_desiredLocalManagementEnabledObject, "false", 0, m_localManagementEnabledObject, "false" },
         { m_desiredLocalManagementEnabledObject, "notImplemented", 22, m_localManagementEnabledObject, "false" },
-        { m_desiredFullLoggingEnabledObject, "true", 0, m_fullLoggingEnabledObject, "true" },
-        { m_desiredFullLoggingEnabledObject, "false", 0, m_fullLoggingEnabledObject, "false" },
-        { m_desiredFullLoggingEnabledObject, "notImplemented", 22, m_fullLoggingEnabledObject, "false" },
+        { m_desiredDebugLoggingEnabledObject, "true", 0, m_debugLoggingEnabledObject, "true" },
+        { m_desiredDebugLoggingEnabledObject, "false", 0, m_debugLoggingEnabledObject, "false" },
+        { m_desiredDebugLoggingEnabledObject, "notImplemented", 22, m_debugLoggingEnabledObject, "false" },
         { m_desiredCommandLoggingEnabledObject, "true", 0, m_commandLoggingEnabledObject, "true" },
         { m_desiredCommandLoggingEnabledObject, "false", 0, m_commandLoggingEnabledObject, "false" },
         { m_desiredCommandLoggingEnabledObject, "notImplemented", 22, m_commandLoggingEnabledObject, "false" },

--- a/src/modules/configuration/tests/ConfigurationTests.cpp
+++ b/src/modules/configuration/tests/ConfigurationTests.cpp
@@ -29,7 +29,6 @@ class ConfigurationTest : public ::testing::Test
         const char* m_refreshIntervalObject = "refreshInterval";
         const char* m_localManagementEnabledObject = "localManagementEnabled";
         const char* m_debugLoggingEnabledObject = "debugLoggingEnabled";
-        const char* m_commandLoggingEnabledObject = "commandLoggingEnabled";
         const char* m_iotHubManagementEnabledObject = "iotHubManagementEnabled";
         const char* m_iotHubProtocolObject = "iotHubProtocol";
         const char* m_gitManagementEnabledObject = "gitManagementEnabled";
@@ -130,7 +129,6 @@ TEST_F(ConfigurationTest, MmiGet)
         m_refreshIntervalObject,
         m_localManagementEnabledObject,
         m_debugLoggingEnabledObject,
-        m_commandLoggingEnabledObject,
         m_iotHubManagementEnabledObject,
         m_iotHubProtocolObject,
         m_gitManagementEnabledObject,
@@ -167,7 +165,6 @@ TEST_F(ConfigurationTest, MmiGetTruncatedPayload)
         m_refreshIntervalObject,
         m_localManagementEnabledObject,
         m_debugLoggingEnabledObject,
-        m_commandLoggingEnabledObject,
         m_iotHubManagementEnabledObject,
         m_iotHubProtocolObject,
         m_gitManagementEnabledObject,
@@ -264,9 +261,6 @@ TEST_F(ConfigurationTest, MmiSet)
         { m_desiredDebugLoggingEnabledObject, "true", 0, m_debugLoggingEnabledObject, "true" },
         { m_desiredDebugLoggingEnabledObject, "false", 0, m_debugLoggingEnabledObject, "false" },
         { m_desiredDebugLoggingEnabledObject, "notImplemented", 22, m_debugLoggingEnabledObject, "false" },
-        { m_desiredCommandLoggingEnabledObject, "true", 0, m_commandLoggingEnabledObject, "true" },
-        { m_desiredCommandLoggingEnabledObject, "false", 0, m_commandLoggingEnabledObject, "false" },
-        { m_desiredCommandLoggingEnabledObject, "notImplemented", 22, m_commandLoggingEnabledObject, "false" },
         { m_desiredIotHubManagementEnabledObject, "true", 0, m_iotHubManagementEnabledObject, "true" },
         { m_desiredIotHubManagementEnabledObject, "false", 0, m_iotHubManagementEnabledObject, "false" },
         { m_desiredIotHubManagementEnabledObject, "notImplemented", 22, m_iotHubManagementEnabledObject, "false" },

--- a/src/modules/deliveryoptimization/src/lib/DeliveryOptimization.c
+++ b/src/modules/deliveryoptimization/src/lib/DeliveryOptimization.c
@@ -121,7 +121,7 @@ int DeliveryOptimizationMmiGetInfo(const char* clientName, MMI_JSON_STRING* payl
         status = ENOMEM;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(DeliveryOptimizationGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
@@ -228,7 +228,7 @@ int DeliveryOptimizationMmiGet(MMI_HANDLE clientSession, const char* componentNa
                 }
                 else
                 {
-                    if (IsFullLoggingEnabled())
+                    if (IsDebugLoggingEnabled())
                     {
                         OsConfigLogError(DeliveryOptimizationGetLog(), "MmiGet failed to serialize JSON property '%s'", jsonPropertyName);
                     }
@@ -237,7 +237,7 @@ int DeliveryOptimizationMmiGet(MMI_HANDLE clientSession, const char* componentNa
             }
             else
             {
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogError(DeliveryOptimizationGetLog(), "MmiGet failed to find JSON property '%s'", jsonPropertyName);
                 }
@@ -246,7 +246,7 @@ int DeliveryOptimizationMmiGet(MMI_HANDLE clientSession, const char* componentNa
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(DeliveryOptimizationGetLog(), "MmiGet failed to parse JSON file '%s'", g_deliveryOptimizationConfigFile);
             }
@@ -288,7 +288,7 @@ int DeliveryOptimizationMmiGet(MMI_HANDLE clientSession, const char* componentNa
         }
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(DeliveryOptimizationGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }

--- a/src/modules/deviceinfo/src/lib/DeviceInfo.c
+++ b/src/modules/deviceinfo/src/lib/DeviceInfo.c
@@ -173,10 +173,7 @@ int DeviceInfoMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* 
         status = ENOMEM;
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(DeviceInfoGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(DeviceInfoGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     return status;
 }
@@ -317,10 +314,7 @@ int DeviceInfoMmiGet(MMI_HANDLE clientSession, const char* componentName, const 
         }
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(DeviceInfoGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(DeviceInfoGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     return status;
 }

--- a/src/modules/deviceinfo/src/lib/DeviceInfo.c
+++ b/src/modules/deviceinfo/src/lib/DeviceInfo.c
@@ -173,7 +173,7 @@ int DeviceInfoMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* 
         status = ENOMEM;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(DeviceInfoGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }
@@ -317,7 +317,7 @@ int DeviceInfoMmiGet(MMI_HANDLE clientSession, const char* componentName, const 
         }
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(DeviceInfoGetLog(), "MmiGet(%p, %s, %s, %.*s, %d) returning %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }

--- a/src/modules/firewall/src/lib/Firewall.cpp
+++ b/src/modules/firewall/src/lib/Firewall.cpp
@@ -230,7 +230,7 @@ int FirewallModuleBase::Set(const char* componentName, const char* objectName, c
             }
             else
             {
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogError(FirewallLog::Get(), "Failed to parse JSON payload: %s", payloadJson.c_str());
                     status = EINVAL;
@@ -401,7 +401,7 @@ GenericRule& GenericRule::Parse(const rapidjson::Value& value)
         m_parseError.push_back("Rule JSON is not an object");
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         for (auto& error : m_parseError)
         {
@@ -595,7 +595,7 @@ int IpTables::SetDefaultPolicies(const std::vector<IpTablesPolicy> policies)
     for (const std::string& error : errors)
     {
         errorMessage += error + "\n";
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
         }
@@ -630,7 +630,7 @@ int IpTables::Add(const IpTables::Rule& rule, std::string& error)
 
     if (0 != (status = ExecuteCommand(nullptr, command.c_str(), true, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(FirewallLog::Get(), "Failed to add rule (%s): %s", command.c_str(), textResult);
         }
@@ -655,7 +655,7 @@ int IpTables::Remove(const IpTables::Rule& rule, std::string& error)
 
     if (0 != (status = ExecuteCommand(nullptr, command.c_str(), true, false, 0, 0, &textResult, nullptr, FirewallLog::Get())))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(FirewallLog::Get(), "Failed to remove rule (%s): %s", command.c_str(), textResult);
         }
@@ -733,7 +733,7 @@ int IpTables::SetRules(const std::vector<IpTables::Rule>& rules)
         for (const std::string& error : errors)
         {
             errorMessage += error + "\n";
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
             }
@@ -831,7 +831,7 @@ std::vector<IpTablesPolicy> IpTables::GetDefaultPolicies() const
                         OsConfigLogError(FirewallLog::Get(), "Invalid action: %s", match[2].str().c_str());
                     }
                 }
-                else if (IsFullLoggingEnabled())
+                else if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogError(FirewallLog::Get(), "Invalid policy line: %s", line.c_str());
                 }
@@ -906,7 +906,7 @@ GenericPolicy& GenericPolicy::Parse(const rapidjson::Value& value)
 
     for (auto& error : m_parseError)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(FirewallLog::Get(), "%s", error.c_str());
         }

--- a/src/modules/firewall/src/so/FirewallModule.cpp
+++ b/src/modules/firewall/src/so/FirewallModule.cpp
@@ -28,7 +28,7 @@ int MmiGetInfo(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(FirewallLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -39,7 +39,7 @@ int MmiGetInfo(
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(FirewallLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -169,7 +169,7 @@ int MmiGet(
 
     ScopeGuard sg{[&]()
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {

--- a/src/modules/hostname/src/lib/HostName.cpp
+++ b/src/modules/hostname/src/lib/HostName.cpp
@@ -27,7 +27,7 @@ int HostName::RunCommand(const char* command, bool replaceEol, std::string* text
             *textResult = buffer;
         }
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogError(HostNameLog::Get(), "Failed to run command: %d, '%s'", status, buffer);
     }

--- a/src/modules/hostname/src/lib/HostNameBase.cpp
+++ b/src/modules/hostname/src/lib/HostNameBase.cpp
@@ -140,7 +140,7 @@ int HostNameBase::Get(
 
     if (!IsValidComponentName(componentName))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_COMPONENT, "Get", componentName, m_componentName);
         }
@@ -149,7 +149,7 @@ int HostNameBase::Get(
 
     if (!IsValidObjectName(objectName, false))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_OBJECT, "Get", objectName ? objectName : "-", m_propertyName, m_propertyHosts);
         }
@@ -158,7 +158,7 @@ int HostNameBase::Get(
 
     if (!payload || !payloadSizeBytes)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_PAYLOAD, "Get");
         }
@@ -187,7 +187,7 @@ int HostNameBase::Get(
     *payloadSizeBytes = buffer.GetSize();
     if ((0 != m_maxPayloadSizeBytes) && (*payloadSizeBytes > static_cast<int>(m_maxPayloadSizeBytes)))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(HostNameLog::Get(), ERROR_PAYLOAD_TOO_LARGE, "Get", *payloadSizeBytes, static_cast<int>(m_maxPayloadSizeBytes));
         }
@@ -199,7 +199,7 @@ int HostNameBase::Get(
         *payload = new char[buffer.GetSize()];
         if (!payload)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(HostNameLog::Get(), ERROR_MEMORY_ALLOCATION, "Get", static_cast<uint>(buffer.GetSize()));
             }
@@ -214,7 +214,7 @@ int HostNameBase::Get(
             // Validate payload.
             if (!HostNameBase::IsValidJsonString(*payload, *payloadSizeBytes))
             {
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_PAYLOAD, "Get");
                 }
@@ -234,7 +234,7 @@ int HostNameBase::Get(
         if (!payload)
         {
             // Unable to allocate an empty payload, cannot return MMI_OK at this point.
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(HostNameLog::Get(), ERROR_MEMORY_ALLOCATION, "Get", static_cast<uint>(buffer.GetSize()));
             }
@@ -290,7 +290,7 @@ int HostNameBase::SetName(const std::string &value)
     std::regex pattern(g_regexHostname);
     if (!std::regex_match(name, pattern))
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_VALUE, "SetName", IsFullLoggingEnabled() ? name.c_str() : "-");
+        OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_VALUE, "SetName", IsDebugLoggingEnabled() ? name.c_str() : "-");
         return EINVAL;
     }
 
@@ -298,7 +298,7 @@ int HostNameBase::SetName(const std::string &value)
     int status = RunCommand(command.c_str(), true, nullptr);
     if (status != MMI_OK)
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_SET_RETURNED, "SetName", IsFullLoggingEnabled() ? name.c_str() : "-", status);
+        OsConfigLogError(HostNameLog::Get(), ERROR_SET_RETURNED, "SetName", IsDebugLoggingEnabled() ? name.c_str() : "-", status);
     }
     return status;
 }
@@ -315,7 +315,7 @@ int HostNameBase::SetHosts(const std::string &value)
         std::string line = RemoveRepeatedCharacters(Trim(*it, g_trimDefault), ' ');
         if (!std::regex_match(line, pattern))
         {
-            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_VALUE, "SetHosts", IsFullLoggingEnabled() ? line.c_str() : "-");
+            OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_VALUE, "SetHosts", IsDebugLoggingEnabled() ? line.c_str() : "-");
             return EINVAL;
         }
 
@@ -330,7 +330,7 @@ int HostNameBase::SetHosts(const std::string &value)
     int status = RunCommand(command.c_str(), true, nullptr);
     if (status != MMI_OK)
     {
-        OsConfigLogError(HostNameLog::Get(), ERROR_SET_RETURNED, "SetHosts", IsFullLoggingEnabled() ? hosts.c_str() : "-", status);
+        OsConfigLogError(HostNameLog::Get(), ERROR_SET_RETURNED, "SetHosts", IsDebugLoggingEnabled() ? hosts.c_str() : "-", status);
     }
     return status;
 }
@@ -362,7 +362,7 @@ bool HostNameBase::IsValidJsonString(const char* data, const int size)
     document.Parse(str.c_str());
     if (document.HasParseError())
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             const size_t errorOffset = document.GetErrorOffset();
             const char* errorCode = rapidjson::GetParseError_En(document.GetParseError());

--- a/src/modules/hostname/src/so/HostNameModule.cpp
+++ b/src/modules/hostname/src/so/HostNameModule.cpp
@@ -51,7 +51,7 @@ int MmiGetInfoInternal(const char* clientName, MMI_JSON_STRING* payload, int* pa
     {
         if (status == MMI_OK)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(HostNameLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -62,7 +62,7 @@ int MmiGetInfoInternal(const char* clientName, MMI_JSON_STRING* payload, int* pa
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(HostNameLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -199,7 +199,7 @@ int MmiSet(MMI_HANDLE clientSession, const char* componentName, const char* obje
         int status = MMI_OK;
         ScopeGuard sg{[&]()
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 if (MMI_OK == status)
                 {
@@ -245,7 +245,7 @@ int MmiGet(MMI_HANDLE clientSession, const char* componentName, const char* obje
         int status = MMI_OK;
         ScopeGuard sg{[&]()
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 if (MMI_OK == status)
                 {
@@ -261,7 +261,7 @@ int MmiGet(MMI_HANDLE clientSession, const char* componentName, const char* obje
         HostName *hostName = reinterpret_cast<HostName *>(clientSession);
         if (!hostName)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(HostNameLog::Get(), ERROR_INVALID_CLIENT_SESSION, "MmiGet");
             }

--- a/src/modules/mim/configuration.json
+++ b/src/modules/mim/configuration.json
@@ -19,13 +19,7 @@
           "schema": "boolean"
         },
         {
-          "name": "desiredFullLoggingEnabled",
-          "type": "mimObject",
-          "desired": true,
-          "schema": "boolean"
-        },
-        {
-          "name": "desiredCommandLoggingEnabled",
+          "name": "desiredDebugLoggingEnabled",
           "type": "mimObject",
           "desired": true,
           "schema": "boolean"
@@ -90,13 +84,7 @@
           "schema": "boolean"
         },
         {
-          "name": "fullLoggingEnabled",
-          "type": "mimObject",
-          "desired": false,
-          "schema": "boolean"
-        },
-        {
-          "name": "commandLoggingEnabled",
+          "name": "debugLoggingEnabled",
           "type": "mimObject",
           "desired": false,
           "schema": "boolean"

--- a/src/modules/networking/src/lib/Networking.cpp
+++ b/src/modules/networking/src/lib/Networking.cpp
@@ -115,7 +115,7 @@ std::string NetworkingObject::RunCommand(const char* command)
     {
         commandOutputToReturn = (nullptr != textResult) ? std::string(textResult) : g_emptyString;
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogError(NetworkingLog::Get(), "Failed to execute command '%s': %d, '%s'", command, status, (nullptr != textResult) ? textResult : g_dash);
     }
@@ -506,7 +506,7 @@ void NetworkingObjectBase::GenerateInterfaceTypesMap()
     }
     if (this->m_networkManagementService == NetworkManagementService::Unknown)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(NetworkingLog::Get(), "Network interface management service not found");
         }
@@ -895,7 +895,7 @@ int NetworkingObjectBase::Get(
 
     if ((nullptr == componentName) || (0 != std::strcmp(componentName, NETWORKING)))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) componentName %s is invalid, %s is expected",
                 componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), componentName, NETWORKING);
@@ -904,7 +904,7 @@ int NetworkingObjectBase::Get(
     }
     else if ((nullptr == objectName) || (0 != std::strcmp(objectName, NETWORK_CONFIGURATION)))
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) objectName %s is invalid, %s is expected",
                 componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), objectName, NETWORK_CONFIGURATION);
@@ -913,7 +913,7 @@ int NetworkingObjectBase::Get(
     }
     else if (nullptr == payload)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) payload %.*s is null",
                 componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), (payloadSizeBytes ? *payloadSizeBytes : 0), *payload);
@@ -922,7 +922,7 @@ int NetworkingObjectBase::Get(
     }
     else if (nullptr == payloadSizeBytes)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(NetworkingLog::Get(), "NetworkingObjectBase::Get(%s, %s, %.*s, %d) payloadSizeBytes %d is null",
                 componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), (payloadSizeBytes ? *payloadSizeBytes : 0));

--- a/src/modules/networking/src/so/NetworkingModule.cpp
+++ b/src/modules/networking/src/so/NetworkingModule.cpp
@@ -46,7 +46,7 @@ int MmiGetInfo(
 
         if ((nullptr == clientName) || (nullptr == payload) || (nullptr == payloadSizeBytes))
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(NetworkingLog::Get(), "MmiGetInfo(%s, %.*s, %d) invalid arguments",
                     clientName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0));
@@ -74,7 +74,7 @@ int MmiGetInfo(
         {
             if ((MMI_OK == status) && (nullptr != payload) && (nullptr != payloadSizeBytes))
             {
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(NetworkingLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
                 }
@@ -85,7 +85,7 @@ int MmiGetInfo(
             }
             else
             {
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogError(NetworkingLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), status);
                 }
@@ -209,13 +209,13 @@ int MmiGet(
     {
         if ((MMI_OK == status) && (nullptr != payload) && (nullptr != payloadSizeBytes))
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(NetworkingLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d",
                     clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
         }
-        else if (IsFullLoggingEnabled())
+        else if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(NetworkingLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d",
                 clientSession, componentName, objectName, (payloadSizeBytes ? *payloadSizeBytes : 0), *payload, (payloadSizeBytes ? *payloadSizeBytes : 0), status);

--- a/src/modules/pmc/src/lib/Pmc.cpp
+++ b/src/modules/pmc/src/lib/Pmc.cpp
@@ -54,7 +54,7 @@ std::string Pmc::GetSourcesFingerprint(const char* sourcesDirectory)
         std::string command = std::regex_replace(g_commandGetSourcesContent, std::regex("\\$value"), sourcesDirectory);
         hash = HashCommand(command.c_str(), PmcLog::Get());
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogError(PmcLog::Get(), "Unable to get the fingerprint of source files. Directory %s does not exist", sourcesDirectory);
     }
@@ -71,7 +71,7 @@ bool Pmc::CanRunOnThisPlatform()
         std::string command = std::regex_replace(g_commandCheckToolPresence, std::regex("\\$value"), tool);
         if (RunCommand(command.c_str(), nullptr) != PMC_0K)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(PmcLog::Get(), "Cannot run on this platform, could not find required tool %s", tool.c_str());
             }

--- a/src/modules/pmc/src/lib/PmcBase.cpp
+++ b/src/modules/pmc/src/lib/PmcBase.cpp
@@ -135,7 +135,7 @@ int PmcBase::Set(const char* componentName, const char* objectName, const MMI_JS
     size_t payloadHash = HashString(payload);
     if (m_lastReachedStateHash == payloadHash)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(PmcLog::Get(), "Ignoring update, desired state equals current state.");
         }
@@ -471,7 +471,7 @@ int PmcBase::ExecuteUpdate(const std::string &value)
     std::string command = std::regex_replace(g_commandExecuteUpdate, std::regex("\\$value"), value);
 
     int status = RunCommand(command.c_str(), nullptr, true);
-    if (status != PMC_0K && IsFullLoggingEnabled())
+    if (status != PMC_0K && IsDebugLoggingEnabled())
     {
         OsConfigLogError(PmcLog::Get(), "ExecuteUpdate failed with status %d and arguments '%s'", status, value.c_str());
     }
@@ -606,7 +606,7 @@ std::vector<std::string> PmcBase::GetReportedPackages(const std::vector<std::str
 
             std::string rawVersion = "";
             status = RunCommand(command.c_str(), &rawVersion);
-            if (status != PMC_0K && IsFullLoggingEnabled())
+            if (status != PMC_0K && IsDebugLoggingEnabled())
             {
                 OsConfigLogError(PmcLog::Get(), "Get the installed version of package %s failed with status %d", packageName.c_str(), status);
             }
@@ -708,7 +708,7 @@ std::vector<std::string> PmcBase::ListFiles(const char* directory, const char* f
         }
         closedir(directoryStream);
     }
-    else if (IsFullLoggingEnabled())
+    else if (IsDebugLoggingEnabled())
     {
         OsConfigLogError(PmcLog::Get(), "Failed to open directory %s, cannot list files", directory);
     }
@@ -733,7 +733,7 @@ int PmcBase::ConfigureSources(const std::map<std::string, std::string>& sources,
             {
                 status = remove(sourcesFilePath.c_str());
             }
-            else if (IsFullLoggingEnabled())
+            else if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(PmcLog::Get(), "Nothing to delete. Source(s) file: %s does not exist", sourcesFilePath.c_str());
             }
@@ -859,14 +859,14 @@ int PmcBase::DownloadGpgKeys(const std::map<std::string, std::string>& gpgKeys)
                     m_executionState.SetExecutionState(StateComponent::Failed, SubstateComponent::ModifyingSources, key.first);
                 }
             }
-            else if (IsFullLoggingEnabled())
+            else if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(PmcLog::Get(), "Nothing to delete. Key file %s does not exist", keyFilePath.c_str());
             }
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(PmcLog::Get(), "Downloading GPG key from %s to %s", sourceUrl.c_str(), keyFilePath.c_str());
             }

--- a/src/modules/pmc/src/so/PmcModule.cpp
+++ b/src/modules/pmc/src/so/PmcModule.cpp
@@ -31,7 +31,7 @@ int MmiGetInfo(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(PmcLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -42,7 +42,7 @@ int MmiGetInfo(
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(PmcLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -130,14 +130,14 @@ int MmiSet(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(PmcLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(PmcLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
@@ -174,7 +174,7 @@ int MmiGet(
 
     ScopeGuard sg{[&]()
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {

--- a/src/modules/samples/cpp/src/so/SampleModule.cpp
+++ b/src/modules/samples/cpp/src/so/SampleModule.cpp
@@ -31,7 +31,7 @@ int MmiGetInfo(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(SampleLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -42,7 +42,7 @@ int MmiGetInfo(
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(SampleLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -124,14 +124,14 @@ int MmiSet(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(SampleLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(SampleLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
@@ -169,7 +169,7 @@ int MmiGet(
 
     ScopeGuard sg{[&]()
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {

--- a/src/modules/samples/cpp/src/so/SampleModule.cpp
+++ b/src/modules/samples/cpp/src/so/SampleModule.cpp
@@ -33,7 +33,7 @@ int MmiGetInfo(
         {
             if (IsDebugLoggingEnabled())
             {
-                OsConfigLogInfo(SampleLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
+                OsConfigLogDebug(SampleLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
             else
             {
@@ -124,10 +124,7 @@ int MmiSet(
     {
         if (MMI_OK == status)
         {
-            if (IsDebugLoggingEnabled())
-            {
-                OsConfigLogInfo(SampleLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
-            }
+            OsConfigLogDebug(SampleLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
         }
         else
         {
@@ -173,7 +170,7 @@ int MmiGet(
         {
             if (MMI_OK == status)
             {
-                OsConfigLogInfo(SampleLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
+                OsConfigLogDebug(SampleLog::Get(), "MmiGet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
             else
             {

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -115,10 +115,7 @@ int SecurityBaselineMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload,
         status = ENOMEM;
     }
 
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(SecurityBaselineGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
-    }
+    OsConfigLogDebug(SecurityBaselineGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
 
     return status;
 }

--- a/src/modules/securitybaseline/src/lib/SecurityBaseline.c
+++ b/src/modules/securitybaseline/src/lib/SecurityBaseline.c
@@ -115,7 +115,7 @@ int SecurityBaselineMmiGetInfo(const char* clientName, MMI_JSON_STRING* payload,
         status = ENOMEM;
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(SecurityBaselineGetLog(), "MmiGetInfo(%s, %.*s, %d) returning %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
     }

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -848,8 +848,7 @@ int main(int argc, char const* argv[])
         else if (strcmp(argv[i], "--verbose") == 0)
         {
             g_verbose = true;
-            SetFullLogging(true);
-            SetCommandLogging(true);
+            SetDebugLogging(true);
         }
         else if (strcmp(argv[i], "--help") == 0)
         {

--- a/src/modules/test/recipes/ConfigurationTests.json
+++ b/src/modules/test/recipes/ConfigurationTests.json
@@ -76,63 +76,32 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "Configuration",
-    "ObjectName": "desiredFullLoggingEnabled",
+    "ObjectName": "desiredDebugLoggingEnabled",
     "Payload": "invalid",
     "ExpectedResult": 22
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "Configuration",
-    "ObjectName": "desiredFullLoggingEnabled",
+    "ObjectName": "desiredDebugLoggingEnabled",
     "Payload": true
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "Configuration",
-    "ObjectName": "fullLoggingEnabled",
+    "ObjectName": "debugLoggingEnabled",
     "Payload": true
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "Configuration",
-    "ObjectName": "desiredFullLoggingEnabled",
+    "ObjectName": "desiredDebugLoggingEnabled",
     "Payload": false
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "Configuration",
-    "ObjectName": "fullLoggingEnabled",
-    "Payload": false
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "Configuration",
-    "ObjectName": "desiredCommandLoggingEnabled",
-    "Payload": "invalid",
-    "ExpectedResult": 22
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "Configuration",
-    "ObjectName": "desiredCommandLoggingEnabled",
-    "Payload": true
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "Configuration",
-    "ObjectName": "commandLoggingEnabled",
-    "Payload": true
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "Configuration",
-    "ObjectName": "desiredCommandLoggingEnabled",
-    "Payload": false
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "Configuration",
-    "ObjectName": "commandLoggingEnabled",
+    "ObjectName": "debugLoggingEnabled",
     "Payload": false
   },
   {

--- a/src/modules/tpm/src/so/TpmModule.cpp
+++ b/src/modules/tpm/src/so/TpmModule.cpp
@@ -35,7 +35,7 @@ int MmiGetInfo(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(TpmLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -46,7 +46,7 @@ int MmiGetInfo(
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(TpmLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -141,7 +141,7 @@ int MmiGet(
 
     ScopeGuard sg{[&]()
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {

--- a/src/modules/ztsi/src/lib/Ztsi.cpp
+++ b/src/modules/ztsi/src/lib/Ztsi.cpp
@@ -493,7 +493,7 @@ bool Ztsi::IsValidConfiguration(const Ztsi::AgentConfiguration& configuration)
 
     if (configuration.maxManualAttestationsPerDay < 0 || configuration.maxScheduledAttestationsPerDay < 0)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(ZtsiLog::Get(), "MaxManualAttestationsPerDay and MaxScheduledAttestationsPerDay must both be nonnegative");
         }
@@ -503,7 +503,7 @@ bool Ztsi::IsValidConfiguration(const Ztsi::AgentConfiguration& configuration)
 
     if (configuration.maxManualAttestationsPerDay + configuration.maxScheduledAttestationsPerDay > g_totalAttestationsAllowedPerDay)
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(ZtsiLog::Get(), "The total number of attestations per day (Scheduled + Manual) cannot exceed %s", std::to_string(g_totalAttestationsAllowedPerDay).c_str());
         }
@@ -522,7 +522,7 @@ std::FILE* Ztsi::OpenAndLockFile(const char* mode)
     {
         if (!LockFile(file, ZtsiLog::Get()))
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(ZtsiLog::Get(), "Failed to lock file %s", m_agentConfigurationFile.c_str());
             }
@@ -632,7 +632,7 @@ int Ztsi::ParseAgentConfiguration(const std::string& configurationJson, Ztsi::Ag
 
     if (document.Parse(configurationJson.c_str()).HasParseError())
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogError(ZtsiLog::Get(), "Failed to parse JSON %s", configurationJson.c_str());
         }

--- a/src/modules/ztsi/src/so/ZtsiModule.cpp
+++ b/src/modules/ztsi/src/so/ZtsiModule.cpp
@@ -37,7 +37,7 @@ int MmiGetInfo(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(ZtsiLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -48,7 +48,7 @@ int MmiGetInfo(
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(ZtsiLog::Get(), "MmiGetInfo(%s, %.*s, %d) returned %d", clientName, *payloadSizeBytes, *payload, *payloadSizeBytes, status);
             }
@@ -140,14 +140,14 @@ int MmiSet(
     {
         if (MMI_OK == status)
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(ZtsiLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
         }
         else
         {
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogError(ZtsiLog::Get(), "MmiSet(%p, %s, %s, %.*s, %d) returned %d", clientSession, componentName, objectName, payloadSizeBytes, payload, payloadSizeBytes, status);
             }
@@ -184,7 +184,7 @@ int MmiGet(
 
     ScopeGuard sg{[&]()
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {

--- a/src/platform/Main.c
+++ b/src/platform/Main.c
@@ -182,7 +182,7 @@ static bool IsLoggingEnabledInJsonConfig(const char* jsonString, const char* log
 
 bool IsDebugLoggingEnabledInJsonConfig(const char* jsonString)
 {
-    return IsDebugLoggingEnabledInJsonConfig(jsonString, DEBUG_LOGGING);
+    return IsLoggingEnabledInJsonConfig(jsonString, DEBUG_LOGGING);
 }
 
 int main(int argc, char* argv[])

--- a/src/platform/Main.c
+++ b/src/platform/Main.c
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
 
     if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(GetPlatformLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
+        OsConfigLogInfo(GetPlatformLog(), "WARNING: debug logging is enabled. To disable debug logging, edit '%s' and restart OSConfig", CONFIG_FILE);
     }
 
     for (int i = 0; i < stopSignalsCount; i++)

--- a/src/platform/Main.c
+++ b/src/platform/Main.c
@@ -17,8 +17,7 @@
 #define LOG_FILE "/var/log/osconfig_platform.log"
 #define ROLLED_LOG_FILE "/var/log/osconfig_platform.bak"
 
-#define COMMAND_LOGGING "CommandLogging"
-#define FULL_LOGGING "FullLogging"
+#define DEBUG_LOGGING "DebugLogging"
 
 static unsigned int g_lastTime = 0;
 
@@ -181,14 +180,9 @@ static bool IsLoggingEnabledInJsonConfig(const char* jsonString, const char* log
     return result;
 }
 
-bool IsCommandLoggingEnabledInJsonConfig(const char* jsonString)
+bool IsDebugLoggingEnabledInJsonConfig(const char* jsonString)
 {
-    return IsLoggingEnabledInJsonConfig(jsonString, COMMAND_LOGGING);
-}
-
-bool IsFullLoggingEnabledInJsonConfig(const char* jsonString)
-{
-    return IsLoggingEnabledInJsonConfig(jsonString, FULL_LOGGING);
+    return IsDebugLoggingEnabledInJsonConfig(jsonString, DEBUG_LOGGING);
 }
 
 int main(int argc, char* argv[])
@@ -202,8 +196,7 @@ int main(int argc, char* argv[])
     char* jsonConfiguration = LoadStringFromFile(CONFIG_FILE, false, GetPlatformLog());
     if (NULL != jsonConfiguration)
     {
-        SetCommandLogging(IsCommandLoggingEnabledInJsonConfig(jsonConfiguration));
-        SetFullLogging(IsFullLoggingEnabledInJsonConfig(jsonConfiguration));
+        SetDebugLogging(IsDebugLoggingEnabledInJsonConfig(jsonConfiguration));
         FREE_MEMORY(jsonConfiguration);
     }
 
@@ -214,9 +207,9 @@ int main(int argc, char* argv[])
     OsConfigLogInfo(GetPlatformLog(), "OSConfig Platform starting (PID: %d, PPID: %d)", pid = getpid(), getppid());
     OsConfigLogInfo(GetPlatformLog(), "OSConfig version: %s", OSCONFIG_VERSION);
 
-    if (IsCommandLoggingEnabled() || IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
-        OsConfigLogInfo(GetPlatformLog(), "WARNING: verbose logging (command and/or full) is enabled. To disable verbose logging edit %s and restart OSConfig", CONFIG_FILE);
+        OsConfigLogInfo(GetPlatformLog(), "WARNING: debug logging is enabled. To disable debug logging edit %s and restart OSConfig", CONFIG_FILE);
     }
 
     for (int i = 0; i < stopSignalsCount; i++)

--- a/src/platform/ModulesManager.c
+++ b/src/platform/ModulesManager.c
@@ -199,7 +199,7 @@ static void LoadModules(const char* directory, const char* configJson)
                         }
                         else
                         {
-                            if (IsFullLoggingEnabled())
+                            if (IsDebugLoggingEnabled())
                             {
                                 OsConfigLogInfo(GetPlatformLog(), "LoadModules: found reported property (%s.%s)", reported[i].component, reported[i].object);
                             }
@@ -366,7 +366,7 @@ MPI_HANDLE MpiOpen(const char* clientName, const unsigned int maxPayloadSizeByte
     }
     else
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(GetPlatformLog(), "MpiOpen: creating session with UUID '%s'", uuid);
         }
@@ -454,7 +454,7 @@ void MpiClose(MPI_HANDLE handle)
     }
     else
     {
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             OsConfigLogInfo(GetPlatformLog(), "MpiClose: closing session with UUID '%s'", session->uuid);
         }
@@ -586,7 +586,7 @@ int MpiGet(MPI_HANDLE handle, const char* component, const char* object, MPI_JSO
     {
         status = moduleSession->module->get(moduleSession->handle, component, object, payload, payloadSizeBytes);
 
-        if (IsFullLoggingEnabled())
+        if (IsDebugLoggingEnabled())
         {
             if (MMI_OK == status)
             {
@@ -700,7 +700,7 @@ int MpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, const int pa
         FREE_MEMORY(json);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         if (MMI_OK == status)
         {
@@ -768,7 +768,7 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
             {
                 mmiStatus = moduleSession->module->get(moduleSession->handle, g_reported[i].component, g_reported[i].object, &mmiPayload, &mmiPayloadSizeBytes);
 
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(GetPlatformLog(), "MmiGet(%s, %s) returned %d (%.*s)", g_reported[i].component, g_reported[i].object, mmiStatus, mmiPayloadSizeBytes, mmiPayload);
                 }
@@ -787,7 +787,7 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
 
                     if (NULL == (objectValue = json_parse_string(payloadJson)))
                     {
-                        if (IsFullLoggingEnabled())
+                        if (IsDebugLoggingEnabled())
                         {
                             OsConfigLogError(GetPlatformLog(), "MmiGet(%s, %s) returned an invalid payload '%s'", g_reported[i].component, g_reported[i].object, payloadJson);
                         }
@@ -826,7 +826,7 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
         json_value_free(rootValue);
     }
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         if (MMI_OK == status)
         {

--- a/src/platform/ModulesManager.c
+++ b/src/platform/ModulesManager.c
@@ -199,11 +199,7 @@ static void LoadModules(const char* directory, const char* configJson)
                         }
                         else
                         {
-                            if (IsDebugLoggingEnabled())
-                            {
-                                OsConfigLogInfo(GetPlatformLog(), "LoadModules: found reported property (%s.%s)", reported[i].component, reported[i].object);
-                            }
-
+                            OsConfigLogDebug(GetPlatformLog(), "LoadModules: found reported property (%s.%s)", reported[i].component, reported[i].object);
                             reportedTotal++;
                         }
                     }
@@ -366,10 +362,7 @@ MPI_HANDLE MpiOpen(const char* clientName, const unsigned int maxPayloadSizeByte
     }
     else
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(GetPlatformLog(), "MpiOpen: creating session with UUID '%s'", uuid);
-        }
+        OsConfigLogDebug(GetPlatformLog(), "MpiOpen: creating session with UUID '%s'", uuid);
 
         if (NULL != (session = (SESSION*)malloc(sizeof(SESSION))))
         {
@@ -454,10 +447,7 @@ void MpiClose(MPI_HANDLE handle)
     }
     else
     {
-        if (IsDebugLoggingEnabled())
-        {
-            OsConfigLogInfo(GetPlatformLog(), "MpiClose: closing session with UUID '%s'", session->uuid);
-        }
+        OsConfigLogDebug(GetPlatformLog(), "MpiClose: closing session with UUID '%s'", session->uuid);
 
         // Remove the session from the linked list
         if (session == g_sessions)
@@ -590,7 +580,7 @@ int MpiGet(MPI_HANDLE handle, const char* component, const char* object, MPI_JSO
         {
             if (MMI_OK == status)
             {
-                OsConfigLogInfo(GetPlatformLog(), "MpiGet(%p, %s, %s, %p, %p) succeeded", handle, component, object, payload, payloadSizeBytes);
+                OsConfigLogDebug(GetPlatformLog(), "MpiGet(%p, %s, %s, %p, %p) succeeded", handle, component, object, payload, payloadSizeBytes);
             }
             else
             {
@@ -704,7 +694,7 @@ int MpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, const int pa
     {
         if (MMI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiSetDesired(%p, %p, %d) succeeded", handle, payload, payloadSizeBytes);
+            OsConfigLogDebug(GetPlatformLog(), "MpiSetDesired(%p, %p, %d) succeeded", handle, payload, payloadSizeBytes);
         }
         else
         {
@@ -768,10 +758,7 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
             {
                 mmiStatus = moduleSession->module->get(moduleSession->handle, g_reported[i].component, g_reported[i].object, &mmiPayload, &mmiPayloadSizeBytes);
 
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(GetPlatformLog(), "MmiGet(%s, %s) returned %d (%.*s)", g_reported[i].component, g_reported[i].object, mmiStatus, mmiPayloadSizeBytes, mmiPayload);
-                }
+                OsConfigLogDebug(GetPlatformLog(), "MmiGet(%s, %s) returned %d (%.*s)", g_reported[i].component, g_reported[i].object, mmiStatus, mmiPayloadSizeBytes, mmiPayload);
 
                 if (MMI_OK != mmiStatus)
                 {
@@ -830,7 +817,7 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
     {
         if (MMI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiGetDesired(%p, %p) succeeded", handle, payload);
+            OsConfigLogDebug(GetPlatformLog(), "MpiGetDesired(%p, %p) succeeded", handle, payload);
         }
         else
         {

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -52,11 +52,7 @@ static MPI_HANDLE CallMpiOpen(const char* clientName, const unsigned int maxPayl
 
 static void CallMpiClose(MPI_HANDLE handle)
 {
-    if (IsDebugLoggingEnabled())
-    {
-        OsConfigLogInfo(GetPlatformLog(), "Received MpiClose request, session %p ('%s')", handle, (char*)handle);
-    }
-
+    OsConfigLogDebug(GetPlatformLog(), "Received MpiClose request, session %p ('%s')", handle, (char*)handle);
     MpiClose((MPI_HANDLE)handle);
 }
 
@@ -72,7 +68,7 @@ static int CallMpiSet(MPI_HANDLE handle, const char* componentName, const char* 
     {
         if (MPI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiSet(%s, %s) request, session %p ('%s')", componentName, objectName, handle, (char*)handle);
+            OsConfigLogDebug(GetPlatformLog(), "MpiSet(%s, %s) request, session %p ('%s')", componentName, objectName, handle, (char*)handle);
         }
         else
         {
@@ -97,7 +93,7 @@ static int CallMpiGet(MPI_HANDLE handle, const char* componentName, const char* 
     {
         if (MPI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiGet(%s, %s) request, session %p ('%s')", componentName, objectName, handle, (char*)handle);
+            OsConfigLogDebug(GetPlatformLog(), "MpiGet(%s, %s) request, session %p ('%s')", componentName, objectName, handle, (char*)handle);
         }
         else
         {
@@ -122,7 +118,7 @@ static int CallMpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, c
     {
         if (MPI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiSetDesired request, session %p ('%s')", handle, (char*)handle);
+            OsConfigLogDebug(GetPlatformLog(), "MpiSetDesired request, session %p ('%s')", handle, (char*)handle);
         }
         else
         {
@@ -147,7 +143,7 @@ static int CallMpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* 
     {
         if (MPI_OK == status)
         {
-            OsConfigLogInfo(GetPlatformLog(), "MpiGetReported request, session %p ('%s')", handle, (char*)handle);
+            OsConfigLogDebug(GetPlatformLog(), "MpiGetReported request, session %p ('%s')", handle, (char*)handle);
         }
         else
         {
@@ -383,10 +379,7 @@ HTTP_STATUS HandleMpiCall(const char* uri, const char* requestBody, char** respo
                     else if (MPI_OK != (mpiStatus = handlers.mpiGet((MPI_HANDLE)client, component, object, response, responseSize)))
                     {
                         status = SetErrorResponse(uri, mpiStatus, response, responseSize);
-                        if (IsDebugLoggingEnabled())
-                        {
-                            OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed for client '%s' with %d (returning %d)", uri, component, object, client, mpiStatus, status);
-                        }
+                        OsConfigLogDebug(GetPlatformLog(), "%s(%s, %s): failed for client '%s' with %d (returning %d)", uri, component, object, client, mpiStatus, status);
                     }
                 }
             }
@@ -494,10 +487,7 @@ static void* MpiServerWorker(void* arguments)
         {
             AreModulesLoadedAndLoadIfNot(MODULES_BIN_PATH, CONFIG_JSON_PATH);
 
-            if (IsDebugLoggingEnabled())
-            {
-                OsConfigLogInfo(GetPlatformLog(), "Accepted connection: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
-            }
+            OsConfigLogDebug(GetPlatformLog(), "Accepted connection: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
 
             if (NULL == (uri = ReadUriFromSocket(socketHandle, GetPlatformLog())))
             {
@@ -524,11 +514,7 @@ static void* MpiServerWorker(void* arguments)
 
             if (HTTP_OK == status)
             {
-                if (IsDebugLoggingEnabled())
-                {
-                    OsConfigLogInfo(GetPlatformLog(), "%s: content-length %d, body, '%s'", uri, contentLength, requestBody);
-                }
-
+                OsConfigLogDebug(GetPlatformLog(), "%s: content-length %d, body, '%s'", uri, contentLength, requestBody);
                 status = HandleMpiCall(uri, requestBody, &responseBody, &responseSize, mpiCalls);
             }
 
@@ -557,10 +543,7 @@ static void* MpiServerWorker(void* arguments)
                 OsConfigLogError(GetPlatformLog(), "Failed to close socket: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
             }
 
-            if (IsDebugLoggingEnabled())
-            {
-                OsConfigLogInfo(GetPlatformLog(), "Closed connection: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
-            }
+            OsConfigLogDebug(GetPlatformLog(), "Closed connection: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
 
             contentLength = 0;
             responseSize = 0;

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -52,7 +52,7 @@ static MPI_HANDLE CallMpiOpen(const char* clientName, const unsigned int maxPayl
 
 static void CallMpiClose(MPI_HANDLE handle)
 {
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         OsConfigLogInfo(GetPlatformLog(), "Received MpiClose request, session %p ('%s')", handle, (char*)handle);
     }
@@ -68,7 +68,7 @@ static int CallMpiSet(MPI_HANDLE handle, const char* componentName, const char* 
 
     status = MpiSet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         if (MPI_OK == status)
         {
@@ -93,7 +93,7 @@ static int CallMpiGet(MPI_HANDLE handle, const char* componentName, const char* 
 
     status = MpiGet((MPI_HANDLE)handle, componentName, objectName, payload, payloadSize);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         if (MPI_OK == status)
         {
@@ -118,7 +118,7 @@ static int CallMpiSetDesired(MPI_HANDLE handle, const MPI_JSON_STRING payload, c
 
     status = MpiSetDesired((MPI_HANDLE)handle, payload, payloadSize);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         if (MPI_OK == status)
         {
@@ -143,7 +143,7 @@ static int CallMpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* 
 
     status = MpiGetReported((MPI_HANDLE)handle, payload, payloadSize);
 
-    if (IsFullLoggingEnabled())
+    if (IsDebugLoggingEnabled())
     {
         if (MPI_OK == status)
         {
@@ -373,7 +373,7 @@ HTTP_STATUS HandleMpiCall(const char* uri, const char* requestBody, char** respo
                             if (MPI_OK != (mpiStatus = handlers.mpiSet((MPI_HANDLE)client, component, object, (MPI_JSON_STRING)payload, strlen(payload))))
                             {
                                 status = SetErrorResponse(uri, mpiStatus, response, responseSize);
-                                if (IsFullLoggingEnabled())
+                                if (IsDebugLoggingEnabled())
                                 {
                                     OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed for client '%s' with %d (returning %d)", uri, component, object, client, mpiStatus, status);
                                 }
@@ -383,7 +383,7 @@ HTTP_STATUS HandleMpiCall(const char* uri, const char* requestBody, char** respo
                     else if (MPI_OK != (mpiStatus = handlers.mpiGet((MPI_HANDLE)client, component, object, response, responseSize)))
                     {
                         status = SetErrorResponse(uri, mpiStatus, response, responseSize);
-                        if (IsFullLoggingEnabled())
+                        if (IsDebugLoggingEnabled())
                         {
                             OsConfigLogError(GetPlatformLog(), "%s(%s, %s): failed for client '%s' with %d (returning %d)", uri, component, object, client, mpiStatus, status);
                         }
@@ -494,7 +494,7 @@ static void* MpiServerWorker(void* arguments)
         {
             AreModulesLoadedAndLoadIfNot(MODULES_BIN_PATH, CONFIG_JSON_PATH);
 
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(GetPlatformLog(), "Accepted connection: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
             }
@@ -524,7 +524,7 @@ static void* MpiServerWorker(void* arguments)
 
             if (HTTP_OK == status)
             {
-                if (IsFullLoggingEnabled())
+                if (IsDebugLoggingEnabled())
                 {
                     OsConfigLogInfo(GetPlatformLog(), "%s: content-length %d, body, '%s'", uri, contentLength, requestBody);
                 }
@@ -557,7 +557,7 @@ static void* MpiServerWorker(void* arguments)
                 OsConfigLogError(GetPlatformLog(), "Failed to close socket: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
             }
 
-            if (IsFullLoggingEnabled())
+            if (IsDebugLoggingEnabled())
             {
                 OsConfigLogInfo(GetPlatformLog(), "Closed connection: path %s, handle '%d'", g_socketaddr.sun_path, socketHandle);
             }

--- a/src/tests/fuzzer/seed_corpus/IsCommandLoggingEnabledInJsonConfig.target
+++ b/src/tests/fuzzer/seed_corpus/IsCommandLoggingEnabledInJsonConfig.target
@@ -1,1 +1,0 @@
-IsCommandLoggingEnabledInJsonConfig.

--- a/src/tests/fuzzer/seed_corpus/IsFullLoggingEnabledInJsonConfig.target
+++ b/src/tests/fuzzer/seed_corpus/IsFullLoggingEnabledInJsonConfig.target
@@ -1,1 +1,1 @@
-IsFullLoggingEnabledInJsonConfig.
+IsDebugLoggingEnabledInJsonConfig.

--- a/src/tests/fuzzer/target.cpp
+++ b/src/tests/fuzzer/target.cpp
@@ -834,17 +834,10 @@ static int RemoveEscapeSequencesFromFile_target(const char* data, std::size_t si
     return 0;
 }
 
-static int IsCommandLoggingEnabledInJsonConfig_target(const char* data, std::size_t size) noexcept
+static int IsDebugLoggingEnabledInJsonConfig_target(const char* data, std::size_t size) noexcept
 {
     auto json = std::string(data, size);
-    IsCommandLoggingEnabledInJsonConfig(json.c_str());
-    return 0;
-}
-
-static int IsFullLoggingEnabledInJsonConfig_target(const char* data, std::size_t size) noexcept
-{
-    auto json = std::string(data, size);
-    IsFullLoggingEnabledInJsonConfig(json.c_str());
+    IsDebugLoggingEnabledInJsonConfig(json.c_str());
     return 0;
 }
 
@@ -1103,7 +1096,7 @@ static const std::map<std::string, int (*)(const char*, std::size_t)> g_targets 
     { "RepairBrokenEolCharactersIfAny.", RepairBrokenEolCharactersIfAny_target },
     { "RemoveEscapeSequencesFromFile.", RemoveEscapeSequencesFromFile_target },
     { "IsCommandLoggingEnabledInJsonConfig.", IsCommandLoggingEnabledInJsonConfig_target },
-    { "IsFullLoggingEnabledInJsonConfig.", IsFullLoggingEnabledInJsonConfig_target },
+    { "IsDebugLoggingEnabledInJsonConfig.", IsDebugLoggingEnabledInJsonConfig_target },
     { "IsIotHubManagementEnabledInJsonConfig.", IsIotHubManagementEnabledInJsonConfig_target },
     { "GetReportingIntervalFromJsonConfig.", GetReportingIntervalFromJsonConfig_target },
     { "GetModelVersionFromJsonConfig.", GetModelVersionFromJsonConfig_target },


### PR DESCRIPTION
## Description

This is the second phase of improvements for the 'OSConfig for MC' logging, and more will follow. In this phase:
- The two legacy 'CommandLogging' and 'FullLogging' configuration options are merged into one single option called 'DebugLogging'.
- A new logging level enumeration is added to the logging library, with values matching the severity values in RFC 5424.  from which currently we actively only use 2 values:
- LoggingLevelInformational (6) is default and for this we use the [INFO] and [ERROR] labels
- LoggingLevelDebug (7) is optional, uses the [DEBUG] label, and is managed via the 'DebugLogging' entry in osconfig.json configuration.
- Continuing on the work started in first phase, the [ERROR] traces changed to [INFO] got a deeper refactoring, to avoid ambiguous 'foo failed' when taken out of context. Instead of 'failed' we use now in many places 'cannot', 'returned', 'returning' etc.
- The OsConfigLogDebug macro added in the first phase now can be invoked by itself, without calling IsDebugLoggingEnabled() first. 
- Not all legacy code was completely cleaned of extra IsDebugLoggingEnabled() calls, focus being on currently kept components. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
