### PR TITLE
Add the ability to mock ExecuteCommand calls

### DIFF
--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -57,6 +57,11 @@ typedef int(*CommandCallback)(void* context);
 
 int ExecuteCommand(void* context, const char* command, bool replaceEol, bool forJson, unsigned int maxTextResultBytes, unsigned int timeoutSeconds, char** textResult, CommandCallback callback, OsConfigLogHandle log);
 
+#ifdef TEST_CODE
+void AddMockCommand(const char* expectedCommand, bool matchPrefix, const char* output, int returnCode);
+void CleanupMockCommands();
+#endif
+
 int RestrictFileAccessToCurrentAccountOnly(const char* fileName);
 
 bool IsAFile(const char* fileName, OsConfigLogHandle log);


### PR DESCRIPTION
## Description
Add functionality that allows mocking ExecuteCommand calls, to be used in unit tests.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
