### PR TITLE
Fix missing OpenLog call in RC/DC scenario

### DIFF
--- a/src/modules/compliance/src/lib/Engine.cpp
+++ b/src/modules/compliance/src/lib/Engine.cpp
@@ -21,8 +21,6 @@
 
 namespace compliance
 {
-static constexpr const char* cLogFile = "/var/log/osconfig_compliance.log";
-static constexpr const char* cRolledLogFile = "/var/log/osconfig_compliance.bak";
 static constexpr const char* cModuleInfo = "{\"Name\": \"Compliance\","
                                            "\"Description\": \"Provides functionality to audit and remediate Security Baseline policies on device\","
                                            "\"Manufacturer\": \"Microsoft\","
@@ -36,20 +34,6 @@ static constexpr const char* cModuleInfo = "{\"Name\": \"Compliance\","
 Engine::Engine(OsConfigLogHandle log) noexcept
     : mLog{log}
 {
-}
-
-Engine::Engine() noexcept
-    : mLog{OpenLog(cLogFile, cRolledLogFile)},
-      mLocalLog{true}
-{
-}
-
-Engine::~Engine()
-{
-    if (mLocalLog)
-    {
-        CloseLog(&mLog);
-    }
 }
 
 void Engine::setMaxPayloadSize(unsigned int value) noexcept

--- a/src/modules/compliance/src/lib/Engine.h
+++ b/src/modules/compliance/src/lib/Engine.h
@@ -62,7 +62,6 @@ public:
 
 private:
     OsConfigLogHandle mLog = nullptr;
-    bool mLocalLog = false;
     unsigned int mMaxPayloadSize = 0;
     std::map<std::string, Procedure> mDatabase;
 
@@ -72,11 +71,8 @@ private:
     Result<bool> executeRemediation(const std::string& ruleName, const char* payload, const int payloadSizeBytes);
 
 public:
-    // Create engine with external log file
-    Engine(OsConfigLogHandle log) noexcept;
-    // Create engine with locally initialized log file
-    Engine() noexcept;
-    ~Engine();
+    explicit Engine(OsConfigLogHandle log) noexcept;
+    ~Engine() = default;
 
     void setMaxPayloadSize(unsigned int value) noexcept;
     unsigned int getMaxPayloadSize() const noexcept;

--- a/src/modules/compliance/src/so/ComplianceModule.c
+++ b/src/modules/compliance/src/so/ComplianceModule.c
@@ -4,6 +4,7 @@
 #include <Mmi.h>
 #include "ComplianceInterface.h"
 #include <stddef.h>
+#include <assert.h>
 
 static OsConfigLogHandle gLog = NULL;
 static const char* gLogFile = "/var/log/osconfig_compliance.log";
@@ -12,12 +13,7 @@ static const char* gRolledLogFile = "/var/log/osconfig_compliance.bak";
 void __attribute__((constructor)) InitModule(void)
 {
     gLog = OpenLog(gLogFile, gRolledLogFile);
-    if (NULL == gLog)
-    {
-        OsConfigLogError(NULL, "Failed to open log file");
-        return;
-    }
-
+    assert(NULL != gLog);
     ComplianceInitialize(gLog);
 }
 

--- a/src/modules/compliance/src/so/ComplianceModule.c
+++ b/src/modules/compliance/src/so/ComplianceModule.c
@@ -5,14 +5,26 @@
 #include "ComplianceInterface.h"
 #include <stddef.h>
 
+static OsConfigLogHandle gLog = NULL;
+static const char* gLogFile = "/var/log/osconfig_compliance.log";
+static const char* gRolledLogFile = "/var/log/osconfig_compliance.bak";
+
 void __attribute__((constructor)) InitModule(void)
 {
-    ComplianceInitialize(NULL);
+    gLog = OpenLog(gLogFile, gRolledLogFile);
+    if (NULL == gLog)
+    {
+        OsConfigLogError(NULL, "Failed to open log file");
+        return;
+    }
+
+    ComplianceInitialize(gLog);
 }
 
 void __attribute__((destructor)) DestroyModule(void)
 {
-    ComplianceShutdown(NULL);
+    CloseLog(&gLog);
+    ComplianceShutdown();
 }
 
 int MmiGetInfo(const char* clientName, MMI_JSON_STRING* payload, int* payloadSizeBytes)

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -26,10 +26,15 @@ static Result<bool> auditSuccess(std::map<std::string, std::string>, std::ostrin
 
 class ComplianceEngineTest : public ::testing::Test
 {
+public:
+    ComplianceEngineTest()
+        : mEngine(nullptr)
+    {
+    }
+
 protected:
     Engine mEngine;
     std::map<std::string, std::pair<action_func_t, action_func_t>> mProcedureMap;
-    // std::map<std::string, std::string> mParameters;
 
     void SetUp() override
     {
@@ -38,7 +43,6 @@ protected:
             {"failure", {auditFailure, auditFailure}},
             {"NoAudit", {nullptr, auditSuccess}},
         };
-        // mEngine.setProcedureMap(mProcedureMap);
     }
 };
 


### PR DESCRIPTION
## Description

Due to code rearrangements the Compliance module did not properly open log file in the RC/DC scenario. This PR moves log file initialization to the ComplianceModule.c and unifies compliance::Engine class initalization. The changes were tested manually.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
