### PR TITLE
Add clang static analysis worfklow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,6 +34,8 @@ jobs:
           --exclude src/adapters/pnp/azure-iot-sdk-c \
           --exclude src/adapters/pnp/PnpUtils.c \
           --exclude src/adapters/pnp/AisUtils.c \
+          --exclude src/common/parson \
+          --exclude src/modules/commandrunner/src/lib \
           --cdb build/compile_commands.json \
           --output output/scan-build
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,6 +21,11 @@ jobs:
         cd build
         cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ../src
 
+    - name: "Temporary: install clang-tools"
+      run: |
+        apt-get update
+        apt-get install -y clang-tools
+
     - name: Run clang static analyzer
       run: |
         mkdir -p output

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,40 @@
+name: Static analysis
+
+on: [push, pull_request]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/azure/azure-osconfig/ubuntu-22.04-amd64
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        clean: true
+
+    - name: Prepare compile command database
+      run: |
+        mkdir -p build
+        cd build
+        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ../src
+
+    - name: Run clang static analyzer
+      run: |
+        mkdir -p output
+        analyze-build-14 --verbose \
+          --status-bugs \
+          --exclude src/adapters/pnp/azure-iot-sdk-c \
+          --exclude src/adapters/pnp/PnpUtils.c \
+          --exclude src/adapters/pnp/AisUtils.c \
+          --cdb build/compile_commands.json \
+          --output output/scan-build
+
+    - uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: scan-build
+        path: |
+          output/scan-build

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -20,6 +20,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug ../src
+        cmake --build . --target ProcedureMap
 
     - name: "Temporary: install clang-tools"
       run: |

--- a/devops/docker/centos-8-amd64/Dockerfile
+++ b/devops/docker/centos-8-amd64/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Add mcr.io retagged images
-FROM centos:latest
+FROM centos:8
 
 # CentOS Linux 8 had reached the End Of Life (EOL) on December 31st, 2021.
 # It means that CentOS 8 will no longer receive development resources from

--- a/devops/docker/ubuntu-22.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-22.04-amd64/Dockerfile
@@ -24,7 +24,8 @@ RUN apt -y update && apt-get -y install \
     file \
     libasan8 \
     libubsan1 \
-    clang
+    clang \
+    clang-tools
 
 WORKDIR /git
 

--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -533,7 +533,7 @@ void MI_CALL OsConfigResource_Invoke_GetTargetResource(
     MI_Value miValueReasonResult = {0};
     MI_Boolean isCompliant = MI_FALSE;
 
-    OsConfigResource_GetTargetResource get_result_object;
+    OsConfigResource_GetTargetResource get_result_object = {{0},{0},{0},{0},{0}};
 
     if ((NULL == in) || (MI_FALSE == in->InputResource.exists) || (NULL == in->InputResource.value))
     {
@@ -1170,7 +1170,6 @@ void MI_CALL OsConfigResource_Invoke_TestTargetResource(
                 {
                     // We have both a procedure object name and value, we need to set then now to apply context for compliance
                     SetDesiredObjectValueToDevice("OsConfigResource.Test", g_componentName, g_procedureObjectName, g_procedureObjectValue, context);
-                    miResult = MI_RESULT_FAILED;
                 }
             }
             else
@@ -1261,7 +1260,7 @@ void MI_CALL OsConfigResource_Invoke_SetTargetResource(
     MI_Result miResult = MI_RESULT_OK;
     MI_Result miCleanup = MI_RESULT_OK;
 
-    OsConfigResource_SetTargetResource set_result_object;
+    OsConfigResource_SetTargetResource set_result_object = {{0},{0},{0},{0},{0}};
 
     if ((NULL == in) || (MI_FALSE == in->InputResource.exists) || (NULL == in->InputResource.value))
     {

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -407,7 +407,7 @@ void CloseAgent(void)
     if (NULL != g_mpiHandle)
     {
         CallMpiClose(g_mpiHandle, GetLog());
-        g_mpiHandle = NULL;
+        FREE_MEMORY(g_mpiHandle);
     }
 
     FREE_MEMORY(g_reportedProperties);

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -406,7 +406,7 @@ void CloseAgent(void)
     if (NULL != g_mpiHandle)
     {
         CallMpiClose(g_mpiHandle, GetLog());
-        FREE_MEMORY(g_mpiHandle);
+        g_mpiHandle = NULL;
     }
 
     FREE_MEMORY(g_reportedProperties);

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -597,6 +597,9 @@ int main(int argc, char *argv[])
     FREE_MEMORY(cpuType);
     FREE_MEMORY(cpuVendor);
     FREE_MEMORY(cpuModel);
+    FREE_MEMORY(kernelName);
+    FREE_MEMORY(kernelRelease);
+    FREE_MEMORY(kernelVersion);
     FREE_MEMORY(productName);
     FREE_MEMORY(productVendor);
     FREE_MEMORY(encodedProductInfo);
@@ -709,6 +712,7 @@ int main(int argc, char *argv[])
 done:
     OsConfigLogInfo(GetLog(), "OSConfig Agent (PID: %d) exiting with %d", pid, g_stopSignal);
 
+    FREE_MEMORY(jsonConfiguration);
     FREE_MEMORY(g_x509Certificate);
     FREE_MEMORY(g_x509PrivateKeyHandle);
     FREE_MEMORY(connectionString);

--- a/src/adapters/pnp/PnpAgent.c
+++ b/src/adapters/pnp/PnpAgent.c
@@ -122,9 +122,6 @@ static void SignalInterrupt(int signal)
 {
     int logDescriptor = -1;
     char* errorMessage = NULL;
-    ssize_t writeResult = -1;
-
-    UNUSED(writeResult);
 
     if (SIGSEGV == signal)
     {
@@ -156,7 +153,9 @@ static void SignalInterrupt(int signal)
     {
         if (0 < (logDescriptor = open(LOG_FILE, O_APPEND | O_WRONLY | O_NONBLOCK)))
         {
+            ssize_t writeResult = -1;
             writeResult = write(logDescriptor, (const void*)errorMessage, strlen(errorMessage));
+            UNUSED(writeResult);
             close(logDescriptor);
         }
         _exit(signal);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -230,7 +230,7 @@ typedef struct ReportedProperty
 } ReportedProperty;
 
 bool IsIotHubManagementEnabledInJsonConfig(const char* jsonString);
-int GetLoggingLevelFromJsonConfig(const char* jsonString, OsConfigLogHandle log);
+LoggingLevel GetLoggingLevelFromJsonConfig(const char* jsonString, OsConfigLogHandle log);
 int GetMaxLogSizeFromJsonConfig(const char* jsonString, OsConfigLogHandle log);
 int GetMaxLogSizeDebugMultiplierFromJsonConfig(const char* jsonString, OsConfigLogHandle log);
 int GetReportingIntervalFromJsonConfig(const char* jsonString, OsConfigLogHandle log);

--- a/src/common/commonutils/ConfigUtils.c
+++ b/src/common/commonutils/ConfigUtils.c
@@ -131,7 +131,7 @@ static int GetIntegerFromJsonConfig(const char* valueName, const char* jsonStrin
     return valueToReturn;
 }
 
-int GetLoggingLevelFromJsonConfig(const char* jsonString, OsConfigLogHandle log)
+LoggingLevel GetLoggingLevelFromJsonConfig(const char* jsonString, OsConfigLogHandle log)
 {
     return GetIntegerFromJsonConfig(LOGGING_LEVEL, jsonString, DEFAULT_LOGGING_LEVEL, MIN_LOGGING_LEVEL, MAX_LOGGING_LEVEL, log);
 }
@@ -353,7 +353,6 @@ int SetLoggingLevelPersistently(LoggingLevel level, OsConfigLogHandle log)
     const char* loggingLevelTemplateWithComma = "  \"LoggingLevel\": %d,\n";
     const char* configurationTemplate = "{\n  \"LoggingLevel\": %d\n}\n";
 
-    LoggingLevel existingLevel = LoggingLevelInformational;
     char* jsonConfiguration = NULL;
     char* buffer = NULL;
     int result = 0;
@@ -369,7 +368,7 @@ int SetLoggingLevelPersistently(LoggingLevel level, OsConfigLogHandle log)
         {
             if (NULL != (jsonConfiguration = LoadStringFromFile(configurationFile, false, log)))
             {
-                if (level != (existingLevel = GetLoggingLevelFromJsonConfig(jsonConfiguration, log)))
+                if (level != GetLoggingLevelFromJsonConfig(jsonConfiguration, log))
                 {
                     if (NULL == (buffer = FormatAllocateString(strstr(jsonConfiguration, ",") ? loggingLevelTemplateWithComma : loggingLevelTemplate, level)))
                     {

--- a/src/common/commonutils/DaemonUtils.c
+++ b/src/common/commonutils/DaemonUtils.c
@@ -88,7 +88,7 @@ bool CheckDaemonNotActive(const char* daemonName, char** reason, OsConfigLogHand
 {
     bool result = false;
 
-    if (true == (result = IsDaemonActive(daemonName, log)))
+    if (true == IsDaemonActive(daemonName, log))
     {
         OsConfigLogInfo(log, "CheckDaemonNotActive: service '%s' is active", daemonName);
         OsConfigCaptureReason(reason, "Service '%s' is active", daemonName);

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -423,7 +423,6 @@ static char* GetOsReleaseEntry(const char* commandTemplate, const char* name, ch
     char* command = NULL;
     char* result = NULL;
     size_t commandLength = 0;
-    int status = 0;
 
     if ((NULL == commandTemplate) || (NULL == name) || (0 == strlen(name)))
     {
@@ -443,7 +442,7 @@ static char* GetOsReleaseEntry(const char* commandTemplate, const char* name, ch
             memset(command, 0, commandLength);
             snprintf(command, commandLength, commandTemplate, name);
 
-            if ((0 == (status = ExecuteCommand(NULL, command, true, false, 0, 0, &result, NULL, log))) && result)
+            if ((0 == ExecuteCommand(NULL, command, true, false, 0, 0, &result, NULL, log)) && result)
             {
                 RemovePrefixBlanks(result);
                 RemoveTrailingBlanks(result);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -657,7 +657,7 @@ static int SetAccess(bool directory, const char* name, unsigned int desiredOwner
 
     if (directory ? DirectoryExists(name) : FileExists(name))
     {
-        if (0 == (result = CheckAccess(directory, name, desiredOwnerId, desiredGroupId, desiredAccess, false, NULL, log)))
+        if (0 == CheckAccess(directory, name, desiredOwnerId, desiredGroupId, desiredAccess, false, NULL, log))
         {
             OsConfigLogInfo(log, "SetAccess: desired '%s' ownership (owner %u, group %u with access %03o) already set",
                 name, desiredOwnerId, desiredGroupId, desiredAccess);

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -278,7 +278,7 @@ int CheckAllWirelessInterfacesAreDisabled(char** reason, OsConfigLogHandle log)
     const char* command = "iwconfig 2>&1 | egrep -v 'no wireless extensions|not found' | grep Frequency";
     int status = 0;
 
-    if (0 == (status = ExecuteCommand(NULL, command, true, false, 0, 0, NULL, NULL, log)))
+    if (0 == ExecuteCommand(NULL, command, true, false, 0, 0, NULL, NULL, log))
     {
         OsConfigLogInfo(log, "CheckAllWirelessInterfacesAreDisabled: wireless interfaces are enabled");
         OsConfigCaptureReason(reason, "At least one active wireless interface is present");

--- a/src/common/commonutils/PackageUtils.c
+++ b/src/common/commonutils/PackageUtils.c
@@ -471,7 +471,7 @@ int InstallPackage(const char* packageName, OsConfigLogHandle log)
 {
     int status = ENOENT;
 
-    if (0 != (status = IsPackageInstalled(packageName, log)))
+    if (0 != IsPackageInstalled(packageName, log))
     {
         if (0 == (status = InstallOrUpdatePackage(packageName, log)))
         {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -19,7 +19,7 @@ static char* FindPamModule(const char* pamModule, OsConfigLogHandle log)
         "/lib/x86_64-linux-gnu/security/%s" };
     int numPaths = ARRAY_SIZE(paths);
     char* result = NULL;
-    int status = 0, i = 0;
+    int i = 0;
 
     if (NULL == pamModule)
     {
@@ -31,7 +31,7 @@ static char* FindPamModule(const char* pamModule, OsConfigLogHandle log)
     {
         if (NULL != (result = FormatAllocateString(paths[i], pamModule)))
         {
-            if (0 == (status = CheckFileExists(result, NULL, log)))
+            if (0 == CheckFileExists(result, NULL, log))
             {
                 break;
             }

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -700,7 +700,7 @@ int CheckSshProtocol(char** reason, OsConfigLogHandle log)
                 OsConfigCaptureReason(reason, "'%s' is not found included in %s", g_osconfigRemediationConf, g_sshServerConfiguration);
                 status = ENOENT;
             }
-            else if (0 == (status = CheckLineFoundNotCommentedOut(g_osconfigRemediationConf, '#', protocol, reason, log)))
+            else if (0 == CheckLineFoundNotCommentedOut(g_osconfigRemediationConf, '#', protocol, reason, log))
             {
                 OsConfigLogInfo(log, "CheckSshProtocol: '%s' is found uncommented in %s", protocol, g_osconfigRemediationConf);
                 status = 0;

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -210,7 +210,6 @@ static int IsSshConfigIncludeSupported(OsConfigLogHandle log)
     const int minVersionMajor = 8;
     const int minVersionMinor = 2;
     char* textResult = NULL;
-    size_t textResultLength = 0;
     size_t textPrefixLength = 0;
     char* textCursor = NULL;
     char versionMajorString[2] = {0};
@@ -232,7 +231,8 @@ static int IsSshConfigIncludeSupported(OsConfigLogHandle log)
 
     if (NULL != textResult)
     {
-        if (((textPrefixLength = strlen(expectedPrefix)) + 3) < (textResultLength = strlen(textResult)))
+        textPrefixLength = strlen(expectedPrefix) + 3;
+        if (textPrefixLength < strlen(textResult))
         {
             textCursor = textResult + strlen(expectedPrefix) + 1;
             if (isdigit(textCursor[0]) && ('.' == textCursor[1]) && isdigit(textCursor[2]))
@@ -671,7 +671,7 @@ int CheckSshProtocol(char** reason, OsConfigLogHandle log)
         OsConfigCaptureReason(reason, "'%s' is not present on this device", g_sshServerConfiguration);
         status = EEXIST;
     }
-    if (0 == (status = CheckLineFoundNotCommentedOut(g_sshServerConfiguration, '#', protocol, reason, log)))
+    else if (0 == CheckLineFoundNotCommentedOut(g_sshServerConfiguration, '#', protocol, reason, log))
     {
         OsConfigLogInfo(log, "CheckSshProtocol: '%s' is found uncommented in %s", protocol, g_sshServerConfiguration);
         status = 0;

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -669,7 +669,7 @@ int CheckSshProtocol(char** reason, OsConfigLogHandle log)
     {
         OsConfigLogInfo(log, "CheckSshProtocol: the SSH Server configuration file '%s' is not present on this device", g_sshServerConfiguration);
         OsConfigCaptureReason(reason, "'%s' is not present on this device", g_sshServerConfiguration);
-        status = EEXIST;
+        status = ENOENT;
     }
     else if (0 == CheckLineFoundNotCommentedOut(g_sshServerConfiguration, '#', protocol, reason, log))
     {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -918,6 +918,7 @@ static int IncludeRemediationSshConfFile(OsConfigLogHandle log)
     else if ((NULL == (inclusion = FormatInclusionForRemediation(log))) || (0 == (inclusionSize = strlen(inclusion))))
     {
         OsConfigLogInfo(log, "IncludeRemediationSshConfFile: failed preparing the inclusion statement, cannot include '%s' into '%s'", g_osconfigRemediationConf, g_sshServerConfiguration);
+        FREE_MEMORY(inclusion);
         return ENOMEM;
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3050,7 +3050,7 @@ int RemoveUserAccounts(const char* names, OsConfigLogHandle log)
         OsConfigLogError(log, "RemoveUserAccounts: cannot read from '%s'", g_passwdFile);
         return EPERM;
     }
-    else if (0 == (status = CheckUserAccountsNotFound(names, NULL, log)))
+    else if (0 == CheckUserAccountsNotFound(names, NULL, log))
     {
         OsConfigLogInfo(log, "RemoveUserAccounts: the requested user accounts '%s' appear already removed", names);
         return 0;

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -53,6 +53,7 @@ void SetConsoleLoggingEnabled(bool enabledOrDisabled)
 const char* GetLoggingLevelName(LoggingLevel level)
 {
     const char* result = g_debug;
+    (void)result;
 
     switch (level)
     {
@@ -85,8 +86,8 @@ const char* GetLoggingLevelName(LoggingLevel level)
             break;
 
         case LoggingLevelDebug:
+        default:
             result = g_debug;
-            break;
     }
 
     return result;

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -85,8 +85,8 @@ const char* GetLoggingLevelName(LoggingLevel level)
             break;
 
         case LoggingLevelDebug:
-        default:
             result = g_debug;
+            break;
     }
 
     return result;

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -241,7 +241,11 @@ void TrimLog(OsConfigLogHandle log)
 
             // Reapply restrictions once the file is recreated (also for backup, if any):
             RestrictFileAccessToCurrentAccountOnly(log->logFileName);
-            RestrictFileAccessToCurrentAccountOnly(log->backLogFileName);
+            if (NULL != log->backLogFileName)
+            {
+                // Reapply restrictions to the backup file:
+                RestrictFileAccessToCurrentAccountOnly(log->backLogFileName);
+            }
         }
     }
 

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -196,8 +196,9 @@ char* GetFormattedTime(void)
 {
     time_t rawTime = {0};
     struct tm* timeInfo = NULL;
+    struct tm result = {0};
     time(&rawTime);
-    timeInfo = localtime(&rawTime);
+    timeInfo = localtime_r(&rawTime, &result);
     strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S", timeInfo);
     return g_logTime;
 }

--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -227,10 +227,14 @@ MPI_HANDLE CallMpiOpen(const char* clientName, const unsigned int maxPayloadSize
     FREE_MEMORY(request);
 
     mpiHandle = (MPI_OK == status) ? (MPI_HANDLE)response : NULL;
-
-    if ((NULL != mpiHandle) && (NULL == (mpiHandleValue = ParseString(log, (char*)mpiHandle))))
+    if (NULL == mpiHandle)
+    {
+        FREE_MEMORY(response);
+    }
+    else if (NULL == (mpiHandleValue = ParseString(log, (char*)mpiHandle)))
     {
         OsConfigLogError(log, "CallMpiOpen: invalid MPI handle '%s'", (char*)mpiHandle);
+        FREE_MEMORY(response);
         mpiHandle = NULL;
     }
 

--- a/src/common/mpiclient/MpiClient.c
+++ b/src/common/mpiclient/MpiClient.c
@@ -246,6 +246,8 @@ MPI_HANDLE CallMpiOpen(const char* clientName, const unsigned int maxPayloadSize
     return mpiHandle;
 }
 
+// We're responsible for free-ing the handle even on failure.
+// The handle comes from the response allocated in CallMpiOpen.
 void CallMpiClose(MPI_HANDLE clientSession, OsConfigLogHandle log)
 {
     const char *name = "MpiClose";
@@ -259,6 +261,7 @@ void CallMpiClose(MPI_HANDLE clientSession, OsConfigLogHandle log)
     if ((NULL == clientSession) || (0 == strlen((char*)clientSession)))
     {
         OsConfigLogError(log, "CallMpiClose(%p) called with invalid argument", clientSession);
+        FREE_MEMORY(clientSession);
         return;
     }
 
@@ -268,6 +271,7 @@ void CallMpiClose(MPI_HANDLE clientSession, OsConfigLogHandle log)
     if (NULL == request)
     {
         OsConfigLogError(log, "CallMpiClose(%p): failed to allocate memory for request", clientSession);
+        FREE_MEMORY(clientSession);
         return;
     }
 
@@ -279,6 +283,7 @@ void CallMpiClose(MPI_HANDLE clientSession, OsConfigLogHandle log)
     FREE_MEMORY(response);
 
     OsConfigLogInfo(log, "CallMpiClose(%p)", clientSession);
+    FREE_MEMORY(clientSession);
 }
 
 int CallMpiSet(const char* componentName, const char* propertyName, const MPI_JSON_STRING payload, const int payloadSizeBytes, OsConfigLogHandle log)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1161,7 +1161,7 @@ TEST_F(CommonUtilsTest, FormatAllocateString)
     FREE_MEMORY(formatted);
     EXPECT_STREQ("Test ABC 123", formatted = FormatAllocateString("Test %s %d", "ABC", 123));
     FREE_MEMORY(formatted);
-    ASSERT_NE(nullptr, longString = (char*)malloc(longStringLength + 1));
+    EXPECT_NE(nullptr, longString = (char*)malloc(longStringLength + 1));
     memset(longString, 'a', longStringLength);
     longString[4095] = 0;
     EXPECT_STREQ(longString, formatted = FormatAllocateString("%s", longString));

--- a/src/modules/compliance/src/lib/CMakeLists.txt
+++ b/src/modules/compliance/src/lib/CMakeLists.txt
@@ -40,6 +40,9 @@ add_library(compliancelib STATIC
 
 set_property(TARGET compliancelib PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+add_custom_target(ProcedureMap
+    DEPENDS ProcedureMap.cpp ProcedureMap.h
+)
 add_custom_command(
     OUTPUT ProcedureMap.cpp ProcedureMap.h
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/GenProcedureMap.sh ${CMAKE_CURRENT_SOURCE_DIR}/procedures/

--- a/src/modules/compliance/tests/OptionalTest.cpp
+++ b/src/modules/compliance/tests/OptionalTest.cpp
@@ -40,7 +40,9 @@ TEST_F(OptionalTest, MoveContructor)
 {
     Optional<int> opt1(42);
     Optional<int> opt2(std::move(opt1));
+#ifndef __clang_analyzer__
     ASSERT_FALSE(opt1.HasValue());
+#endif
     ASSERT_TRUE(opt2.HasValue());
     ASSERT_EQ(opt2.Value(), 42);
 }
@@ -60,7 +62,9 @@ TEST_F(OptionalTest, MoveAssignment)
     Optional<int> opt1(42);
     Optional<int> opt2;
     opt2 = std::move(opt1);
+#ifndef __clang_analyzer__
     ASSERT_FALSE(opt1.HasValue());
+#endif
     ASSERT_TRUE(opt2.HasValue());
     ASSERT_EQ(opt2.Value(), 42);
 }

--- a/src/modules/compliance/tests/ResultTest.cpp
+++ b/src/modules/compliance/tests/ResultTest.cpp
@@ -42,7 +42,9 @@ TEST_F(ResultTest, MoveContructor)
 {
     Result<int> result1(42);
     Result<int> result2(std::move(result1));
+#ifndef __clang_analyzer__
     ASSERT_FALSE(result1.HasValue());
+#endif
     ASSERT_TRUE(result2.HasValue());
     ASSERT_EQ(result2.Value(), 42);
 }
@@ -60,7 +62,9 @@ TEST_F(ResultTest, MoveAssignment)
 {
     Result<int> result1(42);
     Result<int> result2 = std::move(result1);
+#ifndef __clang_analyzer__
     ASSERT_FALSE(result1.HasValue());
+#endif
     ASSERT_TRUE(result2.HasValue());
     ASSERT_EQ(result2.Value(), 42);
 }

--- a/src/modules/compliance/tests/procedures/EnsureFilePermissionsTest.cpp
+++ b/src/modules/compliance/tests/procedures/EnsureFilePermissionsTest.cpp
@@ -51,15 +51,19 @@ protected:
     void CreateFile(std::string& filename, int owner, int group, short permissions)
     {
         char* newFileName = strdup(fileTemplate);
-        ASSERT_NE(newFileName, nullptr);
+        EXPECT_NE(newFileName, nullptr);
         int f = mkstemp(newFileName);
-        ASSERT_GE(f, 0);
+        if (f < 0)
+        {
+            free(newFileName);
+            GTEST_FAIL() << "Failed to create temporary file";
+        }
         close(f);
-        ASSERT_EQ(chown(newFileName, owner, group), 0);
-        ASSERT_EQ(chmod(newFileName, permissions), 0);
         filename = newFileName;
         files.push_back(filename);
         free(newFileName);
+        ASSERT_EQ(chown(filename.c_str(), owner, group), 0);
+        ASSERT_EQ(chmod(filename.c_str(), permissions), 0);
     }
 };
 

--- a/src/modules/test/Module.c
+++ b/src/modules/test/Module.c
@@ -211,17 +211,16 @@ int ParseModuleInfo(const JSON_Value* value, MODULE_INFO** moduleInfo)
                     }
                 }
             }
+        }
 
-            if (0 == status)
-            {
-                *moduleInfo = info;
-            }
-            else
-            {
-                FreeModuleInfo(info);
-                info = NULL;
-            }
-
+        if (0 == status)
+        {
+            *moduleInfo = info;
+        }
+        else
+        {
+            FreeModuleInfo(info);
+            info = NULL;
         }
     }
 
@@ -339,7 +338,7 @@ MANAGEMENT_MODULE* LoadModule(const char* client, const char* path)
     if ((status != 0) && (module != NULL))
     {
         UnloadModule(module);
-        module = NULL;
+        FREE_MEMORY(module);
     }
     json_value_free(value);
     FREE_MEMORY(payload);

--- a/src/modules/test/Module.c
+++ b/src/modules/test/Module.c
@@ -354,7 +354,8 @@ void UnloadModule(MANAGEMENT_MODULE* module)
 
     if (NULL != module->handle)
     {
-        module->close(module->session);
+        if ((NULL != module->close) && (module->session != NULL))
+            module->close(module->session);
         module->session = NULL;
 
         module->getInfo = NULL;

--- a/src/platform/Main.c
+++ b/src/platform/Main.c
@@ -59,8 +59,6 @@ static void SignalInterrupt(int signal)
     size_t sizeOfMpiMessage = 0;
     ssize_t writeResult = -1;
 
-    UNUSED(writeResult);
-
     if (SIGSEGV == signal)
     {
         errorMessage = ERROR_MESSAGE_SIGSEGV;
@@ -91,7 +89,7 @@ static void SignalInterrupt(int signal)
     {
         if (0 < (logDescriptor = open(LOG_FILE, O_APPEND | O_WRONLY | O_NONBLOCK)))
         {
-            if (0 < (writeResult = write(logDescriptor, (const void*)errorMessage, strlen(errorMessage))))
+            if (0 < write(logDescriptor, (const void*)errorMessage, strlen(errorMessage)))
             {
                 sizeOfMpiMessage = strlen(g_mpiCall);
                 if (sizeOfMpiMessage > 0)
@@ -102,6 +100,7 @@ static void SignalInterrupt(int signal)
                 {
                     writeResult = write(logDescriptor, (const void*)EOL_TERMINATOR, sizeof(char));
                 }
+                UNUSED(writeResult);
             }
             close(logDescriptor);
         }

--- a/src/platform/MmiClient.c
+++ b/src/platform/MmiClient.c
@@ -204,15 +204,14 @@ static int ParseModuleInfo(const JSON_Value* value, MODULE_INFO** moduleInfo)
                     }
                 }
             }
-
-            if (0 == status)
-            {
-                *moduleInfo = info;
-            }
-            else
-            {
-                FreeModuleInfo(info);
-            }
+        }
+        if (0 == status)
+        {
+            *moduleInfo = info;
+        }
+        else
+        {
+            FreeModuleInfo(info);
         }
     }
 

--- a/src/platform/MmiClient.c
+++ b/src/platform/MmiClient.c
@@ -318,6 +318,14 @@ MODULE* LoadModule(const char* client, const char* path)
         }
     }
 
+    if (value)
+    {
+        json_value_free(value);
+    }
+    if (payload)
+    {
+        module->free(payload);
+    }
     if (0 != status)
     {
         UnloadModule(module);

--- a/src/platform/ModulesManager.c
+++ b/src/platform/ModulesManager.c
@@ -780,7 +780,8 @@ int MpiGetReported(MPI_HANDLE handle, MPI_JSON_STRING* payload, int* payloadSize
                 }
                 else
                 {
-                    memcpy(payloadJson, mmiPayload, mmiPayloadSizeBytes + 1);
+                    memcpy(payloadJson, mmiPayload, mmiPayloadSizeBytes);
+                    payloadJson[mmiPayloadSizeBytes] = '\0';
 
                     if (NULL == (objectValue = json_parse_string(payloadJson)))
                     {

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -547,8 +547,6 @@ static void* MpiServerWorker(void* arguments)
 
             contentLength = 0;
             responseSize = 0;
-            actualSize = 0;
-            estimatedSize = 0;
 
             FREE_MEMORY(requestBody);
             FREE_MEMORY(responseBody);

--- a/src/platform/MpiServer.c
+++ b/src/platform/MpiServer.c
@@ -32,6 +32,7 @@ static struct sockaddr_un g_socketaddr = {0};
 static socklen_t g_socketlen = 0;
 
 static pthread_t g_mpiServerWorker = 0;
+static int g_mpiServerWorkerError = -1;
 static bool g_serverActive = false;
 
 char g_mpiCall[MPI_CALL_MESSAGE_LENGTH] = {0};
@@ -594,7 +595,7 @@ void MpiInitialize(void)
                 OsConfigLogInfo(GetPlatformLog(), "Listening on socket '%s'", g_mpiSocket);
 
                 g_serverActive = true;
-                g_mpiServerWorker = pthread_create(&g_mpiServerWorker, NULL, MpiServerWorker, NULL);
+                g_mpiServerWorkerError = pthread_create(&g_mpiServerWorker, NULL, MpiServerWorker, NULL);
             }
             else
             {
@@ -616,9 +617,10 @@ void MpiShutdown(void)
 {
     g_serverActive = false;
 
-    if (g_mpiServerWorker > 0)
+    if (g_mpiServerWorkerError == 0)
     {
         pthread_join(g_mpiServerWorker, NULL);
+        g_mpiServerWorkerError = -1;
     }
 
     UnloadModules();


### PR DESCRIPTION
## Description

Add clang static analysis to our CI. This relies on clang's internal analyzer, called through a script shipped with clang called analyze-build (there exists also a helper tool called scan-build).

This PR also fixes all of the findings. The findings were (in quantity)

* dead stores (writes to variables that are never used or read)
* memory leaks (missing frees on some paths through functions)
* destroying uninitialized objects (OsConfigResource.c)
* mismatched new[]/delete[] (mmi payloads should be free'd using the modules free function)
* use after move in tests disabled using ifdef __clang_analyzer__ (the tests intentionally test to move constructor).

If there are findings in the future, the best way is to download the artifact from the workflow, unpack and open index.html which provides a step-by-step explanation for each finding.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
