### PR TITLE
Normalize compliance procedure names

### DIFF
--- a/src/modules/compliance/src/lib/Evaluator.h
+++ b/src/modules/compliance/src/lib/Evaluator.h
@@ -29,10 +29,10 @@ struct json_object_t;
 // "yetanotherparameter:This one is validated::^[0-9]+$"
 
 #define AUDIT_FN(fn_name, parameters...)                                                                                                               \
-    ::compliance::Result<bool> Audit_##fn_name(std::map<std::string, std::string> args, std::ostringstream& logstream, OsConfigLogHandle log)
+    ::compliance::Result<bool> Audit##fn_name(std::map<std::string, std::string> args, std::ostringstream& logstream, OsConfigLogHandle log)
 
 #define REMEDIATE_FN(fn_name, parameters...)                                                                                                           \
-    ::compliance::Result<bool> Remediate_##fn_name(std::map<std::string, std::string> args, std::ostringstream& logstream, OsConfigLogHandle log)
+    ::compliance::Result<bool> Remediate##fn_name(std::map<std::string, std::string> args, std::ostringstream& logstream, OsConfigLogHandle log)
 
 namespace compliance
 {

--- a/src/modules/compliance/src/lib/GenProcedureMap.sh
+++ b/src/modules/compliance/src/lib/GenProcedureMap.sh
@@ -29,14 +29,14 @@ for filepath in "$directory"/*.cpp; do
         if [[ $buffer =~ AUDIT_FN\(([^,]+)(,.*)?\) ]]; then
             procedure_name=${BASH_REMATCH[1]}
             audit_loc_map[$procedure_name]="$filename:$lineno"
-            audit_map[$procedure_name]="Audit_$procedure_name"
+            audit_map[$procedure_name]="Audit$procedure_name"
             if [[ ! " ${procedures[@]} " =~ " ${procedure_name} " ]]; then
                 procedures+=("$procedure_name")
             fi
         elif [[ $buffer =~ REMEDIATE_FN\(([^,]+)(,.*)?\) ]]; then
             procedure_name=${BASH_REMATCH[1]}
             remediate_loc_map[$procedure_name]="$filename:$lineno"
-            remediate_map[$procedure_name]="Remediate_$procedure_name"
+            remediate_map[$procedure_name]="Remediate$procedure_name"
             if [[ ! " ${procedures[@]} " =~ " ${procedure_name} " ]]; then
                 procedures+=("$procedure_name")
             fi

--- a/src/modules/compliance/src/lib/procedures/ensureAllGroupsFromEtcPasswdExistInEtcGroup.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureAllGroupsFromEtcPasswdExistInEtcGroup.cpp
@@ -10,7 +10,7 @@
 
 namespace compliance
 {
-AUDIT_FN(ensureAllGroupsFromEtcPasswdExistInEtcGroup)
+AUDIT_FN(EnsureAllGroupsFromEtcPasswdExistInEtcGroup)
 {
     UNUSED(args);
     UNUSED(log);
@@ -55,10 +55,10 @@ AUDIT_FN(ensureAllGroupsFromEtcPasswdExistInEtcGroup)
     return result;
 }
 
-REMEDIATE_FN(ensureAllGroupsFromEtcPasswdExistInEtcGroup)
+REMEDIATE_FN(EnsureAllGroupsFromEtcPasswdExistInEtcGroup)
 {
     UNUSED(args);
-    auto result = Audit_ensureAllGroupsFromEtcPasswdExistInEtcGroup(args, logstream, log);
+    auto result = AuditEnsureAllGroupsFromEtcPasswdExistInEtcGroup(args, logstream, log);
     if (result)
     {
         return true;

--- a/src/modules/compliance/src/lib/procedures/ensureAllGroupsFromEtcPasswdExistInEtcGroup.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureAllGroupsFromEtcPasswdExistInEtcGroup.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "ensureAllGroupsFromEtcPasswdExistInEtcGroup"
+            "EnsureAllGroupsFromEtcPasswdExistInEtcGroup"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureAllGroupsFromEtcPasswdExistInEtcGroup": {
+            "EnsureAllGroupsFromEtcPasswdExistInEtcGroup": {
               "type": "object",
               "required": [],
               "additionalProperties": false,
@@ -25,11 +25,11 @@
         {
           "type": "object",
           "required": [
-            "ensureAllGroupsFromEtcPasswdExistInEtcGroup"
+            "EnsureAllGroupsFromEtcPasswdExistInEtcGroup"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureAllGroupsFromEtcPasswdExistInEtcGroup": {
+            "EnsureAllGroupsFromEtcPasswdExistInEtcGroup": {
               "type": "object",
               "required": [],
               "additionalProperties": false,

--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
@@ -13,7 +13,7 @@
 namespace compliance
 {
 
-AUDIT_FN(ensureFilePermissions, "filename:Path to the file:M", "owner:Required owner of the file", "group:Required group of the file",
+AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required owner of the file", "group:Required group of the file",
     "permissions:Required octal permissions of the file::^[0-7]{3,4}$", "mask:Required octal permissions of the file - mask::^[0-7]{3,4}$")
 {
     UNUSED(log);
@@ -115,7 +115,7 @@ AUDIT_FN(ensureFilePermissions, "filename:Path to the file:M", "owner:Required o
     return true;
 }
 
-REMEDIATE_FN(ensureFilePermissions, "filename:Path to the file:M", "owner:Required owner of the file", "group:Required group of the file",
+REMEDIATE_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required owner of the file", "group:Required group of the file",
     "permissions:Required octal permissions of the file::^[0-7]{3,4}$", "mask:Required octal permissions of the file - mask::^[0-7]{3,4}$")
 {
     UNUSED(log);

--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "ensureFilePermissions"
+            "EnsureFilePermissions"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureFilePermissions": {
+            "EnsureFilePermissions": {
               "type": "object",
               "required": [
                 "filename"
@@ -50,11 +50,11 @@
         {
           "type": "object",
           "required": [
-            "ensureFilePermissions"
+            "EnsureFilePermissions"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureFilePermissions": {
+            "EnsureFilePermissions": {
               "type": "object",
               "required": [
                 "filename"

--- a/src/modules/compliance/src/lib/procedures/ensureFilesystemOption.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureFilesystemOption.cpp
@@ -104,7 +104,7 @@ static bool CheckOptions(const std::vector<std::string>& options, const std::set
     return true;
 };
 
-AUDIT_FN(ensureFilesystemOption, "mountpoint:Filesystem mount point:M", "optionsSet:Comma-separated list of options that must be set",
+AUDIT_FN(EnsureFilesystemOption, "mountpoint:Filesystem mount point:M", "optionsSet:Comma-separated list of options that must be set",
     "optionsNotSet:Comma-separated list of options that must not be set", "test_fstab:Location of the fstab file", "test_mtab:Location of the mtab file")
 {
     UNUSED(log);
@@ -176,7 +176,7 @@ AUDIT_FN(ensureFilesystemOption, "mountpoint:Filesystem mount point:M", "options
     return true;
 }
 
-REMEDIATE_FN(ensureFilesystemOption, "mountpoint:Filesystem mount point:M", "optionsSet:Comma-separated list of options that must be set",
+REMEDIATE_FN(EnsureFilesystemOption, "mountpoint:Filesystem mount point:M", "optionsSet:Comma-separated list of options that must be set",
     "optionsNotSet:Comma-separated list of options that must not be set", "test_fstab:Location of the fstab file",
     "test_mtab:Location of the mtab file", "test_mount:Location of the mount binary")
 {

--- a/src/modules/compliance/src/lib/procedures/ensureFilesystemOption.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureFilesystemOption.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "ensureFilesystemOption"
+            "EnsureFilesystemOption"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureFilesystemOption": {
+            "EnsureFilesystemOption": {
               "type": "object",
               "required": [
                 "mountpoint"
@@ -48,11 +48,11 @@
         {
           "type": "object",
           "required": [
-            "ensureFilesystemOption"
+            "EnsureFilesystemOption"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureFilesystemOption": {
+            "EnsureFilesystemOption": {
               "type": "object",
               "required": [
                 "mountpoint"

--- a/src/modules/compliance/src/lib/procedures/ensureKernelModule.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureKernelModule.cpp
@@ -25,7 +25,7 @@ static bool MultilineRegexSearch(const std::string& str, const regex& pattern)
     return false;
 }
 
-AUDIT_FN(ensureKernelModuleUnavailable, "moduleName:Name of the kernel module:M")
+AUDIT_FN(EnsureKernelModuleUnavailable, "moduleName:Name of the kernel module:M")
 {
     UNUSED(log);
     char* output = NULL;

--- a/src/modules/compliance/src/lib/procedures/ensureKernelModule.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureKernelModule.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "ensureKernelModuleUnavailable"
+            "EnsureKernelModuleUnavailable"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureKernelModuleUnavailable": {
+            "EnsureKernelModuleUnavailable": {
               "type": "object",
               "required": [
                 "moduleName"

--- a/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.cpp
@@ -16,7 +16,7 @@
 
 namespace compliance
 {
-AUDIT_FN(ensureNoDuplicateEntriesExist)
+AUDIT_FN(EnsureNoDuplicateEntriesExist)
 {
     UNUSED(log);
     auto it = args.find("filename");

--- a/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "ensureNoDuplicateEntriesExist"
+            "EnsureNoDuplicateEntriesExist"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureNoDuplicateEntriesExist": {
+            "EnsureNoDuplicateEntriesExist": {
               "type": "object",
               "required": [],
               "additionalProperties": false,

--- a/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.cpp
@@ -13,7 +13,7 @@
 
 namespace compliance
 {
-AUDIT_FN(ensureNoUserHasPrimaryShadowGroup)
+AUDIT_FN(EnsureNoUserHasPrimaryShadowGroup)
 {
     UNUSED(args);
     UNUSED(log);
@@ -49,7 +49,7 @@ AUDIT_FN(ensureNoUserHasPrimaryShadowGroup)
     return result;
 }
 
-REMEDIATE_FN(ensureNoUserHasPrimaryShadowGroup)
+REMEDIATE_FN(EnsureNoUserHasPrimaryShadowGroup)
 {
     UNUSED(args);
     UNUSED(log);

--- a/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureNoUserHasPrimaryShadowGroup.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "ensureNoUserHasPrimaryShadowGroup"
+            "EnsureNoUserHasPrimaryShadowGroup"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureNoUserHasPrimaryShadowGroup": {
+            "EnsureNoUserHasPrimaryShadowGroup": {
               "type": "object",
               "required": [],
               "additionalProperties": false,
@@ -25,11 +25,11 @@
         {
           "type": "object",
           "required": [
-            "ensureNoUserHasPrimaryShadowGroup"
+            "EnsureNoUserHasPrimaryShadowGroup"
           ],
           "additionalProperties": false,
           "properties": {
-            "ensureNoUserHasPrimaryShadowGroup": {
+            "EnsureNoUserHasPrimaryShadowGroup": {
               "type": "object",
               "required": [],
               "additionalProperties": false,

--- a/src/modules/compliance/src/lib/procedures/fileRegexMatch.cpp
+++ b/src/modules/compliance/src/lib/procedures/fileRegexMatch.cpp
@@ -79,7 +79,7 @@ bool StatePatternMatchMode(std::ifstream& input, const std::string& matchPattern
 }
 } // anonymous namespace
 
-AUDIT_FN(fileRegexMatch, "filename:Path to the file to check:M", "matchOperation:Operation to perform on the file contents:M:^pattern match$",
+AUDIT_FN(FileRegexMatch, "filename:Path to the file to check:M", "matchOperation:Operation to perform on the file contents:M:^pattern match$",
     "matchPattern:The pattern to match against the file contents:M",
     "stateOperation:Operation to perform on each line that matches the 'matchPattern'::^pattern match$",
     "statePattern:The pattern to match against each line that matches the 'statePattern'",

--- a/src/modules/compliance/src/lib/procedures/fileRegexMatch.schema.json
+++ b/src/modules/compliance/src/lib/procedures/fileRegexMatch.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "fileRegexMatch"
+            "FileRegexMatch"
           ],
           "additionalProperties": false,
           "properties": {
-            "fileRegexMatch": {
+            "FileRegexMatch": {
               "type": "object",
               "required": [
                 "filename",

--- a/src/modules/compliance/src/lib/procedures/packageInstalled.cpp
+++ b/src/modules/compliance/src/lib/procedures/packageInstalled.cpp
@@ -7,7 +7,7 @@
 namespace compliance
 {
 
-AUDIT_FN(packageInstalled, "packageName:Package name:M")
+AUDIT_FN(PackageInstalled, "packageName:Package name:M")
 {
     UNUSED(log);
     char* output = NULL;

--- a/src/modules/compliance/src/lib/procedures/packageInstalled.schema.json
+++ b/src/modules/compliance/src/lib/procedures/packageInstalled.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "packageInstalled"
+            "PackageInstalled"
           ],
           "additionalProperties": false,
           "properties": {
-            "packageInstalled": {
+            "PackageInstalled": {
               "type": "object",
               "required": [
                 "packageName"

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.cpp
@@ -6,7 +6,7 @@
 
 namespace compliance
 {
-REMEDIATE_FN(remediationFailure, "message:message to be logged")
+REMEDIATE_FN(RemediationFailure, "message:message to be logged")
 {
     UNUSED(log);
     auto it = args.find("message");
@@ -17,7 +17,7 @@ REMEDIATE_FN(remediationFailure, "message:message to be logged")
     return false;
 }
 
-REMEDIATE_FN(remediationSuccess, "message:message to be logged")
+REMEDIATE_FN(RemediationSuccess, "message:message to be logged")
 {
     UNUSED(log);
     auto it = args.find("message");
@@ -28,7 +28,7 @@ REMEDIATE_FN(remediationSuccess, "message:message to be logged")
     return true;
 }
 
-AUDIT_FN(auditFailure, "message:message to be logged")
+AUDIT_FN(AuditFailure, "message:message to be logged")
 {
     UNUSED(log);
     auto it = args.find("message");
@@ -39,7 +39,7 @@ AUDIT_FN(auditFailure, "message:message to be logged")
     return false;
 }
 
-AUDIT_FN(auditSuccess, "message:message to be logged")
+AUDIT_FN(AuditSuccess, "message:message to be logged")
 {
     UNUSED(log);
     auto it = args.find("message");
@@ -50,7 +50,7 @@ AUDIT_FN(auditSuccess, "message:message to be logged")
     return true;
 }
 
-REMEDIATE_FN(remediationParametrized, "result:Expected remediation result - success or failure:M")
+REMEDIATE_FN(RemediationParametrized, "result:Expected remediation result - success or failure:M")
 {
     UNUSED(logstream);
     UNUSED(log);

--- a/src/modules/compliance/src/lib/procedures/testingProcedures.schema.json
+++ b/src/modules/compliance/src/lib/procedures/testingProcedures.schema.json
@@ -6,11 +6,11 @@
         {
           "type": "object",
           "required": [
-            "auditFailure"
+            "AuditFailure"
           ],
           "additionalProperties": false,
           "properties": {
-            "auditFailure": {
+            "AuditFailure": {
               "type": "object",
               "required": [],
               "additionalProperties": false,
@@ -26,11 +26,11 @@
         {
           "type": "object",
           "required": [
-            "auditSuccess"
+            "AuditSuccess"
           ],
           "additionalProperties": false,
           "properties": {
-            "auditSuccess": {
+            "AuditSuccess": {
               "type": "object",
               "required": [],
               "additionalProperties": false,
@@ -50,11 +50,11 @@
         {
           "type": "object",
           "required": [
-            "remediationFailure"
+            "RemediationFailure"
           ],
           "additionalProperties": false,
           "properties": {
-            "remediationFailure": {
+            "RemediationFailure": {
               "type": "object",
               "required": [],
               "additionalProperties": false,
@@ -70,11 +70,11 @@
         {
           "type": "object",
           "required": [
-            "remediationSuccess"
+            "RemediationSuccess"
           ],
           "additionalProperties": false,
           "properties": {
-            "remediationSuccess": {
+            "RemediationSuccess": {
               "type": "object",
               "required": [],
               "additionalProperties": false,
@@ -90,11 +90,11 @@
         {
           "type": "object",
           "required": [
-            "remediationParametrized"
+            "RemediationParametrized"
           ],
           "additionalProperties": false,
           "properties": {
-            "remediationParametrized": {
+            "RemediationParametrized": {
               "type": "object",
               "required": [
                 "result"

--- a/src/modules/compliance/tests/EvaluatorTest.cpp
+++ b/src/modules/compliance/tests/EvaluatorTest.cpp
@@ -122,7 +122,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_2)
 
 TEST_F(EvaluatorTest, ExecuteAudit_3)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"auditSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"AuditSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -134,7 +134,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_3)
 
 TEST_F(EvaluatorTest, ExecuteAudit_4)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"auditFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"AuditFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -145,7 +145,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_4)
 
 TEST_F(EvaluatorTest, ExecuteAudit_5)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"auditFailure\":{}}, {\"auditSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"AuditFailure\":{}}, {\"AuditSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -156,7 +156,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_5)
 
 TEST_F(EvaluatorTest, ExecuteAudit_6)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"auditSuccess\":{}}, {\"auditFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"AuditSuccess\":{}}, {\"AuditFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -167,7 +167,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_6)
 
 TEST_F(EvaluatorTest, ExecuteAudit_7)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"auditFailure\":{}}, {\"auditSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"AuditFailure\":{}}, {\"AuditSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -178,7 +178,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_7)
 
 TEST_F(EvaluatorTest, ExecuteAudit_8)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"auditSuccess\":{}}, {\"auditFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"AuditSuccess\":{}}, {\"AuditFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -189,7 +189,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_8)
 
 TEST_F(EvaluatorTest, ExecuteAudit_9)
 {
-    auto json = compliance::ParseJson("{\"not\":{\"auditSuccess\":{}}}");
+    auto json = compliance::ParseJson("{\"not\":{\"AuditSuccess\":{}}}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -200,7 +200,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_9)
 
 TEST_F(EvaluatorTest, ExecuteAudit_10)
 {
-    auto json = compliance::ParseJson("{\"not\":{\"auditFailure\":{}}}");
+    auto json = compliance::ParseJson("{\"not\":{\"AuditFailure\":{}}}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -211,7 +211,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_10)
 
 TEST_F(EvaluatorTest, ExecuteAudit_11)
 {
-    auto json = compliance::ParseJson("{\"not\":{\"not\":{\"auditFailure\":{}}}}");
+    auto json = compliance::ParseJson("{\"not\":{\"not\":{\"AuditFailure\":{}}}}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -255,7 +255,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_2)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_3)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"remediationSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"RemediationSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -266,7 +266,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_3)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_4)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -277,7 +277,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_4)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_5)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationFailure\":{}}, {\"remediationSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationFailure\":{}}, {\"RemediationSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -288,7 +288,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_5)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_6)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationSuccess\":{}}, {\"remediationFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationSuccess\":{}}, {\"RemediationFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -299,7 +299,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_6)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_7)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"remediationFailure\":{}}, {\"remediationSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"RemediationFailure\":{}}, {\"RemediationSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -310,7 +310,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_7)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_8)
 {
-    auto json = compliance::ParseJson("{\"allOf\":[{\"remediationSuccess\":{}}, {\"remediationFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"allOf\":[{\"RemediationSuccess\":{}}, {\"RemediationFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -321,7 +321,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_8)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_9)
 {
-    auto json = compliance::ParseJson("{\"not\":{\"remediationSuccess\":{}}}");
+    auto json = compliance::ParseJson("{\"not\":{\"RemediationSuccess\":{}}}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -331,7 +331,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_9)
 
 TEST_F(EvaluatorTest, ExecuteAudit_ProcedureMising_1)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationSuccess\":{}}, {\"auditFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationSuccess\":{}}, {\"AuditFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -341,7 +341,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_ProcedureMising_1)
 
 TEST_F(EvaluatorTest, ExecuteAudit_ProcedureMising_2)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"auditFailure\":{}}, {\"remediationSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"AuditFailure\":{}}, {\"RemediationSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -351,7 +351,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_ProcedureMising_2)
 
 TEST_F(EvaluatorTest, ExecuteAudit_ProcedureMising_3)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"auditSuccess\":{}}, {\"remediationSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"AuditSuccess\":{}}, {\"RemediationSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -362,7 +362,7 @@ TEST_F(EvaluatorTest, ExecuteAudit_ProcedureMising_3)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_ProcedureMising_1)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"foo\":{}}, {\"remediationFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"foo\":{}}, {\"RemediationFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -372,7 +372,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_ProcedureMising_1)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_ProcedureMising_2)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationSuccess\":{}}, {\"foo\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationSuccess\":{}}, {\"foo\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -383,7 +383,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_ProcedureMising_2)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_AuditFallback_1)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationFailure\":{}}, {\"auditSuccess\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationFailure\":{}}, {\"AuditSuccess\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -394,7 +394,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_AuditFallback_1)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_AuditFallback_2)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationFailure\":{}}, {\"auditFailure\":{}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationFailure\":{}}, {\"AuditFailure\":{}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -405,7 +405,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_AuditFallback_2)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_1)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"foo\":\"bar\"}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"foo\":\"bar\"}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -416,7 +416,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_1)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_2)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"result\":\"bar\"}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"result\":\"bar\"}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -426,7 +426,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_2)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_3)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"result\":\"success\"}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"result\":\"success\"}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -437,7 +437,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_3)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_4)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"result\":\"failure\"}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"result\":\"failure\"}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -448,7 +448,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_4)
 
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_5)
 {
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"result\":123}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"result\":123}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 
@@ -460,7 +460,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_5)
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_6)
 {
     mParameters = {{"placeholder", "failure"}};
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"result\":\"$placeholder\"}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"result\":\"$placeholder\"}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 }
@@ -468,7 +468,7 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_6)
 TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_7)
 {
     mParameters = {{"placeholder", "success"}};
-    auto json = compliance::ParseJson("{\"anyOf\":[{\"remediationParametrized\":{\"result\":\"$placeholder\"}}]}");
+    auto json = compliance::ParseJson("{\"anyOf\":[{\"RemediationParametrized\":{\"result\":\"$placeholder\"}}]}");
     ASSERT_TRUE(json.get());
     Evaluator evaluator1(json_value_get_object(json.get()), mParameters, nullptr);
 

--- a/src/modules/compliance/tests/procedures/ensureFilePermissionsTest.cpp
+++ b/src/modules/compliance/tests/procedures/ensureFilePermissionsTest.cpp
@@ -12,9 +12,9 @@
 #include <unistd.h>
 #include <vector>
 
-using compliance::Audit_ensureFilePermissions;
+using compliance::AuditEnsureFilePermissions;
 using compliance::Error;
-using compliance::Remediate_ensureFilePermissions;
+using compliance::RemediateEnsureFilePermissions;
 using compliance::Result;
 
 class EnsureFilePermissionsTest : public ::testing::Test
@@ -62,7 +62,7 @@ TEST_F(EnsureFilePermissionsTest, AuditFileMissing)
     args["filename"] = "/this_doesnt_exist_for_sure";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Stat error") != std::string::npos);
@@ -77,7 +77,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongOwner)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Invalid owner") != std::string::npos);
@@ -92,7 +92,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongOwner)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
     struct stat st;
@@ -111,7 +111,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongGroup)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Invalid group") != std::string::npos);
@@ -126,7 +126,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongGroup)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
     struct stat st;
@@ -145,7 +145,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongPermissions)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
@@ -160,7 +160,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongPermissions)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
     struct stat st;
@@ -179,7 +179,7 @@ TEST_F(EnsureFilePermissionsTest, AuditWrongMask)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
@@ -194,7 +194,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongMask)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
     struct stat st;
@@ -213,7 +213,7 @@ TEST_F(EnsureFilePermissionsTest, AuditAllWrong)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -227,7 +227,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateAllWrong)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
     struct stat st;
@@ -246,7 +246,7 @@ TEST_F(EnsureFilePermissionsTest, AuditAllOk)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
 }
@@ -260,7 +260,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateAllOk)
     args["permissions"] = "0400";
     args["mask"] = "0066";
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
     struct stat st;
@@ -274,7 +274,7 @@ TEST_F(EnsureFilePermissionsTest, AuditMissingFilename)
 {
     std::map<std::string, std::string> args;
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
     ASSERT_EQ(result.Error().message, "No filename provided");
 }
@@ -283,7 +283,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateMissingFilename)
 {
     std::map<std::string, std::string> args;
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
     ASSERT_EQ(result.Error().message, "No filename provided");
 }
@@ -294,7 +294,7 @@ TEST_F(EnsureFilePermissionsTest, AuditBadFileOwner)
     std::ostringstream logstream;
     CreateFile(args["filename"], 15213, 0, 0600);
     args["owner"] = "boohoonotarealuser";
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -305,7 +305,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateBadFileOwner)
     std::ostringstream logstream;
     CreateFile(args["filename"], 15213, 0, 0600);
     args["owner"] = "boohoonotarealuser";
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -316,7 +316,7 @@ TEST_F(EnsureFilePermissionsTest, AuditBadFileGroup)
     std::ostringstream logstream;
     CreateFile(args["filename"], 0, 15213, 0600);
     args["group"] = "boohoonotarealgroup";
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -327,7 +327,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateBadFileGroup)
     std::ostringstream logstream;
     CreateFile(args["filename"], 0, 15213, 0600);
     args["group"] = "boohoonotarealgroup";
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -338,7 +338,7 @@ TEST_F(EnsureFilePermissionsTest, AuditBadPermissions)
     std::ostringstream logstream;
     CreateFile(args["filename"], 0, 0, 0600);
     args["permissions"] = "999";
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
@@ -350,7 +350,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateBadPermissions)
     std::ostringstream logstream;
     CreateFile(args["filename"], 0, 0, 0600);
     args["permissions"] = "999";
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
 }
 
@@ -360,7 +360,7 @@ TEST_F(EnsureFilePermissionsTest, AuditBadMask)
     std::ostringstream logstream;
     CreateFile(args["filename"], 0, 0, 0600);
     args["mask"] = "999";
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
     ASSERT_TRUE(logstream.str().find("Invalid permissions") != std::string::npos);
@@ -372,7 +372,7 @@ TEST_F(EnsureFilePermissionsTest, RemediateBadMask)
     std::ostringstream logstream;
     CreateFile(args["filename"], 0, 0, 0600);
     args["mask"] = "999";
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
 }
 
@@ -383,7 +383,7 @@ TEST_F(EnsureFilePermissionsTest, AuditSameBitsSet)
     CreateFile(args["filename"], 0, 0, 0600);
     args["permissions"] = "600";
     args["mask"] = "600";
-    Result<bool> result = Audit_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
 }
 
@@ -394,6 +394,6 @@ TEST_F(EnsureFilePermissionsTest, RemediateSameBitsSet)
     CreateFile(args["filename"], 0, 0, 0600);
     args["permissions"] = "600";
     args["mask"] = "600";
-    Result<bool> result = Remediate_ensureFilePermissions(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilePermissions(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
 }

--- a/src/modules/compliance/tests/procedures/ensureFilesystemOptionTest.cpp
+++ b/src/modules/compliance/tests/procedures/ensureFilesystemOptionTest.cpp
@@ -11,9 +11,9 @@
 #include <string>
 #include <unistd.h>
 
-using compliance::Audit_ensureFilesystemOption;
+using compliance::AuditEnsureFilesystemOption;
 using compliance::Error;
-using compliance::Remediate_ensureFilesystemOption;
+using compliance::RemediateEnsureFilesystemOption;
 using compliance::Result;
 
 class EnsureFilesystemOptionTest : public ::testing::Test
@@ -63,7 +63,7 @@ TEST_F(EnsureFilesystemOptionTest, AuditEnsureFilesystemOptionSuccess)
     args["optionsNotSet"] = "noreltime";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilesystemOption(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilesystemOption(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
 }
@@ -79,7 +79,7 @@ TEST_F(EnsureFilesystemOptionTest, AuditEnsureFilesystemOptionMissing)
     args["optionsNotSet"] = "noreltime";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilesystemOption(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilesystemOption(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -95,7 +95,7 @@ TEST_F(EnsureFilesystemOptionTest, AuditEnsureFilesystemOptionForbidden)
     args["optionsNotSet"] = "nodev";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureFilesystemOption(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureFilesystemOption(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_FALSE(result.Value());
 }
@@ -112,7 +112,7 @@ TEST_F(EnsureFilesystemOptionTest, RemediateEnsureFilesystemOption)
     args["test_mount"] = "touch " + dir + " /remounted; /bin/true ";
 
     std::ostringstream logstream;
-    Result<bool> result = Remediate_ensureFilesystemOption(args, logstream, nullptr);
+    Result<bool> result = RemediateEnsureFilesystemOption(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_TRUE(result.Value());
 

--- a/src/modules/compliance/tests/procedures/ensureKernelModuleTest.cpp
+++ b/src/modules/compliance/tests/procedures/ensureKernelModuleTest.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <unistd.h>
 
-using compliance::Audit_ensureKernelModuleUnavailable;
+using compliance::AuditEnsureKernelModuleUnavailable;
 using compliance::Error;
 using compliance::Result;
 
@@ -70,7 +70,7 @@ TEST_F(EnsureKernelModuleTest, AuditNoArgument)
     std::map<std::string, std::string> args;
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
     ASSERT_EQ(result.Error().message, "No module name provided");
 }
@@ -85,7 +85,7 @@ TEST_F(EnsureKernelModuleTest, FailedFindExecution)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
     ASSERT_EQ(result.Error().message, "Failed to execute find command");
 }
@@ -100,7 +100,7 @@ TEST_F(EnsureKernelModuleTest, FailedLsmodExecution)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
     ASSERT_EQ(result.Error().message, "Failed to execute lsmod");
 }
@@ -115,7 +115,7 @@ TEST_F(EnsureKernelModuleTest, FailedModprobeExecution)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_FALSE(result.HasValue());
     ASSERT_EQ(result.Error().message, "Failed to execute modprobe");
 }
@@ -130,7 +130,7 @@ TEST_F(EnsureKernelModuleTest, ModuleNotFoundInFind)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), true);
 }
@@ -145,7 +145,7 @@ TEST_F(EnsureKernelModuleTest, ModuleFoundInLsmod)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), false);
 }
@@ -160,7 +160,7 @@ TEST_F(EnsureKernelModuleTest, NoAlias)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), false);
 }
@@ -175,7 +175,7 @@ TEST_F(EnsureKernelModuleTest, NoBlacklist)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), false);
 }
@@ -190,7 +190,7 @@ TEST_F(EnsureKernelModuleTest, ModuleBlocked)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), true);
 }
@@ -205,7 +205,7 @@ TEST_F(EnsureKernelModuleTest, OverlayedModuleNotBlocked)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), false);
 }
@@ -220,7 +220,7 @@ TEST_F(EnsureKernelModuleTest, OverlayedModuleBlocked)
     args["moduleName"] = "hator";
 
     std::ostringstream logstream;
-    Result<bool> result = Audit_ensureKernelModuleUnavailable(args, logstream, nullptr);
+    Result<bool> result = AuditEnsureKernelModuleUnavailable(args, logstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), true);
 }

--- a/src/modules/compliance/tests/procedures/fileRegexMatchTest.cpp
+++ b/src/modules/compliance/tests/procedures/fileRegexMatchTest.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <unistd.h>
 
-using compliance::Audit_fileRegexMatch;
+using compliance::AuditFileRegexMatch;
 using compliance::Error;
 using compliance::Result;
 
@@ -46,7 +46,7 @@ protected:
 
 TEST_F(FileRegexMatchTest, Audit_InvalidArguments_1)
 {
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(!result.HasValue());
     ASSERT_EQ(result.Error().code, EINVAL);
 }
@@ -54,7 +54,7 @@ TEST_F(FileRegexMatchTest, Audit_InvalidArguments_1)
 TEST_F(FileRegexMatchTest, Audit_InvalidArguments_2)
 {
     mArgs["filename"] = mTempfile;
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(!result.HasValue());
     ASSERT_EQ(result.Error().code, EINVAL);
 }
@@ -63,7 +63,7 @@ TEST_F(FileRegexMatchTest, Audit_InvalidArguments_3)
 {
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "test";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     if (result.HasValue())
     {
         std::cerr << mLogstream.str() << std::endl;
@@ -78,7 +78,7 @@ TEST_F(FileRegexMatchTest, Audit_InvalidArguments_4)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "test";
     mArgs["matchOperation"] = "test"; // invalid match operation value
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(!result.HasValue());
     ASSERT_EQ(result.Error().code, EINVAL);
 }
@@ -88,7 +88,7 @@ TEST_F(FileRegexMatchTest, Audit_InvalidArguments_5)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "(?i)"; // invalid regex pattern
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_FALSE(result.Value());
 }
@@ -98,7 +98,7 @@ TEST_F(FileRegexMatchTest, Audit_EmptyFile_1)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "test";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), false);
 }
@@ -109,7 +109,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_1)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "test";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -120,7 +120,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_2)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "test";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -131,7 +131,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_3)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "tests";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_FALSE(result.Value());
 }
@@ -142,7 +142,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_4)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "te.t";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -153,7 +153,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_5)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = "^te.t$";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -164,7 +164,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_6)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = R"(^[[:space:]]*te[a-z]t.*$)";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -176,7 +176,7 @@ TEST_F(FileRegexMatchTest, Audit_CaseInsensitive_1)
     mArgs["matchPattern"] = R"(^[[:space:]]*Te[a-z]t.*$)";
     mArgs["matchOperation"] = "pattern match";
     mArgs["caseSensitive"] = "false";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -189,7 +189,7 @@ TEST_F(FileRegexMatchTest, Audit_State_1)
     mArgs["matchOperation"] = "pattern match";
     mArgs["statePattern"] = R"(^key=foo$)";
     mArgs["stateOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -202,7 +202,7 @@ TEST_F(FileRegexMatchTest, Audit_State_2)
     mArgs["matchOperation"] = "pattern match";
     mArgs["statePattern"] = R"(^key=bar$)";
     mArgs["stateOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_FALSE(result.Value());
 }
@@ -213,7 +213,7 @@ TEST_F(FileRegexMatchTest, Audit_Multiline_Match_2)
     mArgs["filename"] = mTempfile;
     mArgs["matchPattern"] = R"(^key=.*$)";
     mArgs["matchOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -226,7 +226,7 @@ TEST_F(FileRegexMatchTest, Audit_Multiline_State_2)
     mArgs["matchOperation"] = "pattern match";
     mArgs["statePattern"] = R"(^key=bar$)";
     mArgs["stateOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_FALSE(result.Value());
 }
@@ -239,7 +239,7 @@ TEST_F(FileRegexMatchTest, Audit_Multiline_State_3)
     mArgs["matchOperation"] = "pattern match";
     mArgs["statePattern"] = R"(^key=(foo|bar|baz)$)";
     mArgs["stateOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_TRUE(result.Value());
 }
@@ -252,7 +252,7 @@ TEST_F(FileRegexMatchTest, Audit_Multiline_State_4)
     mArgs["matchOperation"] = "pattern match";
     mArgs["statePattern"] = R"(^key=(foo|bar)$)";
     mArgs["stateOperation"] = "pattern match";
-    auto result = Audit_fileRegexMatch(mArgs, mLogstream, nullptr);
+    auto result = AuditFileRegexMatch(mArgs, mLogstream, nullptr);
     ASSERT_TRUE(result.HasValue());
     EXPECT_FALSE(result.Value());
 }

--- a/src/modules/test/recipes/compliance/EnsureAllGroupsFromEtcPasswdArePresentInEtcGroup.json
+++ b/src/modules/test/recipes/compliance/EnsureAllGroupsFromEtcPasswdArePresentInEtcGroup.json
@@ -17,7 +17,7 @@
       "audit": {
         "allOf": [
           {
-            "ensureAllGroupsFromEtcPasswdExistInEtcGroup": {}
+            "EnsureAllGroupsFromEtcPasswdExistInEtcGroup": {}
           }
         ]
       }
@@ -30,7 +30,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditEnsureAllGroupsFromEtcPasswdArePresentInEtcGroup",
-    "Payload": "PASS{ allOf: [{ ensureAllGroupsFromEtcPasswdExistInEtcGroup: All user groups from '\/etc\/passwd' exist in '\/etc\/group' } == TRUE] == TRUE }"
+    "Payload": "PASS{ allOf: [{ EnsureAllGroupsFromEtcPasswdExistInEtcGroup: All user groups from '\/etc\/passwd' exist in '\/etc\/group' } == TRUE] == TRUE }"
   },
 
 
@@ -44,7 +44,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditEnsureAllGroupsFromEtcPasswdArePresentInEtcGroup",
-    "Payload": "PASS{ allOf: [{ ensureAllGroupsFromEtcPasswdExistInEtcGroup: All user groups from '\/etc\/passwd' exist in '\/etc\/group' } == TRUE] == TRUE }"
+    "Payload": "PASS{ allOf: [{ EnsureAllGroupsFromEtcPasswdExistInEtcGroup: All user groups from '\/etc\/passwd' exist in '\/etc\/group' } == TRUE] == TRUE }"
   },
 
 
@@ -63,7 +63,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditEnsureAllGroupsFromEtcPasswdArePresentInEtcGroup",
-    "Payload": "{ allOf: [{ ensureAllGroupsFromEtcPasswdExistInEtcGroup: User's 'securitybaselinetest2' group 8888 from \/etc\/passwd does not exist in \/etc\/group } == FALSE] == FALSE }"
+    "Payload": "{ allOf: [{ EnsureAllGroupsFromEtcPasswdExistInEtcGroup: User's 'securitybaselinetest2' group 8888 from \/etc\/passwd does not exist in \/etc\/group } == FALSE] == FALSE }"
   },
 
 

--- a/src/modules/test/recipes/compliance/EnsureNoDuplicateEntriesExist.json
+++ b/src/modules/test/recipes/compliance/EnsureNoDuplicateEntriesExist.json
@@ -14,7 +14,7 @@
       "audit": {
         "allOf": [
           {
-            "ensureNoDuplicateEntriesExist": {
+            "EnsureNoDuplicateEntriesExist": {
               "filename": "/etc/passwd",
               "delimiter": ":",
               "column": "2"
@@ -32,7 +32,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ allOf: [{ ensureNoDuplicateEntriesExist:  } == TRUE] == TRUE }"
+    "Payload": "PASS{ allOf: [{ EnsureNoDuplicateEntriesExist:  } == TRUE] == TRUE }"
   },
 
 
@@ -45,7 +45,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ allOf: [{ ensureNoDuplicateEntriesExist: Duplicate entries found in \/etc\/passwd: [8888]  } == FALSE] == FALSE }"
+    "Payload": "{ allOf: [{ EnsureNoDuplicateEntriesExist: Duplicate entries found in \/etc\/passwd: [8888]  } == FALSE] == FALSE }"
   },
 
 
@@ -58,7 +58,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ allOf: [{ ensureNoDuplicateEntriesExist:  } == TRUE] == TRUE }"
+    "Payload": "PASS{ allOf: [{ EnsureNoDuplicateEntriesExist:  } == TRUE] == TRUE }"
   },
 
 
@@ -86,7 +86,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ allOf: [{ ensureNoDuplicateEntriesExist: Duplicate entries found in \/etc\/passwd: [8888, 8889]  } == FALSE] == FALSE }"
+    "Payload": "{ allOf: [{ EnsureNoDuplicateEntriesExist: Duplicate entries found in \/etc\/passwd: [8888, 8889]  } == FALSE] == FALSE }"
   },
 
 

--- a/src/modules/test/recipes/compliance/EnsureNoUserHasPrimaryShadowGroup.json
+++ b/src/modules/test/recipes/compliance/EnsureNoUserHasPrimaryShadowGroup.json
@@ -23,14 +23,14 @@
       "audit": {
         "allOf": [
           {
-            "ensureNoUserHasPrimaryShadowGroup": {}
+            "EnsureNoUserHasPrimaryShadowGroup": {}
           }
         ]
       },
       "remediate": {
         "allOf": [
           {
-            "ensureNoUserHasPrimaryShadowGroup": {}
+            "EnsureNoUserHasPrimaryShadowGroup": {}
           }
         ]
       }
@@ -43,7 +43,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ allOf: [{ ensureNoUserHasPrimaryShadowGroup: User's 'securitybaselinetest' primary group is 'shadow' } == FALSE] == FALSE }"
+    "Payload": "{ allOf: [{ EnsureNoUserHasPrimaryShadowGroup: User's 'securitybaselinetest' primary group is 'shadow' } == FALSE] == FALSE }"
   },
 
 
@@ -62,7 +62,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ allOf: [{ ensureNoUserHasPrimaryShadowGroup: No user has 'shadow' as primary group } == TRUE] == TRUE }"
+    "Payload": "PASS{ allOf: [{ EnsureNoUserHasPrimaryShadowGroup: No user has 'shadow' as primary group } == TRUE] == TRUE }"
   },
 
 
@@ -78,7 +78,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ allOf: [{ ensureNoUserHasPrimaryShadowGroup: No user has 'shadow' as primary group } == TRUE] == TRUE }"
+    "Payload": "PASS{ allOf: [{ EnsureNoUserHasPrimaryShadowGroup: No user has 'shadow' as primary group } == TRUE] == TRUE }"
   },
 
 

--- a/src/modules/test/recipes/compliance/FileRegexMatch.json
+++ b/src/modules/test/recipes/compliance/FileRegexMatch.json
@@ -12,7 +12,7 @@
     "ObjectName": "procedureTest",
     "Payload": {
       "audit": {
-        "fileRegexMatch": {
+        "FileRegexMatch": {
           "filename": "$PATH",
           "matchOperation": "$OPERATION",
           "matchPattern": "$PATTERN"
@@ -32,7 +32,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern '.*' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern '.*' matched line 1 } == TRUE"
   },
   {
     "ObjectType": "Desired",
@@ -44,7 +44,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern 'foo' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern 'foo' matched line 1 } == TRUE"
   },
 
 
@@ -59,7 +59,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern 'f.*o' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern 'f.*o' matched line 1 } == TRUE"
   },
 
 
@@ -74,7 +74,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ fileRegexMatch: pattern 'f.*O' did not match any line } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*O' did not match any line } == FALSE"
   },
 
 
@@ -86,7 +86,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern 'f.*O' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern 'f.*O' matched line 1 } == TRUE"
   },
 
 
@@ -102,7 +102,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == TRUE"
   },
 
 
@@ -117,7 +117,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ fileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+$' did not match any line } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+$' did not match any line } == FALSE"
   },
 
 
@@ -132,7 +132,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == TRUE"
   },
 
 
@@ -150,7 +150,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ fileRegexMatch: pattern '^[^:#]+::' matched line 1 } == TRUE"
+    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 } == TRUE"
   },
   {
     "RunCommand": "echo '#testuser::1111:1111::/home/someuser:/bin/sh' > /tmp/passwd"
@@ -159,7 +159,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ fileRegexMatch: pattern '^[^:#]+::' did not match any line } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' did not match any line } == FALSE"
   },
 
 


### PR DESCRIPTION
## Description

To comply with our own naming convention, we should drop underscores from function names and use CamelCase.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
