### PR TITLE
Add CheckPackageManagerNotThrottling test

### DIFF
--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2067,7 +2067,7 @@ TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling)
     for (int i = 0; i < 10000; i++)
     {
         EXPECT_NE(429, IsPackageInstalled("gcc", nullptr));
-        EXPECT_EQ(429, CheckPackageInstalled("gcc", nullptr, nullptr));
+        EXPECT_NE(429, CheckPackageInstalled("gcc", nullptr, nullptr));
         EXPECT_NE(429, CheckPackageNotInstalled("gcc", nullptr, nullptr));
     }
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2062,7 +2062,7 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     EXPECT_NE(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
 }
 
-TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling
+TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling)
 {
     for (int i = 0; i < 10000; i++)
     {

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2064,7 +2064,7 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
 
 TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling)
 {
-    for (int i = 0; i < 10; i++)
+    for (int i = 0; i < 100; i++)
     {
         EXPECT_NE(429, IsPackageInstalled("gcc", nullptr));
         EXPECT_NE(429, CheckPackageInstalled("gcc", nullptr, nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2064,7 +2064,7 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
 
 TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling)
 {
-    for (int i = 0; i < 10000; i++)
+    for (int i = 0; i < 10; i++)
     {
         EXPECT_NE(429, IsPackageInstalled("gcc", nullptr));
         EXPECT_NE(429, CheckPackageInstalled("gcc", nullptr, nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2062,6 +2062,16 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     EXPECT_NE(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
 }
 
+TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling
+{
+    for (int i = 0; i < 10000; i++)
+    {
+        EXPECT_NE(429, IsPackageInstalled("gcc", nullptr));
+        EXPECT_EQ(429, CheckPackageInstalled("gcc", nullptr, nullptr));
+        EXPECT_NE(429, CheckPackageNotInstalled("gcc", nullptr, nullptr));
+    }
+}
+
 TEST_F(CommonUtilsTest, IsCurrentOs)
 {
     char* name = NULL;


### PR DESCRIPTION
## Description

Add CheckPackageManagerNotThrottling test to detect package manager throttling (error 429) when 'is installed' command are executed in as fast as possible sequence. This is for related PR #917. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
