### PR TITLE
Introduce user-defined parameters quoting

### DIFF
--- a/src/modules/compliance/src/lib/Procedure.cpp
+++ b/src/modules/compliance/src/lib/Procedure.cpp
@@ -140,13 +140,25 @@ Optional<Error> Procedure::UpdateUserParameters(const std::string& input)
         {
             const size_t valueStart = pos;
             pos = ParseQuotedValue(input, pos, value);
+
+            // Check if the pos points past a proper quote
             if (input[pos - 1] != input[valueStart])
             {
                 return Error("Invalid key-value pair: missing closing quote or invalid escape sequence");
             }
+
+            // If at the end of the input, we need to check if a closing quote was found, e.g.:
+            // k1=" should fail (ParseQuotedValue will terminate at the opening quote and return valueStart+1)
             if ((pos >= input.size()) && (pos - valueStart == 1))
             {
                 return Error("Invalid key-value pair: missing closing quote at the end of the input");
+            }
+
+            // We want to have at least one space after the value, e.g.:
+            // k1="1"k2="v2" should fail
+            if ((pos < input.size()) && (!isspace(input[pos])))
+            {
+                return Error("Invalid key-value pair: space expected after quoted value");
             }
         }
         else

--- a/src/modules/compliance/src/lib/Procedure.cpp
+++ b/src/modules/compliance/src/lib/Procedure.cpp
@@ -115,6 +115,11 @@ Optional<Error> Procedure::UpdateUserParameters(const std::string& input)
         {
             return result.Error();
         }
+        if (keyStart == pos)
+        {
+            return Error("Invalid key-value pair: empty key");
+        }
+
         pos = result.Value();
         auto key = input.substr(keyStart, pos - keyStart);
         if ((pos >= input.size()) || (input[pos] != '='))

--- a/src/modules/compliance/src/lib/Procedure.cpp
+++ b/src/modules/compliance/src/lib/Procedure.cpp
@@ -115,19 +115,16 @@ Optional<Error> Procedure::UpdateUserParameters(const std::string& input)
         {
             return result.Error();
         }
-
-        auto key = input.substr(keyStart, result.Value() - keyStart);
-        pos = SkipSpaces(input, result.Value());
+        pos = result.Value();
+        auto key = input.substr(keyStart, pos - keyStart);
         if ((pos >= input.size()) || (input[pos] != '='))
         {
             return Error("Invalid key-value pair: '=' expected");
         }
-
-        // Skip space after assignment character
-        pos = SkipSpaces(input, pos + 1);
-        if (pos >= input.size())
+        pos++; // Move past assignment character
+        if (pos >= input.size() || isspace(input[pos]))
         {
-            return Error("Invalid key-value pair: value expected");
+            return Error("Invalid key-value pair: missing value");
         }
 
         // Parse value

--- a/src/modules/compliance/src/lib/Procedure.cpp
+++ b/src/modules/compliance/src/lib/Procedure.cpp
@@ -115,12 +115,12 @@ Optional<Error> Procedure::UpdateUserParameters(const std::string& input)
         {
             return result.Error();
         }
+        pos = result.Value();
         if (keyStart == pos)
         {
             return Error("Invalid key-value pair: empty key");
         }
 
-        pos = result.Value();
         auto key = input.substr(keyStart, pos - keyStart);
         if ((pos >= input.size()) || (input[pos] != '='))
         {

--- a/src/modules/compliance/src/lib/Procedure.cpp
+++ b/src/modules/compliance/src/lib/Procedure.cpp
@@ -5,11 +5,89 @@
 
 #include "Logging.h"
 
+#include <cassert>
 #include <parson.h>
-#include <sstream>
 
 namespace compliance
 {
+namespace
+{
+std::size_t SkipSpaces(const std::string& input, std::size_t pos)
+{
+    while (pos < input.size() && isspace(input[pos]))
+    {
+        ++pos;
+    }
+    return pos;
+}
+
+Result<std::size_t> ParseKey(const std::string& input, std::size_t pos)
+{
+    bool first = true;
+    while (pos < input.size() && !isspace(input[pos]) && input[pos] != '=')
+    {
+        if (islower(input[pos]))
+        {
+            return Error("Invalid key: must be uppercase");
+        }
+
+        if (!isalnum(input[pos]) && input[pos] != '_')
+        {
+            return Error("Invalid key: only alphanumeric and underscore characters are allowed");
+        }
+
+        if (first && isdigit(input[pos]))
+        {
+            return Error("Invalid key: first character must be an uppercase letter");
+        }
+        first = false;
+        ++pos;
+    }
+
+    return pos;
+}
+
+std::size_t ParseQuotedValue(const std::string& input, std::size_t pos, std::string& value)
+{
+    // Assuming the first character is a quote
+    // pos is always > 1 as we are passing value which must follow a valid key, assignment character and a quote
+    assert(pos > 1);
+    assert(input[pos] == '\'');
+    assert(input[pos - 1] == '=');
+
+    while (++pos < input.size())
+    {
+        if (input[pos] != '\'')
+        {
+            // Regular character, move on
+            value += input[pos];
+            continue;
+        }
+
+        // At the quote, look back to see if it is escaped
+        if (input[pos - 1] != '\\')
+        {
+            // Not escaped, end of the value
+            return ++pos;
+        }
+
+        // Found a backslash before the quote, check if there is another one before it
+        if (input[pos - 2] == '\\')
+        {
+            // Found an escaped backslash, end of the value. Drop the last backslash as it was used to escape the quote
+            value.pop_back();
+            return ++pos;
+        }
+
+        // Found an escaped quote, add it to the value, but in place of the last backslash
+        value.pop_back();
+        value += input[pos];
+    }
+
+    return pos;
+}
+} // namespace
+
 void Procedure::SetParameter(const std::string& key, std::string value)
 {
     mParameters[key] = std::move(value);
@@ -17,40 +95,57 @@ void Procedure::SetParameter(const std::string& key, std::string value)
 
 Optional<Error> Procedure::UpdateUserParameters(const std::string& input)
 {
-    std::istringstream stream(input);
-    std::string token;
-
-    while (std::getline(stream, token, ' '))
+    size_t pos = 0;
+    while (pos < input.size())
     {
-        size_t pos = token.find('=');
-        if (pos == std::string::npos)
+        // Skip spaces
+        pos = SkipSpaces(input, pos);
+        if (pos >= input.size())
         {
-            continue;
+            break;
         }
 
-        std::string key = token.substr(0, pos);
-        std::string value = token.substr(pos + 1);
-
-        if (!value.empty() && value[0] == '"')
+        // Parse key
+        const size_t keyStart = pos;
+        auto result = ParseKey(input, pos);
+        if (!result.HasValue())
         {
-            value.erase(0, 1);
-            while (!value.empty() && value.back() == '\\')
+            return result.Error();
+        }
+
+        auto key = input.substr(keyStart, result.Value() - keyStart);
+        pos = SkipSpaces(input, result.Value());
+        if ((pos >= input.size()) || (input[pos] != '='))
+        {
+            return Error("Invalid key-value pair: '=' expected");
+        }
+
+        // Skip space after assignment character
+        pos = SkipSpaces(input, pos + 1);
+        if (pos >= input.size())
+        {
+            return Error("Invalid key-value pair: value expected");
+        }
+
+        // Parse value
+        std::string value;
+        if (input[pos] == '\'')
+        {
+            pos = ParseQuotedValue(input, pos, value);
+            if ((pos >= input.size()) && ((input[pos - 1] != '\'') || (input[pos - 2] == '=')))
             {
-                std::string nextToken;
-                if (std::getline(stream, nextToken, ' '))
-                {
-                    value.pop_back();
-                    value += ' ' + nextToken;
-                }
-                else
-                {
-                    break;
-                }
+                return Error("Invalid key-value pair: missing closing quote");
             }
-            if (!value.empty() && value.back() == '"')
+        }
+        else
+        {
+            // Unquoted value
+            const size_t valueStart = pos;
+            while (pos < input.size() && !isspace(input[pos]))
             {
-                value.pop_back();
+                pos++;
             }
+            value = input.substr(valueStart, pos - valueStart);
         }
 
         auto it = mParameters.find(key);

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
@@ -76,7 +76,7 @@ REMEDIATE_FN(remediationParametrized, "result:Expected remediation result - succ
 AUDIT_FN(auditGetParamValues)
 {
     UNUSED(log);
-    const std::vector<std::string> keys = { "KEY1", "KEY2", "KEY3" };
+    const std::vector<std::string> keys = {"KEY1", "KEY2", "KEY3"};
     bool first = true;
     for (const auto& key : keys)
     {

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
@@ -3,6 +3,7 @@
 #include <CommonUtils.h>
 #include <Evaluator.h>
 #include <Result.h>
+#include <vector>
 
 namespace compliance
 {
@@ -70,5 +71,27 @@ REMEDIATE_FN(remediationParametrized, "result:Expected remediation result - succ
     }
 
     return Error("Invalid 'result' parameter");
+}
+
+AUDIT_FN(auditGetParamValues)
+{
+    UNUSED(log);
+    const std::vector<std::string> keys = { "KEY1", "KEY2", "KEY3" };
+    bool first = true;
+    for (const auto& key : keys)
+    {
+        auto it = args.find(key);
+        if (it != args.end())
+        {
+            if (!first)
+            {
+                logstream << ", ";
+            }
+            logstream << it->first << "=" << it->second;
+            first = false;
+        }
+    }
+
+    return true;
 }
 } // namespace compliance

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.schema.json
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.schema.json
@@ -42,6 +42,21 @@
               }
             }
           }
+        },
+        {
+          "type": "object",
+          "required": [
+            "auditGetParamValues"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "auditGetParamValues": {
+              "type": "object",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {}
+            }
+          }
         }
       ]
     },

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -538,3 +538,12 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_15)
     ASSERT_TRUE(result);
     EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1='x', KEY2="y" } == TRUE)");
 }
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_16)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"v1", "KEY2":"v2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // Space should be required between the key and the value
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1="'x'"KEY2='"y"')"));
+}

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -15,16 +15,6 @@ using compliance::JsonWrapper;
 using compliance::Result;
 using compliance::Status;
 
-static Result<bool> AuditFailure(std::map<std::string, std::string>, std::ostringstream&, OsConfigLogHandle)
-{
-    return false;
-}
-
-static Result<bool> AuditSuccess(std::map<std::string, std::string>, std::ostringstream&, OsConfigLogHandle)
-{
-    return true;
-}
-
 class ComplianceEngineTest : public ::testing::Test
 {
 public:
@@ -35,16 +25,6 @@ public:
 
 protected:
     Engine mEngine;
-    std::map<std::string, std::pair<action_func_t, action_func_t>> mProcedureMap;
-
-    void SetUp() override
-    {
-        mProcedureMap = {
-            {"success", {AuditSuccess, AuditSuccess}},
-            {"failure", {AuditFailure, AuditFailure}},
-            {"NoAudit", {nullptr, AuditSuccess}},
-        };
-    }
 };
 
 TEST_F(ComplianceEngineTest, MmiGet_InvalidArgument_1)
@@ -335,4 +315,186 @@ TEST_F(ComplianceEngineTest, MmiGet_3)
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
     EXPECT_EQ(result.Value().status, Status::NonCompliant);
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_1)
+{
+    std::string payload = R"({"audit":{},"parameters":{"KEY":"VALUE"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    auto result = mEngine.MmiSet("initX", "KEY=value");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_2)
+{
+    std::string payload = R"({"audit":{},"parameters":{"KEY":"VALUE"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    auto result = mEngine.MmiSet("initX", "k=value");
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.Error().message, std::string("Invalid key: must be uppercase"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_3)
+{
+    std::string payload = R"({"audit":{},"parameters":{"KEY":"VALUE"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    auto result = mEngine.MmiSet("initX", "1st=value");
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.Error().message, std::string("Invalid key: first character must be an uppercase letter"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_4)
+{
+    std::string payload = R"({"audit":{},"parameters":{"KEY":"VALUE"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // KEY_ not found in parameters, but is valid
+    auto result = mEngine.MmiSet("initX", "KEY_=value");
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.Error().message, std::string("User parameter 'KEY_' not found"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_5)
+{
+    std::string payload = R"({"audit":{},"parameters":{"KEY":"VALUE"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // $ is not accepted in the key
+    auto result = mEngine.MmiSet("initX", "KEY_$=value");
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.Error().message, std::string("Invalid key: only alphanumeric and underscore characters are allowed"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_6)
+{
+    std::string payload = R"({"audit":{},"parameters":{"KEY":"VALUE"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // check if spaces are trimmed from the key
+    auto result = mEngine.MmiSet("initX", "KEY_1 =  value");
+    ASSERT_FALSE(result);
+    EXPECT_EQ(result.Error().message, std::string("User parameter 'KEY_1' not found"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_1)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // check if spaces are trimmed from the key
+    ASSERT_TRUE(mEngine.MmiSet("initX", "KEY1 =  value"));
+
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=value } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_2)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_TRUE(mEngine.MmiSet("initX", "KEY1 =  value KEY2 = value2   "));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=value, KEY2=value2 } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_3)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_TRUE(mEngine.MmiSet("initX", "KEY1 ='  value' KEY2 = value2   "));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=  value, KEY2=value2 } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_4)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // Check if the escaping backslash is erased and the single quote is preserved
+    ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1=' v ' KEY2='value2\'')"));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= v , KEY2=value2' } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_5)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // We escape only the single quote, the result is expected to be the same
+    ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1=' v ' KEY2='\\value2')"));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= v , KEY2=\\value2 } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_6)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // We don't treat the pair of backslashes as an escape sequence, so the result is expected to contain only one backslash
+    ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1=' v ' KEY2='value2\\')"));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= v , KEY2=value2\ } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_7)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1='')"));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_8)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // Unterminated value
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1=')"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_9)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1=''')"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_10)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1='x)"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_11)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    // middle spaces handling
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1 )"));
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1= )"));
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1=)"));
+    ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1 =)"));
 }

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -513,6 +513,28 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_13)
     std::string payload = R"({"audit":{"auditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
-    // invalid escape character
+    // invalid escape sequence - backslash at the end of the string
     ASSERT_FALSE(mEngine.MmiSet("initX", R"(k1="x\)"));
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_14)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2", "KEY3": "$KEY3"}},"parameters":{"KEY1":"v1", "KEY2":"v2", "KEY3":"v3"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1="x" KEY2='y' KEY3=z)"));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=x, KEY2=y, KEY3=z } == TRUE)");
+}
+
+TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_15)
+{
+    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"v1", "KEY2":"v2"}})";
+    ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
+
+    ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1="'x'" KEY2='"y"')"));
+    auto result = mEngine.MmiGet("auditX");
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1='x', KEY2="y" } == TRUE)");
 }

--- a/src/tests/fuzzer/seed_corpus/ProcedureUpdateUserParameters.target
+++ b/src/tests/fuzzer/seed_corpus/ProcedureUpdateUserParameters.target
@@ -1,0 +1,1 @@
+ProcedureUpdateUserParameters.X="\"help\"" Y='4'

--- a/src/tests/fuzzer/target.cpp
+++ b/src/tests/fuzzer/target.cpp
@@ -9,6 +9,7 @@
 #include "Optional.h"
 #include "parson.h"
 #include "Base64.h"
+#include "Procedure.h"
 #include <unistd.h>
 #include <fcntl.h>
 #include <cstdint>
@@ -995,6 +996,34 @@ static int Base64Decode_target(const char* data, std::size_t size) noexcept
     return c_valid_input;
 }
 
+static int ProcedureUpdateUserParameters_target(const char* data, std::size_t size) noexcept
+{
+    auto input = std::string(data, size);
+    for (auto& c : input)
+    {
+        if (!std::isspace(c) && !std::isprint(c))
+        {
+            return c_skip_input;
+        }
+    }
+    compliance::Procedure proc;
+    proc.SetParameter("X", "1");
+    proc.SetParameter("Y", "2");
+    Optional<Error> error = proc.UpdateUserParameters(input);
+    if (error)
+    {
+        // printf("Error: %s\n", error->message.c_str());
+    }
+    else
+    {
+        for (auto& param : proc.Parameters())
+        {
+            // printf("Parameter: %s = %s\n", param.first.c_str(), param.second.c_str());
+        }
+    }
+    return 0;
+}
+
 // List of supported fuzzing targets.
 // The key is taken from the input data and is used to determine which target to call.
 static const std::map<std::string, int (*)(const char*, std::size_t)> g_targets = {
@@ -1058,6 +1087,7 @@ static const std::map<std::string, int (*)(const char*, std::size_t)> g_targets 
     { "CheckOrEnsureUsersDontHaveDotFiles.", CheckOrEnsureUsersDontHaveDotFiles_target },
     { "CheckUserAccountsNotFound.", CheckUserAccountsNotFound_target },
     { "Base64Decode.", Base64Decode_target },
+    {"ProcedureUpdateUserParameters.", ProcedureUpdateUserParameters_target},
 };
 
 // libfuzzer entry point


### PR DESCRIPTION
## Description

For the compliance module we accept a basic syntax for key-value pairs as input for init and remediation functions:
`key1=value1 key2=value2`
Currently we only split string by space which is obviously not enough for cases where the value contains spaces or equality sign.

This PR introduces a possibility to quote values:
`key1="value1" key2='value2'`
Both single quote and double quote are supported.

To handle cases where the quote itself is part of the value, we allow escaping it with a backslash:
`key1="value1\"s" key2="value2"`
To fulfill this, we also support escaping the backslash itself:
`key1="value1\\" key2=value2`
Here the value for KEY1 is `value1\`.

Special thanks to Jeremi for adding fuzzing target for this feature.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
