### PR TITLE
EnsureSysctl: Initial implementation

### DIFF
--- a/src/modules/compliance/src/lib/GenJSONSchemas.py
+++ b/src/modules/compliance/src/lib/GenJSONSchemas.py
@@ -72,6 +72,8 @@ def process_procedures(content, prefix):
             args.append(current)
         fn_name, arg_dict = parse_macro_args(args)
         if fn_name:
+            if fn_name[0].islower():
+                raise ValueError(f"Error function name '{fn_name}' starts with Lowercase in '{prefix}'")
             # Check for duplicate function names
             if procedures.get(fn_name) is not None:
                 raise ValueError(f"Duplicate function name '{fn_name}' found in '{prefix}'")

--- a/src/modules/compliance/src/lib/payload.schema.json
+++ b/src/modules/compliance/src/lib/payload.schema.json
@@ -152,6 +152,9 @@
           "$ref": "procedures/ensureNoUserHasPrimaryShadowGroup.schema.json#/definitions/audit"
         },
         {
+          "$ref": "procedures/ensureSysctl.schema.json#/definitions/audit"
+        },
+        {
           "$ref": "procedures/fileRegexMatch.schema.json#/definitions/audit"
         },
         {
@@ -184,6 +187,9 @@
         },
         {
           "$ref": "procedures/ensureNoUserHasPrimaryShadowGroup.schema.json#/definitions/remediation"
+        },
+        {
+          "$ref": "procedures/ensureSysctl.schema.json#/definitions/remediation"
         },
         {
           "$ref": "procedures/fileRegexMatch.schema.json#/definitions/remediation"

--- a/src/modules/compliance/src/lib/procedures/ensureSysctl.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureSysctl.cpp
@@ -1,0 +1,203 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <CommonUtils.h>
+#include <Evaluator.h>
+#include <Regex.h>
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+namespace compliance
+{
+
+std::string TrimWhitesSpace(const std::string& str);
+
+AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-Z0-9_-]+)$", "value:Regex that the value of sysctl has to match:M",
+    "test_procfs:Prefix for the /proc/sys from where sysctl will be read")
+{
+    auto log = context.GetLogHandle();
+    char* output = NULL;
+    std::string procfsLocation = "/proc/sys";
+    std::string systemdSysctl = "/lib/systemd/systemd-sysctl";
+
+    auto it = args.find("sysctlName");
+    if (it == args.end())
+    {
+        return Error("Missing 'sysctlName' parameter", EINVAL);
+    }
+    auto sysctlName = std::move(it->second);
+
+    it = args.find("value");
+    if (it == args.end())
+    {
+        return Error("Missing 'value' parameter", EINVAL);
+    }
+    auto sysctlValue = std::move(it->second);
+
+    it = args.find("test_procfs");
+    if (it != args.end())
+    {
+        procfsLocation = std::move(it->second);
+    }
+
+    auto sysctlPath = sysctlName;
+    std::replace(sysctlPath.begin(), sysctlPath.end(), '.', '/');
+    std::string procSysPath = procfsLocation + std::string("/") + sysctlPath;
+
+    output = LoadStringFromFile(procSysPath.c_str(), false, log);
+    if (output == NULL)
+    {
+        context.GetLogstream() << "Fail sysctl: '" << sysctlName << "' NOT compliant. Expected value: '" << sysctlValue << "' got NULL";
+        return false;
+    }
+    std::string sysctlOutput(output);
+    FREE_MEMORY(output);
+
+    // remove newline caracter
+    if (*sysctlOutput.rbegin() == '\n')
+    {
+        sysctlOutput.erase(sysctlOutput.size() - 1);
+    }
+
+    regex valueRegex;
+    try
+    {
+        valueRegex = regex(sysctlValue);
+    }
+    catch (const std::exception& e)
+    {
+        OsConfigLogError(log, "Regex error: %s", e.what());
+        return Error("Failed to compile regex '" + sysctlValue + "' error: " + e.what());
+    }
+
+    if (regex_search(sysctlOutput, valueRegex) == false)
+    {
+        context.GetLogstream() << "Fail sysctl: '" << sysctlName << "' NOT compliant. Expected value: '" << sysctlValue << "' got '" << sysctlOutput << "'";
+        return false;
+    }
+    if (args.find("test_procfs") == args.end())
+    {
+        struct stat statbuf;
+        if (0 != stat(systemdSysctl.c_str(), &statbuf))
+        {
+            systemdSysctl = std::string("/usr/lib/systemd/systemd-sysctl");
+            if (0 != stat(systemdSysctl.c_str(), &statbuf))
+            {
+                OsConfigLogError(log, "Failed to locate systemdSysctl command");
+                return Error("Failed to locate systemdSysctl command");
+            }
+        }
+    }
+    systemdSysctl += " --cat-config";
+    // systemd-sysclt shows all configs used by system that have sysctl's
+    if ((0 != ExecuteCommand(NULL, systemdSysctl.c_str(), false, false, 0, 0, &output, NULL, log)) || (output == NULL))
+    {
+        OsConfigLogError(log, "Failed to execute systemdSysctl command");
+        return Error("Failed to execute systemdSysctl command");
+    }
+    std::string sysctlConfigs(output);
+    FREE_MEMORY(output);
+
+    std::istringstream configurations(sysctlConfigs);
+    std::string line;
+    std::string runSysctlValue;
+    std::vector<std::string> sysctlConfigLines;
+
+    // Reverse order of output, to check sysctls from most important till less important
+    while (std::getline(configurations, line))
+    {
+        sysctlConfigLines.push_back(line);
+    }
+
+    bool found = false;
+    bool invalid = false;
+    auto lines = sysctlConfigLines.rbegin();
+    // Iterate sysctlConfigLines backwards, when last value matches expected valueRegex
+    // we are done.
+    for (; !found && lines != sysctlConfigLines.rend(); ++lines)
+    {
+        line = *lines;
+        size_t comment = line.find('#');
+        if (comment != std::string::npos)
+        {
+            line = line.substr(0, comment);
+        }
+        if (line == "")
+        {
+            continue;
+        }
+
+        // TODO(kkanas) consider using regex_match when we have all platforms with up to date support
+        auto nameValuePattern = regex("\\s*([a-zA-Z0-9_]+[\\.a-zA-Z0-9_-]+)\\s*=\\s*(.*)");
+        if (regex_search(line, nameValuePattern))
+        {
+            size_t eqPos = line.find('=');
+            if (eqPos == std::string::npos)
+            {
+                continue;
+            }
+
+            std::string name = line.substr(0, eqPos);
+            name = TrimWhitesSpace(name);
+            runSysctlValue = line.substr(eqPos + 1, line.size() - eqPos);
+            runSysctlValue = TrimWhitesSpace(runSysctlValue);
+
+            if (name == sysctlName)
+            {
+                found = true;
+                if (not regex_search(runSysctlValue, valueRegex))
+                {
+                    invalid = true;
+                }
+            }
+        }
+    }
+    // we found a match with correct value, or no match at all was found
+    if (!invalid || !found)
+    {
+        context.GetLogstream() << "sysctl: '" << sysctlName << "' compliant with value: '" << sysctlValue << "'";
+        return true;
+    }
+
+    // lines are iterated backwards so filename is before last value marked by lines
+    std::string fileName;
+    for (; lines != sysctlConfigLines.rend(); ++lines)
+    {
+        line = *lines;
+        // TODO(kkanas) consider using regex_match when we have all platforms with up to date support
+        regex fileNamePattern("^\\s*#\\s*(\\/.*\\.conf)$");
+        if (regex_search(line, fileNamePattern))
+        {
+            size_t comment = line.find('#');
+            if (comment == std::string::npos)
+            {
+                continue;
+            }
+            size_t slash = line.find_first_of('/', comment + 1);
+            if (slash == std::string::npos)
+            {
+                continue;
+            }
+            fileName = line.substr(slash, line.size() - slash + 1);
+            break;
+        }
+    }
+    context.GetLogstream() << "ERROR sysctl: '" << sysctlName << "' NOT compliant expected value: '" << sysctlValue << "' got '" << runSysctlValue
+                           << "' found in: '" << fileName << "'";
+    return false;
+}
+
+std::string TrimWhitesSpace(const std::string& str)
+{
+    auto start = std::find_if_not(str.begin(), str.end(), ::isspace);
+    auto end = std::find_if_not(str.rbegin(), str.rend(), ::isspace).base();
+    if (start < end)
+    {
+        return std::string(start, end);
+    }
+    return std::string();
+}
+} // namespace compliance

--- a/src/modules/compliance/src/lib/procedures/ensureSysctl.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureSysctl.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "audit": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "EnsureSysctl"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "EnsureSysctl": {
+              "type": "object",
+              "required": [
+                "sysctlName",
+                "value"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "sysctlName": {
+                  "type": "string",
+                  "description": "Name of the sysctl",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:(([a-zA-Z0-9_]+[\\\\.a-zA-Z0-9_-]+))$|(^([a-zA-Z0-9_]+[\\\\.a-zA-Z0-9_-]+)$))"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "Regex that the value of sysctl has to match"
+                },
+                "test_procfs": {
+                  "type": "string",
+                  "description": "Prefix for the /proc/sys from where sysctl will be read"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "remediation": {
+      "anyOf": []
+    }
+  }
+}

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
@@ -68,7 +68,7 @@ REMEDIATE_FN(RemediationParametrized, "result:Expected remediation result - succ
     return Error("Invalid 'result' parameter");
 }
 
-AUDIT_FN(auditGetParamValues)
+AUDIT_FN(AuditGetParamValues)
 {
     const std::vector<std::string> keys = {"KEY1", "KEY2", "KEY3"};
     bool first = true;

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.schema.json
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.schema.json
@@ -46,11 +46,11 @@
         {
           "type": "object",
           "required": [
-            "auditGetParamValues"
+            "AuditGetParamValues"
           ],
           "additionalProperties": false,
           "properties": {
-            "auditGetParamValues": {
+            "AuditGetParamValues": {
               "type": "object",
               "required": [],
               "additionalProperties": false,

--- a/src/modules/compliance/tests/EngineTest.cpp
+++ b/src/modules/compliance/tests/EngineTest.cpp
@@ -384,88 +384,88 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_7)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_1)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_TRUE(mEngine.MmiSet("initX", "KEY1=value"));
 
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=value } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1=value } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_2)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_TRUE(mEngine.MmiSet("initX", " KEY1=value  KEY2=value2   "));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=value, KEY2=value2 } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1=value, KEY2=value2 } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_3)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_TRUE(mEngine.MmiSet("initX", R"( KEY1="  value" KEY2=value2   )"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=  value, KEY2=value2 } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1=  value, KEY2=value2 } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_4)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // Check if the escaping backslash is erased and the single quote is preserved
     ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1=" v " KEY2="value2\"")"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= v , KEY2=value2" } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1= v , KEY2=value2" } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_5)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // Check if the backslash is properly escaped
     ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1=" v " KEY2="\\value2")"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= v , KEY2=\value2 } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1= v , KEY2=\value2 } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_6)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"VALUE1", "KEY2":"VALUE2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // We don't treat the pair of backslashes as an escape sequence, so the result is expected to contain only one backslash
     ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1=" v " KEY2="value2\\")"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= v , KEY2=value2\ } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1= v , KEY2=value2\ } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_7)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1="")"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1= } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1= } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_8)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // Unterminated value
@@ -474,7 +474,7 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_8)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_9)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1=""")"));
@@ -482,7 +482,7 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_9)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_10)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1"}},"parameters":{"KEY1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_FALSE(mEngine.MmiSet("initX", R"(KEY1="x)"));
@@ -490,7 +490,7 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_10)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_11)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // middle spaces handling
@@ -502,7 +502,7 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_11)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_12)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // invalid escape character
@@ -511,7 +511,7 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_12)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_13)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"k1": "$KEY1"}},"parameters":{"k1":"VALUE1"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // invalid escape sequence - backslash at the end of the string
@@ -520,29 +520,29 @@ TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_13)
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_14)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2", "KEY3": "$KEY3"}},"parameters":{"KEY1":"v1", "KEY2":"v2", "KEY3":"v3"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2", "KEY3": "$KEY3"}},"parameters":{"KEY1":"v1", "KEY2":"v2", "KEY3":"v3"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1="x" KEY2='y' KEY3=z)"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1=x, KEY2=y, KEY3=z } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1=x, KEY2=y, KEY3=z } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_15)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"v1", "KEY2":"v2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"v1", "KEY2":"v2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     ASSERT_TRUE(mEngine.MmiSet("initX", R"(KEY1="'x'" KEY2='"y"')"));
     auto result = mEngine.MmiGet("auditX");
     ASSERT_TRUE(result);
-    EXPECT_EQ(result.Value().payload, R"(PASS{ auditGetParamValues: KEY1='x', KEY2="y" } == TRUE)");
+    EXPECT_EQ(result.Value().payload, R"(PASS{ AuditGetParamValues: KEY1='x', KEY2="y" } == TRUE)");
 }
 
 TEST_F(ComplianceEngineTest, MmiSet_externalParams_value_16)
 {
-    std::string payload = R"({"audit":{"auditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"v1", "KEY2":"v2"}})";
+    std::string payload = R"({"audit":{"AuditGetParamValues":{"KEY1": "$KEY1", "KEY2": "$KEY2"}},"parameters":{"KEY1":"v1", "KEY2":"v2"}})";
     ASSERT_TRUE(mEngine.MmiSet("procedureX", payload));
 
     // Space should be required between the key and the value

--- a/src/modules/compliance/tests/procedures/ensureSysctlTest.cpp
+++ b/src/modules/compliance/tests/procedures/ensureSysctlTest.cpp
@@ -1,0 +1,450 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "CommonUtils.h"
+#include "Evaluator.h"
+#include "MockContext.h"
+#include "ProcedureMap.h"
+
+#include <algorithm>
+#include <dirent.h>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <linux/limits.h>
+#include <string.h>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using compliance::AuditEnsureSysctl;
+using compliance::Error;
+using compliance::Result;
+
+bool startsWith(const std::string& str, const std::string& prefix)
+{
+    return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+
+static const char systemdSysctlCat[] = "/lib/systemd/systemd-sysctl --cat-config";
+static const char sysctlIpForward0[] = "net.ipv4.ip_forward = 0";
+static const char sysctlIpForward1[] = "net.ipv4.ip_forward = 1";
+static const char sysctlIpForward0Comment[] = "                          # net.ipv4.ip_forward = 1";
+
+struct SysctlNameValue
+{
+    std::string name;
+    std::string value;
+    SysctlNameValue(std::string a_name, std::string a_value)
+        : name(a_name),
+          value(a_value)
+    {
+    }
+    std::string CfgOutput() const
+    {
+        auto fname = name;
+        std::replace(fname.begin(), fname.end(), '.', '/');
+        fname = std::string("# /etc/") + fname + ".conf\n";
+        auto nameEqVal = name + " = " + value + "\n";
+        return fname + nameEqVal;
+    }
+};
+
+// sysctl names that should be matchec correctly using regexp in ensureSysctl
+static const std::vector<SysctlNameValue> unsuportedSysctlTests = {
+    // This is sysctl with multiline output as stated in SysctlNameValue.value string, currenlty due to regex limitation we can handle it
+    SysctlNameValue(std::string("fs.binfmt_misc.python3/10"),
+        std::string("enabled\ninterpreter /usr/bin/python3.10\nflags:\noffset 0\nmagic 6f0d0d0a\n")),
+};
+
+static const std::vector<SysctlNameValue> cisSsysctlNames = {
+    SysctlNameValue(std::string("net.ipv4.conf.all.accept_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.all.accept_source_route"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.all.log_martians"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv4.conf.all.rp_filter"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv4.conf.all.secure_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.all.send_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.default.accept_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.default.accept_source_route"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.default.log_martians"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv4.conf.default.rp_filter"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv4.conf.default.secure_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.conf.default.send_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.icmp_echo_ignore_broadcasts"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv4.icmp_ignore_bogus_error_responses"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv4.ip_forward"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv4.tcp_syncookies"), std::string("1")),
+    SysctlNameValue(std::string("net.ipv6.conf.all.accept_ra"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv6.conf.all.accept_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv6.conf.all.accept_source_route"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv6.conf.all.forwarding"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv6.conf.default.accept_ra"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv6.conf.default.accept_redirects"), std::string("0")),
+    SysctlNameValue(std::string("net.ipv6.conf.default.accept_source_route"), std::string("0")),
+};
+/*
+ */
+static const char sysctlIpForward1Then0Than1Than0[] =
+    "net.ipv4.ip_forward = 1\n"
+    "net.ipv4.ip_forward = 0\n"
+    "net.ipv4.ip_forward = 1\n"
+    "net.ipv4.ip_forward = 0";
+
+static const char emptyOutput[] = "";
+
+static const char sysctlIpForward0FilenameExtraSpaces[] =
+    ""
+    "# /etc/sysctl.d/foo.conf\n"
+    "     net.ipv4.ip_forward    =          0     \n"
+    "     \n";
+
+static const char sysctlIpForward0FilenameTabs[] =
+    ""
+    "# /etc/sysctl.d/foo.conf\n"
+    " \t net.ipv4.ip_forward    =\t0\t     \n"
+    "     \n";
+
+static const char sysctlIpForward1Then0Than1Than0WithFilenames[] =
+    "# /etc/sysctl.d/fwd_1.conf\n"
+    "   net.ipv4.ip_forward = 1\n"
+    "# /etc/sysctl.d/fwd_0.conf\n"
+    "   net.ipv4.ip_forward = 0\n"
+    "# /etc/sysctl.d/fwd_1_v2.conf\n"
+    "   net.ipv4.ip_forward = 1\n"
+    "# /etc/sysctl.d/fwd_0_v2.conf\n"
+    "   net.ipv4.ip_forward = 0\n";
+
+class EnsureSysctlTest : public ::testing::Test
+{
+    struct LengthComparator
+    {
+        bool operator()(const std::string& lhs, const std::string& rhs) const
+        {
+            if (lhs.size() == rhs.size())
+            { // If lengths are equal, sort lexicographically
+                return lhs < rhs;
+            }
+            return lhs.size() > rhs.size(); // Sort by length, longest first
+        }
+    };
+
+protected:
+    char dirTemplate[PATH_MAX] = "/tmp/ensureSysctlTest.XXXXXX";
+    std::string dir;
+    std::set<std::string, LengthComparator> sysctlDirs;
+    std::set<std::string, LengthComparator> sysctlFiles;
+    MockContext mContext;
+
+    void SetUp() override
+    {
+        dir = mkdtemp(dirTemplate);
+        ASSERT_TRUE(dir != "");
+    }
+
+    // sysctlName: is sysctl name in dot notation e.g net.net/ipv4/ip_forwardipv4.ip_forward
+    void CreateSysctlFile(std::string sysctlName, std::string data)
+    {
+        int ret;
+        std::replace(sysctlName.begin(), sysctlName.end(), '.', '/');
+        std::string path = dir + std::string("/") + sysctlName;
+
+        size_t pos = 0;
+        while ((pos = path.find('/', pos)) != std::string::npos)
+        {
+            auto pathPart = path.substr(0, pos);
+            pos++;
+            if (startsWith(dir, pathPart))
+            {
+                continue;
+            }
+            ret = ::mkdir(pathPart.c_str(), 0777);
+            ASSERT_TRUE((ret == 0) || (ret != 0 && (errno == EEXIST)))
+                << "ERROR creating directory " << pathPart << " errno " << errno << ": " << strerror(errno);
+            sysctlDirs.insert(pathPart);
+        }
+
+        std::ofstream sysctlFile(path);
+        sysctlFile << data;
+        sysctlFile.close();
+        sysctlFiles.insert(path);
+    }
+
+    void TearDown() override
+    {
+        for (auto& file : sysctlFiles)
+        {
+            unlink(file.c_str());
+        }
+        for (auto& dir : sysctlDirs)
+        {
+            rmdir(dir.c_str());
+        }
+        rmdir(dir.c_str());
+    }
+};
+
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationNoOverride)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "0";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueConfigurationEqualEmptyOuput)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, emptyOutput, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "0";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWins)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1Then0Than1Than0, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "0";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationComment)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0Comment, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "0";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueNotEqual)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "0";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationOverride)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "0";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+// Regexp value tests
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpDotEqualConfiruationNoOverride)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = ".";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "[0]";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "[0]";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeNotEqual)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "[0]";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+// Invalid Args tests
+TEST_F(EnsureSysctlTest, UnHappyPathRegexError)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "(?)[1]";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_FALSE(result.HasValue());
+    auto should_contain = result.Error().message.find(std::string("Failed to compile regex '" + args["value"] + "' error:"));
+    ASSERT_TRUE(should_contain != std::string::npos);
+}
+
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualTabs)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0FilenameTabs, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_EQ(mContext.ConsumeLogstream(),
+        std::string("ERROR sysctl: 'net.ipv4.ip_forward' NOT compliant expected value: '1' got '0' found in: '/etc/sysctl.d/foo.conf'"));
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualExtraSpacesFilenameReportCheck)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0FilenameExtraSpaces, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+    ASSERT_EQ(mContext.ConsumeLogstream(),
+        std::string("ERROR sysctl: 'net.ipv4.ip_forward' NOT compliant expected value: '1' got '0' found in: '/etc/sysctl.d/foo.conf'"));
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+}
+
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWinsWithFilename)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
+    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1Then0Than1Than0WithFilenames, 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_FALSE(result.Value());
+    ASSERT_EQ(mContext.ConsumeLogstream(),
+        std::string("ERROR sysctl: 'net.ipv4.ip_forward' NOT compliant expected value: '1' got '0' found in: '/etc/sysctl.d/fwd_0_v2.conf'"));
+}
+
+TEST_F(EnsureSysctlTest, HappyPathValidateCisSysctls)
+{
+    for (size_t i = 0; i < cisSsysctlNames.size(); i++)
+    {
+        auto sysctlName = cisSsysctlNames[i].name;
+        auto value = cisSsysctlNames[i].value;
+        auto cfgOuput = cisSsysctlNames[i].CfgOutput();
+
+        CreateSysctlFile(sysctlName, sysctlName + " = " + value + "\n");
+        AddMockCommand(systemdSysctlCat, true, cfgOuput.c_str(), 0);
+        std::map<std::string, std::string> args;
+        args["sysctlName"] = sysctlName;
+        args["value"] = value;
+        args["test_procfs"] = dir;
+
+        Result<bool> result = AuditEnsureSysctl(args, mContext);
+
+        ASSERT_TRUE(result.HasValue()) << "HappyPathValidateSysctlNameAndValues FAILED: nr " << i << " name '" << sysctlName << "'";
+        ASSERT_TRUE(result.Value()) << "HappyPathValidateSysctlNameAndValues FAILED: nr " << i << " name '" << sysctlName << "'";
+        ;
+    }
+}
+
+TEST_F(EnsureSysctlTest, UnhappyPathSysctlMultilineOutput)
+{
+    SysctlNameValue sysctlNameValue(std::string("fs.binfmt_misc.python3/10"),
+        std::string("enabled\ninterpreter /usr/bin/python3.10\nflags:\noffset 0\nmagic 6f0d0d0a\n"));
+
+    auto sysctlName = sysctlNameValue.name;
+    auto value = sysctlNameValue.value;
+    auto cfgOuput = sysctlNameValue.CfgOutput();
+
+    CreateSysctlFile(sysctlName, sysctlName + " = " + value + "\n");
+    AddMockCommand(systemdSysctlCat, true, cfgOuput.c_str(), 0);
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = value;
+    args["test_procfs"] = dir;
+
+    Result<bool> result = AuditEnsureSysctl(args, mContext);
+
+    ASSERT_TRUE(result.HasValue()) << "HappyPathValidateSysctlNameAndValues FAILED: nr "
+                                   << " name '" << sysctlName << "'";
+    ASSERT_FALSE(result.Value()) << "HappyPathValidateSysctlNameAndValues FAILED: nr "
+                                 << " name '" << sysctlName << "'";
+    ;
+}

--- a/src/modules/test/recipes/SecurityBaselineTests_EnsureSyctl.json
+++ b/src/modules/test/recipes/SecurityBaselineTests_EnsureSyctl.json
@@ -1,0 +1,63 @@
+[
+  {
+    "Action": "LoadModule",
+    "Module": "compliance.so"
+  },
+  {
+    "RunCommand": "sysctl net.ipv4.ip_forward=1 && test -f /etc/sysctl.d/99-sysctl.conf && cp /etc/sysctl.d/99-sysctl.conf /etc/sysctl.d/99-sysctl.conf.bak ||  true ; echo net.ipv4.ip_forward=1 >> /etc/sysctl.d/99-sysctl.conf"
+  },
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "EnsureSysctl": {
+          "sysctlName": "net.ipv4.ip_forward",
+          "value": "1"
+        }
+      },
+      "parameters": {
+      }
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ EnsureSysctl: sysctl: 'net.ipv4.ip_forward' compliant with value: '1' } == TRUE"
+
+  },
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "EnsureSysctl": {
+          "sysctlName": "net.ipv4.ip_forward",
+          "value": "0"
+        }
+      },
+      "parameters": {
+      }
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ EnsureSysctl: Fail sysctl: 'net.ipv4.ip_forward' NOT compliant. Expected value: '0' got '1' } == FALSE"
+
+  },
+
+  {
+    "RunCommand": "sysctl net.ipv4.ip_forward=0 && test -f /etc/sysctl.d/99-sysctl.conf.bak && { mv /etc/sysctl.d/99-sysctl.conf.bak /etc/sysctl.d/99-sysctl.conf ; } || { rm /etc/sysctl.d/99-sysctl.conf ; }"
+  },
+
+  {
+    "Action": "UnloadModule"
+  }
+]


### PR DESCRIPTION
## Description

EnsureSysctl validates the runtime sysctl value by reading /proc/sys/sysctl and if that is compliant validates the configuration values to make sure system stays compliant upon next reboot.

The configuration validation is done using
/lib/systemd/systemd-sysctl --cat-config

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
