### PR TITLE
Execute command test and logging fixes.

### DIFF
--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -31,7 +31,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
     }
     if (strlen(command) > (size_t)sysconf(_SC_ARG_MAX))
     {
-        OsConfigLogError(log, "Command too long: %.100s...", command);
+        OsConfigLogError(log, "Command '%.40s...' is too long, %lu characters (maximum %lu characters)", command, strlen(command), (size_t)sysconf(_SC_ARG_MAX));
         return E2BIG;
     }
 

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -31,7 +31,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
     }
     if (strlen(command) > (size_t)sysconf(_SC_ARG_MAX))
     {
-        OsConfigLogError(log, "Command too long: %s", command);
+        OsConfigLogError(log, "Command too long: %.100s...", command);
         return E2BIG;
     }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -547,6 +547,8 @@ TEST_F(CommonUtilsTest, CancelCommand)
 {
     char* textResult = nullptr;
 
+    ::numberOfTimes = 0;
+
     EXPECT_EQ(ECANCELED, ExecuteCommand(nullptr, "sleep 20", false, true, 0, 120, &textResult, &(CallbackContext::TestCommandCallback), nullptr));
 
     FREE_MEMORY(textResult);
@@ -582,6 +584,8 @@ TEST_F(CommonUtilsTest, CancelCommandWithContext)
     CallbackContext context;
 
     char* textResult = nullptr;
+
+    ::numberOfTimes = 0;
 
     EXPECT_EQ(ECANCELED, ExecuteCommand((void*)(&context), "sleep 30", false, true, 0, 120, &textResult, &(CallbackContext::TestCommandCallback), nullptr));
 


### PR DESCRIPTION
## Description

- Fix a bug in ExecuteCommand tests re: cancelation
- Limit the size of the logged too long command to 100 characters

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
