### PR TITLE
Add ubuntu 24.04 ci images

### DIFF
--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -60,7 +60,8 @@ jobs:
               { "os": "rhel", "version": "9" },
               { "os": "sles", "version": "15" },
               { "os": "ubuntu", "version": "20.04" },
-              { "os": "ubuntu", "version": "22.04" }
+              { "os": "ubuntu", "version": "22.04" },
+              { "os": "ubuntu", "version": "24.04" }
             ]
         run: |
           # If no explicit packages defined, use the default packages

--- a/devops/docker/ubuntu-24.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-24.04-amd64/Dockerfile
@@ -1,0 +1,34 @@
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt -y update && apt-get -y install software-properties-common
+RUN apt -y update && apt-get -y install \
+    apt-transport-https \
+    git \
+    cmake \
+    build-essential \
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    uuid-dev \
+    libgtest-dev \
+    libgmock-dev \
+    rapidjson-dev \
+    ninja-build \
+    python3-jsonschema \
+    wget \
+    gcovr\
+    jq \
+    bc \
+    file \
+    libasan8 \
+    libubsan1 \
+    clang \
+    clang-tools
+
+WORKDIR /git
+
+# CMake
+RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
+RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake

--- a/devops/e2e/cloudtest/ubuntu-24_04.json
+++ b/devops/e2e/cloudtest/ubuntu-24_04.json
@@ -1,4 +1,4 @@
-// Base Image: Canonical:ubuntu-24_04-lts:server:latest
+// Base Image: Canonical:ubuntu-24_04-lts:minimal:latest
 {
     "artifacts": [
         {

--- a/devops/e2e/cloudtest/ubuntu-24_04.json
+++ b/devops/e2e/cloudtest/ubuntu-24_04.json
@@ -1,0 +1,32 @@
+// Base Image: Canonical:ubuntu-24_04-lts:server:latest
+{
+    "artifacts": [
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "wget https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb && sudo apt-get install ./packages-microsoft-prod.deb && rm -f ./packages-microsoft-prod.deb && sudo wget https://packages.microsoft.com/config/ubuntu/24.04/insiders-fast.list -O /etc/apt/sources.list.d/packages-microsoft-com_insiders-fast.list"
+            }
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "sudo apt update && sudo apt upgrade -y"
+            }
+        },
+        {
+            "name": "linux-install-packages",
+            "parameters": {
+                "packages": "jq omi powershell"
+            }
+        },
+        {
+            "name": "linux-azcli"
+        },
+        {
+            "name": "linux-bash-command",
+            "parameters": {
+                "command": "apt list --installed"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Description

This PR adds recipes for an Ubuntu 24.04 worker pool image and a build container. After the PR is merged, the worker pool needs to be created manually and then we can add testing to CI jobs. Adding Ubuntu 24.04 to testing is needed for CIS but will also help us validate things in preparation for when Ubuntu 24.04 is added to the ASB support matrix.

Sidenote: `Canonical:ubuntu-24_04-lts:server:latest` is a Gen2 image.
```
$ az vm image show --urn Canonical:ubuntu-24_04-lts:server:latest --query 'hyperVGeneration' --output tsv
V2
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
