### PR TITLE
Support plain JSON object payload in RC/DC scenario

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,8 @@
     // Use JSON with comments
     "files.associations": {
         "*.json": "jsonc",
-        "string": "cpp"
+        "string": "cpp",
+        "any": "cpp",
+        "optional": "cpp"
     }
 }

--- a/src/modules/compliance/src/lib/Engine.cpp
+++ b/src/modules/compliance/src/lib/Engine.cpp
@@ -119,7 +119,13 @@ Optional<Error> Engine::SetProcedure(const std::string& ruleName, const std::str
     auto ruleJSON = DecodeB64Json(payload);
     if (!ruleJSON.HasValue())
     {
-        return ruleJSON.Error();
+        // Fall back to plain JSON, both formats are supported
+        ruleJSON = compliance::ParseJson(payload.c_str());
+        if (!ruleJSON.HasValue())
+        {
+            OsConfigLogError(Log(), "Failed to parse JSON: %s", ruleJSON.Error().message.c_str());
+            return ruleJSON.Error();
+        }
     }
 
     auto object = json_value_get_object(ruleJSON.Value().get());

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -99,7 +99,7 @@ TEST_F(ComplianceEngineTest, MmiSet_setProcedure_InvalidArgument_1)
 {
     auto result = mEngine.MmiSet("procedureX", "");
     ASSERT_FALSE(result);
-    EXPECT_EQ(result.Error().message, std::string("Failed to parse JSON"));
+    EXPECT_EQ(result.Error().message, std::string("Failed to parse JSON object"));
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_setProcedure_InvalidArgument_2)
@@ -107,7 +107,7 @@ TEST_F(ComplianceEngineTest, MmiSet_setProcedure_InvalidArgument_2)
     std::string payload = "dGVzdA=="; // 'test' in base64
     auto result = mEngine.MmiSet("procedureX", payload);
     ASSERT_FALSE(result);
-    EXPECT_EQ(result.Error().message, std::string("Failed to parse JSON"));
+    EXPECT_EQ(result.Error().message, std::string("Failed to parse JSON object"));
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_setProcedure_InvalidArgument_3)
@@ -169,6 +169,22 @@ TEST_F(ComplianceEngineTest, MmiSet_setProcedure_1)
 TEST_F(ComplianceEngineTest, MmiSet_setProcedure_2)
 {
     std::string payload = "eyJhdWRpdCI6e30sICJyZW1lZGlhdGUiOnt9fQ=="; // '{"audit":{}, "remediate":{}}' in base64
+    auto result = mEngine.MmiSet("procedureX", payload);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_setProcedure_3)
+{
+    std::string payload = R"({"audit":{}, "remediate":{}})";
+    auto result = mEngine.MmiSet("procedureX", payload);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_setProcedure_4)
+{
+    std::string payload = R"({ "audit": { } })";
     auto result = mEngine.MmiSet("procedureX", payload);
     ASSERT_TRUE(result);
     EXPECT_EQ(result.Value(), Status::Compliant);


### PR DESCRIPTION
## Description

At the moment the compliance engine accepts only base64-encoded JSON input. For RC/DC scenario we want to support also plain JSON object payload. This is useful for compliance module tests as well.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
