### PR TITLE
Fix for ASB's "Ensure that the SSH warning banner is configured (CIS: L1 - Server - 5.2.19)" rule

### DIFF
--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -590,16 +590,16 @@ static int CheckSshWarningBanner(char** reason, OsConfigLogHandle log)
         return status;
     }
 
-    if (NULL != (bannerPath = GetSshServerState(g_banner, log)))
+    if (NULL != (bannerPath = GetSshServerState(g_sshBanner, log)))
     {
-        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' found in SSH Server response set to '%s'", g_banner, bannerPath);
+        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' found in SSH Server response set to '%s'", g_sshBanner, bannerPath);
         status = CheckFileExists(bannerPath, reason, log);
         FREE_MEMORY(bannerPath);
     }
     else
     {
-        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' not found in SSH Server response", g_banner);
-        OsConfigCaptureReason(reason, "'%s' not found in SSH Server response", g_banner);
+        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' not found in SSH Server response", g_sshBanner);
+        OsConfigCaptureReason(reason, "'%s' not found in SSH Server response", g_sshBanner);
         status = ENOENT;
     }
 

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -582,6 +582,7 @@ static int CheckSshLoginGraceTime(const char* value, char** reason, OsConfigLogH
 
 static int CheckSshWarningBanner(char** reason, OsConfigLogHandle log)
 {
+    const char* banner = "banner";
     char* bannerPath = NULL;
     int status = 0;
 
@@ -590,16 +591,16 @@ static int CheckSshWarningBanner(char** reason, OsConfigLogHandle log)
         return status;
     }
 
-    if (NULL != (bannerPath = GetSshServerState(g_sshBanner, log)))
+    if (NULL != (bannerPath = GetSshServerState(banner, log)))
     {
-        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' found in SSH Server response set to '%s'", g_sshBanner, bannerPath);
+        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' found in SSH Server response set to '%s'", banner, bannerPath);
         status = CheckFileExists(bannerPath, reason, log);
         FREE_MEMORY(bannerPath);
     }
     else
     {
-        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' not found in SSH Server response", g_sshBanner);
-        OsConfigCaptureReason(reason, "'%s' not found in SSH Server response", g_sshBanner);
+        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' not found in SSH Server response", banner);
+        OsConfigCaptureReason(reason, "'%s' not found in SSH Server response", banner);
         status = ENOENT;
     }
 

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -580,48 +580,28 @@ static int CheckSshLoginGraceTime(const char* value, char** reason, OsConfigLogH
     return status;
 }
 
-static int CheckSshWarningBanner(const char* bannerFile, const char* bannerText, unsigned int desiredAccess, char** reason, OsConfigLogHandle log)
+static int CheckSshWarningBanner(char** reason, OsConfigLogHandle log)
 {
-    char* banner = DuplicateStringToLowercase(g_sshBanner);
-    char* actualValue = NULL;
-    char* contents = NULL;
+    char* bannerPath = NULL;
     int status = 0;
 
-    if (0 == IsSshServerActive(log))
+    if (0 != IsSshServerActive(log))
     {
-        if ((NULL == bannerFile) || (NULL == bannerText))
-        {
-            OsConfigLogError(log, "CheckSshWarningBanner: invalid arguments");
-            status = EINVAL;
-        }
-        else if (0 == (status = CheckSshOptionIsSet(banner, bannerFile, &actualValue, reason, log)))
-        {
-            OsConfigResetReason(reason);
-
-            if (NULL == (contents = LoadStringFromFile(bannerFile, false, log)))
-            {
-                OsConfigLogInfo(log, "CheckSshWarningBanner: cannot read from '%s'", bannerFile);
-                OsConfigCaptureReason(reason, "'%s' is set to '%s' but the file cannot be read", banner, actualValue);
-                status = ENOENT;
-            }
-            else  if (0 != strcmp(contents, bannerText))
-            {
-                OsConfigLogInfo(log, "CheckSshWarningBanner: banner text is:\n%s instead of:\n%s", contents, bannerText);
-                OsConfigCaptureReason(reason, "Banner text from file '%s' is different from the expected text", bannerFile);
-                status = ENOENT;
-            }
-            else if (0 == (status = CheckFileAccess(bannerFile, 0, 0, desiredAccess, reason, log)))
-            {
-                OsConfigCaptureSuccessReason(reason, "%s reports that '%s' is set to '%s', this file has access '%u' and contains the expected banner text",
-                    g_sshServerService, banner, actualValue, desiredAccess);
-            }
-        }
-
-        FREE_MEMORY(contents);
-        FREE_MEMORY(actualValue);
+        return status;
     }
 
-    FREE_MEMORY(banner);
+    if (NULL != (bannerPath = GetSshServerState(g_banner, log)))
+    {
+        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' found in SSH Server response set to '%s'", g_banner, bannerPath);
+        status = CheckFileExists(bannerPath, reason, log);
+        FREE_MEMORY(bannerPath);
+    }
+    else
+    {
+        OsConfigLogInfo(log, "CheckSshWarningBanner: '%s' not found in SSH Server response", g_banner);
+        OsConfigCaptureReason(reason, "'%s' not found in SSH Server response", g_banner);
+        status = ENOENT;
+    }
 
     OsConfigLogInfo(log, "CheckSshWarningBanner returning %d", status);
 
@@ -1425,8 +1405,7 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, OsConfigL
     }
     else if (0 == strcmp(name, g_auditEnsureSshWarningBannerIsEnabledObject))
     {
-        CheckSshWarningBanner(g_sshBannerFile, g_desiredSshWarningBannerIsEnabled ? g_desiredSshWarningBannerIsEnabled : g_sshDefaultSshBannerText,
-            strtol(g_desiredPermissionsOnEtcSshSshdConfig ? g_desiredPermissionsOnEtcSshSshdConfig : g_sshDefaultSshSshdConfigAccess, NULL, 8), reason, log);
+        CheckSshWarningBanner(reason, log);
     }
     else if (0 == strcmp(name, g_auditEnsureUsersCannotSetSshEnvironmentOptionsObject))
     {

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -1593,6 +1593,17 @@
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
+    "ObjectName": "initEnsureSshWarningBannerIsEnabled",
+    "Payload": "Test"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "auditEnsureSshWarningBannerIsEnabled"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
     "ObjectName": "initEnsureUsersCannotSetSshEnvironmentOptions",
     "Payload": "no"
   },


### PR DESCRIPTION
## Description

This fixes the { "Ensure that the SSH warning banner is configured (CIS: L1 - Server - 5.2.19)", "9e240540-5e0a-4b60-beb2-57421c65a0b9", "EnsureSshWarningBannerIsEnabled" } rule audit making it check only that there is a banner file set as banner with the SSH server and that the file exists. Previous implementation was requiring specific file name and content, which were meant to come from policy parameters, but ASB does not expose any and this makes this bad experience for customers. We still keep the same automatic remediation.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests and functional tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
