### PR TITLE
Permanently disable auditd module tests

### DIFF
--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -1219,16 +1219,6 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAuditdInstalled"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "remediateEnsureAuditdServiceIsRunning"
-  },
-  {
-    "ObjectType": "Desired",
-    "ComponentName": "SecurityBaseline",
     "ObjectName": "remediateEnsureSnmpServerIsDisabled"
   },
   {
@@ -2387,16 +2377,6 @@
     "ObjectType": "Reported",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "auditEnsureUnnecessaryAccountsAreRemoved"
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAuditdInstalled"
-  },
-  {
-    "ObjectType": "Reported",
-    "ComponentName": "SecurityBaseline",
-    "ObjectName": "auditEnsureAuditdServiceIsRunning"
   },
   {
     "ObjectType": "Reported",


### PR DESCRIPTION
## Description

Auditd clashes with auoms service installed on Azure VMs. This causes auditd service to fail to run due already-existing PID file shared with auoms.

Some failed module test executions show that auditd fails on pidfile creation. In such cases, the following show what's the PID file content:
```
[2025-03-05 13:00:49][INFO][Asb.c:3024] -------------------------------- auditctl -s -----------------------------------------
[2025-03-05 13:00:49][INFO][Asb.c:3026] enabled 1
failure 1
pid 5587
rate_limit 0
backlog_limit 10240
lost 0
backlog 0
backlog_wait_time 1
backlog_wait_time_actual 0
loginuid_immutable 0 unlocked
 ```
Here we can see the PID is 5587. Excerpt of `ps auxf` output in this case shows the following:
```
root        2197  0.6  0.2 1175784 20008 ?       Ssl  12:56   0:01 /opt/microsoft/auoms/bin/auoms
root        5587  0.2  0.1 789428 13668 ?        S<l  12:57   0:00  \_ /opt/microsoft/auoms/bin/auomscollect -n
```
We can see the auoms service is occupying the 5587 PID.

The auoms service is not controlled in any way by the OSConfig agent and is automatically started on Azure VMs we run the tests on. As this is a security-related service and starts in background, we should not attempt to disable it, so the only reasonable solution to this problem is to disable auditd module tests.

As a side note, it may be worth investigating whether ASB policy won't have similar issues if we run it on Azure VMs. It seems we may always face problems with auditd-related rules in remediation mode.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
