### PR TITLE
Add -Wshadow=local to prevent coding errors

### DIFF
--- a/src/modules/compliance/src/lib/CMakeLists.txt
+++ b/src/modules/compliance/src/lib/CMakeLists.txt
@@ -2,7 +2,9 @@
 # Licensed under the MIT License.
 
 project(compliancelib)
-
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow=local")
+endif()
 # Temporary solution, until we stabilize the list of procedures.
 file(GLOB PROCEDURES procedures/*.cpp)
 file(GLOB SCHEMAS procedures/*.schema.json)

--- a/src/modules/compliance/src/lib/Engine.cpp
+++ b/src/modules/compliance/src/lib/Engine.cpp
@@ -166,7 +166,7 @@ Optional<Error> Engine::SetProcedure(const std::string& ruleName, const std::str
             return Error("The 'remediate' value is not an object");
         }
 
-        auto error = procedure.SetRemediation(jsonValue);
+        error = procedure.SetRemediation(jsonValue);
         if (error)
         {
             return error.Value();

--- a/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureFilePermissions.cpp
@@ -172,7 +172,7 @@ REMEDIATE_FN(ensureFilePermissions, "filename:Path to the file:M", "owner:Requir
         }
         if (!groupOk)
         {
-            struct group* grp = getgrnam(firstGroup.c_str());
+            grp = getgrnam(firstGroup.c_str());
             if (grp == nullptr)
             {
                 logstream << "ERROR: No group with name " << args["group"];


### PR DESCRIPTION
Add -Wshadow=local to prevent coding error


## Description
Enable -Wshadow to utilize compiler checks better when local variables shadows some wider scope variable it usually can lead to an error.
I spend some time debugging code due the fact of pasting code sniped that I added during refactoring. 

```
int value = 0;
if (importantThing != end) {
   int value = *importatntThing;
   ExecuteStuff(value);
}
return value;
```
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
