### PR TITLE
Updating the ASB test policy definition with the new parameter for configuring the logging level

### DIFF
--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -15,7 +15,7 @@
         "version": "1.0.0",
         "contentType": "Custom",
         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-        "contentHash": "FFB8E1CA4A7319012BE51C7E651092819679E9F8F7803A3A9741332D061B1AED",
+        "contentHash": "BC94409A587C68363FEBC78D0CED404A368B3E91567E521B70203DB401A8F505",
         "configurationParameter": {
           "loggingLevel": "Ensure the local logging level for Azure OSConfig is configured;DesiredObjectValue"
         }
@@ -315,7 +315,7 @@
               },
               {
                 "field": "Microsoft.GuestConfiguration/guestConfigurationAssignments/parameterHash",
-                "equals": "[base64(concat('Ensure the local logging level for Azure OSConfig is configured;DesiredObjectValue', '=', parameters('loggingLevel')]"
+                "equals": "[base64(concat('Ensure the local logging level for Azure OSConfig is configured;DesiredObjectValue', '=', parameters('loggingLevel')))]"
               }
             ]
           },
@@ -337,7 +337,7 @@
                 },
                 "loggingLevel": {
                   "value": "[parameters('loggingLevel')]"
-                },
+                }
               },
               "template": {
                 "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
@@ -357,7 +357,7 @@
                   },
                   "loggingLevel": {
                     "type": "string"
-                  },
+                  }
                 },
                 "resources": [
                   {
@@ -372,7 +372,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "FFB8E1CA4A7319012BE51C7E651092819679E9F8F7803A3A9741332D061B1AED",
+                        "contentHash": "BC94409A587C68363FEBC78D0CED404A368B3E91567E521B70203DB401A8F505",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {
@@ -395,7 +395,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "FFB8E1CA4A7319012BE51C7E651092819679E9F8F7803A3A9741332D061B1AED",
+                        "contentHash": "BC94409A587C68363FEBC78D0CED404A368B3E91567E521B70203DB401A8F505",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {
@@ -418,7 +418,7 @@
                         "version": "1.0.0",
                         "contentType": "Custom",
                         "contentUri": "https://github.com/Azure/azure-osconfig/releases/download/test_policy_package/AzureLinuxBaseline.zip",
-                        "contentHash": "FFB8E1CA4A7319012BE51C7E651092819679E9F8F7803A3A9741332D061B1AED",
+                        "contentHash": "BC94409A587C68363FEBC78D0CED404A368B3E91567E521B70203DB401A8F505",
                         "assignmentType": "ApplyAndAutoCorrect",
                         "configurationParameter": [
                           {

--- a/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
+++ b/src/adapters/mc/asb/AzureLinuxBaseline_DeployIfNotExists.json
@@ -51,7 +51,7 @@
       "loggingLevel": {
         "type": "string",
         "metadata": {
-          "displayName": "LoggingLevel",
+          "displayName": "Logging level for Azure OSConfig",
           "description": "Configures the logging level for Azure OSConfig on local machine"
         },
         "allowedValues": [


### PR DESCRIPTION
## Description

Updating the ASB test policy definition with the new parameter for configuring the logging level. Validated this definition in our test subscription, with the test package published at https://github.com/Azure/azure-osconfig/releases/tag/test_policy_package (anyone who wants, can also give it a try). The logging level for Azure OSConfig running on each Arc server under audit can be configured at time of the policy assignment to any one of the 7 possible values. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
