### PR TITLE
Drop a duplicated entry in the .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,6 +83,5 @@ TabWidth: 4
 UseCRLF: false
 UseTab: Never
 IndentAccessModifiers: false
-AccessModifierOffset: -4
 EmptyLineBeforeAccessModifier: Always
 IncludeBlocks: Regroup


### PR DESCRIPTION
## Description

The .clang-format file contains a duplicated entry which fails for some versions of clang-format tool. This PR drops the duplicated entry.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
