### PR TITLE
Serialize the execution of JSON schema generation to avoid races.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
         types_or: [c++, json]
         entry: src/modules/compliance/src/lib/GenJSONSchemas.py
         language: python
+        require_serial: true
         files: |
           (?x)(
           ^src/modules/compliance/src/lib/payload.schema.json$|


### PR DESCRIPTION
## Description
By default pre-commit hooks for multiple files are launched in parallel. Since we're rewriting the payload.schema.json in place, if more than one file affected the schema was changed there was a race condition in which one of the executions opened the file for writing (truncating it), while another one tried to read it, leading to failure.
Serialize the execution of JSON schema generation to avoid races.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
