### PR TITLE
EnsureKernelModule: Use /proc/modules for data

### DIFF
--- a/src/modules/compliance/src/lib/CMakeLists.txt
+++ b/src/modules/compliance/src/lib/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(compliancelib STATIC
     Base64.cpp
     Engine.cpp
     Procedure.cpp
+    Result.cpp
     ${PROCEDURES}
     )
 

--- a/src/modules/compliance/src/lib/Result.cpp
+++ b/src/modules/compliance/src/lib/Result.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "Result.h"
+
+#include <ostream>
+
+namespace compliance
+{
+std::ostream& operator<<(std::ostream& os, const compliance::Error& error)
+{
+    os << "Error: " << error.message << ": code " << error.code;
+    return os;
+}
+} // namespace compliance

--- a/src/modules/compliance/src/lib/Result.h
+++ b/src/modules/compliance/src/lib/Result.h
@@ -59,6 +59,7 @@ struct Error
     }
     ~Error() = default;
 };
+std::ostream& operator<<(std::ostream& os, const compliance::Error& error);
 
 template <typename T>
 class Result

--- a/src/modules/compliance/src/lib/procedures/ensureKernelModule.cpp
+++ b/src/modules/compliance/src/lib/procedures/ensureKernelModule.cpp
@@ -45,11 +45,11 @@ AUDIT_FN(EnsureKernelModuleUnavailable, "moduleName:Name of the kernel module:M"
         return findOutput.Error();
     }
 
-    Result<std::string> lsmodOutput = context.ExecuteCommand("lsmod");
-    if (!lsmodOutput.HasValue())
+    Result<std::string> procModules = context.GetFileContents("/proc/modules");
+    if (!procModules.HasValue())
     {
-        context.GetLogstream() << "lsmod: " << lsmodOutput.Error().message;
-        return lsmodOutput.Error();
+        context.GetLogstream() << "procModules: " << procModules.Error();
+        return procModules.Error();
     }
 
     Result<std::string> modprobeOutput = context.ExecuteCommand("modprobe --showconfig");
@@ -89,17 +89,17 @@ AUDIT_FN(EnsureKernelModuleUnavailable, "moduleName:Name of the kernel module:M"
         return true;
     }
 
-    regex lsmodRegex;
+    regex procModulesRegex;
     try
     {
-        lsmodRegex = regex("^" + moduleName + "\\s+");
+        procModulesRegex = regex("^" + moduleName + "\\s+");
     }
     catch (std::exception& e)
     {
         return Error(e.what());
     }
 
-    if (MultilineRegexSearch(lsmodOutput.Value(), lsmodRegex))
+    if (MultilineRegexSearch(procModules.Value(), procModulesRegex))
     {
         context.GetLogstream() << "Module " << moduleName << " is loaded ";
         return false;


### PR DESCRIPTION
## Description

In the container environment that we test in lsmod is not always available. This may also be the case on customer machines. /proc/modules is guaranteed to be present (it is also the underlying data source for lsmod), and has the same (pretty much) layout (modulename at the start of the line). Switch to parsing cat /proc/modules output.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
