### PR TITLE
Add regular expressions sub-pattern functionality fallback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,6 +82,9 @@
         "codecvt": "cpp",
         "source_location": "cpp",
         "numbers": "cpp",
-        "semaphore": "cpp"
+        "semaphore": "cpp",
+        "charconv": "cpp",
+        "format": "cpp",
+        "span": "cpp"
     }
 }

--- a/src/modules/compliance/src/lib/Regex.h
+++ b/src/modules/compliance/src/lib/Regex.h
@@ -1,68 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifndef COMPLIANCE_REGEX_H
+#define COMPLIANCE_REGEX_H
+
 // GCC <= 4.8 has broken std::regex support. This is a very
 // ugly hack that uses libc regexes to emulate std::regex
 // for the functionality that we currently need in compliance.
 // It has to be removed and forgotten after we abandon support
 // for older GCC versions.
 
-#if __cplusplus >= 201103L &&                                                                                                                          \
-    (!defined(__GLIBCXX__) || (__cplusplus >= 201402L) ||                                                                                              \
-        (defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) || defined(_GLIBCXX_REGEX_STATE_LIMIT) || (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE > 4)))
+#if __cplusplus >= 201103L && ((__cplusplus >= 201402L) || (defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) || defined(_GLIBCXX_REGEX_STATE_LIMIT) ||    \
+                                                               (defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE > 4)))
+#define USE_REGEX_FALLBACK 0
+#else
+#define USE_REGEX_FALLBACK 1
+#endif
 
+#if USE_REGEX_FALLBACK == 0
 #include <regex>
 #define regex_search std::regex_search
+#define regex_match std::regex_match
 using regex = std::regex;
+using smatch = std::smatch;
+using regex_error = std::regex_error;
+#else // #if USE_REGEX_FALLBACK == 0
+#include <RegexFallback.h>
+#endif // #if USE_REGEX_FALLBACK == 0
 
-#else
-
-#include <memory>
-#include <regex.h>
-#include <regex>
-#include <string>
-namespace RegexLibcWrapper
-{
-class Regex
-{
-    int ConvertFlags(std::regex_constants::syntax_option_type options)
-    {
-        int flags = 0;
-        if (options & std::regex_constants::icase)
-        {
-            flags |= REG_ICASE;
-        }
-        if (options & std::regex_constants::extended)
-        {
-            flags |= REG_EXTENDED;
-        }
-        return flags;
-    }
-
-public:
-    Regex() = default;
-    Regex(const Regex&) = delete;
-    Regex(Regex&&) noexcept = default;
-    Regex& operator=(Regex&&) noexcept = default;
-    Regex(const std::string& r, std::regex_constants::syntax_option_type options = std::regex_constants::extended)
-    {
-        this->preg = std::unique_ptr<regex_t>(new (regex_t));
-        int v = regcomp(this->preg.get(), r.c_str(), ConvertFlags(options));
-        if (0 != v)
-        {
-            throw std::runtime_error("Invalid regex");
-        }
-    }
-    std::unique_ptr<regex_t> preg;
-};
-
-inline bool regexSearch(const std::string& s, const Regex& r)
-{
-    return (0 == regexec(r.preg.get(), s.c_str(), 0, NULL, 0));
-}
-} // namespace RegexLibcWrapper
-
-#define regex_search RegexLibcWrapper::regexSearch
-using regex = RegexLibcWrapper::Regex;
-
-#endif
+#endif // COMPLIANCE_REGEX_H

--- a/src/modules/compliance/src/lib/RegexFallback.h
+++ b/src/modules/compliance/src/lib/RegexFallback.h
@@ -1,0 +1,350 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCE_REGEX_FALLBACK_H
+#define COMPLIANCE_REGEX_FALLBACK_H
+
+#if USE_REGEX_FALLBACK == 0
+#error "USE_REGEX_FALLBACK should be set to 1 here"
+#endif
+
+#include <cassert>
+#include <memory>
+#include <regex.h>
+#include <regex> // for std::regex_constants
+#include <stdexcept>
+#include <string>
+
+namespace RegexLibcWrapper
+{
+class RegexException : public std::runtime_error
+{
+    std::regex_constants::error_type mCode;
+
+public:
+    RegexException(const std::string& message, int code)
+        : std::runtime_error(message),
+          mCode(std::regex_constants::error_space)
+    {
+        switch (code)
+        {
+            case REG_BADBR:
+                mCode = std::regex_constants::error_backref;
+                break;
+            case REG_BADPAT:
+                mCode = std::regex_constants::error_paren;
+                break;
+            case REG_BADRPT:
+                mCode = std::regex_constants::error_badrepeat;
+                break;
+            case REG_EBRACE:
+                mCode = std::regex_constants::error_brace;
+                break;
+            case REG_EBRACK:
+                mCode = std::regex_constants::error_brack;
+                break;
+            case REG_ECOLLATE:
+                mCode = std::regex_constants::error_collate;
+                break;
+            case REG_ECTYPE:
+                mCode = std::regex_constants::error_ctype;
+                break;
+            case REG_EESCAPE:
+                mCode = std::regex_constants::error_escape;
+                break;
+            case REG_EPAREN:
+                mCode = std::regex_constants::error_paren;
+                break;
+            case REG_ERANGE:
+                mCode = std::regex_constants::error_range;
+                break;
+            case REG_ESUBREG:
+                mCode = std::regex_constants::error_backref;
+                break;
+            default:
+                mCode = std::regex_constants::error_space;
+                break;
+        }
+    }
+
+    RegexException(const RegexException&) = default;
+    RegexException(RegexException&&) = default;
+    RegexException& operator=(RegexException&&) = default;
+    RegexException& operator=(const RegexException&) = default;
+
+    std::regex_constants::error_type code() const
+    {
+        return mCode;
+    }
+};
+
+class Regex
+{
+    int ConvertFlags(std::regex_constants::syntax_option_type options)
+    {
+        int flags = 0;
+        if (options & std::regex_constants::icase)
+        {
+            flags |= REG_ICASE;
+        }
+        if (options & std::regex_constants::extended)
+        {
+            flags |= REG_EXTENDED;
+        }
+        return flags;
+    }
+
+public:
+    Regex() = default;
+    Regex(const Regex&) = delete;
+    Regex(Regex&&) noexcept = default;
+    Regex& operator=(Regex&&) noexcept = default;
+    Regex(const std::string& r, std::regex_constants::syntax_option_type options = std::regex_constants::extended)
+    {
+        preg = std::unique_ptr<regex_t>(new regex_t);
+        int v = regcomp(preg.get(), r.c_str(), ConvertFlags(options));
+        if (0 != v)
+        {
+            char errbuf[256];
+            regerror(v, preg.get(), errbuf, sizeof(errbuf));
+            throw RegexException(errbuf, v);
+        }
+    }
+    ~Regex()
+    {
+        if (preg)
+        {
+            regfree(preg.get());
+        }
+    }
+    std::unique_ptr<regex_t> preg;
+};
+
+class SubMatch
+{
+public:
+    SubMatch() = delete;
+    SubMatch(const SubMatch&) = default;
+    SubMatch& operator=(const SubMatch&) = default;
+    SubMatch(SubMatch&&) = default;
+    SubMatch& operator=(SubMatch&&) = default;
+
+    const bool matched = false;
+    std::string str() const
+    {
+        if (!matched)
+        {
+            return std::string();
+        }
+        return std::string(mTarget->c_str() + mPmatch->rm_so, mPmatch->rm_eo - mPmatch->rm_so);
+    }
+
+    operator std::string() const
+    {
+        return str();
+    }
+
+    std::size_t length() const
+    {
+        if (!matched)
+        {
+            return 0;
+        }
+        return mPmatch->rm_eo - mPmatch->rm_so;
+    }
+
+private:
+    friend class MatchResults;
+    friend class SubMatchIterator;
+    SubMatch(const std::string* target, const regmatch_t* pmatch)
+        : matched((nullptr != pmatch) && (pmatch->rm_so != -1)),
+          mTarget(target),
+          mPmatch(pmatch)
+    {
+    }
+
+    const std::string* mTarget;
+    const regmatch_t* mPmatch;
+};
+
+class SubMatchIterator
+{
+public:
+    SubMatchIterator(const SubMatchIterator&) = default;
+    SubMatchIterator& operator=(const SubMatchIterator&) = default;
+    SubMatchIterator(SubMatchIterator&&) = default;
+    SubMatchIterator& operator=(SubMatchIterator&&) = default;
+
+    SubMatch operator*() const
+    {
+        return SubMatch(mTarget, &mPmatch[mIndex]);
+    }
+
+    SubMatchIterator& operator++()
+    {
+        ++mIndex;
+        return *this;
+    }
+
+    SubMatchIterator operator++(int)
+    {
+        SubMatchIterator tmp = *this;
+        ++mIndex;
+        return tmp;
+    }
+
+    bool operator!=(const SubMatchIterator& other) const
+    {
+        return mIndex != other.mIndex;
+    }
+    bool operator==(const SubMatchIterator& other) const
+    {
+        return mIndex == other.mIndex;
+    }
+
+private:
+    friend class MatchResults;
+    SubMatchIterator() = default;
+    SubMatchIterator(const std::string* target, const regmatch_t* pmatch, std::size_t index)
+        : mTarget(target),
+          mPmatch(pmatch),
+          mIndex(index)
+    {
+    }
+
+    const std::string* mTarget = nullptr;
+    const regmatch_t* mPmatch = nullptr;
+    std::size_t mIndex = 0;
+};
+
+class MatchResults
+{
+public:
+    MatchResults() = default;
+    MatchResults(const MatchResults&) = delete;
+    MatchResults(MatchResults&&) = default;
+    MatchResults& operator=(MatchResults&&) = default;
+
+    std::size_t size() const
+    {
+        return mSize;
+    }
+
+    bool ready() const
+    {
+        return nullptr != mPmatch;
+    }
+
+    SubMatch operator[](std::size_t i) const
+    {
+        assert(ready());
+        if (i < mSize)
+        {
+            return SubMatch(&mTarget, &mPmatch[i]);
+        }
+
+        return SubMatch(&mTarget, nullptr);
+    }
+
+    SubMatchIterator begin() const
+    {
+        return SubMatchIterator(&mTarget, mPmatch.get(), 0);
+    }
+
+    SubMatchIterator end() const
+    {
+        return SubMatchIterator(&mTarget, mPmatch.get(), mSize);
+    }
+
+    std::string prefix() const
+    {
+        assert(ready());
+        assert(size() > 0);
+        return std::string(mTarget.c_str(), mPmatch[0].rm_so);
+    }
+
+    std::string suffix() const
+    {
+        assert(ready());
+        assert(size() > 0);
+        return std::string(mTarget.c_str() + mPmatch[mSize - 1].rm_eo, mTarget.length() - mPmatch[mSize - 1].rm_eo);
+    }
+
+private:
+    friend bool regexSearch(const std::string& s, MatchResults& m, const Regex& r);
+    friend bool regexMatch(const std::string& s, MatchResults& m, const Regex& r);
+    MatchResults(std::string target, std::unique_ptr<regmatch_t[]> matches, std::size_t size)
+        : mTarget(std::move(target)),
+          mPmatch(std::move(matches))
+    {
+        mSize = 0;
+        for (mSize = 0; mSize < size; ++mSize)
+        {
+            if (mPmatch[mSize].rm_so == -1)
+            {
+                break;
+            }
+        }
+    }
+
+    std::string mTarget;
+    std::size_t mSize = 0;
+    std::unique_ptr<regmatch_t[]> mPmatch;
+};
+
+inline bool regexSearch(const std::string& s, MatchResults& m, const Regex& r)
+{
+    const auto size = r.preg->re_nsub + 1;
+    auto matches = std::unique_ptr<regmatch_t[]>(new regmatch_t[size]);
+    auto result = (0 == regexec(r.preg.get(), s.c_str(), size, matches.get(), 0));
+    m = MatchResults(s, std::move(matches), result ? size : 0);
+    return result;
+}
+
+inline bool regexMatch(const std::string& s, const Regex& r)
+{
+    return (0 == regexec(r.preg.get(), s.c_str(), 0, NULL, 0));
+}
+
+inline bool regexMatch(const std::string& s, MatchResults& m, const Regex& r)
+{
+    const auto size = r.preg->re_nsub + 1;
+    auto matches = std::unique_ptr<regmatch_t[]>(new regmatch_t[size]);
+    auto result = (0 == regexec(r.preg.get(), s.c_str(), size, matches.get(), 0));
+    if (result)
+    {
+        if (matches[0].rm_so != 0)
+        {
+            return false;
+        }
+
+        if (matches[0].rm_eo != static_cast<regoff_t>(s.length()))
+        {
+            return false;
+        }
+    }
+    m = MatchResults(s, std::move(matches), result ? size : 0);
+    return result;
+}
+
+inline bool regexSearch(const std::string& s, const Regex& r)
+{
+    return (0 == regexec(r.preg.get(), s.c_str(), 0, NULL, 0));
+}
+} // namespace RegexLibcWrapper
+
+namespace std
+{
+inline std::ostream& operator<<(std::ostream& os, const RegexLibcWrapper::SubMatch& m)
+{
+    os << m.str();
+    return os;
+}
+} // namespace std
+
+#define regex_search RegexLibcWrapper::regexSearch
+#define regex_match RegexLibcWrapper::regexMatch
+using regex = RegexLibcWrapper::Regex;
+using smatch = RegexLibcWrapper::MatchResults;
+using regex_error = RegexLibcWrapper::RegexException;
+#endif // COMPLIANCE_REGEX_FALLBACK_H

--- a/src/modules/compliance/src/lib/procedures/EnsureKernelModule.cpp
+++ b/src/modules/compliance/src/lib/procedures/EnsureKernelModule.cpp
@@ -89,7 +89,7 @@ AUDIT_FN(EnsureKernelModuleUnavailable, "moduleName:Name of the kernel module:M"
     {
         procModulesRegex = regex("^" + moduleName + "\\s+");
     }
-    catch (std::exception& e)
+    catch (regex_error& e)
     {
         return Error(e.what());
     }

--- a/src/modules/compliance/src/lib/procedures/EnsureSshdOption.cpp
+++ b/src/modules/compliance/src/lib/procedures/EnsureSshdOption.cpp
@@ -31,7 +31,7 @@ AUDIT_FN(EnsureSshdOption, "optionName:Name of the SSH daemon option:M", "option
     {
         valueRegex = regex(optionRegex);
     }
-    catch (const std::exception& e)
+    catch (const regex_error& e)
     {
         OsConfigLogError(log, "Regex error: %s", e.what());
         return Error("Failed to compile regex '" + optionRegex + "' error: " + e.what(), EINVAL);

--- a/src/modules/compliance/src/lib/procedures/FileRegexMatch.cpp
+++ b/src/modules/compliance/src/lib/procedures/FileRegexMatch.cpp
@@ -30,7 +30,7 @@ Result<Status> SinglePatternMatchMode(std::ifstream& input, const std::string& m
             lineNumber++;
         }
     }
-    catch (const std::exception& e)
+    catch (const regex_error& e)
     {
         OsConfigLogError(nullptr, "Regex error: %s", e.what());
         return Error("Regex error: " + std::string(e.what()), EINVAL);
@@ -67,7 +67,7 @@ Result<Status> StatePatternMatchMode(std::ifstream& input, const std::string& ma
             lineNumber++;
         }
     }
-    catch (const std::exception& e)
+    catch (const regex_error& e)
     {
         OsConfigLogError(nullptr, "Regex error: %s", e.what());
         return Error("Regex error: " + std::string(e.what()), EINVAL);

--- a/src/modules/compliance/tests/CMakeLists.txt
+++ b/src/modules/compliance/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(compliancetests
     EngineTest.cpp
     EvaluatorTest.cpp
     OptionalTest.cpp
+    RegexFallbackTest.cpp
+    RegexTest.cpp
     ResultTest.cpp
     Base64Test.cpp
     ${PROCEDURES}

--- a/src/modules/compliance/tests/RegexFallbackTest.cpp
+++ b/src/modules/compliance/tests/RegexFallbackTest.cpp
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define USE_REGEX_FALLBACK 1
+#include <RegexFallback.h>
+#include <cstring>
+#include <gtest/gtest.h>
+
+class RegexFallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(RegexFallbackTest, NoMatch)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "notfound";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    EXPECT_FALSE(match.ready());
+
+    bool result = regex_search(target, match, r);
+    EXPECT_FALSE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.size(), 0);
+}
+
+TEST_F(RegexFallbackTest, Match)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "test";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 1);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), 4);
+}
+
+TEST_F(RegexFallbackTest, MatchWithSubMatches_1)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "(test)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 2);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+}
+
+TEST_F(RegexFallbackTest, MatchWithSubMatches_2)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "(test) (string)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 3);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("string"));
+}
+
+TEST_F(RegexFallbackTest, MatchWithSubMatches_3)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 4);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test string"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("test"));
+    EXPECT_EQ(match[3].matched, true);
+    EXPECT_EQ(match[3].length(), std::strlen("string"));
+    EXPECT_EQ(match[100].matched, false);
+    EXPECT_EQ(match[100].length(), 0);
+}
+
+TEST_F(RegexFallbackTest, RangeLoop)
+{
+    std::string target = "This is a test string";
+    std::string pattern = "((test) (string))";
+    std::string output;
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    for (const auto& m : match)
+    {
+        output += m.str();
+    }
+    EXPECT_EQ(output, "test stringtest stringteststring");
+}
+
+TEST_F(RegexFallbackTest, PrefixAndSuffix)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.prefix(), "This is a ");
+    EXPECT_EQ(match.suffix(), "?");
+}
+
+TEST_F(RegexFallbackTest, RegexMatch_1)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_match(target, match, r);
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(match.ready());
+}
+
+TEST_F(RegexFallbackTest, RegexMatch_2)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "This is a ((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_match(target, match, r);
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(match.ready());
+}
+
+TEST_F(RegexFallbackTest, RegexMatch_3)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = R"(This is a ((test) (string))\?)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_match(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+}

--- a/src/modules/compliance/tests/RegexTest.cpp
+++ b/src/modules/compliance/tests/RegexTest.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <Regex.h>
+#include <cstring>
+#include <gtest/gtest.h>
+
+class RegexTest : public ::testing::Test
+{
+};
+
+TEST_F(RegexTest, NoMatch)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "notfound";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    EXPECT_FALSE(match.ready());
+
+    bool result = regex_search(input, match, r);
+    EXPECT_FALSE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.size(), 0);
+}
+
+TEST_F(RegexTest, Match)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "test";
+
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 1);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), 4);
+}
+
+TEST_F(RegexTest, MatchWithSubMatches_1)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "(test)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 2);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+}
+
+TEST_F(RegexTest, MatchWithSubMatches_2)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "(test) (string)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 3);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("string"));
+}
+
+TEST_F(RegexTest, MatchWithSubMatches_3)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    ASSERT_EQ(match.size(), 4);
+    EXPECT_EQ(match[0].matched, true);
+    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].matched, true);
+    EXPECT_EQ(match[1].length(), std::strlen("test string"));
+    EXPECT_EQ(match[2].matched, true);
+    EXPECT_EQ(match[2].length(), std::strlen("test"));
+    EXPECT_EQ(match[3].matched, true);
+    EXPECT_EQ(match[3].length(), std::strlen("string"));
+    EXPECT_EQ(match[100].matched, false);
+    EXPECT_EQ(match[100].length(), 0);
+}
+
+TEST_F(RegexTest, RangeLoop)
+{
+    std::string input = "This is a test string";
+    std::string pattern = "((test) (string))";
+    std::string output;
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(input, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    for (const auto& m : match)
+    {
+        output += m.str();
+    }
+    EXPECT_EQ(output, "test stringtest stringteststring");
+}
+
+TEST_F(RegexTest, PrefixAndSuffix)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_search(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+    EXPECT_EQ(match.prefix(), "This is a ");
+    EXPECT_EQ(match.suffix(), "?");
+}
+
+TEST_F(RegexTest, RegexMatch_1)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_match(target, match, r);
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(match.ready());
+}
+
+TEST_F(RegexTest, RegexMatch_2)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = "This is a ((test) (string))";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_match(target, match, r);
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(match.ready());
+}
+
+TEST_F(RegexTest, RegexMatch_3)
+{
+    std::string target = "This is a test string?";
+    std::string pattern = R"(This is a ((test) (string))\?)";
+    auto r = regex(pattern, std::regex_constants::extended);
+    smatch match;
+    bool result = regex_match(target, match, r);
+    EXPECT_TRUE(result);
+    ASSERT_TRUE(match.ready());
+}


### PR DESCRIPTION
## Description

We have a fallback solution for non-functional std::regex on old and unsupported distributions (RHEL-7/8 and derivatives). This PR adds sub-pattern matching drop-in replacement matching `std::smatch` and adds support for `regex_search(t, m, r)`, previously we only supported `regex_search(t, r)`.

_Note_: Naming convention (CamelCase etc.) is not held on purpose to keep in line with `std::` equivalents.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
