### PR TITLE
Don't throw an Mmi{Get,Set} error on an audit/remediation non-critical error

### DIFF
--- a/src/modules/compliance/tests/ComplianceTest.cpp
+++ b/src/modules/compliance/tests/ComplianceTest.cpp
@@ -120,7 +120,11 @@ TEST_F(ComplianceTest, ComplianceMmiGet_InvalidArguments_3)
 {
     char* payload = nullptr;
     int payloadSizeBytes = 0;
-    ASSERT_NE(MMI_OK, ComplianceMmiGet(mHandle, "Compliance", "auditX", &payload, &payloadSizeBytes));
+    auto result = ComplianceMmiGet(mHandle, "Compliance", "auditX", &payload, &payloadSizeBytes);
+    ASSERT_EQ(result, MMI_OK);
+    ASSERT_NE(payload, nullptr);
+    ASSERT_TRUE(std::string(payload).find("Rule not found") != std::string::npos);
+    free(payload);
 }
 
 TEST_F(ComplianceTest, ComplianceMmiGet_InvalidArguments_4)


### PR DESCRIPTION
## Description
Currently, MmiSet/MmiGet error for a single audit causes the whole benchmark to stop. Only return an error when it's really critical.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.
