### PR TITLE
Simplify ExecuteAudit by encapsulating payload in the result

### DIFF
--- a/src/modules/compliance/src/lib/ComplianceInterface.cpp
+++ b/src/modules/compliance/src/lib/ComplianceInterface.cpp
@@ -14,6 +14,7 @@
 #include <exception>
 
 using compliance::Engine;
+using compliance::Status;
 
 static OsConfigLogHandle g_log = nullptr;
 
@@ -91,8 +92,16 @@ int ComplianceMmiGet(MMI_HANDLE clientSession, const char* componentName, const 
             return result.error().code;
         }
 
-        *payload = strdup(result.value().payload);
-        *payloadSizeBytes = result.value().payloadSize;
+        auto payloadLength = result.value().payload.size();
+        *payload = (char*)malloc(payloadLength);
+        if (NULL == *payload)
+        {
+            OsConfigLogError(engine.log(), "ComplianceMmiGet: failed to allocate memory for payload");
+            return ENOMEM;
+        }
+
+        memcpy(*payload, result.value().payload.c_str(), payloadLength);
+        *payloadSizeBytes = payloadLength;
         OsConfigLogInfo(engine.log(), "MmiGet(%p, %s, %s, %.*s)", clientSession, componentName, objectName, *payloadSizeBytes, *payload);
         return MMI_OK;
     }
@@ -135,7 +144,7 @@ int ComplianceMmiSet(MMI_HANDLE clientSession, const char* componentName, const 
         }
 
         OsConfigLogInfo(engine.log(), "MmiSet(%p, %s, %s, %.*s, %d) returned %s", clientSession, componentName, objectName, payloadSizeBytes, payload,
-            payloadSizeBytes, result.value() ? "true" : "false");
+            payloadSizeBytes, result.value() == Status::Compliant ? "compliant" : "non-compliant");
         return MMI_OK;
     }
     catch (const std::exception& e)

--- a/src/modules/compliance/src/lib/ComplianceInterface.cpp
+++ b/src/modules/compliance/src/lib/ComplianceInterface.cpp
@@ -92,16 +92,13 @@ int ComplianceMmiGet(MMI_HANDLE clientSession, const char* componentName, const 
             return result.error().code;
         }
 
-        auto payloadLength = result.value().payload.size();
-        *payload = (char*)malloc(payloadLength);
+        *payload = strndup(result.value().payload.c_str(), result.value().payload.size());
         if (NULL == *payload)
         {
             OsConfigLogError(engine.log(), "ComplianceMmiGet: failed to allocate memory for payload");
             return ENOMEM;
         }
-
-        memcpy(*payload, result.value().payload.c_str(), payloadLength);
-        *payloadSizeBytes = payloadLength;
+        *payloadSizeBytes = result.value().payload.size();
         OsConfigLogInfo(engine.log(), "MmiGet(%p, %s, %s, %.*s)", clientSession, componentName, objectName, *payloadSizeBytes, *payload);
         return MMI_OK;
     }

--- a/src/modules/compliance/src/lib/Engine.h
+++ b/src/modules/compliance/src/lib/Engine.h
@@ -7,6 +7,7 @@
 #include "JsonWrapper.h"
 #include "Logging.h"
 #include "Mmi.h"
+#include "MmiResults.h"
 #include "Optional.h"
 #include "Procedure.h"
 #include "Result.h"
@@ -21,45 +22,6 @@ namespace compliance
 {
 class Engine
 {
-public:
-    struct AuditResult
-    {
-        bool result = false;
-        char* payload = nullptr;
-        int payloadSize = 0;
-
-        AuditResult() = default;
-        ~AuditResult()
-        {
-            free(payload);
-        }
-
-        AuditResult(const AuditResult&) = delete;
-        AuditResult(AuditResult&& other) noexcept
-        {
-            result = other.result;
-            payload = other.payload;
-            payloadSize = other.payloadSize;
-            other.payload = nullptr;
-        }
-
-        AuditResult& operator=(const AuditResult&) = delete;
-        AuditResult& operator=(AuditResult&& other) noexcept
-        {
-            if (this == &other)
-            {
-                return *this;
-            }
-
-            result = other.result;
-            free(payload);
-            payload = other.payload;
-            payloadSize = other.payloadSize;
-            other.payload = nullptr;
-            return *this;
-        }
-    };
-
 private:
     OsConfigLogHandle mLog = nullptr;
     bool mLocalLog = false;
@@ -69,7 +31,7 @@ private:
     Result<JsonWrapper> decodeB64JSON(const char* input) const;
     Optional<Error> setProcedure(const std::string& ruleName, const char* payload, const int payloadSizeBytes);
     Optional<Error> initAudit(const std::string& ruleName, const char* payload, const int payloadSizeBytes);
-    Result<bool> executeRemediation(const std::string& ruleName, const char* payload, const int payloadSizeBytes);
+    Result<Status> executeRemediation(const std::string& ruleName, const char* payload, const int payloadSizeBytes);
 
 public:
     // Create engine with external log file
@@ -85,7 +47,7 @@ public:
     static const char* getModuleInfo() noexcept;
 
     Result<AuditResult> mmiGet(const char* objectName);
-    Result<bool> mmiSet(const char* objectName, const char* payload, const int payloadSizeBytes);
+    Result<Status> mmiSet(const char* objectName, const char* payload, const int payloadSizeBytes);
 };
 } // namespace compliance
 

--- a/src/modules/compliance/src/lib/Evaluator.h
+++ b/src/modules/compliance/src/lib/Evaluator.h
@@ -5,6 +5,7 @@
 #define COMPLIANCE_EVALUATOR_H
 
 #include "Logging.h"
+#include "MmiResults.h"
 #include "Result.h"
 
 #include <map>
@@ -36,8 +37,8 @@ public:
     Evaluator& operator=(const Evaluator&) = delete;
     Evaluator& operator=(Evaluator&&) = delete;
 
-    Result<bool> ExecuteAudit(char** payload, int* payloadSizeBytes);
-    Result<bool> ExecuteRemediation();
+    Result<AuditResult> ExecuteAudit();
+    Result<Status> ExecuteRemediation();
 
     void setProcedureMap(ProcedureMap procedureMap);
 
@@ -47,7 +48,7 @@ private:
         Audit,
         Remediate
     };
-    Result<bool> EvaluateProcedure(const struct json_object_t* json, const Action action);
+    Result<Status> EvaluateProcedure(const struct json_object_t* json, const Action action);
     const struct json_object_t* mJson;
     const ParameterMap& mParameters;
     std::ostringstream mLogstream;

--- a/src/modules/compliance/src/lib/MmiResults.h
+++ b/src/modules/compliance/src/lib/MmiResults.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCE_MMI_RESULTS_H
+#define COMPLIANCE_MMI_RESULTS_H
+
+#include <string>
+
+namespace compliance
+{
+enum class Status
+{
+    Compliant,
+    NonCompliant
+};
+
+struct AuditResult
+{
+    Status status = Status::NonCompliant;
+    std::string payload;
+
+    AuditResult(Status status, std::string payload)
+        : status(status),
+          payload(std::move(payload))
+    {
+    }
+};
+} // namespace compliance
+
+#endif // COMPLIANCE_MMI_RESULTS_H

--- a/src/modules/compliance/tests/ComplianceTest.cpp
+++ b/src/modules/compliance/tests/ComplianceTest.cpp
@@ -155,6 +155,7 @@ TEST_F(ComplianceTest, ComplianceMmiGet_2)
     int payloadSizeBytes = 0;
     ASSERT_EQ(MMI_OK, ComplianceMmiGet(mHandle, "Compliance", "auditX", &payload, &payloadSizeBytes));
     ASSERT_NE(payload, nullptr);
+    ASSERT_TRUE(payloadSizeBytes >= 5);
     EXPECT_EQ(0, strncmp(payload, "\"PASS", 5));
     free(payload);
 }

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -13,6 +13,7 @@ using compliance::Engine;
 using compliance::Error;
 using compliance::JsonWrapper;
 using compliance::Result;
+using compliance::Status;
 
 static Result<bool> auditFailure(std::map<std::string, std::string>, std::ostringstream&)
 {
@@ -179,7 +180,7 @@ TEST_F(ComplianceEngineTest, MmiSet_setProcedure_1)
     std::string payload = "eyJhdWRpdCI6e319"; // '{"audit":{}}' in base64
     auto result = mEngine.mmiSet("procedureX", payload.c_str(), static_cast<int>(payload.size()));
     ASSERT_TRUE(result);
-    EXPECT_TRUE(result.value());
+    EXPECT_EQ(result.value(), Status::Compliant);
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_setProcedure_2)
@@ -187,7 +188,7 @@ TEST_F(ComplianceEngineTest, MmiSet_setProcedure_2)
     std::string payload = "eyJhdWRpdCI6e30sICJyZW1lZGlhdGUiOnt9fQ=="; // '{"audit":{}, "remediate":{}}' in base64
     auto result = mEngine.mmiSet("procedureX", payload.c_str(), static_cast<int>(payload.size()));
     ASSERT_TRUE(result);
-    EXPECT_TRUE(result.value());
+    EXPECT_EQ(result.value(), Status::Compliant);
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_initAudit_InvalidArgument_1)
@@ -208,7 +209,7 @@ TEST_F(ComplianceEngineTest, MmiSet_initAudit_InvalidArgument_3)
 {
     std::string payload = "eyJhdWRpdCI6e319"; // '{"audit":{}}' in base64
     auto result = mEngine.mmiSet("procedureX", payload.c_str(), static_cast<int>(payload.size()));
-    ASSERT_TRUE(result && result.value());
+    ASSERT_TRUE(result && result.value() == Status::Compliant);
 
     payload = "K=V";
     result = mEngine.mmiSet("initX", payload.c_str(), static_cast<int>(payload.size()));
@@ -220,12 +221,12 @@ TEST_F(ComplianceEngineTest, MmiSet_initAudit_1)
 {
     std::string payload = "eyJhdWRpdCI6e30sICJwYXJhbWV0ZXJzIjp7IksiOiJ2In19"; // '{"audit":{}, "parameters":{"K":"v"}}' in base64
     auto result = mEngine.mmiSet("procedureX", payload.c_str(), static_cast<int>(payload.size()));
-    ASSERT_TRUE(result && result.value());
+    ASSERT_TRUE(result && result.value() == Status::Compliant);
 
     payload = "K=V";
     result = mEngine.mmiSet("initX", payload.c_str(), static_cast<int>(payload.size()));
     ASSERT_TRUE(result);
-    EXPECT_TRUE(result.value());
+    EXPECT_EQ(result.value(), Status::Compliant);
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_executeRemediation_InvalidArgument_1)
@@ -246,7 +247,7 @@ TEST_F(ComplianceEngineTest, MmiSet_executeRemediation_InvalidArgument_3)
 {
     std::string payload = "eyJhdWRpdCI6e319"; // '{"audit":{}}' in base64
     auto result = mEngine.mmiSet("procedureX", payload.c_str(), static_cast<int>(payload.size()));
-    ASSERT_TRUE(result && result.value());
+    ASSERT_TRUE(result && result.value() == Status::Compliant);
 
     result = mEngine.mmiSet("remediateX", "", 0);
     ASSERT_FALSE(result);
@@ -257,7 +258,7 @@ TEST_F(ComplianceEngineTest, MmiSet_executeRemediation_InvalidArgument_4)
 {
     std::string payload = "eyJhdWRpdCI6e30sInJlbWVkaWF0ZSI6e319"; // '{"audit":{},"remediate":{}}' in base64
     auto result = mEngine.mmiSet("procedureX", payload.c_str(), static_cast<int>(payload.size()));
-    ASSERT_TRUE(result && result.value());
+    ASSERT_TRUE(result && result.value() == Status::Compliant);
 
     payload = "K=V";
     result = mEngine.mmiSet("remediateX", payload.c_str(), static_cast<int>(payload.size()));
@@ -286,7 +287,7 @@ TEST_F(ComplianceEngineTest, MmiSet_executeRemediation_2)
     // Result is reported by the Evaluator class
     auto result = mEngine.mmiSet("remediateX", "", 0);
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.value(), true);
+    EXPECT_EQ(result.value(), Status::Compliant);
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_executeRemediation_3)
@@ -298,7 +299,7 @@ TEST_F(ComplianceEngineTest, MmiSet_executeRemediation_3)
     // Result is reported by the Evaluator class
     auto result = mEngine.mmiSet("remediateX", "", 0);
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.value(), false);
+    EXPECT_EQ(result.value(), Status::NonCompliant);
 }
 
 TEST_F(ComplianceEngineTest, MmiGet_1)
@@ -322,7 +323,7 @@ TEST_F(ComplianceEngineTest, MmiGet_2)
     // Result is reported by the Evaluator class
     auto result = mEngine.mmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.value().result, true);
+    EXPECT_EQ(result.value().status, Status::Compliant);
 }
 
 TEST_F(ComplianceEngineTest, MmiGet_3)
@@ -334,5 +335,5 @@ TEST_F(ComplianceEngineTest, MmiGet_3)
     // Result is reported by the Evaluator class
     auto result = mEngine.mmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.value().result, false);
+    EXPECT_EQ(result.value().status, Status::NonCompliant);
 }


### PR DESCRIPTION
## Description

Simplify ExecuteAudit by encapsulating payload in the result. Previously used AuditResult type used char array with size, this has been changed to std::string for simplification. ExecuteAudit calls no longer require output parameters and return the payload in the function result.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
