### PR TITLE
clang-format: Adjust AlwaysBreakBeforeMultilineStrings setting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true

--- a/src/modules/compliance/src/lib/Engine.cpp
+++ b/src/modules/compliance/src/lib/Engine.cpp
@@ -21,15 +21,16 @@
 
 namespace compliance
 {
-static constexpr const char* cModuleInfo = "{\"Name\": \"Compliance\","
-                                           "\"Description\": \"Provides functionality to audit and remediate Security Baseline policies on device\","
-                                           "\"Manufacturer\": \"Microsoft\","
-                                           "\"VersionMajor\": 2,"
-                                           "\"VersionMinor\": 0,"
-                                           "\"VersionInfo\": \"Dilithium\","
-                                           "\"Components\": [\"Compliance\"],"
-                                           "\"Lifetime\": 2,"
-                                           "\"UserAccount\": 0}";
+static constexpr const char* cModuleInfo =
+    "{\"Name\": \"Compliance\","
+    "\"Description\": \"Provides functionality to audit and remediate Security Baseline policies on device\","
+    "\"Manufacturer\": \"Microsoft\","
+    "\"VersionMajor\": 0,"
+    "\"VersionMinor\": 0,"
+    "\"VersionInfo\": \"\","
+    "\"Components\": [\"Compliance\"],"
+    "\"Lifetime\": 2,"
+    "\"UserAccount\": 0}";
 
 Engine::Engine(OsConfigLogHandle log) noexcept
     : mLog{log}

--- a/src/modules/compliance/src/so/ComplianceModule.c
+++ b/src/modules/compliance/src/so/ComplianceModule.c
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <Mmi.h>
 #include "ComplianceInterface.h"
-#include <stddef.h>
+
+#include <Mmi.h>
 #include <assert.h>
+#include <stddef.h>
 
 static OsConfigLogHandle gLog = NULL;
 static const char* gLogFile = "/var/log/osconfig_compliance.log";


### PR DESCRIPTION
## Description

This change results in more readable multiline strings, because they no longer get indented all the way to the '=' sign. Refreshed formatting on all files in src/modules/compliance, which also caught an include ordering change.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
