### PR TITLE
Fix mock ExecuteCommand crash when textResult is null

### DIFF
--- a/src/common/commonutils/CommandUtils.c
+++ b/src/common/commonutils/CommandUtils.c
@@ -85,7 +85,10 @@ int ExecuteCommand(void* context, const char* command, bool replaceEol, bool for
         }
         if (0 == strncmp(mock->expectedCommand, command, stringLen))
         {
-            *textResult = DuplicateString(mock->output);
+            if ((NULL != textResult) && (NULL != mock->output))
+            {
+                *textResult = DuplicateString(mock->output);
+            }
             return mock->returnCode;
         }
 	mock = mock->next;


### PR DESCRIPTION
## Description
ExecuteCommand was crashing if using MockCommand and textResult was null.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
