### PR TITLE
Add regular expressions sub-pattern functionality fallback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,6 +82,9 @@
         "codecvt": "cpp",
         "source_location": "cpp",
         "numbers": "cpp",
-        "semaphore": "cpp"
+        "semaphore": "cpp",
+        "charconv": "cpp",
+        "format": "cpp",
+        "span": "cpp"
     }
 }

--- a/src/modules/compliance/src/lib/Regex.h
+++ b/src/modules/compliance/src/lib/Regex.h
@@ -7,62 +7,26 @@
 // It has to be removed and forgotten after we abandon support
 // for older GCC versions.
 
+#ifndef COMPLIANCE_REGEX_H
+#define COMPLIANCE_REGEX_H
+
 #if __cplusplus >= 201103L &&                                                                                                                          \
     (!defined(__GLIBCXX__) || (__cplusplus >= 201402L) ||                                                                                              \
         (defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) || defined(_GLIBCXX_REGEX_STATE_LIMIT) || (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE > 4)))
+#define USE_REGEX_FALLBACK 0
+#else
+#define USE_REGEX_FALLBACK 1
+#endif
 
+#if USE_REGEX_FALLBACK == 0
 #include <regex>
 #define regex_search std::regex_search
 using regex = std::regex;
-
-#else
-
-#include <memory>
-#include <regex.h>
-#include <regex>
-#include <string>
-namespace RegexLibcWrapper
-{
-class Regex
-{
-    int ConvertFlags(std::regex_constants::syntax_option_type options)
-    {
-        int flags = 0;
-        if (options & std::regex_constants::icase)
-        {
-            flags |= REG_ICASE;
-        }
-        if (options & std::regex_constants::extended)
-        {
-            flags |= REG_EXTENDED;
-        }
-        return flags;
-    }
-
-public:
-    Regex() = default;
-    Regex(const Regex&) = delete;
-    Regex(Regex&&) noexcept = default;
-    Regex& operator=(Regex&&) noexcept = default;
-    Regex(const std::string& r, std::regex_constants::syntax_option_type options = std::regex_constants::extended)
-    {
-        this->preg = std::unique_ptr<regex_t>(new (regex_t));
-        int v = regcomp(this->preg.get(), r.c_str(), ConvertFlags(options));
-        if (0 != v)
-        {
-            throw std::runtime_error("Invalid regex");
-        }
-    }
-    std::unique_ptr<regex_t> preg;
-};
-
-inline bool regexSearch(const std::string& s, const Regex& r)
-{
-    return (0 == regexec(r.preg.get(), s.c_str(), 0, NULL, 0));
-}
-} // namespace RegexLibcWrapper
-
-#define regex_search RegexLibcWrapper::regexSearch
-using regex = RegexLibcWrapper::Regex;
-
-#endif
+using smatch = std::smatch;
+template <typename T>
+using sub_match = std::sub_match<T>;
+#else // #if USE_REGEX_FALLBACK == 1
+#include <RegexFallback.h>
+#endif // #if USE_REGEX_FALLBACK == 0
+#endif // #if COMPLIANCE_REGEX_H
+// #endif

--- a/src/modules/compliance/src/lib/RegexFallback.h
+++ b/src/modules/compliance/src/lib/RegexFallback.h
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCE_REGEX_FALLBACK_H
+#define COMPLIANCE_REGEX_FALLBACK_H
+
+#if USE_REGEX_FALLBACK == 0
+#error "USE_REGEX_FALLBACK should be set to 1 here"
+#endif
+
+#include <cassert>
+#include <memory>
+#include <regex.h>
+#include <regex> // for std::regex_constants
+#include <string>
+
+namespace RegexLibcWrapper
+{
+class Regex
+{
+    int ConvertFlags(std::regex_constants::syntax_option_type options)
+    {
+        int flags = 0;
+        if (options & std::regex_constants::icase)
+        {
+            flags |= REG_ICASE;
+        }
+        if (options & std::regex_constants::extended)
+        {
+            flags |= REG_EXTENDED;
+        }
+        return flags;
+    }
+
+public:
+    Regex() = default;
+    Regex(const Regex&) = delete;
+    Regex(Regex&&) noexcept = default;
+    Regex& operator=(Regex&&) noexcept = default;
+    Regex(const std::string& r, std::regex_constants::syntax_option_type options = std::regex_constants::extended)
+    {
+        int v = regcomp(&preg, r.c_str(), ConvertFlags(options));
+        if (0 != v)
+        {
+            throw std::runtime_error("Invalid regex");
+        }
+    }
+    ~Regex()
+    {
+        regfree(&preg);
+    }
+    regex_t preg;
+};
+
+class SubMatch
+{
+public:
+    SubMatch() = delete;
+    SubMatch(const SubMatch&) = default;
+    SubMatch& operator=(const SubMatch&) = default;
+    SubMatch(SubMatch&&) = default;
+    SubMatch& operator=(SubMatch&&) = default;
+
+    const bool matched = false;
+    std::string str() const
+    {
+        return std::string(mTarget->c_str() + mPmatch->rm_so, mPmatch->rm_eo - mPmatch->rm_so);
+    }
+
+    operator std::string() const
+    {
+        return str();
+    }
+
+    std::size_t length() const
+    {
+        return mPmatch->rm_eo - mPmatch->rm_so;
+    }
+
+private:
+    friend class MatchResults;
+    friend class SubMatchIterator;
+    SubMatch(const std::string* target, const regmatch_t* pmatch)
+        : matched(pmatch->rm_so != -1),
+          mTarget(target),
+          mPmatch(pmatch)
+    {
+    }
+
+    const std::string* mTarget;
+    const regmatch_t* mPmatch;
+};
+
+class SubMatchIterator
+{
+public:
+    SubMatchIterator(const SubMatchIterator&) = default;
+    SubMatchIterator& operator=(const SubMatchIterator&) = default;
+    SubMatchIterator(SubMatchIterator&&) = default;
+    SubMatchIterator& operator=(SubMatchIterator&&) = default;
+
+    SubMatch operator*() const
+    {
+        return SubMatch(mTarget, &mPmatch[mIndex]);
+    }
+
+    SubMatchIterator& operator++()
+    {
+        ++mIndex;
+        return *this;
+    }
+
+    SubMatchIterator operator++(int)
+    {
+        SubMatchIterator tmp = *this;
+        ++mIndex;
+        return tmp;
+    }
+
+    bool operator!=(const SubMatchIterator& other) const
+    {
+        return mIndex != other.mIndex;
+    }
+    bool operator==(const SubMatchIterator& other) const
+    {
+        return mIndex == other.mIndex;
+    }
+
+private:
+    friend class MatchResults;
+    SubMatchIterator() = default;
+    SubMatchIterator(const std::string* target, const regmatch_t* pmatch, std::size_t index)
+        : mTarget(target),
+          mPmatch(pmatch),
+          mIndex(index)
+    {
+    }
+
+    const std::string* mTarget = nullptr;
+    const regmatch_t* mPmatch = nullptr;
+    std::size_t mIndex = 0;
+};
+
+class MatchResults
+{
+public:
+    MatchResults() = default;
+    MatchResults(const MatchResults&) = delete;
+    MatchResults(MatchResults&&) = default;
+    MatchResults& operator=(MatchResults&&) = default;
+
+    std::size_t size() const
+    {
+        return mSize;
+    }
+
+    bool ready() const
+    {
+        return nullptr != mPmatch;
+    }
+
+    SubMatch operator[](std::size_t i) const
+    {
+        assert(ready());
+        assert(i < mSize);
+        return SubMatch(&mTarget, &mPmatch[i]);
+    }
+
+    SubMatchIterator begin() const
+    {
+        return SubMatchIterator(&mTarget, mPmatch.get(), 0);
+    }
+
+    SubMatchIterator end() const
+    {
+        return SubMatchIterator(&mTarget, mPmatch.get(), mSize);
+    }
+
+    std::string prefix() const
+    {
+        assert(ready());
+        assert(size() > 0);
+        return std::string(mTarget.c_str(), mPmatch[0].rm_so);
+    }
+
+    std::string suffix() const
+    {
+        assert(ready());
+        assert(size() > 0);
+        return std::string(mTarget.c_str() + mPmatch[mSize - 1].rm_eo, mTarget.length() - mPmatch[mSize - 1].rm_eo);
+    }
+
+private:
+    friend bool regexSearch(const std::string& s, MatchResults& m, const Regex& r);
+    MatchResults(std::string target, std::unique_ptr<regmatch_t[]> matches, std::size_t size)
+        : mTarget(std::move(target)),
+          mPmatch(std::move(matches))
+    {
+        mSize = 0;
+        for (mSize = 0; mSize < size; ++mSize)
+        {
+            if (mPmatch[mSize].rm_so == -1)
+            {
+                break;
+            }
+        }
+    }
+
+    std::string mTarget;
+    std::size_t mSize = 0;
+    std::unique_ptr<regmatch_t[]> mPmatch;
+};
+
+inline bool regexSearch(const std::string& s, MatchResults& m, const Regex& r)
+{
+    const auto size = r.preg.re_nsub + 1;
+    auto matches = std::unique_ptr<regmatch_t[]>(new regmatch_t[size]);
+    auto result = (0 == regexec(&r.preg, s.c_str(), size, matches.get(), 0));
+    m = MatchResults(s, std::move(matches), result ? size : 0);
+    return result;
+}
+
+inline bool regexSearch(const std::string& s, const Regex& r)
+{
+    return (0 == regexec(&r.preg, s.c_str(), 0, NULL, 0));
+}
+
+} // namespace RegexLibcWrapper
+
+#define regex_search RegexLibcWrapper::regexSearch
+using regex = RegexLibcWrapper::Regex;
+using smatch = RegexLibcWrapper::MatchResults;
+using sub_match = RegexLibcWrapper::SubMatch;
+#endif // COMPLIANCE_REGEX_FALLBACK_H

--- a/src/modules/compliance/tests/CMakeLists.txt
+++ b/src/modules/compliance/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(compliancetests
     EngineTest.cpp
     EvaluatorTest.cpp
     OptionalTest.cpp
+    RegexFallbackTest.cpp
+    RegexTest.cpp
     ResultTest.cpp
     Base64Test.cpp
     ${PROCEDURES}

--- a/src/modules/compliance/tests/RegexFallbackTest.cpp
+++ b/src/modules/compliance/tests/RegexFallbackTest.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define USE_REGEX_FALLBACK 1
+#include <RegexFallback.h>
+#include <cstring>
+#include <gtest/gtest.h>
+
+class RegexFallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(RegexFallbackTest, NoMatch)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "notfound";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    EXPECT_FALSE(match.ready());
+
+    bool result = regex_search(target, match, r);
+    EXPECT_FALSE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.size(), 0);
+}
+
+TEST_F(RegexFallbackTest, Match)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "test";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 1);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), 4);
+}
+
+TEST_F(RegexFallbackTest, MatchWithSubMatches_1)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "(test)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 2);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+}
+
+TEST_F(RegexFallbackTest, MatchWithSubMatches_2)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "(test) (string)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 3);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("string"));
+}
+
+TEST_F(RegexFallbackTest, MatchWithSubMatches_3)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 4);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test string"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("test"));
+    EXPECT_EQ(match[3].matched, true);
+    EXPECT_EQ(match[3].length(), std::strlen("string"));
+}
+
+TEST_F(RegexFallbackTest, RangeLoop)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "((test) (string))";
+    std::string output;
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    for (const auto& m : match)
+    {
+        output += m.str();
+    }
+    EXPECT_EQ(output, "test stringtest stringteststring");
+}
+
+TEST_F(RegexFallbackTest, PrefixAndSuffix)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.prefix(), "This is a ");
+    EXPECT_EQ(match.suffix(), "?");
+}

--- a/src/modules/compliance/tests/RegexTest.cpp
+++ b/src/modules/compliance/tests/RegexTest.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <Regex.h>
+#include <cstring>
+#include <gtest/gtest.h>
+
+class RegexTest : public ::testing::Test
+{
+};
+
+TEST_F(RegexTest, NoMatch)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "notfound";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    EXPECT_FALSE(match.ready());
+
+    bool result = regex_search(input, match, r);
+    EXPECT_FALSE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.size(), 0);
+}
+
+TEST_F(RegexTest, Match)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "test";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 1);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), 4);
+}
+
+TEST_F(RegexTest, MatchWithSubMatches_1)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "(test)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 2);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+}
+
+TEST_F(RegexTest, MatchWithSubMatches_2)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "(test) (string)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 3);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("string"));
+}
+
+TEST_F(RegexTest, MatchWithSubMatches_3)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 4);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test string"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("test"));
+    EXPECT_EQ(match[3].matched, true);
+    EXPECT_EQ(match[3].length(), std::strlen("string"));
+}
+
+TEST_F(RegexTest, RangeLoop)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "((test) (string))";
+    std::string output;
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    for (const auto& m : match)
+    {
+        output += m.str();
+    }
+    EXPECT_EQ(output, "test stringtest stringteststring");
+}
+
+TEST_F(RegexTest, PrefixAndSuffix)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.prefix(), "This is a ");
+    EXPECT_EQ(match.suffix(), "?");
+}


### PR DESCRIPTION
## Description

We have a fallback solution for non-functional std::regex on old and unsupported distributions (RHEL-7/8 and derivatives). This PR adds sub-pattern matching drop-in replacement matching `std::smatch` and adds support for `regex_search(t, m, r)`, previously we only supported `regex_search(t, r)`.

_Note_: Naming convention (CamelCase etc.) is not held on purpose to keep in line with `std::` equivalents.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
