### PR TITLE
Log NRP version including git commit

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,12 @@ else()
     set(CMAKE_PROJECT_VERSION_TWEAK "${_timestamp}")
 endif()
 
+execute_process(COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE GIT_COMMIT_ID
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 set(OsConfigProjectName "osconfig")
 set(OsConfigProjectLongName "Azure OSConfig")
 set(OsConfigProjectDescription "Azure OSConfig is a modular security configuration stack for Linux Edge devices that supports multi-authority device management over Azure, GitOps, as well as local management.")
@@ -78,6 +84,7 @@ set(OsConfigProjectEmail "osconfigcore@microsoft.com")
 set(OsConfigProjectUrl "https://github.com/Azure/azure-osconfig/")
 set(OsConfigHashAlgorithm "SHA256")
 set(OsConfigVersionString ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_PATCH}.${CMAKE_PROJECT_VERSION_TWEAK})
+set(OsConfigVersionStringFull "${OsConfigVersionString}-g${GIT_COMMIT_ID}")
 set(OsConfigRootBinaryDir ${CMAKE_BINARY_DIR})
 
 message(STATUS "${OsConfigProjectName} v${OsConfigVersionString}")

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -3,6 +3,7 @@
 
 #include "Common.h"
 #include "Baseline.h"
+#include <version.h>
 
 // The log file for the NRP
 #define LOG_FILE "/var/log/osconfig_nrp.log"
@@ -39,6 +40,8 @@ static OsConfigLogHandle g_log = NULL;
 
 static const char* g_osconfig = "osconfig";
 static const char* g_mpiServer = "osconfig-platform";
+
+static const char version[] __attribute__((section(".version.info"))) = OSCONFIG_VERSION;
 
 OsConfigLogHandle GetLog(void)
 {
@@ -179,6 +182,7 @@ void MI_CALL OsConfigResource_Load(
     BaselineInitialize(GetLog());
 
     LogInfo(context, GetLog(), "[OsConfigResource] Load (PID: %d)", getpid());
+    LogInfo(context, GetLog(), "[OsConfigResource] Version: %s", version);
 
     MI_Context_PostResult(context, MI_RESULT_OK);
 }

--- a/src/adapters/mc/README.md
+++ b/src/adapters/mc/README.md
@@ -138,6 +138,18 @@ $x.resources[0].properties
 ```
 In addition to the MC traces written to the the PowerShell console, you can also see the NRP's own log at `/var/log/osconfig_mc_nrp.log`.
 
+### 4.4. Validating NRP version
+
+The version and git commit of the repository at the time that the NRP binary was built is stored in the `.version.info` ELF section of `libOsConfigResource.so`.
+To view it, run the following command:
+
+```bash
+$ readelf -p .version.info libOsConfigResource.so
+
+String dump of section '.version.info':
+  [     0]  1.0.5.20250314-g32f48703
+```
+
 ## 5. Onboarding a device to Arc
 
 1. Go to Azure Portal | Azure Arc | Add your infrastructure for free | Add your existing server | Generate script.

--- a/src/cmake/templates/version.h.in
+++ b/src/cmake/templates/version.h.in
@@ -5,6 +5,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define OSCONFIG_VERSION "@OsConfigVersionString@"
+#define OSCONFIG_VERSION "@OsConfigVersionStringFull@"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Description

Current nrp logs lack any version information. Log a line with NRP version information during `Load()`. Extend the version string used for this purpose to include the git commit. The version string now looks like this:
```
1.0.5.20250314-g32f48703
```
This is the same convention used by `git describe.`

The version string is also in an ELF section called `.version.info` so that it is possible to extract it from an existing SO with command line utilities easily:
```
$ readelf -p .version.info build/adapters/mc/compliance/libOsConfigResourceCompliance.so 

String dump of section '.version.info':
  [     0]  1.0.5.20250314-g32f48703
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
