### PR TITLE
[Hot Fix] Optimizing auditing presence of packages 

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1040,7 +1040,7 @@ void AsbShutdown(OsConfigLogHandle log)
     FREE_MEMORY(g_desiredEnsureDefaultDenyFirewallPolicyIsSet);
 
     SshAuditCleanup(log);
-    
+
     PackageUtilsCleanup();
 
     if (0 == StopPerfClock(&g_perfClock, GetPerfLog()))

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -4009,7 +4009,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, OsConfigLogHandle 
 {
     const char* command = "sed -i '/^\\[global\\]/a min protocol = SMB2' /etc/samba/smb.conf";
     const char* smb1 = "SMB1";
-    const char* allSambaPackages = "samba*";
+    //const char* allSambaPackages = "samba*";
     int status = 0;
 
     UNUSED(value);
@@ -4026,7 +4026,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, OsConfigLogHandle 
     }
     else
     {
-        UninstallPackage(allSambaPackages, log);
+        UninstallPackage(g_samba, log);
         remove(g_etcSambaConf);
         status = CheckPackageNotInstalled(g_samba, NULL, log);
     }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -4009,7 +4009,6 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, OsConfigLogHandle 
 {
     const char* command = "sed -i '/^\\[global\\]/a min protocol = SMB2' /etc/samba/smb.conf";
     const char* smb1 = "SMB1";
-    //const char* allSambaPackages = "samba*";
     int status = 0;
 
     UNUSED(value);

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -4009,6 +4009,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, OsConfigLogHandle 
 {
     const char* command = "sed -i '/^\\[global\\]/a min protocol = SMB2' /etc/samba/smb.conf";
     const char* smb1 = "SMB1";
+    const char* allSambaPackages = "samba*";
     int status = 0;
 
     UNUSED(value);
@@ -4025,7 +4026,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, OsConfigLogHandle 
     }
     else
     {
-        UninstallPackage(g_samba, log);
+        UninstallPackage(allSambaPackages, log);
         remove(g_etcSambaConf);
         status = CheckPackageNotInstalled(g_samba, NULL, log);
     }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1040,6 +1040,8 @@ void AsbShutdown(OsConfigLogHandle log)
     FREE_MEMORY(g_desiredEnsureDefaultDenyFirewallPolicyIsSet);
 
     SshAuditCleanup(log);
+    
+    PackageUtilsCleanup();
 
     if (0 == StopPerfClock(&g_perfClock, GetPerfLog()))
     {

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -92,6 +92,7 @@ int CheckPackageNotInstalled(const char* packageName, char** reason, OsConfigLog
 int InstallOrUpdatePackage(const char* packageName, OsConfigLogHandle log);
 int InstallPackage(const char* packageName, OsConfigLogHandle log);
 int UninstallPackage(const char* packageName, OsConfigLogHandle log);
+void PackageUtilsCleanup(void);
 
 unsigned int GetNumberOfLinesInFile(const char* fileName);
 bool CharacterFoundInFile(const char* fileName, char what);

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -211,7 +211,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         }
         else if (NULL == strstr(g_installedPackages, searchTarget))
         {
-            OsConfigLogInfo(log, "IsPackageInstalled: '%s' not found in the list of installed packages", packageName);
+            OsConfigLogInfo(log, "IsPackageInstalled: '%s' is not installed", packageName);
             status = ENOENT;
         }
 
@@ -221,10 +221,6 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
     if (0 == status)
     {
         OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is installed", packageName);
-    }
-    else
-    {
-        OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is not installed", packageName);
     }
 
     return status;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -116,7 +116,7 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
 
     status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
-    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d (errno: %d)", packageManager, command, *results, status, errno);
+    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d (errno: %d)", packageManager, command, status, errno);
     //Change this to Debug
     OsConfigLogInfo(log, "%s", *results);
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i | grep -v '|' | awk '{print $2}'";
+    const char* commandTmeplateZypper = "%s search -i"; //"%s search -i | grep -v '|' | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i | awk 'NR>2 {print $2}' | tr -d '|'";
+    const char* commandTmeplateZypper = "%s search -i"; //"%s search -i | awk 'NR>2 {print $2}' | tr -d '|'";
 
     char* results = NULL;
     int status = ENOENT;
@@ -231,7 +231,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         }
         else if (g_zypperIsPresent)
         {
-            searchTarget = FormatAllocateString("\n%s\n", packageName);
+            searchTarget = FormatAllocateString("| %s", packageName);
         }
         else
         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -134,7 +134,7 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
 static int ListAllInstalledPackages(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
-    const char* commandTemplateYumDnf = "%s list installed  --cacheonly";
+    const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
     const char* commandTmeplateZypper = "%s search --installed-only --query-format '%{name}\n'";
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -194,7 +194,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
         {
             // Leave the cache as-is, just log the error
             OsConfigLogError(log, "UpdateInstalledPackagesCache: out of memory");
-            status = ENOENT;
+            status = ENOMEM;
         }
     }
     else

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -205,7 +205,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     const char* searchTemplateDpkg = "\n%s\n";
     const char* searchTemplateYumDnf = "\n%s.x86_64\n";
-    const char* commandTmeplateZypper = "| %s ";
+    const char* searchTemplateZypper = "| %s ";
 
     char* searchTarget = NULL;
     int status = 0;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -211,7 +211,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
-    const char* searchTemplateDpkg = "\n%s\n";
+    const char* searchTemplateDpkgRpm = "\n%s\n";
     const char* searchTemplateYumDnf = "\n%s.x86_64\n";
     const char* searchTemplateZypper = "| %s ";
 
@@ -245,7 +245,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
     {
         if (g_aptGetIsPresent || g_dpkgIsPresent || g_rpmIsPresent)
         {
-            searchTarget = FormatAllocateString(searchTemplateDpkg, packageName);
+            searchTarget = FormatAllocateString(searchTemplateDpkgRpm, packageName);
         }
         else if (g_tdnfIsPresent || g_dnfIsPresent || g_yumIsPresent)
         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "zypper search -i | awk 'NR>2 {print $2}'"; //"%s search -i | grep -v '|' | awk '{print $2}'";
+    const char* commandTmeplateZypper = "%s search -i | awk 'NR>2 {print $2}'"; //"%s search -i | grep -v '|' | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -227,6 +227,10 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         {
             searchTarget = FormatAllocateString("\n%s.x86_64\n", packageName);
         }
+        else if (g_zypperIsPresent)
+        {
+            searchTarget = FormatAllocateString(" %s", packageName);
+        }
         else
         {
             searchTarget = FormatAllocateString("\n%s\n", packageName);

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -186,8 +186,6 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
-    const char* commandTemplate = "\n%s\n";
-    const char* commandTemplateTdnf = "\n%s.x86_64\n";
     char* searchTarget = NULL;
     char* found = NULL;
     int status = 0;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i | awk 'NR>2 {print $2}'"; //"%s search -i | grep -v '|' | awk '{print $2}'";
+    const char* commandTmeplateZypper = "%s search -i | awk 'NR>2 {print $2}' | tr -d '|'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i"; //"%s search -i | grep -v '|' | awk '{print $2}'";
+    const char* commandTmeplateZypper = "zypper search -i | awk 'NR>2 {print $2}'"; //"%s search -i | grep -v '|' | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;
@@ -231,7 +231,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         }
         else if (g_zypperIsPresent)
         {
-            searchTarget = FormatAllocateString(" %s", packageName);
+            searchTarget = FormatAllocateString("\n%s\n", packageName);
         }
         else
         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "zypper search -i | grep -v '|' | awk '{print $2}'"; //"%s search - i | awk '{print $2}'";
+    const char* commandTmeplateZypper = "%s search -i | grep -v '|' | awk '{print $2}'"; //"%s search - i | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -188,7 +188,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     char* searchTarget = NULL;
     char* found = NULL;
-    size_t lenght = 0;
+    size_t size = 0;
     int status = 0;
 
     if ((NULL == packageName) || (0 == strlen(packageName)))
@@ -212,7 +212,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;
         }
-        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 < (lenght = strlen(found))) && (0 == isalnum(found[length])))
+        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 < (size = strlen(found))) && (0 == isalnum(found[size])))
         {
             OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
             status = 0;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -214,7 +214,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         }
         else
         {
-            searchTarget = FormatAllocateString("\n%s\n", packageName)
+            searchTarget = FormatAllocateString("\n%s\n", packageName);
         }
 
         if (NULL == searchTarget)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -346,7 +346,7 @@ static int ExecuteAptGetUpdate(OsConfigLogHandle log)
 
 static int ExecuteZypperRefresh(OsConfigLogHandle log)
 {
-    const char* zypperClean = "zypper clean";
+    //const char* zypperClean = "zypper clean";
     const char* zypperRefresh = "zypper refresh";
     const char* zypperRefreshServices = "zypper refresh --services";
 
@@ -357,11 +357,11 @@ static int ExecuteZypperRefresh(OsConfigLogHandle log)
         return status;
     }
 
-    if (0 != (status = ExecuteCommand(NULL, zypperClean, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
+    /*if (0 != (status = ExecuteCommand(NULL, zypperClean, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
         OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperClean, status, errno, strerror(errno));
     }
-    else if (0 != (status = ExecuteCommand(NULL, zypperRefresh, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
+    else*/ if (0 != (status = ExecuteCommand(NULL, zypperRefresh, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
         OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperRefresh, status, errno, strerror(errno));
     }

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -212,6 +212,8 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         g_updateInstalledPackagesCache = 0;
     }
 
+    CheckPackageManagersPresence(log);
+
     if (NULL == g_installedPackagesCache)
     {
         if (0 != (status = UpdateInstalledPackagesCache(log)))
@@ -219,8 +221,6 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
             OsConfigLogInfo(log, "IsPackageInstalled(%s) failed (UpdateInstalledPackagesCache failed)", packageName);
         }
     }
-
-    CheckPackageManagersPresence(log);
 
     if (0 == status)
     {
@@ -242,15 +242,17 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;
         }
-        else if (NULL == strstr(g_installedPackagesCache, searchTarget))
-        {
-            OsConfigLogInfo(log, "IsPackageInstalled: '%s' is not installed", packageName);
-            status = ENOENT;
-        }
         else
         {
-            OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
-            status = 0;
+            if (NULL != strstr(g_installedPackagesCache, searchTarget))
+            {
+                OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
+            }
+            else
+            {
+                OsConfigLogInfo(log, "IsPackageInstalled: '%s' is not installed", packageName);
+                status = ENOENT;
+            }
         }
 
         FREE_MEMORY(searchTarget);

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -205,7 +205,7 @@ static int IsPackageListedAsInstalled(const char* packageName, OsConfigLogHandle
 
     if (0 == status)
     {
-        if (NULL == (searchTarget = FormatAllocateString(" %s ", packageName)))
+        if (NULL == (searchTarget = FormatAllocateString("\n%s\n", packageName)))
         {
             OsConfigLogError(log, "IsPackageListedAsInstalled: out of memory");
             status = ENOMEM;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -114,9 +114,11 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
         return ENOMEM;
     }
 
-    status = ExecuteCommand(NULL, command, true, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
+    status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
-    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning '%s' and status %d (errno: %d)", packageManager, command, *results, status, errno);
+    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d (errno: %d)", packageManager, command, *results, status, errno);
+    //Change this to Debug
+    OsConfigLogInfo(log, "%s", *results);
 
     FREE_MEMORY(command);
 
@@ -179,7 +181,7 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 
 static int IsPackageListedAsInstalled(const char* packageName, OsConfigLogHandle log)
 {
-    int status = ENOENT;
+    int status = 0;
 
     if ((NULL == packageName) || (0 == strlen(packageName)))
     {
@@ -187,11 +189,20 @@ static int IsPackageListedAsInstalled(const char* packageName, OsConfigLogHandle
         return EINVAL;
     }
 
-    if ((NULL == g_installedPackages) && (0 != (status = ListAllInstalledPackages(log))))
+    if (NULL == g_installedPackages)
     {
-        if ((NULL != g_installedPackages) && (NULL != strstr(g_installedPackages, packageName)))
+        if (0 != (status = ListAllInstalledPackages(log)))
         {
-            status = 0;
+            OsConfigLogInfo(log, "IsPackageListedAsInstalled(%s) failed (ListAllInstalledPackages failed)", packageName);
+        }
+    }
+
+    if (0 == status)
+    {
+        if (NULL == strstr(g_installedPackages, packageName))
+        {
+            OsConfigLogInfo(log, "IsPackageListedAsInstalled: '%s' not found in the list of installed packages", packageName);
+            status = ENOENT;
         }
     }
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -186,6 +186,8 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
+    const char* commandTemplate = "\n%s\n";
+    const char* commandTemplateTdnf = "\n%s.x86_64\n";
     char* searchTarget = NULL;
     char* found = NULL;
     int status = 0;
@@ -204,9 +206,20 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         }
     }
 
+    CheckPackageManagersPresence(log);
+
     if (0 == status)
     {
-        if (NULL == (searchTarget = FormatAllocateString("\n%s\n", packageName)))
+        if (g_tdnfIsPresent || g_dnfIsPresent || g_yumIsPresent)
+        {
+            searchTarget = FormatAllocateString("\n%s.x86_64\n", packageName);
+        }
+        else
+        {
+            searchTarget = FormatAllocateString("\n%s\n", packageName)
+        }
+
+        if (NULL == searchTarget)
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -121,7 +121,7 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
         return ENOMEM;
     }
 
-    status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
+    status = ExecuteCommand(NULL, command, true, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
     OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d (errno: %d)", packageManager, command, status, errno);
     OsConfigLogInfo(log, "%s", *results); //TODO: Change this to OsConfigLogDebug
@@ -205,7 +205,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 
     if (0 == status)
     {
-        if (NULL == (searchTarget = FormatAllocateString("\n%s", packageName)))
+        if (NULL == (searchTarget = FormatAllocateString(" %s ", packageName)))
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "zypper search -i | awk '{if ($2 != \" | \") print $2}'"; //"%s search - i | awk '{print $2}'";
+    const char* commandTmeplateZypper = "zypper search -i | grep -v '|' | awk '{print $2}'"; //"%s search - i | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -135,7 +135,8 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
     status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
     OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d", packageManager, command, status);
-    OsConfigLogDebug(log, "%s", *results);
+    //OsConfigLogDebug(log, "%s", *results);
+    OsConfigLogInfo(log, "%s", *results);
 
     FREE_MEMORY(command);
 
@@ -145,8 +146,9 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
 static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
-    const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i";
+    //const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
+    //const char* commandTmeplateZypper = "%s search -i";
+    const char* commandTemplateRpm = "%s - qa --queryformat \"%{NAME}\n\"";
 
     char* results = NULL;
     char* buffer = NULL;
@@ -158,7 +160,11 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
     {
         status = CheckAllPackages(commandTemplateDpkg, g_dpkg, &results, log);
     }
-    else if (g_tdnfIsPresent)
+    else
+    {
+        status = CheckAllPackages(commandTemplateRpm, "rpm", &results, log);
+    }
+    /*else if (g_tdnfIsPresent)
     {
         status = CheckAllPackages(commandTemplateYumDnf, g_tdnf, &results, log);
     }
@@ -173,7 +179,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
     else if (g_zypperIsPresent)
     {
         status = CheckAllPackages(commandTmeplateZypper, g_zypper, &results, log);
-    }
+    }*/
 
     if ((0 == status) && (NULL != results))
     {
@@ -204,9 +210,9 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     const char* searchTemplateDpkg = "\n%s\n";
-    const char* searchTemplateYumDnf = "\n%s.x86_64\n";
-    const char* searchTemplateZypper = "| %s ";
-
+    //const char* searchTemplateYumDnf = "\n%s.x86_64\n";
+    //const char* searchTemplateZypper = "| %s ";
+    
     char* searchTarget = NULL;
     int status = 0;
 
@@ -235,6 +241,9 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
     }
     else if (0 == status)
     {
+        searchTarget = FormatAllocateString(searchTemplateDpkg, packageName);
+
+        /*
         if (g_aptGetIsPresent || g_dpkgIsPresent)
         {
             searchTarget = FormatAllocateString(searchTemplateDpkg, packageName);
@@ -246,7 +255,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         else //if (g_zypperIsPresent)
         {
             searchTarget = FormatAllocateString(searchTemplateZypper, packageName);
-        }
+        }*/
 
         if (NULL == searchTarget)
         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -135,7 +135,7 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
     status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
     OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d", packageManager, command, status);
-    OsConfigLogInfo(log, "%s", *results); //TODO: Change this to OsConfigLogDebug
+    OsConfigLogDebug(log, "%s", *results);
 
     FREE_MEMORY(command);
 
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i"; //"%s search -i | awk 'NR>2 {print $2}' | tr -d '|'";
+    const char* commandTmeplateZypper = "%s search -i";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -135,7 +135,8 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search --installed-only --query-format '%{name}\n'";
+    const char* commandTmeplateZypper = "%s search --installed - only | awk '{print $2}'";
+    
     char* results = NULL;
     int status = ENOENT;
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -133,9 +133,8 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
 
 static int ListAllInstalledPackages(OsConfigLogHandle log)
 {
-    const char* commandTemplate = "%s list installed";
-    const char* commandTemplateYumDnf = "%s list installed  --cacheonly";
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
+    const char* commandTemplateYumDnf = "%s list installed  --cacheonly";
     const char* commandTmeplateZypper = "%s search --installed-only --query-format '%{name}\n'";
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -390,6 +390,9 @@ int InstallPackage(const char* packageName, OsConfigLogHandle log)
 
     if (0 != (status = IsPackageInstalled(packageName, log)))
     {
+        // Erase the installed packages cache, we'll need to refresh the cache after installing this package
+        FREE_MEMORY(g_installedPackages);
+
         status = InstallOrUpdatePackage(packageName, log);
     }
     else
@@ -448,6 +451,9 @@ int UninstallPackage(const char* packageName, OsConfigLogHandle log)
         if (0 == status)
         {
             OsConfigLogInfo(log, "UninstallPackage: package '%s' was successfully uninstalled", packageName);
+
+            // Erase the installed packages cache, we'll need to refresh the cache after uninstalling this package
+            FREE_MEMORY(g_installedPackages);
         }
         else
         {

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -236,7 +236,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         {
             searchTarget = FormatAllocateString("| %s", packageName);
         }
-        
+
         if (NULL == searchTarget)
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -135,8 +135,8 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
 static int ListAllInstalledPackages(OsConfigLogHandle log)
 {
     const char* commandTemplate = "%s list installed";
-    const char* commandTemplateDpkg = "%s -l";
-    const char* commandTmeplateZypper = "%s search --installed-only";
+    const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
+    const char* commandTmeplateZypper = "%s search --installed-only --query-format '%{name}\n'";
     char* results = NULL;
     int status = ENOENT;
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -204,7 +204,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 
     if (0 == status)
     {
-        if (NULL == (searchTarget = FormatAllocateString("\n%s\n", packageName)))
+        if (NULL == (searchTarget = FormatAllocateString("\n%s", packageName)))
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -198,7 +198,6 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     char* searchTarget = NULL;
-    char* found = NULL;
     int status = 0;
 
     if ((NULL == packageName) || (0 == strlen(packageName)))
@@ -243,15 +242,15 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;
         }
-        else if ((NULL != (found = strstr(g_installedPackagesCache, searchTarget))) && (0 < strlen(found)))
-        {
-            OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
-            status = 0;
-        }
-        else
+        else if (NULL == strstr(g_installedPackagesCache, searchTarget))
         {
             OsConfigLogInfo(log, "IsPackageInstalled: '%s' is not installed", packageName);
             status = ENOENT;
+        }
+        else
+        {
+            OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
+            status = 0;
         }
 
         FREE_MEMORY(searchTarget);

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -349,14 +349,14 @@ static int ExecuteZypperRefresh(OsConfigLogHandle log)
     const char* zypperClean = "zypper clean";
     const char* zypperRefresh = "zypper refresh";
     const char* zypperRefreshServices = "zypper refresh --services";
-    
+
     int status = 0;
 
     if (true = g_zypperRefreshExecuted)
     {
         return status;
     }
-    
+
     if (0 != (status = ExecuteCommand(NULL, zypperClean, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
         OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' '%s' returned %d (errno: %d '%s')", zypperClean, status, errno, strerror(errno));

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -197,6 +197,10 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
+    const char* searchTemplateDpkg = "\n%s\n";
+    const char* searchTemplateYumDnf = "\n%s.x86_64\n";
+    const char* commandTmeplateZypper = "| %s ";
+
     char* searchTarget = NULL;
     int status = 0;
 
@@ -226,15 +230,15 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
     {
         if (g_aptGetIsPresent || g_dpkgIsPresent)
         {
-            searchTarget = FormatAllocateString("\n%s\n", packageName);
+            searchTarget = FormatAllocateString(searchTemplateDpkg, packageName);
         }
         else if (g_tdnfIsPresent || g_dnfIsPresent || g_yumIsPresent)
         {
-            searchTarget = FormatAllocateString("\n%s.x86_64\n", packageName);
+            searchTarget = FormatAllocateString(searchTemplateYumDnf, packageName);
         }
         else //if (g_zypperIsPresent)
         {
-            searchTarget = FormatAllocateString("| %s ", packageName);
+            searchTarget = FormatAllocateString(searchTemplateZypper, packageName);
         }
 
         if (NULL == searchTarget)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -212,7 +212,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
     const char* searchTemplateDpkg = "\n%s\n";
     //const char* searchTemplateYumDnf = "\n%s.x86_64\n";
     //const char* searchTemplateZypper = "| %s ";
-    
+
     char* searchTarget = NULL;
     int status = 0;
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -234,7 +234,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
         }
         else //if (g_zypperIsPresent)
         {
-            searchTarget = FormatAllocateString("| %s", packageName);
+            searchTarget = FormatAllocateString("| %s ", packageName);
         }
 
         if (NULL == searchTarget)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -188,6 +188,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     char* searchTarget = NULL;
     char* found = NULL;
+    size_t lenght = 0;
     int status = 0;
 
     if ((NULL == packageName) || (0 == strlen(packageName)))
@@ -211,7 +212,7 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;
         }
-        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 == isalnum((char)(found + strlen(found)))))
+        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 < (lenght = strlen(found))) && (0 == isalnum(found[length])))
         {
             OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
             status = 0;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -224,19 +224,19 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 
     if (0 == status)
     {
-        if (g_tdnfIsPresent || g_dnfIsPresent || g_yumIsPresent)
-        {
-            searchTarget = FormatAllocateString("\n%s.x86_64\n", packageName);
-        }
-        else if (g_zypperIsPresent)
-        {
-            searchTarget = FormatAllocateString("| %s", packageName);
-        }
-        else
+        if (g_aptGetIsPresent || g_dpkgIsPresent)
         {
             searchTarget = FormatAllocateString("\n%s\n", packageName);
         }
-
+        else if (g_tdnfIsPresent || g_dnfIsPresent || g_yumIsPresent)
+        {
+            searchTarget = FormatAllocateString("\n%s.x86_64\n", packageName);
+        }
+        else //if (g_zypperIsPresent)
+        {
+            searchTarget = FormatAllocateString("| %s", packageName);
+        }
+        
         if (NULL == searchTarget)
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -148,7 +148,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     //const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
     //const char* commandTmeplateZypper = "%s search -i";
-    const char* commandTemplateRpm = "%s - qa --queryformat \"%{NAME}\n\"";
+    const char* commandTemplateRpm = "%s -qa --queryformat \"%{NAME}\n\"";
 
     char* results = NULL;
     char* buffer = NULL;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search - i | awk '{print $2}'";
+    const char* commandTmeplateZypper = "zypper search -i | awk '{if ($2 != \" | \") print $2}'"; //"%s search - i | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -3,6 +3,10 @@
 
 #include "Internal.h"
 
+#if ((defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)))) || defined(__clang__))
+#include <stdatomic.h>
+#endif
+
 static const char* g_aptGet = "apt-get";
 static const char* g_dpkg = "dpkg";
 static const char* g_tdnf = "tdnf";

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -135,8 +135,8 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search --installed - only | awk '{print $2}'";
-    
+    const char* commandTmeplateZypper = "%s search - i | awk '{print $2}'";
+
     char* results = NULL;
     int status = ENOENT;
 

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -128,7 +128,6 @@ static char* g_installedPackages = NULL;
 static int ListAllInstalledPackages(OsConfigLogHandle log)
 {
     const char* commandTemplate = "%s list installed";
-    const char* commandTemplateAptGet = "%s list --installed";
     const char* commandTemplateDpkg = "%s -l";
     const char* commandTmeplateZypper = "%s search --installed-only";
     char* results = NULL;
@@ -136,11 +135,7 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 
     CheckPackageManagersPresence(log);
 
-    if (g_aptGetIsPresent)
-    {
-        status = CheckAllPackages(commandTemplateAptGet, g_aptGet, &results, log);
-    }
-    else if (g_dpkgIsPresent)
+    if (g_aptGetIsPresent || g_dpkgIsPresent)
     {
         status = CheckAllPackages(commandTemplateDpkg, g_dpkg, &results, log);
     }

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -352,22 +352,22 @@ static int ExecuteZypperRefresh(OsConfigLogHandle log)
 
     int status = 0;
 
-    if (true = g_zypperRefreshExecuted)
+    if (true == g_zypperRefreshExecuted)
     {
         return status;
     }
 
     if (0 != (status = ExecuteCommand(NULL, zypperClean, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' '%s' returned %d (errno: %d '%s')", zypperClean, status, errno, strerror(errno));
+        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperClean, status, errno, strerror(errno));
     }
     else if (0 != (status = ExecuteCommand(NULL, zypperRefresh, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' '%s' returned %d (errno: %d '%s')", zypperRefresh, status, errno, strerror(errno));
+        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperRefresh, status, errno, strerror(errno));
     }
     else if (0 != (status = ExecuteCommand(NULL, zypperRefreshServices, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' '%s' returned %d (errno: %d '%s')", zypperRefreshServices, status, errno, strerror(errno));
+        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperRefreshServices, status, errno, strerror(errno));
     }
 
     if (0 == status)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i | awk '{print $2}'";
+    const char* commandTmeplateZypper = "%s search -i | grep -v '|' | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -105,7 +105,7 @@ static int CheckOrInstallPackage(const char* commandTemplate, const char* packag
 
     status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log);
 
-    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning %d (errno: %d)", packageManager, command, status, errno);
+    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning %d", packageManager, command, status);
 
     FREE_MEMORY(command);
 
@@ -134,7 +134,7 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
 
     status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
-    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d (errno: %d)", packageManager, command, status, errno);
+    OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d", packageManager, command, status);
     OsConfigLogInfo(log, "%s", *results); //TODO: Change this to OsConfigLogDebug
 
     FREE_MEMORY(command);
@@ -187,7 +187,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
     {
         FREE_MEMORY(g_installedPackagesCache);
         status = status ? status : ENOENT;
-        OsConfigLogInfo(log, "UpdateInstalledPackagesCache: enumerating all packages failed with %d, errno: %d (%s)", status, errno, strerror(errno));
+        OsConfigLogInfo(log, "UpdateInstalledPackagesCache: enumerating all packages failed with %d", status);
     }
 
     FREE_MEMORY(results);
@@ -332,7 +332,7 @@ static int ExecuteSimplePackageCommand(const char* command, bool* executed, OsCo
     }
     else
     {
-        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' returned %d (errno: %d)", command, status, errno);
+        OsConfigLogInfo(log, "ExecuteSimplePackageCommand: '%s' returned %d", command, status);
         *executed = false;
     }
 
@@ -346,7 +346,7 @@ static int ExecuteAptGetUpdate(OsConfigLogHandle log)
 
 static int ExecuteZypperRefresh(OsConfigLogHandle log)
 {
-    //const char* zypperClean = "zypper clean";
+    const char* zypperClean = "zypper clean";
     const char* zypperRefresh = "zypper refresh";
     const char* zypperRefreshServices = "zypper refresh --services";
 
@@ -357,17 +357,17 @@ static int ExecuteZypperRefresh(OsConfigLogHandle log)
         return status;
     }
 
-    /*if (0 != (status = ExecuteCommand(NULL, zypperClean, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
+    if (0 != (status = ExecuteCommand(NULL, zypperClean, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperClean, status, errno, strerror(errno));
+        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d", zypperClean, status);
     }
-    else*/ if (0 != (status = ExecuteCommand(NULL, zypperRefresh, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
+    else if (0 != (status = ExecuteCommand(NULL, zypperRefresh, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperRefresh, status, errno, strerror(errno));
+        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d", zypperRefresh, status);
     }
     else if (0 != (status = ExecuteCommand(NULL, zypperRefreshServices, false, false, 0, g_packageManagerTimeoutSeconds, NULL, NULL, log)))
     {
-        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d (errno: %d '%s')", zypperRefreshServices, status, errno, strerror(errno));
+        OsConfigLogInfo(log, "ExecuteZypperRefresh: '%s' returned %d", zypperRefreshServices, status);
     }
 
     if (0 == status)
@@ -441,7 +441,7 @@ int InstallOrUpdatePackage(const char* packageName, OsConfigLogHandle log)
     }
     else
     {
-        OsConfigLogInfo(log, "InstallOrUpdatePackage: installation or update of package '%s' returned %d (errno: %d)", packageName, status, errno);
+        OsConfigLogInfo(log, "InstallOrUpdatePackage: installation or update of package '%s' returned %d", packageName, status);
     }
 
     return status;
@@ -516,7 +516,7 @@ int UninstallPackage(const char* packageName, OsConfigLogHandle log)
         }
         else
         {
-            OsConfigLogInfo(log, "UninstallPackage: uninstallation of package '%s' returned %d (errno: %d)", packageName, status, errno);
+            OsConfigLogInfo(log, "UninstallPackage: uninstallation of package '%s' returned %d", packageName, status);
         }
     }
     else if (EINVAL != status)

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -146,7 +146,7 @@ static int UpdateInstalledPackagesCache(OsConfigLogHandle log)
 {
     const char* commandTemplateDpkg = "%s-query -W -f='${binary:Package}\n'";
     const char* commandTemplateYumDnf = "%s list installed  --cacheonly | awk '{print $1}'";
-    const char* commandTmeplateZypper = "%s search -i | grep -v '|' | awk '{print $2}'"; //"%s search - i | awk '{print $2}'";
+    const char* commandTmeplateZypper = "%s search -i | awk '{print $2}'";
 
     char* results = NULL;
     int status = ENOENT;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -188,7 +188,6 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     char* searchTarget = NULL;
     char* found = NULL;
-    size_t size = 0;
     int status = 0;
 
     if ((NULL == packageName) || (0 == strlen(packageName)))
@@ -207,12 +206,12 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 
     if (0 == status)
     {
-        if (NULL == (searchTarget = FormatAllocateString("\n%s", packageName)))
+        if (NULL == (searchTarget = FormatAllocateString("\n%s\n", packageName)))
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;
         }
-        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 < (size = strlen(found))) && (0 == isalnum(found[size])))
+        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 < strlen(found)))
         {
             OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
             status = 0;

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -194,7 +194,7 @@ static int IsPackageListedAsInstalled(const char* packageName, OsConfigLogHandle
 
     if ((NULL == g_installedPackages) && (0 != (status = ListAllInstalledPackages(log))))
     {
-        if ((NULL == g_installedPackages) && (NULL != strstr(g_installedPackages, packageName)))
+        if ((NULL != g_installedPackages) && (NULL != strstr(g_installedPackages, packageName)))
         {
             status = 0;
         }

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -121,7 +121,7 @@ static int CheckAllPackages(const char* commandTemplate, const char* packageMana
         return ENOMEM;
     }
 
-    status = ExecuteCommand(NULL, command, true, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
+    status = ExecuteCommand(NULL, command, false, false, 0, g_packageManagerTimeoutSeconds, results, NULL, log);
 
     OsConfigLogInfo(log, "Package manager '%s' command '%s' returning  %d (errno: %d)", packageManager, command, status, errno);
     OsConfigLogInfo(log, "%s", *results); //TODO: Change this to OsConfigLogDebug
@@ -187,6 +187,7 @@ static int ListAllInstalledPackages(OsConfigLogHandle log)
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 {
     char* searchTarget = NULL;
+    char* found = NULL;
     int status = 0;
 
     if ((NULL == packageName) || (0 == strlen(packageName)))
@@ -205,23 +206,23 @@ int IsPackageInstalled(const char* packageName, OsConfigLogHandle log)
 
     if (0 == status)
     {
-        if (NULL == (searchTarget = FormatAllocateString(" %s ", packageName)))
+        if (NULL == (searchTarget = FormatAllocateString("\n%s", packageName)))
         {
             OsConfigLogError(log, "IsPackageInstalled: out of memory");
             status = ENOMEM;
         }
-        else if (NULL == strstr(g_installedPackages, searchTarget))
+        else if ((NULL != (found = strstr(g_installedPackages, searchTarget))) && (0 == isalnum((char)(found + strlen(found)))))
+        {
+            OsConfigLogInfo(log, "IsPackageInstalled: '%s' is installed", packageName);
+            status = 0;
+        }
+        else
         {
             OsConfigLogInfo(log, "IsPackageInstalled: '%s' is not installed", packageName);
             status = ENOENT;
         }
 
         FREE_MEMORY(searchTarget);
-    }
-
-    if (0 == status)
-    {
-        OsConfigLogInfo(log, "IsPackageInstalled: package '%s' is installed", packageName);
     }
 
     return status;

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2068,16 +2068,20 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     if (0 == IsPackageInstalled("nano", nullptr))
     {
         EXPECT_EQ(0, UninstallPackage("nano", nullptr));
-        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
-        EXPECT_EQ(0, InstallPackage("nano", nullptr));
+        EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        EXPECT_EQ(0, InstallPackage("nano", nullptr));
+        EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
     }
     else
     {
         EXPECT_EQ(0, InstallPackage("nano", nullptr));
-        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
-        EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+        EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+        EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+        EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
     }
 }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2084,7 +2084,7 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
         EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
-        
+
         EXPECT_EQ(0, InstallPackage("nano", nullptr));
         EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2065,19 +2065,19 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     EXPECT_EQ(0, CheckPackageInstalled("gcc", nullptr, nullptr));
     EXPECT_NE(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
 
-    if (0 == IsPackageInstalled("curl", nullptr))
+    if (0 == IsPackageInstalled("nano", nullptr))
     {
-        EXPECT_EQ(0, UninstallPackage("curl", nullptr));
-        EXPECT_NE(0, CheckPackageNotInstalled("curl", nullptr, nullptr));
-        EXPECT_EQ(0, InstallPackage("curl", nullptr));
-        EXPECT_NE(0, CheckPackageInstalled("curl", nullptr, nullptr));
+        EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+        EXPECT_EQ(0, InstallPackage("nano", nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
     }
     else
     {
-        EXPECT_EQ(0, InstallPackage("curl", nullptr));
-        EXPECT_NE(0, CheckPackageInstalled("curl", nullptr, nullptr));
-        EXPECT_EQ(0, UninstallPackage("curl", nullptr));
-        EXPECT_NE(0, CheckPackageNotInstalled("curl", nullptr, nullptr));
+        EXPECT_EQ(0, InstallPackage("nano", nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
     }
 }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2074,23 +2074,27 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
         EXPECT_EQ(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
     }
 
+    // While running in container during CI we may not be able to install or uninstall
+    // packages so we condition on success of such operations running additional tests:
+
     if (0 == IsPackageInstalled("nano", nullptr))
     {
         EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
 
-        EXPECT_EQ(0, UninstallPackage("nano", nullptr));
-        EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
-        EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
-        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
-
-        // We may not be able to install new packages while running in container during CI
-        if (0 == InstallPackage("nano", nullptr))
+        if (0 == UninstallPackage("nano", nullptr))
         {
-            EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
-            EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
-            EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+            EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
+            EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+            EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        
+            if (0 == InstallPackage("nano", nullptr))
+            {
+                EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
+                EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
+                EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+            }
         }
     }
     else
@@ -2099,17 +2103,18 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
         EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
 
-        // We may not be able to install new packages while running in container during CI
         if (0 == InstallPackage("nano", nullptr))
         {
             EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
             EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
             EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
 
-            EXPECT_EQ(0, UninstallPackage("nano", nullptr));
-            EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
-            EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
-            EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+            if (0 == UninstallPackage("nano", nullptr))
+            {
+                EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
+                EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+                EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+            }
         }
     }
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2085,10 +2085,13 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
         EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
 
-        EXPECT_EQ(0, InstallPackage("nano", nullptr));
-        EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
-        EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
-        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+        // We may not be able to install new packages while running in container during CI
+        if (0 == InstallPackage("nano", nullptr))
+        {
+            EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
+            EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
+            EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+        }
     }
     else
     {
@@ -2096,15 +2099,18 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
         EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
 
-        EXPECT_EQ(0, InstallPackage("nano", nullptr));
-        EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
-        EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
-        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+        // We may not be able to install new packages while running in container during CI
+        if (0 == InstallPackage("nano", nullptr))
+        {
+            EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
+            EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
+            EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
 
-        EXPECT_EQ(0, UninstallPackage("nano", nullptr));
-        EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
-        EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
-        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+            EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+            EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
+            EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+            EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        }
     }
 }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2064,6 +2064,21 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     EXPECT_EQ(0, IsPackageInstalled("gcc", nullptr));
     EXPECT_EQ(0, CheckPackageInstalled("gcc", nullptr, nullptr));
     EXPECT_NE(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
+
+    if (0 == IsPackageInstalled("curl", nullptr))
+    {
+        EXPECT_EQ(0, UninstallPackage("curl", nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("curl", nullptr, nullptr));
+        EXPECT_EQ(0, InstallPackage("curl", nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("curl", nullptr, nullptr));
+    }
+    else
+    {
+        EXPECT_EQ(0, InstallPackage("curl", nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("curl", nullptr, nullptr));
+        EXPECT_EQ(0, UninstallPackage("curl", nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("curl", nullptr, nullptr));
+    }
 }
 
 TEST_F(CommonUtilsTest, CheckPackageManagerNotThrottling)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2076,19 +2076,33 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
 
     if (0 == IsPackageInstalled("nano", nullptr))
     {
+        EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
+        EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+
         EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+        EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        
         EXPECT_EQ(0, InstallPackage("nano", nullptr));
+        EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
     }
     else
     {
+        EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
+        EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+
         EXPECT_EQ(0, InstallPackage("nano", nullptr));
+        EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
+
         EXPECT_EQ(0, UninstallPackage("nano", nullptr));
+        EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
         EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
         EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
     }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2061,9 +2061,18 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
     EXPECT_EQ(0, CheckPackageNotInstalled("~package_that_does_not_exist*", nullptr, nullptr));
     EXPECT_EQ(0, CheckPackageNotInstalled("*~package_that_does_not_exist*", nullptr, nullptr));
 
-    EXPECT_EQ(0, IsPackageInstalled("gcc", nullptr));
-    EXPECT_EQ(0, CheckPackageInstalled("gcc", nullptr, nullptr));
-    EXPECT_NE(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
+    if (0 == IsPackageInstalled("gcc", nullptr))
+    {
+        EXPECT_EQ(0, IsPackageInstalled("gcc", nullptr));
+        EXPECT_EQ(0, CheckPackageInstalled("gcc", nullptr, nullptr));
+        EXPECT_NE(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
+    }
+    else
+    {
+        EXPECT_NE(0, IsPackageInstalled("gcc", nullptr));
+        EXPECT_NE(0, CheckPackageInstalled("gcc", nullptr, nullptr));
+        EXPECT_EQ(0, CheckPackageNotInstalled("gcc", nullptr, nullptr));
+    }
 
     if (0 == IsPackageInstalled("nano", nullptr))
     {

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2088,7 +2088,7 @@ TEST_F(CommonUtilsTest, CheckInstallUninstallPackage)
             EXPECT_NE(0, IsPackageInstalled("nano", nullptr));
             EXPECT_EQ(0, CheckPackageNotInstalled("nano", nullptr, nullptr));
             EXPECT_NE(0, CheckPackageInstalled("nano", nullptr, nullptr));
-        
+
             if (0 == InstallPackage("nano", nullptr))
             {
                 EXPECT_EQ(0, IsPackageInstalled("nano", nullptr));


### PR DESCRIPTION
## Description

We are unintendedly blocking the package managers during ASB audit by invoking the package managers at every rule to check if one of more packages are installed, one by one. We can speed up the overall ASB audit time and also avoid blocking the package managers so much by listing all installed packages once per session and saving to a cache buffer, then when looking to see if a package is installed, to search in that buffer without making any new package manager request. 

We refresh this cache when installing and uninstalling packages during automatic remediation (where we still need to do one package at a time, but nobody complained yet about that, and also remediation does not happen continuously like audit, being executed only once in most cases). In audit-only case however, there shall be only one cache initialization per NRP loaded session.

The Hot Fix in this PR applies to all package managers that we support:
- apt-get
- dpkg
- rpm
- tdnf
- dnf
- yum
- zypper

For building the cache (holding the list of installed packages) we give priority to dpkg and rpm. If these are not present, we try individual managers (tdnf, dnf, yum, zypper) as some distros can have such configurations.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
