### PR TITLE
Redacting out from ASB logging usernames, group names, home directory names, etc. for real user accounts (as opposed to system users)

### DIFF
--- a/src/adapters/pnp/daemon/osconfig.json
+++ b/src/adapters/pnp/daemon/osconfig.json
@@ -3,7 +3,7 @@
   "GitRepositoryUrl": " ",
   "GitBranch": " ",
   "LocalManagement": 1,
-  "LoggingLevel": 6,
+  "LoggingLevel": 7,
   "MaxLogSize": 1048576,
   "MaxLogSizeDebugMultiplier": 5,
   "ModelVersion": 20,

--- a/src/adapters/pnp/daemon/osconfig.json
+++ b/src/adapters/pnp/daemon/osconfig.json
@@ -3,7 +3,7 @@
   "GitRepositoryUrl": " ",
   "GitBranch": " ",
   "LocalManagement": 1,
-  "LoggingLevel": 7,
+  "LoggingLevel": 6,
   "MaxLogSize": 1048576,
   "MaxLogSizeDebugMultiplier": 5,
   "ModelVersion": 20,

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1118,7 +1118,7 @@ static char* AuditEnsureLoggingLevel(OsConfigLogHandle log)
     LoggingLevel desiredLevel = GetLoggingLevelFromString(g_desiredLoggingLevel ? g_desiredLoggingLevel : g_defaultLoggingLevel);
 
     // We need to configure the desired logging level even in audit-only mode
-    SetLoggingLevelPersistently(GetLoggingLevelFromString(desiredLevel), log);
+    SetLoggingLevelPersistently(desiredLevel, log);
 
 // We need to avoid the warning treated as error for 'reason' always being non-NULL in this case
 #pragma GCC diagnostic push

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -954,6 +954,11 @@ void AsbInitialize(OsConfigLogHandle log)
         OsConfigLogWarning(log, "AsbInitialize: console logging is enabled. If the syslog rotation is not enabled this may result in a fill-up of the local storage space");
     }
 
+    if (IsDebugLoggingEnabled())
+    {
+        OsConfigLogWarning(log, "AsbInitialize: debug logging is enabled and this may include private information such as unredacted usernames");
+    }
+
     OsConfigLogInfo(log, "AsbInitialize: %s", g_asbName);
 
     if (NULL != (cpuModel = GetCpuModel(GetPerfLog())))

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -949,6 +949,8 @@ void AsbInitialize(OsConfigLogHandle log)
         RestrictFileAccessToCurrentAccountOnly(g_configurationFile);
     }
 
+    SetLoggingLevel(LoggingLevelDebug);//
+
     if (IsConsoleLoggingEnabled())
     {
         OsConfigLogWarning(log, "AsbInitialize: console logging is enabled. If the syslog rotation is not enabled this may result in a fill-up of the local storage space");

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -949,8 +949,6 @@ void AsbInitialize(OsConfigLogHandle log)
         RestrictFileAccessToCurrentAccountOnly(g_configurationFile);
     }
 
-    SetLoggingLevel(LoggingLevelDebug);//
-
     if (IsConsoleLoggingEnabled())
     {
         OsConfigLogWarning(log, "AsbInitialize: console logging is enabled. If the syslog rotation is not enabled this may result in a fill-up of the local storage space");

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1117,6 +1117,9 @@ static char* AuditEnsureLoggingLevel(OsConfigLogHandle log)
     LoggingLevel existingLevel = GetLoggingLevel();
     LoggingLevel desiredLevel = GetLoggingLevelFromString(g_desiredLoggingLevel ? g_desiredLoggingLevel : g_defaultLoggingLevel);
 
+    // We need to configure the desired logging level even in audit-only mode
+    SetLoggingLevelPersistently(GetLoggingLevelFromString(desiredLevel), log);
+
 // We need to avoid the warning treated as error for 'reason' always being non-NULL in this case
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress"

--- a/src/common/commonutils/Internal.h
+++ b/src/common/commonutils/Internal.h
@@ -25,6 +25,7 @@
 #include <dirent.h>
 #include <math.h>
 #include <libgen.h>
+#include <shadow.h>
 #include <parson.h>
 #include <Logging.h>
 #include <Reasons.h>

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -659,8 +659,7 @@ int CheckAllEtcPasswdGroupsExistInEtcGroup(char** reason, OsConfigLogHandle log)
                     {
                         if (userGroupList[j].groupId == groupList[k].groupId)
                         {
-                            OsConfigLogDebug(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group %u of user %u found in '/etc/group'",
-                                userList[i].userId, userGroupList[j].groupId);
+                            OsConfigLogDebug(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group %u of user %u found in '/etc/group'", userGroupList[j].groupId, userList[i].userId);
                             found = true;
                             break;
                         }
@@ -668,9 +667,8 @@ int CheckAllEtcPasswdGroupsExistInEtcGroup(char** reason, OsConfigLogHandle log)
 
                     if (false == found)
                     {
-                        OsConfigLogInfo(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group %u of user %u not found in '/etc/group'",
-                            userList[i].userId, userGroupList[j].groupId);
-                        OsConfigCaptureReason(reason, "Group %u of user %u not found in '/etc/group'", userList[i].userId, userGroupList[j].groupId);
+                        OsConfigLogInfo(log, "CheckAllEtcPasswdGroupsExistInEtcGroup: group %u of user %u not found in '/etc/group'", userGroupList[j].groupId, userList[i].userId);
+                        OsConfigCaptureReason(reason, "Group %u of user %u not found in '/etc/group'", userGroupList[j].groupId, userList[i].userId);
                         status = ENOENT;
                         break;
                     }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -818,7 +818,7 @@ int RemoveUser(SimplifiedUser* user, bool removeHome, OsConfigLogHandle log)
 {
     const char* commandTemplate = "userdel %s %s";
     char* command = NULL;
-    int status = 0, _status = 0;
+    int status = 0;
 
     if (NULL == user)
     {
@@ -1572,7 +1572,7 @@ int SetUserHomeDirectories(OsConfigLogHandle log)
                     if (0 != (_status = SetDirectoryAccess(userList[i].home, userList[i].userId, userList[i].groupId, defaultHomeDirAccess, log)))
                     {
                         OsConfigLogInfo(log, "SetUserHomeDirectories: cannot set access and ownership for home directory of user %u (%d, errno: %d, %s)",
-                            userList[i].userId, userList[i].groupId, _status, errno, strerror(errno));
+                            userList[i].userId, _status, errno, strerror(errno));
                     }
                 }
 
@@ -1707,7 +1707,8 @@ int CheckRestrictedUserHomeDirectories(unsigned int* modes, unsigned int numberO
                 {
                     if (0 == CheckDirectoryAccess(userList[i].home, userList[i].userId, userList[i].groupId, modes[j], true, NULL, log))
                     {
-                        OsConfigLogInfo(log, "CheckRestrictedUserHomeDirectories: user %u has proper restricted access (%03o) for their assigned home directory", userList[i].userId);
+                        OsConfigLogInfo(log, "CheckRestrictedUserHomeDirectories: user %u has proper restricted access (%03o) for their assigned home directory",
+                            userList[i].userId, modes[j]);
                         oneGoodMode = true;
                         break;
                     }
@@ -1715,7 +1716,8 @@ int CheckRestrictedUserHomeDirectories(unsigned int* modes, unsigned int numberO
 
                 if (false == oneGoodMode)
                 {
-                    OsConfigLogInfo(log, "CheckRestrictedUserHomeDirectories: user %u does not have proper restricted access for their assigned home directory", userList[i].userId);
+                    OsConfigLogInfo(log, "CheckRestrictedUserHomeDirectories: user %u does not have proper restricted access for their assigned home directory",
+                        userList[i].userId);
                     OsConfigCaptureReason(reason, "User %u does not have proper restricted access for their assigned home directory", userList[i].userId);
 
                     if (0 == status)
@@ -1767,7 +1769,8 @@ int SetRestrictedUserHomeDirectories(unsigned int* modes, unsigned int numberOfM
                 {
                     if (0 == CheckDirectoryAccess(userList[i].home, userList[i].userId, userList[i].groupId, modes[j], true, NULL, log))
                     {
-                        OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: user %u already has proper restricted access (%03o) for their assigned home directory", userList[i].userId);
+                        OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: user %u already has proper restricted access (%03o) for their assigned home directory",
+                            userList[i].userId, modes[j]);
                         oneGoodMode = true;
                         break;
                     }
@@ -1777,7 +1780,8 @@ int SetRestrictedUserHomeDirectories(unsigned int* modes, unsigned int numberOfM
                 {
                     if (0 == (_status = SetDirectoryAccess(userList[i].home, userList[i].userId, userList[i].groupId, userList[i].isRoot ? modeForRoot : modeForOthers, log)))
                     {
-                        OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: user %u has now proper restricted access (%03o) for their assigned home directory", userList[i].userId);
+                        OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: user %u has now proper restricted access (%03o) for their assigned home directory",
+                            userList[i].userId, userList[i].isRoot ? modeForRoot : modeForOthers);
                     }
                     else
                     {
@@ -2931,7 +2935,7 @@ int SetUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes, 
                             if (0 == (_status = SetFileAccess(path, userList[i].userId, userList[i].groupId, mode, log)))
                             {
                                 OsConfigLogInfo(log, "SetUsersRestrictedDotFiles: user %u now has restricted access (%03o) set for their dot file '%s'",
-                                    userList[i].userId, umode, path);
+                                    userList[i].userId, mode, path);
                             }
                             else
                             {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -185,7 +185,25 @@ static bool IsUserNonLogin(SimplifiedUser* user)
 
 static bool IsSystemAccount(SimplifiedUser* user)
 {
-    return (user && IsUserNonLogin(user) && (NULL == user->home) && (user->userId && (user->userId < 1000))) ? true : false;
+    bool result = false;
+    
+    if (user)
+    {
+        if (user->username && (0 == strcmp(user->username, g_root)))
+        {
+            result = true;
+        }
+        else if (true == IsUserNonLogin(user))
+        {
+            result = true;
+        }
+        else if (user->userId < 1000)
+        {
+            result = true;
+        }
+    }
+    
+    return result;
 }
 
 static int SetUserNonLogin(SimplifiedUser* user, OsConfigLogHandle log)

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -497,7 +497,8 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
 
     if ((0 == status) && (0 < numberOfGroups))
     {
-        OsConfigLogDebug(log, "EnumerateUserGroups: user %u (%u) is in %d group%s", user->userId, user->groupId, numberOfGroups, (1 == numberOfGroups) ? "" : "s");
+        OsConfigLogDebug(log, "EnumerateUserGroups: user %u ('%s', gid: %u) is in %d group%s",
+            user->userId, IsSystemAccount(user) ? user->username : g_redacted, user->groupId, numberOfGroups, (1 == numberOfGroups) ? "" : "s");
 
         if (NULL == (*groupList = malloc(sizeof(SimplifiedGroup) * numberOfGroups)))
         {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1786,7 +1786,7 @@ int SetRestrictedUserHomeDirectories(unsigned int* modes, unsigned int numberOfM
                     else
                     {
                         OsConfigLogInfo(log, "SetRestrictedUserHomeDirectories: cannot set restricted access (%03o) for user %u assigned home directory (%d, %s)",
-                            userList[i].userId, _status, strerror(_status));
+                            userList[i].userId, userList[i].isRoot ? modeForRoot : modeForOthers, _status, strerror(_status));
 
                         if (0 == status)
                         {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -839,7 +839,7 @@ int RemoveUser(SimplifiedUser* user, bool removeHome, OsConfigLogHandle log)
 
             if (DirectoryExists(user->home))
             {
-                OsConfigLogInfo(log, "RemoveUser: home directory of user %u remains and needs to be manually deleted");
+                OsConfigLogInfo(log, "RemoveUser: home directory of user %u remains and needs to be manually deleted", user->userId);
             }
             else
             {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -410,8 +410,8 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
         for (i = 0; i < *size; i++)
         {
             OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
-                IsSystemAccount((*userList)[i].username) ? (*userList)[i].username : "-", (*userList)[i].groupId,
-                IsSystemAccount((*userList)[i].username) ? (*userList)[i].home : "-", (*userList)[i].shell);
+                IsSystemAccount((*userList)[i]) ? (*userList)[i].username : "-", (*userList)[i].groupId,
+                IsSystemAccount((*userList)[i]) ? (*userList)[i].home : "-", (*userList)[i].shell);
         }
     }
 
@@ -1402,9 +1402,9 @@ int CheckRootIsOnlyUidZeroAccount(char** reason, OsConfigLogHandle log)
             if (((NULL == userList[i].username) || (0 != strcmp(userList[i].username, g_root))) && (0 == userList[i].userId))
             {
                 OsConfigLogInfo(log, "CheckRootIsOnlyUidZeroAccount: user '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(userList[i].username) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
                 OsConfigCaptureReason(reason, "User '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(userList[i].username) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
                 status = EACCES;
             }
         }
@@ -1434,7 +1434,7 @@ int SetRootIsOnlyUidZeroAccount(OsConfigLogHandle log)
             if (((NULL == userList[i].username) || (0 != strcmp(userList[i].username, g_root))) && (0 == userList[i].userId))
             {
                 OsConfigLogInfo(log, "SetRootIsOnlyUidZeroAccount: user '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(userList[i].username) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
 
                 if ((0 != (_status = RemoveUser(&(userList[i]), false, log))) && (0 == status))
                 {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -243,7 +243,7 @@ static int SetUserNonLogin(SimplifiedUser* user, OsConfigLogHandle log)
 
     if (ENOENT == result)
     {
-        OsConfigLogInfo(log, "SetUserNonLogin: no suitable no login shell found (to make user %u non-login)", user->userId);
+        OsConfigLogInfo(log, "SetUserNonLogin: no suitable 'no login shell' found (to make user %u non-login)", user->userId);
     }
 
     return result;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -185,7 +185,7 @@ static bool IsUserNonLogin(SimplifiedUser* user)
 
 static bool IsSystemAccount(SimplifiedUser* user)
 {
-    return (IsUserNonLogin(user) && (NULL == user->home) && (user->userId && (user->userId < 1000))) ? true : false;
+    return (user && IsUserNonLogin(user) && (NULL == user->home) && (user->userId && (user->userId < 1000))) ? true : false;
 }
 
 static int SetUserNonLogin(SimplifiedUser* user, OsConfigLogHandle log)

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -184,11 +184,16 @@ static bool IsUserNonLogin(SimplifiedUser* user)
     return noLogin;
 }
 
+// For logging purposes, we identify an user account as a system account if either has name "root", or has a no-loging shell,
+// or has an UID below 1000. For non-system accounts we redact usernames and home names, for system accounts we log everything.
+// We do this in order to log in full clear deviant accounts (that for example use a no-login shell while having UID above 1000)
 static bool IsSystemAccount(SimplifiedUser* user)
 {
     return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000))) ? true : false;
 }
 
+// Similar to determining if an user account is system, we identify a group to be system if either
+// has name "root" or has a GID below 1000 (and all such system groups get logged in full)
 static bool IsSystemGroup(SimplifiedGroup* group)
 {
     return (group && ((group->groupName && (0 == strcmp(group->groupName, g_root))) || (group->groupId < 1000))) ? true : false;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1302,24 +1302,30 @@ int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log)
         {
             if (userList[i].hasPassword)
             {
-                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u appears to have a password set", userList[i].userId);
+                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') appears to have a password set",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
             }
             else if (userList[i].noLogin)
             {
-                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u is no login", userList[i].userId);
+                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is no login",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
             }
             else if (userList[i].isLocked)
             {
-                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u is locked", userList[i].userId);
+                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is locked",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
             }
             else if (userList[i].cannotLogin)
             {
-                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u cannot login with password", userList[i].userId);
+                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') cannot login with password",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
             }
             else
             {
-                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u not found to have a password set", userList[i].userId);
-                OsConfigCaptureReason(reason, "User %u not found to have a password set", userList[i].userId);
+                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s')  not found to have a password set",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
+                OsConfigCaptureReason(reason, "User %u ('%s')  not found to have a password set",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
                 status = ENOENT;
             }
         }
@@ -2834,7 +2840,7 @@ int CheckUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes
                             if (0 == CheckFileAccess(path, userList[i].userId, userList[i].groupId, modes[j], NULL, log))
                             {
                                 OsConfigLogInfo(log, "CheckUsersRestrictedDotFiles: user %u has proper restricted access (%03o) for their dot file '%s'",
-                                    userList[i].userId, modes[j], path);
+                                    userList[i].userId, modes[j], entry->d_name);
                                 oneGoodMode = true;
                                 break;
                             }
@@ -2843,9 +2849,9 @@ int CheckUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes
                         if (false == oneGoodMode)
                         {
                             OsConfigLogInfo(log, "CheckUsersRestrictedDotFiles: user %u does not has have proper restricted access for their dot file '%s'",
-                                userList[i].userId, path);
+                                userList[i].userId, entry->d_name);
                             OsConfigCaptureReason(reason, "User %u does not has have proper restricted access for their dot file '%s'",
-                                userList[i].userId, path);
+                                userList[i].userId, entry->d_name);
 
                             if (0 == status)
                             {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -410,8 +410,8 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
         for (i = 0; i < *size; i++)
         {
             OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
-                IsSystemAccount((*userList)[i]) ? (*userList)[i].username : "-", (*userList)[i].groupId,
-                IsSystemAccount((*userList)[i]) ? (*userList)[i].home : "-", (*userList)[i].shell);
+                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].username : "-", (*userList)[i].groupId,
+                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : "-", (*userList)[i].shell);
         }
     }
 
@@ -1402,9 +1402,9 @@ int CheckRootIsOnlyUidZeroAccount(char** reason, OsConfigLogHandle log)
             if (((NULL == userList[i].username) || (0 != strcmp(userList[i].username, g_root))) && (0 == userList[i].userId))
             {
                 OsConfigLogInfo(log, "CheckRootIsOnlyUidZeroAccount: user '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(&userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
                 OsConfigCaptureReason(reason, "User '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(&userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
                 status = EACCES;
             }
         }
@@ -1434,7 +1434,7 @@ int SetRootIsOnlyUidZeroAccount(OsConfigLogHandle log)
             if (((NULL == userList[i].username) || (0 != strcmp(userList[i].username, g_root))) && (0 == userList[i].userId))
             {
                 OsConfigLogInfo(log, "SetRootIsOnlyUidZeroAccount: user '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(&userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
 
                 if ((0 != (_status = RemoveUser(&(userList[i]), false, log))) && (0 == status))
                 {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1308,24 +1308,24 @@ int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log)
             else if (userList[i].noLogin)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is no login",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
             }
             else if (userList[i].isLocked)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is locked",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
             }
             else if (userList[i].cannotLogin)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') cannot login with password",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
             }
             else
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s')  not found to have a password set",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
                 OsConfigCaptureReason(reason, "User %u ('%s')  not found to have a password set",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-"););
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
                 status = ENOENT;
             }
         }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -529,7 +529,7 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
                         memset((*groupList)[i].groupName, 0, groupNameLength + 1);
                         memcpy((*groupList)[i].groupName, groupEntry->gr_name, groupNameLength);
 
-                        OsConfigLogDebug(log, "EnumerateUserGroups: user %u ('%s', gid: %u) is in group %u ('%s')", 
+                        OsConfigLogDebug(log, "EnumerateUserGroups: user %u ('%s', gid: %u) is in group %u ('%s')",
                             user->userId, IsSystemAccount(user) ? user->username : g_redacted, user->groupId,
                             (*groupList)[i].groupId, IsSystemGroup(&(*groupList)[i]) ? (*groupList)[i].groupName : g_redacted);
                     }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -9,6 +9,7 @@
 
 static const char* g_root = "root";
 static const char* g_shadow = "shadow";
+static const char* g_redacted = "***";
 
 static const char* g_noLoginShell[] = { "/usr/sbin/nologin", "/sbin/nologin", "/bin/false", "/bin/true", "/usr/bin/true", "/usr/bin/false", "/dev/null", "" };
 
@@ -410,8 +411,8 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
         for (i = 0; i < *size; i++)
         {
             OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
-                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].username : "-", (*userList)[i].groupId,
-                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : "-", (*userList)[i].shell);
+                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].username : g_redacted, (*userList)[i].groupId,
+                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : g_redacted, (*userList)[i].shell);
         }
     }
 
@@ -1303,29 +1304,29 @@ int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log)
             if (userList[i].hasPassword)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') appears to have a password set",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
             }
             else if (userList[i].noLogin)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is no login",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
             }
             else if (userList[i].isLocked)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is locked",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
             }
             else if (userList[i].cannotLogin)
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') cannot login with password",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
             }
             else
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s')  not found to have a password set",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
                 OsConfigCaptureReason(reason, "User %u ('%s')  not found to have a password set",
-                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : "-");
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
                 status = ENOENT;
             }
         }
@@ -1408,9 +1409,9 @@ int CheckRootIsOnlyUidZeroAccount(char** reason, OsConfigLogHandle log)
             if (((NULL == userList[i].username) || (0 != strcmp(userList[i].username, g_root))) && (0 == userList[i].userId))
             {
                 OsConfigLogInfo(log, "CheckRootIsOnlyUidZeroAccount: user '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(&userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted, userList[i].userId, userList[i].groupId);
                 OsConfigCaptureReason(reason, "User '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(&userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted, userList[i].userId, userList[i].groupId);
                 status = EACCES;
             }
         }
@@ -1440,7 +1441,7 @@ int SetRootIsOnlyUidZeroAccount(OsConfigLogHandle log)
             if (((NULL == userList[i].username) || (0 != strcmp(userList[i].username, g_root))) && (0 == userList[i].userId))
             {
                 OsConfigLogInfo(log, "SetRootIsOnlyUidZeroAccount: user '%s' (%u, %u) is not root but has uid 0",
-                    IsSystemAccount(&userList[i]) ? userList[i].username : "-", userList[i].userId, userList[i].groupId);
+                    IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted, userList[i].userId, userList[i].groupId);
 
                 if ((0 != (_status = RemoveUser(&(userList[i]), false, log))) && (0 == status))
                 {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -185,25 +185,7 @@ static bool IsUserNonLogin(SimplifiedUser* user)
 
 static bool IsSystemAccount(SimplifiedUser* user)
 {
-    bool result = false;
-    
-    if (user)
-    {
-        if (user->username && (0 == strcmp(user->username, g_root)))
-        {
-            result = true;
-        }
-        else if (true == IsUserNonLogin(user))
-        {
-            result = true;
-        }
-        else if (user->userId < 1000)
-        {
-            result = true;
-        }
-    }
-    
-    return result;
+    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000))) ? true : false;
 }
 
 static int SetUserNonLogin(SimplifiedUser* user, OsConfigLogHandle log)

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -528,7 +528,8 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
                         memset((*groupList)[i].groupName, 0, groupNameLength + 1);
                         memcpy((*groupList)[i].groupName, groupEntry->gr_name, groupNameLength);
 
-                        OsConfigLogDebug(log, "EnumerateUserGroups: user %u (%u) is in group %u ('%s')", user->userId, user->groupId, 
+                        OsConfigLogDebug(log, "EnumerateUserGroups: user %u ('%s', gid: %u) is in group %u ('%s')", 
+                            user->userId, IsSystemAccount(user) ? user->username : g_redacted, user->groupId,
                             (*groupList)[i].groupId, IsSystemGroup(&(*groupList)[i]) ? (*groupList)[i].groupName : g_redacted);
                     }
                     else


### PR DESCRIPTION
## Description

The changes in this PR increase customer's privacy in case that the Azure OSConfig logs are sent back to Microsoft, redacting out from logging things such as:
- usernames for real, human user accounts.
- group names for real user accounts.
- home directory names for real user accounts.

Users and groups are now mainly identified by their numeric UID and GID.

The only private information may remain at Debug (7) logging level, where raw output (that we do not directly control) of system commands is logged for debugging purposes. For this the logs warn the user:

'Debug logging is enabled and this may include private information such as unredacted usernames'

Here are examples of redacted logging.

During users enumeration, debug level traces that redact real usernames and homes:

```
[2025-04-22 09:53:07][DEBUG][UserUtils.c:409] EnumerateUsers: 49 users found
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 0): uid 0, name 'root', gid 0, home '/root', shell '/bin/bash'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 1): uid 1, name 'daemon', gid 1, home '/usr/sbin', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 2): uid 2, name 'bin', gid 2, home '/bin', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 3): uid 3, name 'sys', gid 3, home '/dev', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 4): uid 4, name 'sync', gid 65534, home '/bin', shell '/bin/sync'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 5): uid 6, name 'man', gid 12, home '/var/cache/man', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 6): uid 7, name 'lp', gid 7, home '/var/spool/lpd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 7): uid 8, name 'mail', gid 8, home '/var/mail', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 8): uid 9, name 'news', gid 9, home '/var/spool/news', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 9): uid 10, name 'uucp', gid 10, home '/var/spool/uucp', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 10): uid 13, name 'proxy', gid 13, home '/bin', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 11): uid 33, name 'www-data', gid 33, home '/var/www', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 12): uid 34, name 'backup', gid 34, home '/var/backups', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 13): uid 38, name 'list', gid 38, home '/var/list', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 14): uid 39, name 'irc', gid 39, home '/run/ircd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 15): uid 41, name 'gnats', gid 41, home '/var/lib/gnats', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 16): uid 65534, name 'nobody', gid 65534, home '/nonexistent', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 17): uid 100, name 'systemd-network', gid 102, home '/run/systemd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 18): uid 101, name 'systemd-resolve', gid 103, home '/run/systemd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 19): uid 102, name 'messagebus', gid 105, home '/nonexistent', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 20): uid 103, name 'systemd-timesync', gid 106, home '/run/systemd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 21): uid 104, name 'syslog', gid 111, home '/home/syslog', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 22): uid 105, name '_apt', gid 65534, home '/nonexistent', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 23): uid 106, name 'tss', gid 112, home '/var/lib/tpm', shell '/bin/false'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 24): uid 107, name 'uuidd', gid 116, home '/run/uuidd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 25): uid 108, name 'tcpdump', gid 117, home '/nonexistent', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 26): uid 109, name 'avahi-autoipd', gid 119, home '/var/lib/avahi-autoipd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 27): uid 110, name 'usbmux', gid 46, home '/var/lib/usbmux', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 28): uid 111, name 'dnsmasq', gid 65534, home '/var/lib/misc', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 29): uid 112, name 'kernoops', gid 65534, home '/', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 30): uid 113, name 'avahi', gid 120, home '/run/avahi-daemon', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 31): uid 114, name 'cups-pk-helper', gid 121, home '/home/cups-pk-helper', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 32): uid 115, name 'lightdm', gid 122, home '/var/lib/lightdm', shell '/bin/false'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 33): uid 116, name 'rtkit', gid 124, home '/proc', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 34): uid 117, name 'whoopsie', gid 125, home '/nonexistent', shell '/bin/false'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 35): uid 118, name 'sssd', gid 126, home '/var/lib/sss', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 36): uid 119, name 'speech-dispatcher', gid 29, home '/run/speech-dispatcher', shell '/bin/false'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 37): uid 120, name 'fwupd-refresh', gid 127, home '/run/systemd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 38): uid 121, name 'nm-openvpn', gid 128, home '/var/lib/openvpn/chroot', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 39): uid 122, name 'saned', gid 130, home '/var/lib/saned', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 40): uid 123, name 'colord', gid 131, home '/var/lib/colord', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 41): uid 124, name 'geoclue', gid 132, home '/var/lib/geoclue', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 42): uid 125, name '_flatpak', gid 133, home '/nonexistent', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 43): uid 126, name 'pulse', gid 134, home '/run/pulse', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 44): uid 127, name 'hplip', gid 7, home '/run/hplip', shell '/bin/false'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 45): uid 1000, name '***', gid 1000, home '***', shell '/bin/bash'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 46): uid 128, name 'sshd', gid 65534, home '/run/sshd', shell '/usr/sbin/nologin'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 47): uid 999, name 'himds', gid 999, home '/home/himds', shell '/bin/false'
[2025-04-22 09:53:07][DEBUG][UserUtils.c:413] EnumerateUsers(user 48): uid 998, name 'arcproxy', gid 999, home '/home/arcproxy', shell '/bin/false'
```

Informational traces that identify users by their UIDs and redact out usernames (see user 1000 for example, which is my own local account on the machine):

```
[2025-04-22 09:53:07][INFO][UserUtils.c:2464] CheckUsersRecordedPasswordChangeDates: user 1000 has 289 days since last password change
[2025-04-22 09:53:07][INFO][UserUtils.c:2485] CheckUsersRecordedPasswordChangeDates: all users who have passwords have dates of last password change in the past
[2025-04-22 09:53:07][INFO][Asb.c:4940] AsbMmiGet(SecurityBaseline, auditEnsureInactivePasswordLockPeriod, "PASSAll non-root users who have passwords have correct number of maximum inactivity days (30) before lockout, also user 1000 has 289 days since last password change, also all users who have passwords have dates of last password change in the past", 248) returning 0
[2025-04-22 09:53:07][CRITICAL][Asb.c:4959] TargetName: 'Ubuntu 22.04.5 LTS', ComponentName: 'SecurityBaseline', 'ObjectName:'auditEnsureInactivePasswordLockPeriod', ObjectResult:'Success (0)', Reason: '"PASSAll non-root users who have passwords have correct number of maximum inactivity days (30) before lockout, also user 1000 has 289 days since last password change, also all users who have passwords have dates of last password change in the past"', Microseconds: 1722
[2025-04-22 09:53:07][INFO][SecurityBaseline.c:147] MmiGet(0x7f1e61d860c0, SecurityBaseline, auditEnsureInactivePasswordLockPeriod, "PASSAll non-root users who have passwords have correct number of maximum inactivity days (30) before lockout, also user 1000 has 289 days since last password change, also all users who have passwords have dates of last password change in the past", 248) returning 0
```

In this example, home directories are redacted out by being omitted from the logged paths of the user dot files:

```
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.bash_logout'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.gitconfig'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.Xauthority'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.sudo_as_admin_successful'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (600) for their dot file '.xsession-errors.old'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (600) for their dot file '.lesshst'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.profile'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.bashrc'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (600) for their dot file '.xsession-errors'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (600) for their dot file '.bash_history'
[2025-04-22 09:53:06][INFO][UserUtils.c:2843] CheckUsersRestrictedDotFiles: user 1000 has proper restricted access (744) for their dot file '.wget-hsts'
```

In this example we can see redacted our group names (see GID 1000 and GID 65534):

```
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 0): group name 'root', gid 0, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 1): group name 'daemon', gid 1, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 2): group name 'bin', gid 2, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 3): group name 'sys', gid 3, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 4): group name 'adm', gid 4, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 5): group name 'tty', gid 5, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 6): group name 'disk', gid 6, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 7): group name 'lp', gid 7, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 8): group name 'mail', gid 8, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 9): group name 'news', gid 9, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 10): group name 'uucp', gid 10, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 11): group name 'man', gid 12, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 12): group name 'proxy', gid 13, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 13): group name 'kmem', gid 15, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 14): group name 'dialout', gid 20, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 15): group name 'fax', gid 21, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 16): group name 'voice', gid 22, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 17): group name 'cdrom', gid 24, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 18): group name 'floppy', gid 25, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 19): group name 'tape', gid 26, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 20): group name 'sudo', gid 27, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 21): group name 'audio', gid 29, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 22): group name 'dip', gid 30, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 23): group name 'www-data', gid 33, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 24): group name 'backup', gid 34, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 25): group name 'operator', gid 37, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 26): group name 'list', gid 38, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 27): group name 'irc', gid 39, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 28): group name 'src', gid 40, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 29): group name 'gnats', gid 41, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 30): group name 'shadow', gid 42, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 31): group name 'utmp', gid 43, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 32): group name 'video', gid 44, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 33): group name 'sasl', gid 45, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 34): group name 'plugdev', gid 46, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 35): group name 'staff', gid 50, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 36): group name 'users', gid 100, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 37): group name '***', gid 65534, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 38): group name 'systemd-journal', gid 101, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 39): group name 'systemd-network', gid 102, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 40): group name 'systemd-resolve', gid 103, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 41): group name 'crontab', gid 104, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 42): group name 'messagebus', gid 105, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 43): group name 'systemd-timesync', gid 106, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 44): group name 'input', gid 107, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 45): group name 'sgx', gid 108, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 46): group name 'kvm', gid 109, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 47): group name 'render', gid 110, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 48): group name 'syslog', gid 111, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 49): group name 'tss', gid 112, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 50): group name 'bluetooth', gid 113, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 51): group name 'ssl-cert', gid 114, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 52): group name 'netdev', gid 115, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 53): group name 'uuidd', gid 116, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 54): group name 'tcpdump', gid 117, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 55): group name '_ssh', gid 118, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 56): group name 'avahi-autoipd', gid 119, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 57): group name 'avahi', gid 120, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 58): group name 'lpadmin', gid 121, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 59): group name 'lightdm', gid 122, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 60): group name 'nopasswdlogin', gid 123, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 61): group name 'rtkit', gid 124, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 62): group name 'whoopsie', gid 125, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 63): group name 'sssd', gid 126, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 64): group name 'fwupd-refresh', gid 127, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 65): group name 'nm-openvpn', gid 128, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 66): group name 'scanner', gid 129, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 67): group name 'saned', gid 130, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 68): group name 'colord', gid 131, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 69): group name 'geoclue', gid 132, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 70): group name '_flatpak', gid 133, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 71): group name 'pulse', gid 134, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 72): group name 'pulse-access', gid 135, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 73): group name 'lxd', gid 136, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 74): group name '***', gid 1000, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 75): group name 'sambashare', gid 137, has users
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 76): group name 'himds', gid 999, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:595] EnumerateAllGroups(group 77): group name 'rdma', gid 138, empty
[2025-04-22 10:12:17][DEBUG][UserUtils.c:611] EnumerateAllGroups: found 78 groups (expected 78)
```

More group names redaction examples here:

```
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 29 of user 126 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:500] EnumerateUserGroups: user 127 ('hplip', gid: 7) is in 1 group
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 127 ('hplip', gid: 7) is in group 7 ('lp')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 7 of user 127 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:500] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in 9 groups
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 1000 ('***')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 4 ('adm')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 24 ('cdrom')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 27 ('sudo')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 30 ('dip')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 46 ('plugdev')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 121 ('lpadmin')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 136 ('lxd')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 1000 ('***', gid: 1000) is in group 137 ('sambashare')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 1000 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 4 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 24 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 27 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 30 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 46 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 121 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 136 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 137 of user 1000 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:500] EnumerateUserGroups: user 128 ('sshd', gid: 65534) is in 1 group
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 128 ('sshd', gid: 65534) is in group 65534 ('***')
[2025-04-22 13:12:53][DEBUG][UserUtils.c:664] CheckAllEtcPasswdGroupsExistInEtcGroup: group 65534 of user 128 found in '/etc/group'
[2025-04-22 13:12:53][DEBUG][UserUtils.c:500] EnumerateUserGroups: user 999 ('himds', gid: 999) is in 1 group
[2025-04-22 13:12:53][DEBUG][UserUtils.c:532] EnumerateUserGroups: user 999 ('himds', gid: 999) is in group 999 ('himds')
```

Another example, for auditing if all users who need passowords have passwords set:

```

[2025-04-22 13:22:09][INFO][UserUtils.c:1323] CheckAllUsersHavePasswordsSet: user 0 ('root') is locked
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 1 ('daemon') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 2 ('bin') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 3 ('sys') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1328] CheckAllUsersHavePasswordsSet: user 4 ('sync') cannot login with password
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 6 ('man') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 7 ('lp') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 8 ('mail') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 9 ('news') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 10 ('uucp') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 13 ('proxy') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 33 ('www-data') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 34 ('backup') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 38 ('list') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 39 ('irc') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 41 ('gnats') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 65534 ('nobody') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 100 ('systemd-network') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 101 ('systemd-resolve') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 102 ('messagebus') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 103 ('systemd-timesync') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 104 ('syslog') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 105 ('_apt') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 106 ('tss') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 107 ('uuidd') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 108 ('tcpdump') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 109 ('avahi-autoipd') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 110 ('usbmux') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 111 ('dnsmasq') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 112 ('kernoops') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 113 ('avahi') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 114 ('cups-pk-helper') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 115 ('lightdm') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 116 ('rtkit') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 117 ('whoopsie') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 118 ('sssd') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 119 ('speech-dispatcher') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 120 ('fwupd-refresh') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 121 ('nm-openvpn') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 122 ('saned') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 123 ('colord') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 124 ('geoclue') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 125 ('_flatpak') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 126 ('pulse') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 127 ('hplip') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1313] CheckAllUsersHavePasswordsSet: user 1000 ('***') appears to have a password set
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 128 ('sshd') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 999 ('himds') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1318] CheckAllUsersHavePasswordsSet: user 998 ('arcproxy') is no login
[2025-04-22 13:22:09][INFO][UserUtils.c:1346] CheckAllUsersHavePasswordsSet: all users who need passwords appear to have passwords set
```
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
