### PR TITLE
Remove dockerfiles from pre-commit exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
             src/tests/fuzzer/seed_corpus/.*|
             devops/docker/.*/Dockerfile
             )$
+    - id: trailing-whitespace
     - id: mixed-line-ending
       args: ['--fix', 'lf']
       files: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,8 @@ repos:
             src/tests/fuzzer/seed_corpus/.*|
             devops/docker/.*/Dockerfile
             )$
-    - id: trailing-whitespace
-      exclude: |
-         (?x)(
-          ^devops/docker/.*/Dockerfile$
-         )
     - id: mixed-line-ending
       args: ['--fix', 'lf']
-      exclude: |
-         (?x)(
-          ^devops/docker/.*/Dockerfile$
-         )
       files: |
          (?x)(
           .*\.c|

--- a/devops/docker/almalinux-9-amd64/Dockerfile
+++ b/devops/docker/almalinux-9-amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/amazonlinux-2-amd64/Dockerfile
+++ b/devops/docker/amazonlinux-2-amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/centos-7-amd64/Dockerfile
+++ b/devops/docker/centos-7-amd64/Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/centos-8-amd64/Dockerfile
+++ b/devops/docker/centos-8-amd64/Dockerfile
@@ -1,9 +1,9 @@
 # TODO: Add mcr.io retagged images
 FROM centos:latest
 
-# CentOS Linux 8 had reached the End Of Life (EOL) on December 31st, 2021. 
+# CentOS Linux 8 had reached the End Of Life (EOL) on December 31st, 2021.
 # It means that CentOS 8 will no longer receive development resources from
-# the official CentOS project. After Dec 31st, 2021, if you need to update 
+# the official CentOS project. After Dec 31st, 2021, if you need to update
 # your CentOS, you need to change the mirrors to vault.centos.org where they
 # will be archived permanently
 RUN cd /etc/yum.repos.d/
@@ -20,7 +20,7 @@ RUN yum update -y && yum install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/oraclelinux-7-amd64/Dockerfile
+++ b/devops/docker/oraclelinux-7-amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/oraclelinux-8-amd64/Dockerfile
+++ b/devops/docker/oraclelinux-8-amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/rhel-9-amd64/Dockerfile
+++ b/devops/docker/rhel-9-amd64/Dockerfile
@@ -13,7 +13,7 @@ RUN yum install -y --disableplugin=subscription-manager \
     ninja-build \
     openssl-devel \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/rockylinux-9-amd64/Dockerfile
+++ b/devops/docker/rockylinux-9-amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/sles-15-amd64/Dockerfile
+++ b/devops/docker/sles-15-amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN zypper install -y \
     libtool \
     make \
     libopenssl-devel \
-    rpm-build 
+    rpm-build
 
 WORKDIR /git
 

--- a/devops/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-14.04-amd64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get -y update && apt-get -y install \ 
+RUN apt-get -y update && apt-get -y install \
     gcc \
     git \
     build-essential \


### PR DESCRIPTION
## Description

* Removes the `devops/docker/.*/Dockerfile` exclusion from the `trailing-whitespace` and `mixed-line-ending` pre-commit hooks in the `.pre-commit-config.yaml

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.
