### PR TITLE
Fixes and tests for ensureFilePermissions procedures

### DIFF
--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
@@ -27,7 +27,7 @@ AUDIT_FN(ensureFilePermissions)
         return false;
     }
 
-    if (args.find("user") != args.end())
+    if (args.find("owner") != args.end())
     {
         struct passwd* pwd = getpwuid(statbuf.st_uid);
         if (nullptr == pwd)
@@ -35,9 +35,9 @@ AUDIT_FN(ensureFilePermissions)
             logstream << "No user with uid " << statbuf.st_uid;
             return false;
         }
-        if (args["user"] != pwd->pw_name)
+        if (args["owner"] != pwd->pw_name)
         {
-            logstream << "Invalid user - is " << pwd->pw_name << " should be " << args["user"];
+            logstream << "Invalid owner - is " << pwd->pw_name << " should be " << args["owner"];
             return false;
         }
     }
@@ -130,13 +130,13 @@ REMEDIATE_FN(ensureFilePermissions)
     uid_t uid = statbuf.st_uid;
     gid_t gid = statbuf.st_gid;
     bool owner_changed = false;
-    if (args.find("user") != args.end())
+    if (args.find("owner") != args.end())
     {
-        struct passwd* pwd = getpwnam(args["user"].c_str());
+        struct passwd* pwd = getpwnam(args["owner"].c_str());
         if (pwd == nullptr)
         {
-            logstream << "ERROR: No user with name " << args["user"];
-            return Error("No user with name " + args["user"]);
+            logstream << "ERROR: No user with name " << args["owner"];
+            return false;
         }
         uid = pwd->pw_uid;
         owner_changed = true;

--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.schema.json
@@ -21,7 +21,7 @@
                   "type": "string",
                   "description": "Path to the file"
                 },
-                "user": {
+                "owner": {
                   "type": "string",
                   "description": "Required owner of the file"
                 },

--- a/src/modules/compliance/tests/procedures/ensureFilePermissionsTest.cpp
+++ b/src/modules/compliance/tests/procedures/ensureFilePermissionsTest.cpp
@@ -1,0 +1,399 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "Evaluator.h"
+#include "ProcedureMap.h"
+
+#include <dirent.h>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <linux/limits.h>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using compliance::Audit_ensureFilePermissions;
+using compliance::Error;
+using compliance::Remediate_ensureFilePermissions;
+using compliance::Result;
+
+class EnsureFilePermissionsTest : public ::testing::Test
+{
+protected:
+    char fileTemplate[PATH_MAX] = "/tmp/permTest.XXXXXX";
+    std::vector<std::string> files;
+
+    void SetUp() override
+    {
+        if (0 != getuid())
+        {
+            GTEST_SKIP() << "This test suite requires root privileges or fakeroot";
+        }
+        // SLES15 docker image doesn't have the bin group/user, create if it doesn't exist.
+        system("groupadd -g 1 bin >/dev/null 2>&1");
+        system("useradd -g 1 -u 1 bin >/dev/null 2>&1");
+    }
+    void TearDown() override
+    {
+        for (auto& file : files)
+        {
+            unlink(file.c_str());
+        }
+    }
+
+    void CreateFile(std::string& filename, int owner, int group, short permissions)
+    {
+        char* newFileName = strdup(fileTemplate);
+        ASSERT_NE(newFileName, nullptr);
+        int f = mkstemp(newFileName);
+        ASSERT_GE(f, 0);
+        close(f);
+        ASSERT_EQ(chown(newFileName, owner, group), 0);
+        ASSERT_EQ(chmod(newFileName, permissions), 0);
+        filename = newFileName;
+        files.push_back(filename);
+        free(newFileName);
+    }
+};
+
+TEST_F(EnsureFilePermissionsTest, AuditFileMissing)
+{
+    std::map<std::string, std::string> args;
+    args["filename"] = "/this_doesnt_exist_for_sure";
+
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Stat error") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditWrongOwner)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 1, 0, 0610);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Invalid owner") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateWrongOwner)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 1, 0, 0610);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+    struct stat st;
+    ASSERT_EQ(stat(args["filename"].c_str(), &st), 0);
+    ASSERT_EQ(st.st_uid, 0);
+    ASSERT_EQ(st.st_gid, 0);
+    ASSERT_EQ(st.st_mode & 0777, 0610);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditWrongGroup)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 1, 0610);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Invalid group") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateWrongGroup)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 1, 0610);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+    struct stat st;
+    ASSERT_EQ(stat(args["filename"].c_str(), &st), 0);
+    ASSERT_EQ(st.st_uid, 0);
+    ASSERT_EQ(st.st_gid, 0);
+    ASSERT_EQ(st.st_mode & 0777, 0610);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditWrongPermissions)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 0, 0210);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateWrongPermissions)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 0, 0210);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+    struct stat st;
+    ASSERT_EQ(stat(args["filename"].c_str(), &st), 0);
+    ASSERT_EQ(st.st_uid, 0);
+    ASSERT_EQ(st.st_gid, 0);
+    ASSERT_EQ(st.st_mode & 0777, 0610);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditWrongMask)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 0, 0654);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateWrongMask)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 0, 0654);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+    struct stat st;
+    ASSERT_EQ(stat(args["filename"].c_str(), &st), 0);
+    ASSERT_EQ(st.st_uid, 0);
+    ASSERT_EQ(st.st_gid, 0);
+    ASSERT_EQ(st.st_mode & 0777, 0610);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditAllWrong)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 1, 1, 0276);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateAllWrong)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 1, 1, 0276);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+    struct stat st;
+    ASSERT_EQ(stat(args["filename"].c_str(), &st), 0);
+    ASSERT_EQ(st.st_uid, 0);
+    ASSERT_EQ(st.st_gid, 0);
+    ASSERT_EQ(st.st_mode & 0777, 0610);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditAllOk)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 0, 0610);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateAllOk)
+{
+    std::map<std::string, std::string> args;
+    CreateFile(args["filename"], 0, 0, 0610);
+    args["owner"] = "root";
+    args["group"] = "root";
+    args["permissions"] = "0400";
+    args["mask"] = "0066";
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+    struct stat st;
+    ASSERT_EQ(stat(args["filename"].c_str(), &st), 0);
+    ASSERT_EQ(st.st_uid, 0);
+    ASSERT_EQ(st.st_gid, 0);
+    ASSERT_EQ(st.st_mode & 0777, 0610);
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditMissingFilename)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().message, "No filename provided");
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateMissingFilename)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().message, "No filename provided");
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditBadFileOwner)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 15213, 0, 0600);
+    args["owner"] = "boohoonotarealuser";
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateBadFileOwner)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 15213, 0, 0600);
+    args["owner"] = "boohoonotarealuser";
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditBadFileGroup)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 15213, 0600);
+    args["group"] = "boohoonotarealgroup";
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateBadFileGroup)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 15213, 0600);
+    args["group"] = "boohoonotarealgroup";
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditBadPermissions)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 0, 0600);
+    args["permissions"] = "999";
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateBadPermissions)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 0, 0600);
+    args["permissions"] = "999";
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_FALSE(result.HasValue());
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditBadMask)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 0, 0600);
+    args["mask"] = "999";
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateBadMask)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 0, 0600);
+    args["mask"] = "999";
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_FALSE(result.HasValue());
+}
+
+TEST_F(EnsureFilePermissionsTest, AuditSameBitsSet)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 0, 0600);
+    args["permissions"] = "600";
+    args["mask"] = "600";
+    Result<bool> result = Audit_ensureFilePermissions(args, logstream);
+    ASSERT_FALSE(result.HasValue());
+}
+
+TEST_F(EnsureFilePermissionsTest, RemediateSameBitsSet)
+{
+    std::map<std::string, std::string> args;
+    std::ostringstream logstream;
+    CreateFile(args["filename"], 0, 0, 0600);
+    args["permissions"] = "600";
+    args["mask"] = "600";
+    Result<bool> result = Remediate_ensureFilePermissions(args, logstream);
+    ASSERT_FALSE(result.HasValue());
+}


### PR DESCRIPTION
## Description
1. Use "owner" and not "user" parameter
2. Change behaviour of mask and permissions - mask has bits that must be cleared, permissions has bits that must be set
3. Full suite of unit tests

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
