### PR TITLE
common: Cache IsRedHatBased calculation

### DIFF
--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -796,7 +796,7 @@ bool IsCurrentOs(const char* name, OsConfigLogHandle log)
     return result;
 }
 
-bool IsRedHatBased(OsConfigLogHandle log)
+static bool IsRedHatBasedInternal(OsConfigLogHandle log)
 {
     const char* distros[] = {"Red Hat", "CentOS", "AlmaLinux", "Rocky Linux", "Oracle Linux"};
     int numDistros = ARRAY_SIZE(distros);
@@ -838,6 +838,18 @@ bool IsRedHatBased(OsConfigLogHandle log)
     FREE_MEMORY(prettyName);
 
     return result;
+}
+
+bool IsRedHatBased(OsConfigLogHandle log)
+{
+    static bool firstTime = true;
+    static bool redHatBased = false;
+    if (firstTime)
+    {
+        redHatBased = IsRedHatBasedInternal(log);
+        firstTime = false;
+    }
+    return redHatBased;
 }
 
 int EnableVirtualMemoryRandomization(OsConfigLogHandle log)


### PR DESCRIPTION
## Description

This code is executed on every package related operation on RedHat-like systems and results in many lines in the log that say something like:

  [2025-03-19 13:25:42][INFO][DeviceInfoUtils.c:826] Running on 'AlmaLinux 9.5 (Teal Serval)' which is Red Hat based

Reduce the number of log messages by caching the state of this check.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
