### PR TITLE
Fix ASB rule "Ensure that postfix network listening is disabled" to pass audit when postfix package is not installed

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2440,7 +2440,7 @@ static char* AuditEnsurePostfixPackageIsUninstalled(OsConfigLogHandle log)
 static char* AuditEnsurePostfixNetworkListeningIsDisabled(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    if (0 == CheckFileExists(g_etcPostfixMainCf, &reason, log))
+    if ((0 != CheckPackageNotInstalled(g_postfix, &reason, log)) && (0 == CheckFileExists(g_etcPostfixMainCf, &reason, log)))
     {
         CheckTextIsFoundInFile(g_etcPostfixMainCf, g_inetInterfacesLocalhost, &reason, log);
     }
@@ -4025,14 +4025,19 @@ static int RemediateEnsurePostfixPackageIsUninstalled(char* value, OsConfigLogHa
 static int RemediateEnsurePostfixNetworkListeningIsDisabled(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return DisablePostfixNetworkListening(log);
+    int result = 0;
+    if (0 == IsPackageInstalled(g_postfix, log))
+    {
+        result = DisablePostfixNetworkListening(log);
+    }
+    return result;
 }
 
 static int CheckAndFreeReason(char *reason)
 {
-    int ret = (0 == strncmp(g_pass, reason, strlen(g_pass))) ? 0 : ENOENT;
+    int result = (0 == strncmp(g_pass, reason, strlen(g_pass))) ? 0 : ENOENT;
     FREE_MEMORY(reason);
-    return ret;
+    return result;
 }
 
 static int RemediateEnsureRpcgssdServiceIsDisabled(char* value, OsConfigLogHandle log)


### PR DESCRIPTION
## Description

This ASB rule: { "Ensure that postfix network listening is disabled", "d0cc4e35-70a1-4ee5-b572-3b969201562e", "EnsurePostfixNetworkListeningIsDisabled" }, needs to be fixed to pass audit (and skip remediation) when the postfix package is not installed. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit and functional tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
