### PR TITLE
Simplify RemoveUserAccounts

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -4065,7 +4065,7 @@ static int RemediateEnsureRloginServiceIsDisabled(char* value, OsConfigLogHandle
 static int RemediateEnsureUnnecessaryAccountsAreRemoved(char* value, OsConfigLogHandle log)
 {
     InitEnsureUnnecessaryAccountsAreRemoved(value);
-    return RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, true, log);
+    return RemoveUserAccounts(g_desiredEnsureUnnecessaryAccountsAreRemoved, log);
 }
 
 int AsbMmiGet(const char* componentName, const char* objectName, char** payload, int* payloadSizeBytes, unsigned int maxPayloadSizeBytes, OsConfigLogHandle log)

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3004,13 +3004,12 @@ int CheckUserAccountsNotFound(const char* names, char** reason, OsConfigLogHandl
             break;
         }
 
-        OsConfigLogInfo(log, "CheckUserAccountsNotFound: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, usernames);
         for (token = strtok(usernames, ","); token != NULL; token = strtok(NULL, ","))
         {
-            OsConfigLogInfo(log, "CheckUserAccountsNotFound: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, token);
-
             if (0 != strcmp(pw->pw_name, token))
+            {
                 continue;
+            }
             OsConfigLogInfo(log, "CheckUserAccountsNotFound: user '%s' found with id %u, gid %u, home '%s'",
                 pw->pw_name, pw->pw_uid, pw->pw_gid, pw->pw_dir);
 
@@ -3025,7 +3024,7 @@ int CheckUserAccountsNotFound(const char* names, char** reason, OsConfigLogHandl
 
         FREE_MEMORY(usernames);
     }
-    if (status == 0 && 0 != errno)
+    if ((0 == status) && (0 != errno))
     {
         status = errno;
         OsConfigLogError(log, "CheckUserAccountsNotFound: getpwent() failed with error %d", status);
@@ -3074,10 +3073,8 @@ int RemoveUserAccounts(const char* names, OsConfigLogHandle log)
             break;
         }
 
-        OsConfigLogInfo(log, "RemoveUserAccounts: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, usernames);
         for (token = strtok(usernames, ","); token != NULL; token = strtok(NULL, ","))
         {
-            OsConfigLogInfo(log, "RemoveUserAccounts: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, token);
             // Skip root user
             if (pw->pw_uid == 0)
             {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3195,6 +3195,12 @@ int RemoveUserAccounts(const char* names, OsConfigLogHandle log)
         char* token = NULL;
         for (token = strtok(usernames, ","); token != NULL; token = strtok(NULL, ","))
         {
+            // Skip root user
+            if (pw->pw_uid == 0)
+            {
+                continue;
+            }
+
             if (0 == strcmp(pw->pw_name, token))
             {
                 if ((0 != (_status = RemoveUser2(pw->pw_name, log))) && (0 == status))

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3132,8 +3132,10 @@ int RemoveUserAccounts(const char* names, OsConfigLogHandle log)
             break;
         }
 
+        OsConfigLogInfo(log, "RemoveUserAccounts: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, usernames);
         for (token = strtok(usernames, ","); token != NULL; token = strtok(NULL, ","))
         {
+            OsConfigLogInfo(log, "RemoveUserAccounts: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, token);
             // Skip root user
             if (pw->pw_uid == 0)
             {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -2980,7 +2980,6 @@ int SetUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes, 
 
 int CheckUserAccountsNotFound(const char* names, char** reason, OsConfigLogHandle log)
 {
-    char* name = NULL;
     bool found = false;
     int status = 0;
     struct passwd* pw;
@@ -3010,19 +3009,18 @@ int CheckUserAccountsNotFound(const char* names, char** reason, OsConfigLogHandl
         {
             OsConfigLogInfo(log, "CheckUserAccountsNotFound: checking user '%s' (%u, %u) against '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, token);
 
-            if (0 == strcmp(pw->pw_name, token))
+            if (0 != strcmp(pw->pw_name, token))
+                continue;
+            OsConfigLogInfo(log, "CheckUserAccountsNotFound: user '%s' found with id %u, gid %u, home '%s'",
+                pw->pw_name, pw->pw_uid, pw->pw_gid, pw->pw_dir);
+
+            if (DirectoryExists(pw->pw_dir))
             {
-                OsConfigLogInfo(log, "CheckUserAccountsNotFound: user '%s' found with id %u, gid %u, home '%s'",
-                    pw->pw_name, pw->pw_uid, pw->pw_gid, pw->pw_dir);
-
-                if (DirectoryExists(pw->pw_dir))
-                {
-                    OsConfigLogInfo(log, "CheckUserAccountsNotFound: home directory of user '%s' exists ('%s')", name, pw->pw_dir);
-                }
-
-                OsConfigCaptureReason(reason, "User '%s' found with id %u, gid %u, home '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, pw->pw_dir);
-                found = true;
+                OsConfigLogInfo(log, "CheckUserAccountsNotFound: home directory of user '%s' exists ('%s')", pw->pw_name, pw->pw_dir);
             }
+
+            OsConfigCaptureReason(reason, "User '%s' found with id %u, gid %u, home '%s'", pw->pw_name, pw->pw_uid, pw->pw_gid, pw->pw_dir);
+            found = true;
         }
 
         FREE_MEMORY(usernames);

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -90,8 +90,6 @@ int CheckRootIsOnlyUidZeroAccount(char** reason, OsConfigLogHandle log);
 int SetRootIsOnlyUidZeroAccount(OsConfigLogHandle log);
 int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log);
 int RemoveUsersWithoutPasswords(OsConfigLogHandle log);
-int RemoveUser(SimplifiedUser* user, bool removeHomeDir, OsConfigLogHandle log);
-int RemoveUser2(const char* username, OsConfigLogHandle log);
 int CheckDefaultRootAccountGroupIsGidZero(char** reason, OsConfigLogHandle log);
 int SetDefaultRootAccountGroupIsGidZero(OsConfigLogHandle log);
 int CheckAllUsersHomeDirectoriesExist(char** reason, OsConfigLogHandle log);

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -92,7 +92,6 @@ int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log);
 int RemoveUsersWithoutPasswords(OsConfigLogHandle log);
 int RemoveUser(SimplifiedUser* user, bool removeHomeDir, OsConfigLogHandle log);
 int RemoveUser2(const char* username, OsConfigLogHandle log);
-int RemoveGroup(SimplifiedGroup* group, bool removeHomeDirs, OsConfigLogHandle log);
 int CheckDefaultRootAccountGroupIsGidZero(char** reason, OsConfigLogHandle log);
 int SetDefaultRootAccountGroupIsGidZero(OsConfigLogHandle log);
 int CheckAllUsersHomeDirectoriesExist(char** reason, OsConfigLogHandle log);

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -91,6 +91,7 @@ int SetRootIsOnlyUidZeroAccount(OsConfigLogHandle log);
 int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log);
 int RemoveUsersWithoutPasswords(OsConfigLogHandle log);
 int RemoveUser(SimplifiedUser* user, bool removeHomeDir, OsConfigLogHandle log);
+int RemoveUser2(const char* username, OsConfigLogHandle log);
 int RemoveGroup(SimplifiedGroup* group, bool removeHomeDirs, OsConfigLogHandle log);
 int CheckDefaultRootAccountGroupIsGidZero(char** reason, OsConfigLogHandle log);
 int SetDefaultRootAccountGroupIsGidZero(OsConfigLogHandle log);
@@ -119,7 +120,7 @@ int CheckOrEnsureUsersDontHaveDotFiles(const char* name, bool removeDotFiles, ch
 int CheckUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes, char** reason, OsConfigLogHandle log);
 int SetUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes, unsigned int mode, OsConfigLogHandle log);
 int CheckUserAccountsNotFound(const char* names, char** reason, OsConfigLogHandle log);
-int RemoveUserAccounts(const char* names, bool removeHomeDirs, OsConfigLogHandle log);
+int RemoveUserAccounts(const char* names, OsConfigLogHandle log);
 int RestrictSuToRootGroup(OsConfigLogHandle log);
 
 #ifdef __cplusplus

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -2404,6 +2404,33 @@
     "ObjectName": "auditEnsureSmbWithSambaIsDisabled"
   },
   {
+    "RunCommand": "useradd securitybaselinetest && id securitybaselinetest"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureUnnecessaryAccountsAreRemoved",
+    "Payload": "games,test"
+  },
+  {
+    "RunCommand": "id securitybaselinetest"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureUnnecessaryAccountsAreRemoved",
+    "Payload": "securitybaselinetest"
+  },
+  {
+    "RunCommand": "! id securitybaselinetest"
+  },
+  {
+    "RunCommand": "userdel securitybaselinetest || true"
+  },
+  {
+    "RunCommand": "groupdel securitybaselinetest || true"
+  },
+  {
     "Action": "UnloadModule"
   }
 ]


### PR DESCRIPTION
## Description

Simplify RemoveUserAccounts:

* Avoid 2-stage iteration over /etc/passwd entries
* Add module test to make sure we no longer remove users whose names end with one of supplied names to be removed
* Add a temporary function to remove users based on username instead of SimplifiedUser structure
* Simplify iteration over /etc/passwd entries
* Drop home directory removal functionality

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
