### PR TITLE
Adding logging option to disable console logging from the OSConfig Universal NRP

### DIFF
--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -187,7 +187,7 @@ jobs:
         uses: ./.github/actions/check-size
         with:
           package: '${{ steps.normalize.outputs.path }}'
-          limit: 290
+          limit: 300
 
       - name: Run Guest Configuration Test
         working-directory: ${{ steps.normalize.outputs.PolicyPackageDir }}

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -176,6 +176,8 @@ void MI_CALL OsConfigResource_Load(
         g_mpiHandle = NULL;
     }
 
+    SetConsoleLoggingEnabled(false);
+
     BaselineInitialize(GetLog());
 
     LogInfo(context, GetLog(), "[OsConfigResource] Load (PID: %d)", getpid());

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -883,6 +883,8 @@ void AsbInitialize(OsConfigLogHandle log)
 
     OsConfigLogInfo(log, "AsbInitialize: %s", g_asbName);
 
+    OsConfigLogInfo(log, "AsbInitialize: console logging is %s", IsConsoleLoggingEnabled() ? "enabled" : "disabled");
+
     if (NULL != (cpuModel = GetCpuModel(GetPerfLog())))
     {
         OsConfigLogInfo(log, "AsbInitialize: CPU model: %s", cpuModel);

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -24,6 +24,18 @@ struct OsConfigLog
     unsigned int trimLogCount;
 };
 
+static bool g_consoleLoggingEnabled = true;
+
+bool IsConsoleLoggingEnabled(void)
+{
+    return g_consoleLoggingEnabled;
+}
+
+void SetConsoleLoggingEnabled(bool enabledOrDisabled)
+{
+    g_consoleLoggingEnabled = enabledOrDisabled;
+}
+
 void SetDebugLogging(bool fullLogging)
 {
     g_loggingLevel = fullLogging ? LoggingLevelDebug : LoggingLevelInformational;

--- a/src/common/logging/Logging.h
+++ b/src/common/logging/Logging.h
@@ -47,6 +47,9 @@ void CloseLog(OsConfigLogHandle* log);
 bool IsDebugLoggingEnabled(void);
 void SetDebugLogging(bool fullLogging);
 
+bool IsConsoleLoggingEnabled(void);
+void SetConsoleLoggingEnabled(bool enabledOrDisabled);
+
 FILE* GetLogFile(OsConfigLogHandle log);
 char* GetFormattedTime(void);
 void TrimLog(OsConfigLogHandle log);
@@ -77,7 +80,7 @@ bool IsDaemon(void);
         OSCONFIG_FILE_LOG_INFO(log, FORMAT, ##__VA_ARGS__);\
         fflush(GetLogFile(log));\
     }\
-    if ((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) {\
+    if (((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) && (true == IsConsoleLoggingEnabled())) {\
         OSCONFIG_LOG_INFO(log, FORMAT, ##__VA_ARGS__);\
     }\
 }\
@@ -87,7 +90,7 @@ bool IsDaemon(void);
         OSCONFIG_FILE_LOG_ERROR(log, FORMAT, ##__VA_ARGS__);\
         fflush(GetLogFile(log));\
     }\
-    if ((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) {\
+    if (((false == IsDaemon()) || (false == IsDebugLoggingEnabled())) && (true == IsConsoleLoggingEnabled())) {\
         OSCONFIG_LOG_ERROR(log, FORMAT, ##__VA_ARGS__);\
     }\
 }\
@@ -98,7 +101,7 @@ bool IsDaemon(void);
             OSCONFIG_FILE_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
             fflush(GetLogFile(log));\
         }\
-        if (false == IsDaemon()) {\
+        if ((false == IsDaemon()) && (true == IsConsoleLoggingEnabled())) {\
             OSCONFIG_LOG_DEBUG(log, FORMAT, ##__VA_ARGS__);\
         }\
     }\


### PR DESCRIPTION
## Description

Adding logging option to disable console logging from the OSConfig Universal NRP. Since the NRP runs loaded in an MC worker process started by the MC agent and not directly loaded into the MC agent process we cannot rely on the daemon check. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
