### PR TITLE
pipeline: update tj-actions/change-files to post cve

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get changed containers
         id: changed-containers
-        uses: tj-actions/changed-files@v46.0.0
+        uses: tj-actions/changed-files@v46.0.1
         with:
           files: ./devops/docker/**/Dockerfile
 

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get changed containers
         id: changed-containers
-        uses: tj-actions/changed-files@v41.0.0
+        uses: tj-actions/changed-files@v46.0.0
         with:
           files: ./devops/docker/**/Dockerfile
 


### PR DESCRIPTION
## Description
The th-actions/change-files version we use is vunrable to cve 
https://www.cve.org/CVERecord?id=CVE-2025-30066
Update to the not vunrable one

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
