### PR TITLE
Proc modules

### DIFF
--- a/src/modules/compliance/src/lib/procedures/ensureKernelModule.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureKernelModule.cpp
@@ -49,10 +49,10 @@ AUDIT_FN(EnsureKernelModuleUnavailable, "moduleName:Name of the kernel module:M"
     free(output);
     output = NULL;
 
-    if ((0 != ExecuteCommand(NULL, "lsmod", false, false, 0, 0, &output, NULL, NULL)) || (output == NULL))
+    if ((0 != ExecuteCommand(NULL, "cat /proc/modules", false, false, 0, 0, &output, NULL, NULL)) || (output == NULL))
     {
-        logstream << "Failed to execute lsmod ";
-        return Error("Failed to execute lsmod");
+        logstream << "Failed to execute cat";
+        return Error("Failed to execute cat");
     }
     std::string lsmodOutput(output);
     free(output);


### PR DESCRIPTION
## Description

In the container environment that we test in `lsmod` is not always available. This may also be the case on customer machines. /proc/modules is guaranteed to be present (it is also the underlying data source for lsmod), and has the same (pretty much) layout (modulename at the start of the line). Switch to parsing `cat /proc/modules` output.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
