### PR TITLE
Adding safety timeouts for package manager operations and increasing the test limit for remediations 

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -643,8 +643,8 @@ static PerfClock g_perfClock = {{0, 0}, {0, 0}};
 // Expected time limits under ideal conditions
 // Maximum per-rule audit time: 5 seconds
 static const long g_maxAuditTime = 5000000;
-// Maximum ASB rule remediation time: 99 seconds
-static const long g_maxRemediateTime = 99000000;
+// Maximum ASB rule remediation time: 5 minutes
+static const long g_maxRemediateTime = 300000000;
 // Maximum baseline run times: 30 minutes
 static const long g_maxTotalTime = 1800000000;
 

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -76,16 +76,16 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
 #ifdef TEST_CODE
     // Allow mocked call for unit testing of things that execute commands.
     struct MockCommand* mock = g_mockCommand;
-    
-    while (NULL != mock) 
+
+    while (NULL != mock)
     {
         size_t stringLen = strlen(mock->expectedCommand);
-        
+
         if (!mock->matchPrefix && (strlen(command) > stringLen))
         {
             stringLen = strlen(command);
         }
-        
+
         if (0 == strncmp(mock->expectedCommand, command, stringLen))
         {
             *textResult = DuplicateString(mock->output);
@@ -109,7 +109,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
         OsConfigLogError(log, "Cannot get time for command '%s', clock_gettime() failed with %d (%s)", command, errno, strerror(errno));
         return errno;
     }
-    
+
     if (0 != pipe(pipefd))
     {
         OsConfigLogError(log, "Cannot create pipe for command '%s', pipe() failed with %d (%s)", command, errno, strerror(errno));
@@ -140,7 +140,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
         }
 
         execl("/bin/sh", "sh", "-c", command, (char*)NULL);
-        
+
         // If execl() fails, exit with the error code
         exit(errno);
     }
@@ -243,7 +243,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
                 {
                     continue;
                 }
-            
+
                 OsConfigLogError(log, "Error reading from pipe for command '%s', read() failed with %d (%s)", command, errno, strerror(errno));
                 status = errno;
                 break;
@@ -268,7 +268,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
                 FREE_MEMORY(*textResult);
                 break;
             }
-            
+
             *textResult = tmp;
 
             for (inputBufferPos = 0; (inputBufferPos < bytesRead) && (outputBufferPos < outputBufferSize); inputBufferPos++, outputBufferPos++)

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -47,7 +47,7 @@ void CleanupMockCommands()
 {
     while (NULL != g_mockCommand)
     {
-        struct MockCommand* next = g_mockCommand->next;
+	struct MockCommand* next = g_mockCommand->next;
         free(g_mockCommand);
         g_mockCommand = next;
     }
@@ -88,7 +88,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
             *textResult = DuplicateString(mock->output);
             return mock->returnCode;
         }
-        mock = mock->next;
+	mock = mock->next;
     }
 #endif
 

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -179,7 +179,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
 
             tv = selectInterval;
 
-            if (0 > (ret = select(pipefd[0] + 1, &fdset, NULL, NULL, &tv) < 0))
+            if (0 > (ret = select(pipefd[0] + 1, &fdset, NULL, NULL, &tv)))
             {
                 if (EINTR == errno)
                 {

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -263,7 +263,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
 
             if (NULL == (tmp = realloc(*textResult, outputBufferSize + 1)))
             {
-                OsConfigLogError(log, "Cannot allocate %ld bytes as buffer for command '%s'", outputBufferSize + 1, command);
+                OsConfigLogError(log, "Cannot allocate %d bytes as buffer for command '%s'", outputBufferSize + 1, command);
                 status = ENOMEM;
                 FREE_MEMORY(*textResult);
                 break;

--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -60,7 +60,7 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
     char** textResult, CommandCallback callback, OsConfigLogHandle log)
 {
     int workerPid = -1;
-    int pipefd[2] = { 0 };
+    int pipefd[2] = {0};
     long startTime = 0;
 
     if (NULL == command)
@@ -158,12 +158,12 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
 
         for (;;)
         {
-            const struct timeval selectInterval = { 0, 100 * 1000 }; // 100 ms, accuracy of timeouts.
+            const struct timeval selectInterval = {0, 100 * 1000}; // 100 ms, accuracy of timeouts.
             struct timeval tv;
             int bytesRead = 0;
             int inputBufferPos = 0;
             long currentTime = 0;
-            char buffer[BUFFER_SIZE] = { 0 };
+            char buffer[BUFFER_SIZE] = {0};
             fd_set fdset;
             int ret = 0;
             char* tmp = NULL;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -10,6 +10,9 @@ static const char* g_dnf = "dnf";
 static const char* g_yum = "yum";
 static const char* g_zypper = "zypper";
 
+// 30 minutes
+static const unsigned int g_packageManagerTimeoutSeconds = 1800;
+
 static bool g_checkedPackageManagersPresence = false;
 static bool g_aptGetIsPresent = false;
 static bool g_dpkgIsPresent = false;
@@ -38,7 +41,7 @@ int IsPresent(const char* what, OsConfigLogHandle log)
 
     if (NULL != (command = FormatAllocateString(commandTemplate, what)))
     {
-        if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+        if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
         {
             OsConfigLogInfo(log, "'%s' is locally present", what);
         }
@@ -85,7 +88,7 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
         return ENOMEM;
     }
 
-    status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log);
+    status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log);
 
     OsConfigLogInfo(log, "Package manager '%s' command '%s' returning %d (errno: %d)", packageManager, command, status, errno);
 
@@ -199,7 +202,7 @@ static int ExecuteSimplePackageCommand(const char* command, bool* executed, OsCo
         return status;
     }
 
-    if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+    if (0 == (status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
         OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' was successful", command);
         *executed = true;


### PR DESCRIPTION
## Description

Adding safety timeouts for package manager operations (30 minutes, which can act during RC/DC where we do not have overall timeouts like Azure Policy) and increasing the test limit for remediations (5 minutes per rule, this being the actual fix to the random CI failures, problem being that we just had too strict limits there, which we expected and now thanks to such findings we are adjusting). 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
