### PR TITLE
GenJSONSchemas: Improve error reporting, handle trailing comma and add info on quote

### DIFF
--- a/src/modules/compliance/src/lib/GenJSONSchemas.py
+++ b/src/modules/compliance/src/lib/GenJSONSchemas.py
@@ -29,7 +29,7 @@ def parse_macro_args(args):
         if len(arg) >= 2 and arg[0] == '"' and arg[-1] == '"':
             arg = arg[1:-1]
         else:
-            raise ValueError("Improperly quoted parameter")
+            raise ValueError(f"Improperly quoted parameter in args {args[1:]}")
         parts = arg.split(':')
         name = parts[0]
         if len(name) == 0:
@@ -80,6 +80,8 @@ def process_procedures(content, prefix):
                 current += char
             endpos += 1
         if len(current) > 0:
+            if not current.strip():
+                raise ValueError(f"Trailing comma in AUDIT_FN in {content[startpos:endpos]}")
             args.append(current)
         fn_name, arg_dict = parse_macro_args(args)
         if fn_name:


### PR DESCRIPTION
## Description

Improve AUDIT_FN parsing and add more contet to errors raised.

When AUDIT_FN(EnsureFoo, "arg1:some arg stuff:M", ) is valid it shows
vauge description of error. Check if last arg tokken is empty and rasie
ValueError.

When args are improperly quotes add all args to ValueError

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
