### PR TITLE
Introduce timeout for wait loop in tests

### DIFF
--- a/.github/actions/defer-tests/action.yml
+++ b/.github/actions/defer-tests/action.yml
@@ -18,19 +18,20 @@ runs:
     - name: Wait for packages installed by azsec
       run: |
         source /etc/os-release
-        if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
-          until dpkg -l azsec-bpftrace 2>/dev/null | grep -q '^ii'; do
-            echo "Waiting for azsec-bpftrace to be installed..."
-            sleep 5
-          done
-        elif [[ "$ID" == "mariner" ]]; then
-          until rpm -q azsec-bpftrace &>/dev/null; do
-            echo "Waiting for azsec-bpftrace to be installed..."
-            sleep 5
-          done
-          until rpm -q KeysInUse-OpenSSL &>/dev/null; do
-            echo "Waiting for azsec-bpftrace to be installed..."
-            sleep 5
-          done
-        fi
+        for i in $(seq 1 60); do
+          if [[ "$ID" != "ubuntu" ]] && [[ "$ID" != "debian" ]] && [[ "$ID" != "mariner" ]]; then
+            break
+          fi
+          if [[ "$ID" == "ubuntu" ]] || [[ "$ID" == "debian" ]]; then
+            if dpkg -l azsec-bpftrace 2>/dev/null | grep -q '^ii'; then
+              break
+            fi
+          elif [[ "$ID" == "mariner" ]]; then
+            if rpm -q azsec-bpftrace &>/dev/null && rpm -q KeysInUse-OpenSSL &>/dev/null; then
+              break
+            fi
+          fi
+          echo "Waiting for required packages to be installed..."
+          sleep 5
+        done
       shell: bash


### PR DESCRIPTION
## Description

There was a case where defer-tests action would end up in an infinite loop state on Marinuer 2 distro. This PR adds a 5-minute timeout to the wait loop to prevent the action from hanging indefinitely.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
