### PR TITLE
EnsureFilePermissions compliance check module tests

### DIFF
--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
@@ -16,32 +16,46 @@ namespace compliance
 AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required owner of the file", "group:Required group of the file",
     "permissions:Required octal permissions of the file::^[0-7]{3,4}$", "mask:Required octal permissions of the file - mask::^[0-7]{3,4}$")
 {
-    UNUSED(log);
     struct stat statbuf;
     if (args.find("filename") == args.end())
     {
-        return Error("No filename provided");
+        OsConfigLogError(log, "No filename provided");
+        return Error("No filename provided", EINVAL);
     }
-    logstream << "ensureFilePermissions for '" << args["filename"] << "' ";
+    const auto filename = args["filename"];
 
     if (0 != stat(args["filename"].c_str(), &statbuf))
     {
-        logstream << "Stat error '" << strerror(errno) << "'";
-        return false;
+        const int status = errno;
+        if (ENOENT == status)
+        {
+            OsConfigLogDebug(log, "File '%s' does not exist", args["filename"].c_str());
+            logstream << "File '" << args["filename"] << "' does not exist";
+            return false;
+        }
+
+        OsConfigLogError(log, "Stat error %s (%d)", strerror(status), status);
+        return Error(std::string("Stat error '") + strerror(status) + "'", status);
     }
 
     if (args.find("owner") != args.end())
     {
-        struct passwd* pwd = getpwuid(statbuf.st_uid);
+        const struct passwd* pwd = getpwuid(statbuf.st_uid);
         if (nullptr == pwd)
         {
-            logstream << "No user with uid " << statbuf.st_uid;
+            OsConfigLogDebug(log, "No user with UID %d", statbuf.st_gid);
+            logstream << "Invalid '" << filename << "' owner: " << statbuf.st_gid << " - no such user";
             return false;
         }
         if (args["owner"] != pwd->pw_name)
         {
-            logstream << "Invalid owner - is " << pwd->pw_name << " should be " << args["owner"];
+            OsConfigLogDebug(log, "Invalid '%s' owner - is '%s' should be '%s'", filename.c_str(), pwd->pw_name, args["owner"].c_str());
+            logstream << "Invalid '" << filename << "' owner - is '" << pwd->pw_name << "' should be '" << args["owner"] << "' ";
             return false;
+        }
+        else
+        {
+            OsConfigLogDebug(log, "Matched owner '%s' to '%s'", args["owner"].c_str(), pwd->pw_name);
         }
     }
 
@@ -50,7 +64,8 @@ AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required o
         struct group* grp = getgrgid(statbuf.st_gid);
         if (nullptr == grp)
         {
-            logstream << "No group with gid " << statbuf.st_gid;
+            OsConfigLogDebug(log, "No group with GID %d", statbuf.st_gid);
+            logstream << "Invalid '" << filename << "' group: " << statbuf.st_gid << " - no such group";
             return false;
         }
         std::istringstream iss(args["group"]);
@@ -60,14 +75,19 @@ AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required o
         {
             if (group == grp->gr_name)
             {
+                OsConfigLogDebug(log, "Matched group '%s' to '%s'", group.c_str(), grp->gr_name);
                 groupOk = true;
                 break;
             }
         }
         if (!groupOk)
         {
-            logstream << "Invalid group - is '" << grp->gr_name << "' should be '" << args["group"] << "' ";
+            logstream << "Invalid '" << filename << "' group - is '" << grp->gr_name << "' should be '" << args["group"] << "' ";
             return false;
+        }
+        else
+        {
+            OsConfigLogDebug(log, "Matched group '%s' to '%s'", args["group"].c_str(), grp->gr_name);
         }
     }
 
@@ -81,8 +101,8 @@ AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required o
         perms = strtol(args["permissions"].c_str(), &endptr, 8);
         if ('\0' != *endptr)
         {
-            logstream << "Invalid permissions: " << args["permissions"];
-            return false;
+            OsConfigLogError(log, "Invalid permissions: %s", args["permissions"].c_str());
+            return Error("Invalid permissions argument: " + args["permissions"], EINVAL);
         }
         has_permissions = true;
     }
@@ -92,44 +112,72 @@ AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required o
         mask = strtol(args["mask"].c_str(), &endptr, 8);
         if ('\0' != *endptr)
         {
-            logstream << "Invalid permissions mask: " << args["mask"];
-            return false;
+            OsConfigLogError(log, "Invalid mask argument: %s", args["mask"].c_str());
+            return Error("Invalid mask argument: " + args["mask"], EINVAL);
         }
         has_mask = true;
     }
     if ((has_permissions && has_mask) && (0 != (perms & mask)))
     {
-        logstream << "ERROR: Invalid permissions and mask - same bits set in both";
+        OsConfigLogError(log, "Invalid permissions and mask - same bits set in both");
         return Error("Invalid permissions and mask - same bits set in both");
     }
-    if (has_permissions && (perms != (statbuf.st_mode & perms)))
+    const mode_t displayMask = 07777;
+    if (has_permissions)
     {
-        logstream << "Invalid permissions - are " << std::oct << statbuf.st_mode << " should be at least " << std::oct << perms;
-        return false;
+        if (perms != (statbuf.st_mode & perms))
+        {
+            logstream << "Invalid '" << filename << "' permissions - are " << std::oct << (statbuf.st_mode & displayMask) << " should be at least "
+                      << std::oct << perms;
+            return false;
+        }
+        else
+        {
+            OsConfigLogDebug(log, "Permissions are correct");
+        }
     }
-    if (has_mask && (0 != (statbuf.st_mode & mask)))
+    if (has_mask)
     {
-        logstream << "Invalid permissions - are " << std::oct << statbuf.st_mode << " while " << std::oct << mask << " should not be set";
-        return false;
+        if (0 != (statbuf.st_mode & mask))
+        {
+            logstream << "Invalid '" << filename << "' permissions - are " << std::oct << (statbuf.st_mode & displayMask) << " while " << std::oct
+                      << mask << " should not be set";
+            return false;
+        }
+        else
+        {
+            OsConfigLogDebug(log, "Mask is correct");
+        }
     }
+
+    OsConfigLogDebug(log, "File '%s' has correct permissions", filename.c_str());
+    logstream << "File '" << filename << "' has correct permissions";
     return true;
 }
 
 REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required owner of the file", "group:Required group of the file",
     "permissions:Required octal permissions of the file::^[0-7]{3,4}$", "mask:Required octal permissions of the file - mask::^[0-7]{3,4}$")
 {
-    UNUSED(log);
     if (args.find("filename") == args.end())
     {
-        logstream << "ERROR: No filename provided";
-        return Error("No filename provided");
+        OsConfigLogError(log, "No filename provided");
+        return Error("No filename provided", EINVAL);
     }
+    const auto filename = args["filename"];
 
     struct stat statbuf;
     if (stat(args["filename"].c_str(), &statbuf) < 0)
     {
-        logstream << "ERROR: Stat error " << strerror(errno);
-        return false;
+        const int status = errno;
+        if (ENOENT == status)
+        {
+            OsConfigLogDebug(log, "File '%s' does not exist", filename.c_str());
+            logstream << "File '" << filename << "' does not exist";
+            return false;
+        }
+
+        OsConfigLogError(log, "Stat error %s (%d)", strerror(status), status);
+        return Error(std::string("Stat error '") + strerror(status) + "'", status);
     }
 
     uid_t uid = statbuf.st_uid;
@@ -137,21 +185,30 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
     bool owner_changed = false;
     if (args.find("owner") != args.end())
     {
-        struct passwd* pwd = getpwnam(args["owner"].c_str());
+        const struct passwd* pwd = getpwnam(args["owner"].c_str());
         if (pwd == nullptr)
         {
-            logstream << "ERROR: No user with name " << args["owner"];
+            OsConfigLogDebug(log, "No user with UID %d", statbuf.st_gid);
+            logstream << "Invalid '" << filename << "' owner: " << statbuf.st_gid << " - no such user";
             return false;
         }
         uid = pwd->pw_uid;
-        owner_changed = true;
+        if (uid != statbuf.st_uid)
+        {
+            owner_changed = true;
+        }
+        else
+        {
+            OsConfigLogDebug(log, "Matched owner '%s' to '%s'", args["owner"].c_str(), pwd->pw_name);
+        }
     }
     if (args.find("group") != args.end())
     {
-        struct group* grp = getgrgid(statbuf.st_gid);
+        const struct group* grp = getgrgid(statbuf.st_gid);
         if (nullptr == grp)
         {
-            logstream << "ERROR: No group with gid " << statbuf.st_gid;
+            OsConfigLogDebug(log, "No group with GID %d", statbuf.st_gid);
+            logstream << "Invalid '" << filename << "' group: " << statbuf.st_gid << " - no such group";
             return false;
         }
         std::istringstream iss(args["group"]);
@@ -166,6 +223,7 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
             }
             if (group == grp->gr_name)
             {
+                OsConfigLogDebug(log, "Matched group '%s' to '%s'", group.c_str(), grp->gr_name);
                 groupOk = true;
                 break;
             }
@@ -175,19 +233,30 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
             struct group* grp = getgrnam(firstGroup.c_str());
             if (grp == nullptr)
             {
-                logstream << "ERROR: No group with name " << args["group"];
-                return Error("No group with name " + args["group"]);
+                OsConfigLogDebug(log, "No group with GID %d", statbuf.st_gid);
+                logstream << "Invalid '" << filename << "' group: " << statbuf.st_gid << " - no such group";
+                return false;
             }
             gid = grp->gr_gid;
+            if (gid != statbuf.st_gid)
+            {
+                owner_changed = true;
+            }
+            else
+            {
+                OsConfigLogDebug(log, "Matched group '%s' to '%s'", args["group"].c_str(), grp->gr_name);
+            }
             owner_changed = true;
         }
     }
     if (owner_changed)
     {
+        OsConfigLogInfo(log, "Changing owner of '%s' from %d:%d to %d:%d", args["filename"].c_str(), statbuf.st_uid, statbuf.st_gid, uid, gid);
         if (0 != chown(args["filename"].c_str(), uid, gid))
         {
-            logstream << "ERROR: Chown error " << strerror(errno);
-            return Error("Chown error");
+            int status = errno;
+            OsConfigLogError(log, "Chown error %s (%d)", strerror(status), status);
+            return Error(std::string("Chown error: ") + strerror(status), status);
         }
     }
 
@@ -202,8 +271,8 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
         perms = strtol(args["permissions"].c_str(), &endptr, 8);
         if ('\0' != *endptr)
         {
-            logstream << "ERROR: Invalid permissions: " << args["permissions"];
-            return Error("Invalid permissions: " + args["permissions"]);
+            OsConfigLogError(log, "Invalid permissions argument: %s", args["permissions"].c_str());
+            return Error("Invalid permissions argument: " + args["permissions"]);
         }
         new_perms |= perms;
         has_permissions = true;
@@ -214,8 +283,8 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
         mask = strtol(args["mask"].c_str(), &endptr, 8);
         if ('\0' != *endptr)
         {
-            logstream << "ERROR: Invalid permissions mask: " << args["mask"];
-            return Error("Invalid permissions mask: " + args["mask"]);
+            OsConfigLogError(log, "Invalid mask argument: %s", args["mask"].c_str());
+            return Error("Invalid mask argument: " + args["mask"], EINVAL);
         }
         new_perms &= ~mask;
         has_mask = true;
@@ -223,18 +292,21 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
     // Sanity check - we can't have bits set in the mask and permissions at the same time.
     if ((has_permissions && has_mask) && (0 != (perms & mask)))
     {
-        logstream << "ERROR: Invalid permissions and mask - same bits set in both";
-        return Error("Invalid permissions and mask - same bits set in both");
+        OsConfigLogError(log, "Invalid permissions and mask - same bits set in both");
+        return Error("Invalid permissions and mask - same bits set in both", EINVAL);
     }
     if (new_perms != statbuf.st_mode)
     {
+        OsConfigLogInfo(log, "Changing permissions of '%s' from %o to %o", args["filename"].c_str(), statbuf.st_mode, new_perms);
         if (chmod(args["filename"].c_str(), new_perms) < 0)
         {
-            logstream << "ERROR: Chmod error";
-            return Error("Chmod error");
+            int status = errno;
+            OsConfigLogError(log, "Chmod error %s (%d)", strerror(status), status);
+            return Error(std::string("Chmod error: ") + strerror(status), status);
         }
     }
 
+    OsConfigLogDebug(log, "File '%s' remediation succeeded", filename.c_str());
     return true;
 }
 } // namespace compliance

--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
@@ -262,7 +262,6 @@ REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Requir
             {
                 OsConfigLogDebug(log, "Matched group '%s' to '%s'", groupName.c_str(), grp->gr_name);
             }
-            owner_changed = true;
         }
     }
     if (owner_changed)

--- a/src/modules/compliance/tests/procedures/ensureFilePermissionsTest.cpp
+++ b/src/modules/compliance/tests/procedures/ensureFilePermissionsTest.cpp
@@ -65,7 +65,7 @@ TEST_F(EnsureFilePermissionsTest, AuditFileMissing)
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Stat error") != std::string::npos);
+    ASSERT_TRUE(logstream.str().find("does not exist") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditWrongOwner)
@@ -80,7 +80,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongOwner)
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Invalid owner") != std::string::npos);
+    ASSERT_TRUE(logstream.str().find(std::string("Invalid '") + args["filename"] + "' owner") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, RemediateWrongOwner)
@@ -114,7 +114,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongGroup)
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Invalid group") != std::string::npos);
+    ASSERT_TRUE(logstream.str().find(std::string("Invalid '") + args["filename"] + "' group") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, RemediateWrongGroup)
@@ -148,7 +148,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongPermissions)
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+    ASSERT_TRUE(logstream.str().find(std::string("Invalid '") + args["filename"] + "' permissions") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, RemediateWrongPermissions)
@@ -182,7 +182,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongMask)
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+    ASSERT_TRUE(logstream.str().find(std::string("Invalid '") + args["filename"] + "' permissions") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, RemediateWrongMask)
@@ -339,9 +339,8 @@ TEST_F(EnsureFilePermissionsTest, AuditBadPermissions)
     CreateFile(args["filename"], 0, 0, 0600);
     args["permissions"] = "999";
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
-    ASSERT_TRUE(result.HasValue());
-    ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_TRUE(result.Error().message.find("Invalid permissions argument") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, RemediateBadPermissions)
@@ -361,9 +360,8 @@ TEST_F(EnsureFilePermissionsTest, AuditBadMask)
     CreateFile(args["filename"], 0, 0, 0600);
     args["mask"] = "999";
     Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
-    ASSERT_TRUE(result.HasValue());
-    ASSERT_FALSE(result.Value());
-    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_TRUE(result.Error().message.find("Invalid mask argument") != std::string::npos);
 }
 
 TEST_F(EnsureFilePermissionsTest, RemediateBadMask)

--- a/src/modules/test/recipes/compliance/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/compliance/EnsureFilePermissions.json
@@ -12,7 +12,7 @@
     "ObjectName": "procedureTest",
     "Payload": {
       "audit": {
-        "ensureFilePermissions": {
+        "EnsureFilePermissions": {
           "filename": "/tmp/testfile",
           "permissions": "$PERMISSIONS",
           "owner": "$USER",
@@ -20,7 +20,7 @@
         }
       },
       "remediate": {
-        "ensureFilePermissions": {
+        "EnsureFilePermissions": {
           "filename": "/tmp/testfile",
           "permissions": "$PERMISSIONS",
           "owner": "$USER",
@@ -38,7 +38,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: File '\/tmp\/testfile' does not exist } == FALSE"
+    "Payload": "{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == FALSE"
   },
   {
     "RunCommand": "touch /tmp/testfile && chmod 777 /tmp/testfile && chown root:root /tmp/testfile"
@@ -53,7 +53,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
 
 
@@ -68,7 +68,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0777\/-rwxrwxrwx)'"
@@ -85,7 +85,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "ObjectType": "Desired",
@@ -97,7 +97,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
 
 
@@ -112,7 +112,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -124,7 +124,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' group - is 'root' should be 'bar'  } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' group - is 'root' should be 'bar'  } == FALSE"
   },
 
 
@@ -135,7 +135,7 @@
     "ObjectName": "procedureTest",
     "Payload": {
       "audit": {
-        "ensureFilePermissions": {
+        "EnsureFilePermissions": {
           "filename": "/tmp/testfile",
           "owner": "$USER",
           "group": "$GROUP",
@@ -143,7 +143,7 @@
         }
       },
       "remediate": {
-        "ensureFilePermissions": {
+        "EnsureFilePermissions": {
           "filename": "/tmp/testfile",
           "owner": "$USER",
           "group": "$GROUP",
@@ -167,7 +167,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "ObjectType": "Desired",
@@ -179,7 +179,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 777 while 177 should not be set } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 777 while 177 should not be set } == FALSE"
   },
 
 
@@ -191,7 +191,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
 
 
@@ -209,7 +209,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0600\/-rw-------)'"
@@ -227,7 +227,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
   },
 
 
@@ -242,7 +242,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' group - is 'root' should be 'bar'  } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' group - is 'root' should be 'bar'  } == FALSE"
   },
 
 
@@ -260,7 +260,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0644\/-rw-r--r--)' | grep root | grep bar"
@@ -278,7 +278,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -290,7 +290,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0600\/-rw-------)' | grep foo | grep bar"
@@ -304,7 +304,7 @@
     "ObjectName": "procedureTest",
     "Payload": {
       "audit": {
-        "ensureFilePermissions": {
+        "EnsureFilePermissions": {
           "filename": "/tmp/testfile",
           "owner": "$USER",
           "permissions": "$PERMISSIONS",
@@ -313,7 +313,7 @@
         }
       },
       "remediate": {
-        "ensureFilePermissions": {
+        "EnsureFilePermissions": {
           "filename": "/tmp/testfile",
           "owner": "$USER",
           "permissions": "$PERMISSIONS",
@@ -336,7 +336,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 777 while 777 should not be set } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 777 while 777 should not be set } == FALSE"
   },
 
 
@@ -351,7 +351,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
 
 
@@ -369,7 +369,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 0 should be at least 333 } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 0 should be at least 333 } == FALSE"
   },
 
 
@@ -384,7 +384,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0333\/--wx-wx-wx)'"
@@ -402,7 +402,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (1333\/--wx-wx-wt)'"

--- a/src/modules/test/recipes/compliance/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/compliance/EnsureFilePermissions.json
@@ -1,0 +1,425 @@
+[
+  {
+    "Action": "LoadModule",
+    "Module": "compliance.so"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "ensureFilePermissions": {
+          "filename": "/tmp/testfile",
+          "permissions": "$PERMISSIONS",
+          "owner": "$USER",
+          "group": "$GROUP"
+        }
+      },
+      "remediate": {
+        "ensureFilePermissions": {
+          "filename": "/tmp/testfile",
+          "permissions": "$PERMISSIONS",
+          "owner": "$USER",
+          "group": "$GROUP"
+        }
+      },
+      "parameters": {
+        "PERMISSIONS": "644",
+        "USER": "root",
+        "GROUP": "root"
+      }
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: File '\/tmp\/testfile' does not exist } == FALSE"
+  },
+  {
+    "RunCommand": "touch /tmp/testfile && chmod 777 /tmp/testfile && chown root:root /tmp/testfile"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PERMISSIONS=777 USER=root GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "PERMISSIONS=777 USER=root GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/testfile | grep 'Access: (0777\/-rwxrwxrwx)'"
+  },
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PERMISSIONS=644 USER=root GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": ""
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PERMISSIONS=777 USER=foo GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PERMISSIONS=777 USER=root GROUP=bar"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' group - is 'root' should be 'bar'  } == FALSE"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "ensureFilePermissions": {
+          "filename": "/tmp/testfile",
+          "owner": "$USER",
+          "group": "$GROUP",
+          "mask": "$MASK"
+        }
+      },
+      "remediate": {
+        "ensureFilePermissions": {
+          "filename": "/tmp/testfile",
+          "owner": "$USER",
+          "group": "$GROUP",
+          "mask": "$MASK"
+        }
+      },
+      "parameters": {
+        "USER": "root",
+        "GROUP": "root",
+        "MASK": "777"
+      }
+    }
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "MASK=000 USER=root GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "MASK=177 USER=root GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 777 while 177 should not be set } == FALSE"
+  },
+
+
+
+  {
+    "RunCommand": "chmod 400 /tmp/testfile && chown root:root /tmp/testfile"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+
+
+
+  {
+    "RunCommand": "chmod 777 /tmp/testfile && chown root:root /tmp/testfile"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "MASK=177 USER=root GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/testfile | grep 'Access: (0600\/-rw-------)'"
+  },
+
+
+  // The remediation fails because the 'foo' user does not exist, so the following audig fails as well
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "MASK=177 USER=foo GROUP=root"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
+  },
+
+
+  // Similarly to the above, the remediation fails because the 'bar' group does not exist, so the following audit fails as well
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "MASK=177 USER=root GROUP=bar"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' group - is 'root' should be 'bar'  } == FALSE"
+  },
+
+
+
+  {
+    "RunCommand": "groupadd bar && useradd -g bar foo && chmod 777 /tmp/testfile && chown root:root /tmp/testfile"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "MASK=133 USER=root GROUP=bar"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/testfile | grep 'Access: (0644\/-rw-r--r--)' | grep root | grep bar"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "MASK=177 USER=foo GROUP=bar"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' owner - is 'root' should be 'foo'  } == FALSE"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "MASK=177 USER=foo GROUP=bar"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/testfile | grep 'Access: (0600\/-rw-------)' | grep foo | grep bar"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "ensureFilePermissions": {
+          "filename": "/tmp/testfile",
+          "owner": "$USER",
+          "permissions": "$PERMISSIONS",
+          "group": "$GROUP",
+          "mask": "$MASK"
+        }
+      },
+      "remediate": {
+        "ensureFilePermissions": {
+          "filename": "/tmp/testfile",
+          "owner": "$USER",
+          "permissions": "$PERMISSIONS",
+          "group": "$GROUP",
+          "mask": "$MASK"
+        }
+      },
+      "parameters": {
+        "USER": "root",
+        "GROUP": "root",
+        "PERMISSIONS": "000",
+        "MASK": "777"
+      }
+    }
+  },
+  {
+    "RunCommand": "chmod 777 /tmp/testfile && chown root:root /tmp/testfile"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 777 while 777 should not be set } == FALSE"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PERMISSIONS=777 MASK=000"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+
+
+
+  {
+    "RunCommand": "chmod 000 /tmp/testfile && chown root:root /tmp/testfile"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PERMISSIONS=333 MASK=444"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ ensureFilePermissions: Invalid '\/tmp\/testfile' permissions - are 0 should be at least 333 } == FALSE"
+  },
+
+
+  // remediation with mask and permissions
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "PERMISSIONS=333 MASK=444"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/testfile | grep 'Access: (0333\/--wx-wx-wx)'"
+  },
+
+
+  // sticky bit
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": "PERMISSIONS=1000 MASK=0"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ ensureFilePermissions: File '\/tmp\/testfile' has correct permissions } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/testfile | grep 'Access: (1333\/--wx-wx-wt)'"
+  },
+
+
+
+  {
+    "RunCommand": "rm -f /tmp/testfile"
+  },
+  {
+    "RunCommand": "userdel foo || true"
+  },
+  {
+    "RunCommand": "groupdel bar || true"
+  },
+  {
+    "Action": "UnloadModule"
+  }
+]


### PR DESCRIPTION
## Description

Add a bunch of module tests and fix some issues popped up during testing:
- Do not allow passing both permissions and mask parameters to ensureFilePermissions
- Fix mask handling
- Do not report error but return failure if a user/group does not exist

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
