### PR TITLE
Fix EnsureNoDuplicateEntriesExist schema

### DIFF
--- a/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.cpp
@@ -16,7 +16,9 @@
 
 namespace compliance
 {
-AUDIT_FN(EnsureNoDuplicateEntriesExist)
+AUDIT_FN(EnsureNoDuplicateEntriesExist, "filename:The file to be checked for duplicate entries:M",
+    "delimiter:A single character used to separate entries:M", "column:Column index to check for duplicates:M",
+    "context:Context for the entries used in the messages")
 {
     UNUSED(log);
     auto it = args.find("filename");

--- a/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.schema.json
+++ b/src/modules/compliance/src/lib/procedures/ensureNoDuplicateEntriesExist.schema.json
@@ -12,9 +12,30 @@
           "properties": {
             "EnsureNoDuplicateEntriesExist": {
               "type": "object",
-              "required": [],
+              "required": [
+                "filename",
+                "delimiter",
+                "column"
+              ],
               "additionalProperties": false,
-              "properties": {}
+              "properties": {
+                "filename": {
+                  "type": "string",
+                  "description": "The file to be checked for duplicate entries"
+                },
+                "delimiter": {
+                  "type": "string",
+                  "description": "A single character used to separate entries"
+                },
+                "column": {
+                  "type": "string",
+                  "description": "Column index to check for duplicates"
+                },
+                "context": {
+                  "type": "string",
+                  "description": "Context for the entries used in the messages"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Description

Add missing schema decorators for AUDIT_FN macro which causes failures of the JSON schema validator in Augmentation Engine pipeline.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
