### PR TITLE
 Fix & enable  sysctl module tests revert (#975) 

### DIFF
--- a/src/modules/test/recipes/compliance/EnsureSyctl.json
+++ b/src/modules/test/recipes/compliance/EnsureSyctl.json
@@ -1,64 +1,61 @@
 [
-  // TODO(robertwoj, kkanas): This test randomly fails especially on Mariner 2. Disabled temporarily until the root cause is identified.
-  // {
-  //   "Action": "LoadModule",
-  //   "Module": "compliance.so"
-  // },
-  // {
-  //   "RunCommand": "sysctl net.ipv4.ip_forward=1 && test -f /etc/sysctl.d/99-sysctl.conf && cp /etc/sysctl.d/99-sysctl.conf /etc/sysctl.d/99-sysctl.conf.bak ||  true ; echo net.ipv4.ip_forward=1 >> /etc/sysctl.d/99-sysctl.conf"
-  // },
+  {
+    "Action": "LoadModule",
+    "Module": "compliance.so"
+  },
+  {
+    "RunCommand": "sysctl net.ipv4.conf.default.log_martians=1 && test -f /etc/sysctl.d/99-sysctl.conf && cp /etc/sysctl.d/99-sysctl.conf /etc/sysctl.d/99-sysctl.conf.bak ||  true ; echo net.ipv4.conf.default.log_martians=1 >> /etc/sysctl.d/99-sysctl.conf"
+  },
 
-  // {
-  //   "ObjectType": "Desired",
-  //   "ComponentName": "Compliance",
-  //   "ObjectName": "procedureTest",
-  //   "Payload": {
-  //     "audit": {
-  //       "EnsureSysctl": {
-  //         "sysctlName": "net.ipv4.ip_forward",
-  //         "value": "1"
-  //       }
-  //     },
-  //     "parameters": {
-  //     }
-  //   }
-  // },
-  // {
-  //   "ObjectType": "Reported",
-  //   "ComponentName": "Compliance",
-  //   "ObjectName": "auditTest",
-  //   "Payload": "PASS{ EnsureSysctl: sysctl: 'net.ipv4.ip_forward' compliant with value: '1' } == TRUE"
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "EnsureSysctl": {
+          "sysctlName": "net.ipv4.conf.default.log_martians",
+          "value": "1"
+        }
+      },
+      "parameters": {
+      }
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ EnsureSysctl: Correct value for 'net.ipv4.conf.default.log_martians': '1' } == TRUE"
+  },
 
-  // },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "EnsureSysctl": {
+          "sysctlName": "net.ipv4.conf.default.log_martians",
+          "value": "0"
+        }
+      },
+      "parameters": {
+      }
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ EnsureSysctl: Expected 'net.ipv4.conf.default.log_martians' value: '0' got '1' } == FALSE"
+  },
 
-  // {
-  //   "ObjectType": "Desired",
-  //   "ComponentName": "Compliance",
-  //   "ObjectName": "procedureTest",
-  //   "Payload": {
-  //     "audit": {
-  //       "EnsureSysctl": {
-  //         "sysctlName": "net.ipv4.ip_forward",
-  //         "value": "0"
-  //       }
-  //     },
-  //     "parameters": {
-  //     }
-  //   }
-  // },
-  // {
-  //   "ObjectType": "Reported",
-  //   "ComponentName": "Compliance",
-  //   "ObjectName": "auditTest",
-  //   "Payload": "{ EnsureSysctl: Fail sysctl: 'net.ipv4.ip_forward' NOT compliant. Expected value: '0' got '1' } == FALSE"
+  {
+    "RunCommand": "sysctl net.ipv4.conf.default.log_martians=0 && test -f /etc/sysctl.d/99-sysctl.conf.bak && { mv /etc/sysctl.d/99-sysctl.conf.bak /etc/sysctl.d/99-sysctl.conf ; } || { rm /etc/sysctl.d/99-sysctl.conf ; }"
+  },
 
-  // },
-
-  // {
-  //   "RunCommand": "sysctl net.ipv4.ip_forward=0 && test -f /etc/sysctl.d/99-sysctl.conf.bak && { mv /etc/sysctl.d/99-sysctl.conf.bak /etc/sysctl.d/99-sysctl.conf ; } || { rm /etc/sysctl.d/99-sysctl.conf ; }"
-  // },
-
-  // {
-  //   "Action": "UnloadModule"
-  // }
+  {
+    "Action": "UnloadModule"
+  }
 ]


### PR DESCRIPTION
## Description

 Fix & enable  sysctl module tests revert (#975) 

 This reverts commit b3ea690f78ffddd6be4890a56b5459ef70d0686f.

The CBL Mariner had and issue with sysctl net.ipv4.ip_forward - some agent changed the settings during test and in turn the test keep failing randomly.  This fixes this by changing tested sysctl so the CBL Mariner test works.




## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
