### PR TITLE
Prepare module tests to run compliance tests

### DIFF
--- a/.github/workflows/module-test-run.yml
+++ b/.github/workflows/module-test-run.yml
@@ -52,7 +52,7 @@ jobs:
           sudo chmod +x ./moduletest
 
           result=0
-          recipes=$(ls -d ../../src/modules/test/recipes/*.json)
+          recipes=$(find ../../src/modules/test/recipes/ -name "*.json")
 
           for recipe in $recipes; do
             if [ ! -f ../../src/tests/e2e-test-recipes/$(basename $recipe) ]; then

--- a/src/modules/test/main.c
+++ b/src/modules/test/main.c
@@ -491,8 +491,19 @@ int RunTestStep(const TEST_STEP* test, const MANAGEMENT_MODULE* module)
             }
             else
             {
-                LOG_ERROR("Assertion failed, expected: '%s', actual: (null)", test->payload);
-                result = EFAULT;
+                if (NULL == (expectedJsonValue = json_parse_string(test->payload)))
+                {
+                    LOG_ERROR("Assertion failed, expected: '%s', actual: (null)", test->payload);
+                    result = EFAULT;
+                }
+                else
+                {
+                    if (json_value_get_type(expectedJsonValue) != JSONNull)
+                    {
+                        LOG_ERROR("Assertion failed, expected: '%s', actual: (null)", test->payload);
+                        result = EFAULT;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Prepare module tests to run compliance module tests which are intended to be split into separate recipe files. This PR separates work included in #913 as asked: https://github.com/Azure/azure-osconfig/pull/913#discussion_r2001793137
- Allow to run module tests from a subdirectory (use find command)
- Allow to verify if NULL has been reported as the output payload (helps testing failures)

This PR depends on #934 as currently module tests are broken.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
