### PR TITLE
Revert FileRegexMatch logic when statePattern is not present

### DIFF
--- a/src/modules/compliance/src/lib/CMakeLists.txt
+++ b/src/modules/compliance/src/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(compliancelib STATIC
     ContextInterface.cpp
     Engine.cpp
     Evaluator.cpp
+    FactExistenceValidator.cpp
     Indicators.cpp
     JsonWrapper.cpp
     Procedure.cpp

--- a/src/modules/compliance/src/lib/FactExistenceValidator.cpp
+++ b/src/modules/compliance/src/lib/FactExistenceValidator.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <FactExistenceValidator.h>
+#include <cassert>
+#include <map>
+
+namespace compliance
+{
+FactExistenceValidator::FactExistenceValidator(Behavior behavior)
+    : mBehavior(behavior)
+{
+}
+
+void FactExistenceValidator::Finish()
+{
+    if (Done())
+    {
+        return;
+    }
+
+    switch (mBehavior)
+    {
+        case Behavior::AllExist:
+            mState = Status::Compliant;
+            break;
+        case Behavior::NoneExist:
+            assert(!mHasAtLeastOneFact);
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::AtLeastOneExists:
+            assert(!mHasAtLeastOneFact);
+            mState = Status::NonCompliant;
+            break;
+
+        case Behavior::AnyExist:
+            assert(!mHasAtLeastOneFact);
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::OnlyOneExists:
+            mState = mHasAtLeastOneFact ? Status::Compliant : Status::NonCompliant;
+            break;
+    }
+    assert(Done());
+}
+
+void FactExistenceValidator::CriteriaMet()
+{
+    if (Done())
+    {
+        return;
+    }
+
+    switch (mBehavior)
+    {
+        case Behavior::AllExist:
+            break;
+
+        case Behavior::AnyExist:
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::AtLeastOneExists:
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::NoneExist:
+            mState = Status::NonCompliant;
+            break;
+
+        case Behavior::OnlyOneExists:
+            if (mHasAtLeastOneFact)
+            {
+                mState = Status::NonCompliant;
+            }
+            break;
+    }
+    mHasAtLeastOneFact = true;
+}
+
+void FactExistenceValidator::CriteriaUnmet()
+{
+    if (Done())
+    {
+        return;
+    }
+
+    switch (mBehavior)
+    {
+        case Behavior::AllExist:
+            mState = Status::NonCompliant;
+            break;
+        default:
+            break;
+    }
+}
+
+bool FactExistenceValidator::Done() const
+{
+    return mState.HasValue();
+}
+
+Status FactExistenceValidator::Result() const
+{
+    assert(mState.HasValue());
+    return mState.Value();
+}
+
+compliance::Result<FactExistenceValidator::Behavior> FactExistenceValidator::MapBehavior(const std::string& value)
+{
+    static const std::map<std::string, Behavior> sMap = {
+        {"all_exist", Behavior::AllExist},
+        {"any_exist", Behavior::AnyExist},
+        {"at_least_one_exists", Behavior::AtLeastOneExists},
+        {"none_exist", Behavior::NoneExist},
+        {"only_one_exists", Behavior::OnlyOneExists},
+    };
+
+    auto it = sMap.find(value);
+    if (it == sMap.end())
+    {
+        return Error("unsupported value: " + value, EINVAL);
+    }
+
+    return it->second;
+}
+} // namespace compliance

--- a/src/modules/compliance/src/lib/FactExistenceValidator.h
+++ b/src/modules/compliance/src/lib/FactExistenceValidator.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCE_FACT_EXISTENCE_VALIDATOR_H
+#define COMPLIANCE_FACT_EXISTENCE_VALIDATOR_H
+
+#include <MmiResults.h>
+#include <Optional.h>
+#include <Result.h>
+#include <string>
+
+namespace compliance
+{
+class FactExistenceValidator
+{
+public:
+    enum class Behavior
+    {
+        AllExist,
+        AnyExist,
+        AtLeastOneExists,
+        NoneExist,
+        OnlyOneExists,
+    };
+
+    explicit FactExistenceValidator(Behavior behavior);
+    FactExistenceValidator(const FactExistenceValidator&) = default;
+    FactExistenceValidator(FactExistenceValidator&&) = default;
+    FactExistenceValidator& operator=(const FactExistenceValidator&) = default;
+    FactExistenceValidator& operator=(FactExistenceValidator&&) = default;
+    ~FactExistenceValidator() = default;
+
+    void Finish();
+    void CriteriaMet();
+    void CriteriaUnmet();
+    bool Done() const;
+    Status Result() const;
+    static compliance::Result<Behavior> MapBehavior(const std::string& value);
+
+private:
+    Behavior mBehavior;
+    Optional<Status> mState;
+    bool mHasAtLeastOneFact = false;
+};
+} // namespace compliance
+
+#endif // COMPLIANCE_FACT_EXISTENCE_VALIDATOR_H

--- a/src/modules/compliance/src/lib/RegexFallback.h
+++ b/src/modules/compliance/src/lib/RegexFallback.h
@@ -87,7 +87,7 @@ class Regex
         {
             flags |= REG_ICASE;
         }
-        if (options & std::regex_constants::extended)
+        if ((options & std::regex_constants::extended) || (options & std::regex_constants::ECMAScript))
         {
             flags |= REG_EXTENDED;
         }

--- a/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
+++ b/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
@@ -14,7 +14,6 @@
               "type": "object",
               "required": [
                 "filename",
-                "matchOperation",
                 "matchPattern"
               ],
               "additionalProperties": false,
@@ -45,6 +44,11 @@
                   "type": "string",
                   "description": "Determine whether the match should be case sensitive, applies to both 'matchPattern' and 'statePattern'",
                   "pattern": "(^\\$[a-zA-Z0-9_]+:(true|false)$|(^true|false$))"
+                },
+                "behavior": {
+                  "type": "string",
+                  "description": "Determine the function behavior",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:((all_exist|any_exist|at_least_one_exists|none_exist))$|(^(all_exist|any_exist|at_least_one_exists|none_exist)$))"
                 }
               }
             }

--- a/src/modules/compliance/tests/CMakeLists.txt
+++ b/src/modules/compliance/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(compliancetests
     ComplianceTest.cpp
     EngineTest.cpp
     EvaluatorTest.cpp
+    FactExistenceValidatorTest.cpp
     OptionalTest.cpp
     RegexFallbackTest.cpp
     RegexTest.cpp

--- a/src/modules/compliance/tests/FactExistenceValidatorTest.cpp
+++ b/src/modules/compliance/tests/FactExistenceValidatorTest.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "FactExistenceValidator.h"
+
+#include <gtest/gtest.h>
+
+using compliance::Error;
+using compliance::FactExistenceValidator;
+using compliance::Result;
+
+class FactExistenceValidatorTest : public ::testing::Test
+{
+};
+
+TEST_F(FactExistenceValidatorTest, MapBehavior)
+{
+    auto result = compliance::FactExistenceValidator::MapBehavior("all_exist");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::AllExist);
+
+    result = compliance::FactExistenceValidator::MapBehavior("any_exist");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::AnyExist);
+
+    result = compliance::FactExistenceValidator::MapBehavior("at_least_one_exists");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+
+    result = compliance::FactExistenceValidator::MapBehavior("none_exist");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::NoneExist);
+
+    result = compliance::FactExistenceValidator::MapBehavior("only_one_exists");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+
+    result = compliance::FactExistenceValidator::MapBehavior("invalid_value");
+    ASSERT_FALSE(result.HasValue());
+}
+
+TEST_F(FactExistenceValidatorTest, AllExist_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AllExist);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+
+    // Already done, Finish should not affact the state
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AllExist_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AllExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaUnmet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AllExist_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AllExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AnyExist_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AnyExist);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AnyExist_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AnyExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AnyExist_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AnyExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AtLeastOneExists_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AtLeastOneExists_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AtLeastOneExists_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, NoneExist_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, NoneExist_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, NoneExist_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, OnlyOneExists_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, OnlyOneExists_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, OnlyOneExists_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}

--- a/src/modules/test/recipes/compliance/FileRegexMatch.json
+++ b/src/modules/test/recipes/compliance/FileRegexMatch.json
@@ -32,7 +32,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '.*' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '.*' matched line 1 } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -44,7 +44,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern 'foo' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern 'foo' matched line 1 } == FALSE"
   },
 
 
@@ -59,7 +59,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern 'f.*o' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*o' matched line 1 } == FALSE"
   },
 
 
@@ -74,7 +74,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'f.*O' did not match any line } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -86,7 +86,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern 'f.*O' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*O' matched line 1 } == FALSE"
   },
 
 
@@ -102,7 +102,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == FALSE"
   },
 
 
@@ -117,7 +117,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+$' did not match any line } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -132,7 +132,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == FALSE"
   },
 
 
@@ -150,7 +150,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 } == FALSE"
   },
   {
     "RunCommand": "echo '#testuser::1111:1111::/home/someuser:/bin/sh' > /tmp/passwd"
@@ -159,7 +159,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' did not match any line } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 


### PR DESCRIPTION
## Description

The FileRegexMatch function is used to match against one or 2 patterns. In case of a single pattern match, the logic was incorrect and it has been fixed.

These are the most notable changes:
- Merge single pattern and double patten modes into one function
- Make matchOperation and stateOperation arguments optional
- Add some debug output

Depends on:
- [ ] #991 
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [ ] I submitted this PR against the `dev` branch.
