### PR TITLE
devops: ubuntu-24.04: Install gtest manually

### DIFF
--- a/devops/docker/ubuntu-24.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-24.04-amd64/Dockerfile
@@ -12,8 +12,6 @@ RUN apt -y update && apt-get -y install \
     libcurl4-openssl-dev \
     libssl-dev \
     uuid-dev \
-    libgtest-dev \
-    libgmock-dev \
     rapidjson-dev \
     ninja-build \
     python3-jsonschema \
@@ -32,3 +30,7 @@ WORKDIR /git
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7
 RUN cd CMake && ./bootstrap && make -j$(nproc) && make install && hash -r && rm -rf /git/CMake
+
+# GTest
+RUN git clone https://github.com/google/googletest --recursive -b release-1.12.0
+RUN cd googletest && cmake . && cmake --build . --parallel --target install && rm -rf /git/googletest


### PR DESCRIPTION
## Description

The version of gtest that comes with Ubuntu 24.04 requires C++14 and we still intend to support C++11 for some time. So switch to a building gtest from source, to match other distributions we test on. Only after this is merged, we'll be able to add 24.04 to CI jobs.

This is a action where I tested the Ubuntu 24.04 container: https://github.com/Azure/azure-osconfig/actions/runs/14858148831/job/41716256749#step:5:1065
```
analyze-build-18: INFO: In file included from /__w/azure-osconfig/azure-osconfig/src/modules/deviceinfo/tests/DeviceInfoTests.cpp:4:
analyze-build-18: INFO: In file included from /usr/include/gtest/gtest.h:64:
analyze-build-18: INFO: In file included from /usr/include/gtest/gtest-assertion-result.h:46:
analyze-build-18: INFO: In file included from /usr/include/gtest/gtest-message.h:57:
analyze-build-18: INFO: /usr/include/gtest/internal/gtest-port.h:279:2: error: C++ versions less than C++14 are not supported.
analyze-build-18: INFO:   279 | #error C++ versions less than C++14 are not supported.
analyze-build-18: INFO:       |  ^
```

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
