### PR TITLE
Avoid indenting directives after hash

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,7 +52,7 @@ FixNamespaceComments: true
 IndentCaseLabels: true
 IndentExternBlock: NoIndent
 IndentWidth: 4
-IndentPPDirectives: AfterHash
+IndentPPDirectives: None
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''


### PR DESCRIPTION
## Description

Adjust clang-format to avoid indentation of directives after hash.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
