### PR TITLE
CIS Ubuntu 22.04 7.2.4: ensureNoUserHasPrimaryShadowGroup procedure

### DIFF
--- a/src/modules/compliance/src/lib/payload.schema.json
+++ b/src/modules/compliance/src/lib/payload.schema.json
@@ -149,6 +149,9 @@
           "$ref": "procedures/ensureNoDuplicateEntriesExist.schema.json#/definitions/audit"
         },
         {
+          "$ref": "procedures/ensureNoUserHasPrimaryShadowGroup.schema.json#/definitions/audit"
+        },
+        {
           "$ref": "procedures/testingProcedures.schema.json#/definitions/audit"
         },
         {
@@ -175,6 +178,9 @@
         },
         {
           "$ref": "procedures/ensureNoDuplicateEntriesExist.schema.json#/definitions/remediation"
+        },
+        {
+          "$ref": "procedures/ensureNoUserHasPrimaryShadowGroup.schema.json#/definitions/remediation"
         },
         {
           "$ref": "procedures/testingProcedures.schema.json#/definitions/remediation"

--- a/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include <CommonUtils.h>
+#include <Evaluator.h>
+#include <Result.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <pwd.h>
+#include <set>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace compliance
+{
+AUDIT_FN(ensureNoUserHasPrimaryShadowGroup)
+{
+    UNUSED(args);
+
+    struct group* shadow = getgrnam("shadow");
+    if (nullptr == shadow)
+    {
+        return Error("Group 'shadow' not found", EINVAL);
+    }
+
+    setpwent();
+    bool result = true;
+    struct passwd* pwd = nullptr;
+    for (errno = 0, pwd = getpwent(); nullptr != pwd; errno = 0, pwd = getpwent())
+    {
+        if (shadow->gr_gid == pwd->pw_gid)
+        {
+            logstream << "User's '" << pwd->pw_name << "' primary group is 'shadow'";
+            result = false;
+        }
+    }
+    int status = errno;
+    endpwent();
+    if (0 != errno)
+    {
+        return Error(std::string("getpwent failed: ") + strerror(status), status);
+    }
+
+    if (result)
+    {
+        logstream << "No user has 'shadow' as primary group";
+    }
+    return result;
+}
+
+REMEDIATE_FN(ensureNoUserHasPrimaryShadowGroup)
+{
+    UNUSED(args);
+    logstream << "Manual remediation is required to make sure that no user has 'shadow' as primary group ";
+    return false;
+}
+} // namespace compliance

--- a/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "audit": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "ensureNoUserHasPrimaryShadowGroup"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "ensureNoUserHasPrimaryShadowGroup": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          }
+        }
+      ]
+    },
+    "remediation": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "ensureNoUserHasPrimaryShadowGroup"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "ensureNoUserHasPrimaryShadowGroup": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {}
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/modules/test/recipes/compliance/ensureNoUserHasPrimaryShadowGroup.json
+++ b/src/modules/test/recipes/compliance/ensureNoUserHasPrimaryShadowGroup.json
@@ -1,0 +1,89 @@
+[
+  {
+    "Action": "LoadModule",
+    "Module": "compliance.so"
+  },
+
+
+  // Create a test user which has shadow as primary group
+  {
+    "RunCommand": "useradd -g shadow securitybaselinetest && id securitybaselinetest"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "allOf": [
+          {
+            "ensureNoUserHasPrimaryShadowGroup": {}
+          }
+        ]
+      },
+      "remediate": {
+        "allOf": [
+          {
+            "ensureNoUserHasPrimaryShadowGroup": {}
+          }
+        ]
+      }
+    }
+  },
+
+
+  // Audit must fail as the user has shadow as primary group
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ allOf: [{ ensureNoUserHasPrimaryShadowGroup: User's 'securitybaselinetest' primary group is 'shadow' } == FALSE] == FALSE }"
+  },
+
+
+
+  // Re-create the test user, but this time with default primary group
+  {
+    "RunCommand": "userdel securitybaselinetest || true"
+  },
+  {
+    "RunCommand": "useradd securitybaselinetest && id securitybaselinetest"
+  },
+
+
+  // This is expected to pass as the user has default primary group
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ allOf: [{ ensureNoUserHasPrimaryShadowGroup: No user has 'shadow' as primary group } == TRUE] == TRUE }"
+  },
+
+
+
+  // Add the user to the supplementary shadow group
+  {
+    "RunCommand": "usermod -G shadow securitybaselinetest && id securitybaselinetest"
+  },
+
+
+  // This is expected to succeed as shadow is only a supplementary group for the test user
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ allOf: [{ ensureNoUserHasPrimaryShadowGroup: No user has 'shadow' as primary group } == TRUE] == TRUE }"
+  },
+
+
+  // Cleanup
+  {
+    "RunCommand": "userdel securitybaselinetest || true"
+  },
+  {
+    "RunCommand": "groupdel securitybaselinetest || true"
+  },
+  {
+    "Action": "UnloadModule"
+  }
+]


### PR DESCRIPTION
## Description

Introduce a procedure to check if any of the system users has the shadow group as their primary group. The CIS rule consists of 2 checks which are done separately:
- check if shadow is a supplementary group for anyone - this is done by fileRegexMatch procedure, not included in this PR
- check if shadow is a primary group for anyone - this new procedure covers this case.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
