### PR TITLE
Add 'Collection' mode to EnsureFilePermission audit and remediation procedures

### DIFF
--- a/src/modules/compliance/src/lib/procedures/EnsureFilePermissions.cpp
+++ b/src/modules/compliance/src/lib/procedures/EnsureFilePermissions.cpp
@@ -54,7 +54,7 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, std
         if (owner != pwd->pw_name)
         {
             OsConfigLogDebug(log, "Invalid '%s' owner - is '%s' should be '%s'", filename.c_str(), pwd->pw_name, owner.c_str());
-            return indicators.NonCompliant("Invalid " + filename + " owner - is '" + std::string(pwd->pw_name) + "' should be '" + owner + "'");
+            return indicators.NonCompliant("Invalid owner on '" + filename + "' - is '" + std::string(pwd->pw_name) + "' should be '" + owner + "'");
         }
         else
         {
@@ -88,7 +88,7 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, std
         }
         if (!groupOk)
         {
-            return indicators.NonCompliant("Invalid group - is '" + std::string(grp->gr_name) + "' should be '" + groupName + "'");
+            return indicators.NonCompliant("Invalid group on '" + filename + "' - is '" + std::string(grp->gr_name) + "' should be '" + groupName + "'");
         }
         else
         {
@@ -139,7 +139,8 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, std
         if (perms != (statbuf.st_mode & perms))
         {
             std::ostringstream oss;
-            oss << "Invalid permissions - are " << std::oct << (statbuf.st_mode & displayMask) << " should be at least " << std::oct << perms;
+            oss << "Invalid permissions on '" << filename << "' - are " << std::oct << (statbuf.st_mode & displayMask) << " should be at least "
+                << std::oct << perms;
             return indicators.NonCompliant(oss.str());
         }
         else
@@ -156,7 +157,8 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, std
         if (0 != (statbuf.st_mode & mask))
         {
             std::ostringstream oss;
-            oss << "Invalid permissions - are " << std::oct << (statbuf.st_mode & displayMask) << " while " << std::oct << mask << " should not be set";
+            oss << "Invalid permissions on '" << filename << "' - are " << std::oct << (statbuf.st_mode & displayMask) << " while " << std::oct << mask
+                << " should not be set";
             return indicators.NonCompliant(oss.str());
         }
         else

--- a/src/modules/compliance/src/lib/procedures/EnsureFilePermissions.schema.json
+++ b/src/modules/compliance/src/lib/procedures/EnsureFilePermissions.schema.json
@@ -42,6 +42,51 @@
               }
             }
           }
+        },
+        {
+          "type": "object",
+          "required": [
+            "EnsureFilePermissionsCollection"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "EnsureFilePermissionsCollection": {
+              "type": "object",
+              "required": [
+                "directory",
+                "ext"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "directory": {
+                  "type": "string",
+                  "description": "Directory path"
+                },
+                "ext": {
+                  "type": "string",
+                  "description": "File pattern"
+                },
+                "owner": {
+                  "type": "string",
+                  "description": "Required owner of the file"
+                },
+                "group": {
+                  "type": "string",
+                  "description": "Required group of the file"
+                },
+                "permissions": {
+                  "type": "string",
+                  "description": "Required octal permissions of the file",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:([0-7]{3,4})$|(^[0-7]{3,4}$))"
+                },
+                "mask": {
+                  "type": "string",
+                  "description": "Required octal permissions of the file - mask",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:([0-7]{3,4})$|(^[0-7]{3,4}$))"
+                }
+              }
+            }
+          }
         }
       ]
     },
@@ -64,6 +109,51 @@
                 "filename": {
                   "type": "string",
                   "description": "Path to the file"
+                },
+                "owner": {
+                  "type": "string",
+                  "description": "Required owner of the file"
+                },
+                "group": {
+                  "type": "string",
+                  "description": "Required group of the file"
+                },
+                "permissions": {
+                  "type": "string",
+                  "description": "Required octal permissions of the file",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:([0-7]{3,4})$|(^[0-7]{3,4}$))"
+                },
+                "mask": {
+                  "type": "string",
+                  "description": "Required octal permissions of the file - mask",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:([0-7]{3,4})$|(^[0-7]{3,4}$))"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "EnsureFilePermissionsCollection"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "EnsureFilePermissionsCollection": {
+              "type": "object",
+              "required": [
+                "directory",
+                "ext"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "directory": {
+                  "type": "string",
+                  "description": "Directory path"
+                },
+                "ext": {
+                  "type": "string",
+                  "description": "File pattern"
                 },
                 "owner": {
                   "type": "string",

--- a/src/modules/compliance/tests/procedures/EnsureFilePermissionsTest.cpp
+++ b/src/modules/compliance/tests/procedures/EnsureFilePermissionsTest.cpp
@@ -49,7 +49,6 @@ protected:
 
     void TearDown() override
     {
-        return;
         for (auto& file : files)
         {
             unlink(file.c_str());

--- a/src/modules/test/recipes/compliance/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/compliance/EnsureFilePermissions.json
@@ -409,9 +409,59 @@
   },
 
 
+  {
+    "RunCommand": "mkdir /tmp/testdir && touch /tmp/testdir/test1.log && touch /tmp/testdir/test2.txt && chmod 700 /tmp/testdir/*"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "EnsureFilePermissionsCollection": {
+          "directory": "/tmp/testdir",
+          "ext": "*.log",
+          "permissions": "0666"
+        }
+      },
+      "remediate": {
+        "EnsureFilePermissionsCollection": {
+          "directory": "/tmp/testdir",
+          "ext": "*.log",
+          "permissions": "0666"
+        }
+      }
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "FAIL{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == TRUE"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "remediateTest",
+    "Payload": ""
+  },
 
   {
-    "RunCommand": "rm -f /tmp/testfile"
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == TRUE"
+  },
+  {
+    "RunCommand": "stat /tmp/test1.log | grep 'Access: (0666\/-rw-rw-rw-)'"
+  },
+  {
+    "RunCommand": "stat /tmp/test2.txt | grep 'Access: (0700\/-rwx------)'"
+  },
+
+
+  {
+    "RunCommand": "rm -f /tmp/testfile; rm -Rf /tmp/testdir"
   },
   {
     "RunCommand": "userdel foo || true"

--- a/src/modules/test/recipes/compliance/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/compliance/EnsureFilePermissions.json
@@ -112,7 +112,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: Invalid \/tmp\/testfile owner - is 'root' should be 'foo' } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid owner on '\/tmp\/testfile' - is 'root' should be 'foo' } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -124,7 +124,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', Invalid group - is 'root' should be 'bar' } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', Invalid group on '\/tmp\/testfile' - is 'root' should be 'bar' } == FALSE"
   },
 
 
@@ -179,7 +179,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions - are 777 while 177 should not be set } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions on '\/tmp\/testfile' - are 777 while 177 should not be set } == FALSE"
   },
 
 
@@ -227,7 +227,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: Invalid \/tmp\/testfile owner - is 'root' should be 'foo' } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid owner on '\/tmp\/testfile' - is 'root' should be 'foo' } == FALSE"
   },
 
 
@@ -242,7 +242,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', Invalid group - is 'root' should be 'bar' } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', Invalid group on '\/tmp\/testfile' - is 'root' should be 'bar' } == FALSE"
   },
 
 
@@ -278,7 +278,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: Invalid \/tmp\/testfile owner - is 'root' should be 'foo' } == FALSE"
+    "Payload": "{ EnsureFilePermissions: Invalid owner on '\/tmp\/testfile' - is 'root' should be 'foo' } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -336,7 +336,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 0, Invalid permissions - are 777 while 777 should not be set } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 0, Invalid permissions on '\/tmp\/testfile' - are 777 while 777 should not be set } == FALSE"
   },
 
 
@@ -369,7 +369,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions - are 0 should be at least 333 } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions on '\/tmp\/testfile' - are 0 should be at least 333 } == FALSE"
   },
 
 
@@ -437,7 +437,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "FAIL{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == TRUE"
+    "Payload": "{ EnsureFilePermissionsCollection: Invalid permissions on '\/tmp\/testdir\/test1.log' - are 700 should be at least 666 } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -450,13 +450,13 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: File '\/tmp\/testfile' does not exist } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissionsCollection: \/tmp\/testdir\/test1.log matches expected permissions 666, \/tmp\/testdir\/test1.log mask matches expected mask 0, All matching files in '\/tmp\/testdir' match expected permissions } == TRUE"
   },
   {
-    "RunCommand": "stat /tmp/test1.log | grep 'Access: (0666\/-rw-rw-rw-)'"
+    "RunCommand": "stat /tmp/testdir/test1.log | grep 'Access: (0666\/-rw-rw-rw-)'"
   },
   {
-    "RunCommand": "stat /tmp/test2.txt | grep 'Access: (0700\/-rwx------)'"
+    "RunCommand": "stat /tmp/testdir/test2.txt | grep 'Access: (0700\/-rwx------)'"
   },
 
 


### PR DESCRIPTION
## Description
Alternative version of EnsureFilePermission that instead of filename argument takes a directory and "extension" (e.g. '*.exe')

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
