### PR TITLE
Make tdnf, dnf and yum run commands run with '--cacheonly' and only once per instance update the cache with 'check-update'

### DIFF
--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -228,17 +228,17 @@ static int ExecuteZypperRefreshServices(void* log)
     return ExecuteSimplePackageCommand("zypper refresh --services", &g_zypperRefreshServicesExecuted, log);
 }
 
-static int ExecuteTdnfCheckUpdate(OsConfigLogHandle log)
+static int ExecuteTdnfCheckUpdate(void* log)
 {
     return ExecuteSimplePackageCommand("tdnf check-update", &g_tdnfCheckUpdateExecuted, log);
 }
 
-static int ExecuteDnfCheckUpdate(OsConfigLogHandle log)
+static int ExecuteDnfCheckUpdate(void* log)
 {
     return ExecuteSimplePackageCommand("dnf check-update", &g_dnfCheckUpdateExecuted, log);
 }
 
-static int ExecuteYumCheckUpdate(OsConfigLogHandle log)
+static int ExecuteYumCheckUpdate(void* log)
 {
     return ExecuteSimplePackageCommand("yum check-update", &g_yumCheckUpdateExecuted, log);
 }

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -20,6 +20,9 @@ static bool g_zypperIsPresent = false;
 static bool g_aptGetUpdateExecuted = false;
 static bool g_zypperRefreshExecuted = false;
 static bool g_zypperRefreshServicesExecuted = false;
+static bool g_tdnfCheckUpdateExecuted = false;
+static bool g_dnfCheckUpdateExecuted = false;
+static bool g_yumCheckUpdateExecuted = false;
 
 int IsPresent(const char* what, void* log)
 {
@@ -94,7 +97,7 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
 int IsPackageInstalled(const char* packageName, void* log)
 {
     const char* commandTemplateDpkg = "%s -l %s | grep ^ii";
-    const char* commandTemplateYumDnf = "%s list installed %s";
+    const char* commandTemplateYumDnf = "%s list installed  --cacheonly %s";
     const char* commandTemplateRedHat = "%s list installed %s --disableplugin subscription-manager";
     const char* commandTemplateZypper = "%s se -x %s";
     int status = ENOENT;
@@ -225,9 +228,25 @@ static int ExecuteZypperRefreshServices(void* log)
     return ExecuteSimplePackageCommand("zypper refresh --services", &g_zypperRefreshServicesExecuted, log);
 }
 
-int InstallOrUpdatePackage(const char* packageName, void* log)
+static int ExecuteTdnfCheckUpdate(OsConfigLogHandle log)
+{
+    return ExecuteSimplePackageCommand("tdnf check-update", &g_tdnfCheckUpdateExecuted, log);
+}
+
+static int ExecuteDnfCheckUpdate(OsConfigLogHandle log)
+{
+    return ExecuteSimplePackageCommand("dnf check-update", &g_dnfCheckUpdateExecuted, log);
+}
+
+static int ExecuteYumCheckUpdate(OsConfigLogHandle log)
+{
+    return ExecuteSimplePackageCommand("yum check-update", &g_yumCheckUpdateExecuted, log);
+}
+
+int InstallOrUpdatePackage(const char* packageName, OsConfigLogHandle log)
 {
     const char* commandTemplate = "%s install -y %s";
+    const char* commandTemplateTdnfDnfYum = "%s install -y --cacheonly %s";
     int status = ENOENT;
 
     CheckPackageManagersPresence(log);
@@ -239,15 +258,18 @@ int InstallOrUpdatePackage(const char* packageName, void* log)
     }
     else if (g_tdnfIsPresent)
     {
-        status = CheckOrInstallPackage(commandTemplate, g_tdnf, packageName, log);
+        ExecuteTdnfCheckUpdate(log);
+        status = CheckOrInstallPackage(commandTemplateTdnfDnfYum, g_tdnf, packageName, log);
     }
     else if (g_dnfIsPresent)
     {
-        status = CheckOrInstallPackage(commandTemplate, g_dnf, packageName, log);
+        ExecuteDnfCheckUpdate(log);
+        status = CheckOrInstallPackage(commandTemplateTdnfDnfYum, g_dnf, packageName, log);
     }
     else if (g_yumIsPresent)
     {
-        status = CheckOrInstallPackage(commandTemplate, g_yum, packageName, log);
+        ExecuteYumCheckUpdate(log);
+        status = CheckOrInstallPackage(commandTemplateTdnfDnfYum, g_yum, packageName, log);
     }
     else if (g_zypperIsPresent)
     {
@@ -294,7 +316,7 @@ int UninstallPackage(const char* packageName, void* log)
 {
     const char* commandTemplateAptGet = "%s remove -y --purge %s";
     const char* commandTemplateZypper = "%s remove -y --force %s";
-    const char* commandTemplateAllElse = "%s remove -y %s";
+    const char* commandTemplateTdnfDnfYum = "%s remove -y --force --cacheonly %s";
 
     int status = ENOENT;
 
@@ -309,15 +331,18 @@ int UninstallPackage(const char* packageName, void* log)
         }
         else if (g_tdnfIsPresent)
         {
-            status = CheckOrInstallPackage(commandTemplateAllElse, g_tdnf, packageName, log);
+            ExecuteTdnfCheckUpdate(log);
+            status = CheckOrInstallPackage(commandTemplateTdnfDnfYum, g_tdnf, packageName, log);
         }
         else if (g_dnfIsPresent)
         {
-            status = CheckOrInstallPackage(commandTemplateAllElse, g_dnf, packageName, log);
+            ExecuteDnfCheckUpdate(log);
+            status = CheckOrInstallPackage(commandTemplateTdnfDnfYum, g_dnf, packageName, log);
         }
         else if (g_yumIsPresent)
         {
-            status = CheckOrInstallPackage(commandTemplateAllElse, g_yum, packageName, log);
+            ExecuteYumCheckUpdate(log);
+            status = CheckOrInstallPackage(commandTemplateTdnfDnfYum, g_yum, packageName, log);
         }
         else if (g_zypperIsPresent)
         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -243,7 +243,7 @@ static int ExecuteYumCheckUpdate(OsConfigLogHandle log)
     return ExecuteSimplePackageCommand("yum check-update", &g_yumCheckUpdateExecuted, log);
 }
 
-int InstallOrUpdatePackage(const char* packageName, OsConfigLogHandle log)
+int InstallOrUpdatePackage(const char* packageName, void* log)
 {
     const char* commandTemplate = "%s install -y %s";
     const char* commandTemplateTdnfDnfYum = "%s install -y --cacheonly %s";


### PR DESCRIPTION
## Description

Make tdnf, dnf and yum run commands run with '--cacheonly' and only once per instance update the cache with 'check-update' (#917)

 (cherry picked from commit 17709117f8d8a6e945846d2f0c041df380fafea7)

There are no new tests to be added because we cannot test internal tdnf operation (cache-only vs. no-cache). We have UTs for all the package functions that exercise these commands, and we have functional tests that list, install and uninstall packages as part of the Azure security baseline audit and remediation, via both ‘Modules Test’ (end to end tests where ASB is executed via the SecurityBaseline module) and via the ‘Universal NRP’ test (end to end test when we test through the MC agent and the ASB is executed by the ‘OSConfig for MC’). You can see the results of the UTs, ModuleTest and NRP tests in the CI pipeline tests ran here.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
