### PR TITLE
Mitigating conflict between the auoms and auditd services during ASB remediation

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3154,7 +3154,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, OsConfigLogHandle 
         EnableAndStartDaemon(g_auditd, log);
         status = CheckDaemonActive(g_auditd, NULL, log) ? 0 : ENOENT;
     }
-    
+
     return status;
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3132,12 +3132,12 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, OsConfigLogHandle 
     // Conflicts between auoms and auditd can arise because both services attempt to manage and collect audit events.
     // One of the recommended mitigation strategies is Single Service Usage: use either auoms or auditd, but not both.
     // To mitigate this conflict we try to stop and disable auoms when present and we are asked to enable and start auditd:
-    if (IsDaemoNActive(auoms, log))
+    if (IsDaemonActive(auoms, log))
     {
         StopAndDisableDaemon(g_auoms, log);
     }
 
-    if (IsDaemoNActive(g_auoms, log))
+    if (IsDaemonActive(g_auoms, log))
     {
         OsConfigLogWarning(log, "RemediateEnsureAuditdServiceIsRunning: '%s' is active and collides with '%s', %s",
             g_auoms, g_auditd, g_remediationIsNotPossible);

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3132,7 +3132,7 @@ static int RemediateEnsureAuditdServiceIsRunning(char* value, OsConfigLogHandle 
     // Conflicts between auoms and auditd can arise because both services attempt to manage and collect audit events.
     // One of the recommended mitigation strategies is Single Service Usage: use either auoms or auditd, but not both.
     // To mitigate this conflict we try to stop and disable auoms when present and we are asked to enable and start auditd:
-    if (IsDaemonActive(auoms, log))
+    if (IsDaemonActive(g_auoms, log))
     {
         StopAndDisableDaemon(g_auoms, log);
     }


### PR DESCRIPTION
## Description

The auoms service is part of Microsoft's Operations Management Suite (OMS) and is used for collecting audit events from Linux systems. The auoms service conflicts with auditd service which is required under ASB to be enabled and running. To mitigate this conflict, during remediateEnsureAuditdServiceIsRunning we try to stop and disable auoms and if that is not possible, we log a warning, and during auditEnsureAuditdServiceIsRunning we fail the audit if we find auoms running.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
