### PR TITLE
Narrow file permissions used when creating text files (#877) to main

### DIFF
--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -80,8 +80,8 @@ void __attribute__((destructor)) Destroy()
     CloseLog(&g_log);
 
     // When the NRP is done, allow others read-only (no write, search or execute) access to the NRP logs
-    SetFileAccess(LOG_FILE, 0, 0, 6774, NULL);
-    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 6774, NULL);
+    SetFileAccess(LOG_FILE, 0, 0, 644, NULL);
+    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 644, NULL);
 }
 
 static void LogOsConfigVersion(MI_Context* context)

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -382,7 +382,7 @@ int RestrictFileAccessToCurrentAccountOnly(const char* fileName)
     // S_IXUSR (0100): Execute/search permission, owner
     // S_IXGRP (0010): Execute/search permission, group
 
-    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP);
+    return chmod(fileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 }
 
 static bool IsATrueFileOrDirectory(bool directory, const char* name, void* log)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -48,7 +48,7 @@ bool IsFullLoggingEnabled()
 
 static int RestrictAccessToRootOnly(const char* fileName)
 {
-    return chmod(fileName, S_ISUID | S_ISGID | S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IXUSR | S_IXGRP);
+    return chmod(fileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
 }
 
 OSCONFIG_LOG_HANDLE OpenLog(const char* logFileName, const char* bakLogFileName)


### PR DESCRIPTION
## Description

Cherry-pick of #877 to main: remove the SUID/SGID/EXEC bits from log files as they may alarm users.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [ ] I submitted this PR against the `dev` branch.
