### PR TITLE
Updated base image for mariner-2

### DIFF
--- a/devops/e2e/cloudtest/mariner-2.json
+++ b/devops/e2e/cloudtest/mariner-2.json
@@ -1,4 +1,4 @@
-// Base Image: MicrosoftCBLMariner:cblmariner:cbl-mariner-2:latest
+// Base Image: MicrosoftCBLMariner:cblmariner:cbl-mariner-2-gen2/latest
 {
     "artifacts": [
         {


### PR DESCRIPTION
## Description

* Updated `mariner-2` base image to use a Gen2 VM as there seems to be disk-space issues with the previous image Gen1 image. Already tested new ES image which fixed previously failing test runs.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.
