### PR TITLE
EnsureFilePermissions: Return Compliant on missing file

### DIFF
--- a/src/modules/compliance/src/lib/procedures/EnsureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/EnsureFilePermissions.cpp
@@ -38,7 +38,7 @@ AUDIT_FN(EnsureFilePermissions, "filename:Path to the file:M", "owner:Required o
         if (ENOENT == status)
         {
             OsConfigLogDebug(log, "File '%s' does not exist", filename.c_str());
-            return indicators.NonCompliant("File '" + filename + "' does not exist");
+            return indicators.Compliant("File '" + filename + "' does not exist");
         }
 
         OsConfigLogError(log, "Stat error %s (%d)", strerror(status), status);

--- a/src/modules/compliance/tests/procedures/EnsureFilePermissionsTest.cpp
+++ b/src/modules/compliance/tests/procedures/EnsureFilePermissionsTest.cpp
@@ -74,7 +74,7 @@ TEST_F(EnsureFilePermissionsTest, AuditFileMissing)
 
     auto result = AuditEnsureFilePermissions(args, indicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditWrongOwner)

--- a/src/modules/test/recipes/compliance/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/compliance/EnsureFilePermissions.json
@@ -38,7 +38,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == FALSE"
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == TRUE"
   },
   {
     "RunCommand": "touch /tmp/testfile && chmod 777 /tmp/testfile && chown root:root /tmp/testfile"


### PR DESCRIPTION
## Description

CIS considers a missing file to be compliant for file mode/group/user checks. See this output from a test:
```
<xccdf:check-content>
   <command_result href="sce/nix_owner_chk.sh"
                   xccdf="pass"
                   script="(...)/sce/nix_owner_chk.sh"
                   exit-value="101">
      <out>
         <l/>
         <l>- Audit Result:</l>
         <l>  ** PASS **</l>
         <l> - "/boot/grub/grub.cfg" doesn't exist</l>
      </out>
      <err/>
      <env/>
   </command_result>
</xccdf:check-content>
```
Adjust `EnsureFilePermissions` and test to match that behavior.

I considered whether it makes sense to add a parameter (eg. `allowMissing`) to control this behavior but since we map `nix_(owner|group|mode)chk.sh` to `EnsureFilePermissions` and this is their semantic, I don't see us needing the current behavior (non-compliant on missing).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
