### PR TITLE
Mark logging as PUBLIC dependency of commonutils

### DIFF
--- a/src/common/commonutils/CMakeLists.txt
+++ b/src/common/commonutils/CMakeLists.txt
@@ -26,7 +26,10 @@ target_include_directories(commonutils
         ${RAPIDJSON_INCLUDE_DIRS}
 )
 
-target_link_libraries(commonutils PRIVATE
-    logging
-    parsonlib
-    m)
+target_link_libraries(commonutils
+    PUBLIC
+        logging
+    PRIVATE
+        parsonlib
+        m
+)


### PR DESCRIPTION
## Description

CommonUtils.h includes Logging.h. Mark `logging` as a PUBLIC dependency of `commonutils` so that this information is propagated to dependent targets.
This doesn't chang anything because all existing targets linking to commonutils must also link to logging.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
