### PR TITLE
Provide output from ExecuteCommand in case of error

### DIFF
--- a/src/modules/compliance/src/lib/CommonContext.cpp
+++ b/src/modules/compliance/src/lib/CommonContext.cpp
@@ -15,8 +15,9 @@ Result<std::string> CommonContext::ExecuteCommand(const std::string& cmd) const
     int err = ::ExecuteCommand(NULL, cmd.c_str(), false, false, 0, 0, &output, NULL, mLog);
     if (err != 0 || output == nullptr)
     {
+        std::string outStr = output == NULL ? "Failed to execute command" : output;
         free(output);
-        return Error("Failed to execute command:", err);
+        return Error(outStr, err);
     }
     std::string result(output);
     free(output);


### PR DESCRIPTION
## Description
When context::ExecuteCommand fails because the command failed (returned non-zero status code) provide the combined stdout/stderr as the error message.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
