### PR TITLE
build: change jsonschema to check-jsonschema

### DIFF
--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -18,7 +18,7 @@ set(MODULES_BUILD_BIN_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin" CACHE FILEPATH "Dire
 file(MAKE_DIRECTORY ${MODULES_BUILD_BIN_DIR})
 
 set(MIM_SCHEMA ${CMAKE_CURRENT_SOURCE_DIR}/schema/mim.schema.json)
-find_program(JSONSCHEMA_EXEC jsonschema)
+find_program(JSONSCHEMA_EXEC  check-jsonschema)
 
 function(add_module directory)
     get_filename_component(MODULE ${directory} NAME)
@@ -28,7 +28,7 @@ function(add_module directory)
     if (EXISTS ${MODULE_INTERFACE})
         if(JSONSCHEMA_EXEC)
             execute_process(
-                COMMAND ${JSONSCHEMA_EXEC} -i ${MODULE_INTERFACE} ${MIM_SCHEMA}
+                COMMAND ${JSONSCHEMA_EXEC} --schemafile ${MIM_SCHEMA} ${MODULE_INTERFACE}
                 ERROR_VARIABLE SCHEMA_ERROR
             )
             if(SCHEMA_ERROR)


### PR DESCRIPTION
The jsonschema is giving DeprecationWarning as below

DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/

## Description

*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x]  All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
