### PR TITLE
FileRegexMatchTest introduce match sub pattern and behaviors

### DIFF
--- a/src/modules/compliance/src/lib/CMakeLists.txt
+++ b/src/modules/compliance/src/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(compliancelib STATIC
     ContextInterface.cpp
     Engine.cpp
     Evaluator.cpp
+    FactExistenceValidator.cpp
     Indicators.cpp
     JsonWrapper.cpp
     Procedure.cpp

--- a/src/modules/compliance/src/lib/FactExistenceValidator.cpp
+++ b/src/modules/compliance/src/lib/FactExistenceValidator.cpp
@@ -92,6 +92,9 @@ void FactExistenceValidator::CriteriaUnmet()
         case Behavior::AllExist:
             mState = Status::NonCompliant;
             break;
+        case Behavior::NoneExist:
+            mState = Status::Compliant;
+            break;
         default:
             break;
     }

--- a/src/modules/compliance/src/lib/FactExistenceValidator.cpp
+++ b/src/modules/compliance/src/lib/FactExistenceValidator.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <FactExistenceValidator.h>
+#include <cassert>
+#include <map>
+
+namespace compliance
+{
+FactExistenceValidator::FactExistenceValidator(Behavior behavior)
+    : mBehavior(behavior)
+{
+}
+
+void FactExistenceValidator::Finish()
+{
+    if (Done())
+    {
+        return;
+    }
+
+    switch (mBehavior)
+    {
+        case Behavior::AllExist:
+            mState = Status::Compliant;
+            break;
+        case Behavior::NoneExist:
+            assert(!mHasAtLeastOneFact);
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::AtLeastOneExists:
+            assert(!mHasAtLeastOneFact);
+            mState = Status::NonCompliant;
+            break;
+
+        case Behavior::AnyExist:
+            assert(!mHasAtLeastOneFact);
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::OnlyOneExists:
+            mState = mHasAtLeastOneFact ? Status::Compliant : Status::NonCompliant;
+            break;
+    }
+    assert(Done());
+}
+
+void FactExistenceValidator::CriteriaMet()
+{
+    if (Done())
+    {
+        return;
+    }
+
+    switch (mBehavior)
+    {
+        case Behavior::AllExist:
+            break;
+
+        case Behavior::AnyExist:
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::AtLeastOneExists:
+            mState = Status::Compliant;
+            break;
+
+        case Behavior::NoneExist:
+            mState = Status::NonCompliant;
+            break;
+
+        case Behavior::OnlyOneExists:
+            if (mHasAtLeastOneFact)
+            {
+                mState = Status::NonCompliant;
+            }
+            break;
+    }
+    mHasAtLeastOneFact = true;
+}
+
+void FactExistenceValidator::CriteriaUnmet()
+{
+    if (Done())
+    {
+        return;
+    }
+
+    switch (mBehavior)
+    {
+        case Behavior::AllExist:
+            mState = Status::NonCompliant;
+            break;
+        default:
+            break;
+    }
+}
+
+bool FactExistenceValidator::Done() const
+{
+    return mState.HasValue();
+}
+
+Status FactExistenceValidator::Result() const
+{
+    assert(mState.HasValue());
+    return mState.Value();
+}
+
+compliance::Result<FactExistenceValidator::Behavior> FactExistenceValidator::MapBehavior(const std::string& value)
+{
+    static const std::map<std::string, Behavior> sMap = {
+        {"all_exist", Behavior::AllExist},
+        {"any_exist", Behavior::AnyExist},
+        {"at_least_one_exists", Behavior::AtLeastOneExists},
+        {"none_exist", Behavior::NoneExist},
+        {"only_one_exists", Behavior::OnlyOneExists},
+    };
+
+    auto it = sMap.find(value);
+    if (it == sMap.end())
+    {
+        return Error("unsupported value: " + value, EINVAL);
+    }
+
+    return it->second;
+}
+} // namespace compliance

--- a/src/modules/compliance/src/lib/FactExistenceValidator.h
+++ b/src/modules/compliance/src/lib/FactExistenceValidator.h
@@ -11,6 +11,18 @@
 
 namespace compliance
 {
+/// Class to encapsulate logic checks for complex Facts.
+/// Some complex checks like FileRegexMatch validates multiple aspects of the system.
+/// Like, does path exists, does file exists, does file contain expected content, etc.
+/// Expressing it as Not { FileRegexMatch path=/etc/ filePattern=sudo.conf matchPattern=NOPASSWD }
+/// doesn't clearly show if we want to assert /etc/sudo.conf not to exist or assert it should not contain NOPASSWD.
+///
+/// FactExistenceValidator supports following Behaviors:
+/// AllExist - Fact is Compliant if and only if all Criteria are Met (called CriteriaMet) and exists (think like logical and)
+/// AnyExist - Fact is Compliant if and only if at least one of Criteria is met, and exists (think like logical or)
+/// NoneExist - Fact is Compliant if and only if all Criteria are Unmet
+/// OnlyOneExists - Fact is Compliant if and only if only one of Criteria is met
+/// AtLeastOneExists - Fact is Compliant if and only if one or more of Criteria is met
 class FactExistenceValidator
 {
 public:
@@ -18,9 +30,9 @@ public:
     {
         AllExist,
         AnyExist,
-        AtLeastOneExists,
         NoneExist,
         OnlyOneExists,
+        AtLeastOneExists,
     };
 
     explicit FactExistenceValidator(Behavior behavior);
@@ -30,11 +42,21 @@ public:
     FactExistenceValidator& operator=(FactExistenceValidator&&) = default;
     ~FactExistenceValidator() = default;
 
-    void Finish();
+    /// Used by Fact to 'save state' of check executed successfully (regardless of behavior)
+    /// e.g when { FileRegexMatch path=/etc/ filePattern=sudo.conf matchPattern=NOPASSWD }
+    ///  CriteriaMet is when path, filePattern and matchPattern exists
     void CriteriaMet();
+    /// Used by Fact to 'save state' of check executed unsuccessfully (regardless of behavior)
+    /// e.g when { FileRegexMatch path=/etc/ filePattern=sudo.conf matchPattern=NOPASSWD }
+    ///  CriteriaUnmet eg. when file is not found
     void CriteriaUnmet();
+    /// Used by Fact notify FactExistenceValidator that evaluation stooped and Result is present
+    void Finish();
+    /// returns True if FactExistenceValidator can evaluate Result
     bool Done() const;
+    /// returns Result of validation (Compliant or NonCompliant)
     Status Result() const;
+
     static compliance::Result<Behavior> MapBehavior(const std::string& value);
 
 private:

--- a/src/modules/compliance/src/lib/FactExistenceValidator.h
+++ b/src/modules/compliance/src/lib/FactExistenceValidator.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCE_FACT_EXISTENCE_VALIDATOR_H
+#define COMPLIANCE_FACT_EXISTENCE_VALIDATOR_H
+
+#include <MmiResults.h>
+#include <Optional.h>
+#include <Result.h>
+#include <string>
+
+namespace compliance
+{
+class FactExistenceValidator
+{
+public:
+    enum class Behavior
+    {
+        AllExist,
+        AnyExist,
+        AtLeastOneExists,
+        NoneExist,
+        OnlyOneExists,
+    };
+
+    explicit FactExistenceValidator(Behavior behavior);
+    FactExistenceValidator(const FactExistenceValidator&) = default;
+    FactExistenceValidator(FactExistenceValidator&&) = default;
+    FactExistenceValidator& operator=(const FactExistenceValidator&) = default;
+    FactExistenceValidator& operator=(FactExistenceValidator&&) = default;
+    ~FactExistenceValidator() = default;
+
+    void Finish();
+    void CriteriaMet();
+    void CriteriaUnmet();
+    bool Done() const;
+    Status Result() const;
+    static compliance::Result<Behavior> MapBehavior(const std::string& value);
+
+private:
+    Behavior mBehavior;
+    Optional<Status> mState;
+    bool mHasAtLeastOneFact = false;
+};
+} // namespace compliance
+
+#endif // COMPLIANCE_FACT_EXISTENCE_VALIDATOR_H

--- a/src/modules/compliance/src/lib/RegexFallback.h
+++ b/src/modules/compliance/src/lib/RegexFallback.h
@@ -87,7 +87,7 @@ class Regex
         {
             flags |= REG_ICASE;
         }
-        if (options & std::regex_constants::extended)
+        if ((options & std::regex_constants::extended) || (options & std::regex_constants::ECMAScript))
         {
             flags |= REG_EXTENDED;
         }

--- a/src/modules/compliance/src/lib/procedures/EnsureSysctl.schema.json
+++ b/src/modules/compliance/src/lib/procedures/EnsureSysctl.schema.json
@@ -21,7 +21,7 @@
                 "sysctlName": {
                   "type": "string",
                   "description": "Name of the sysctl",
-                  "pattern": "(^\\$[a-zA-Z0-9_]+:(([a-zA-Z0-9_]+[\\\\.a-zA-Z0-9_-]+))$|(^([a-zA-Z0-9_]+[\\\\.a-zA-Z0-9_-]+)$))"
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:(([a-zA-Z0-9_]+[\\.a-zA-Z0-9_-]+))$|(^([a-zA-Z0-9_]+[\\.a-zA-Z0-9_-]+)$))"
                 },
                 "value": {
                   "type": "string",

--- a/src/modules/compliance/src/lib/procedures/FileRegexMatch.cpp
+++ b/src/modules/compliance/src/lib/procedures/FileRegexMatch.cpp
@@ -55,12 +55,17 @@ Result<Status> MultilineMatch(const std::string& filename, const string& matchPa
     {
         lineNumber++;
         OsConfigLogDebug(context.GetLogHandle(), "Matching line %d: %s, pattern: %s", lineNumber, line.c_str(), matchPattern.c_str());
-        if (regex_search(line, matchRegex.Value()))
+        smatch match;
+        if (regex_search(line, match, matchRegex.Value()))
         {
             OsConfigLogDebug(context.GetLogHandle(), "Matched line %d: %s", lineNumber, line.c_str());
             if (stateRegex.HasValue())
             {
-                if (regex_search(line, stateRegex.Value()))
+                assert(match.ready());
+                assert(match.size() > 0);
+                auto valueToMatch = match.size() > 1 ? match[1].str() : match[0].str();
+                OsConfigLogDebug(context.GetLogHandle(), "Value to match: %s", valueToMatch.c_str());
+                if (regex_search(valueToMatch, stateRegex.Value()))
                 {
                     OsConfigLogDebug(context.GetLogHandle(), "Matched line %d: %s", lineNumber, line.c_str());
                     validator.CriteriaMet();

--- a/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
+++ b/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
@@ -13,14 +13,19 @@
             "FileRegexMatch": {
               "type": "object",
               "required": [
-                "filename",
+                "path",
+                "filenamePattern",
                 "matchPattern"
               ],
               "additionalProperties": false,
               "properties": {
-                "filename": {
+                "path": {
                   "type": "string",
-                  "description": "Path to the file to check"
+                  "description": "A directory name contining files to check"
+                },
+                "filenamePattern": {
+                  "type": "string",
+                  "description": "A pattern to match file names in the provided path"
                 },
                 "matchOperation": {
                   "type": "string",

--- a/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
+++ b/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
@@ -14,7 +14,6 @@
               "type": "object",
               "required": [
                 "filename",
-                "matchOperation",
                 "matchPattern"
               ],
               "additionalProperties": false,
@@ -45,6 +44,11 @@
                   "type": "string",
                   "description": "Determine whether the match should be case sensitive, applies to both 'matchPattern' and 'statePattern'",
                   "pattern": "(^\\$[a-zA-Z0-9_]+:(true|false)$|(^true|false$))"
+                },
+                "behavior": {
+                  "type": "string",
+                  "description": "Determine the function behavior",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:((all_exist|any_exist|at_least_one_exists|none_exist))$|(^(all_exist|any_exist|at_least_one_exists|none_exist)$))"
                 }
               }
             }

--- a/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
+++ b/src/modules/compliance/src/lib/procedures/FileRegexMatch.schema.json
@@ -45,10 +45,10 @@
                   "type": "string",
                   "description": "The pattern to match against each line that matches the 'statePattern'"
                 },
-                "caseSensitive": {
+                "ignoreCase": {
                   "type": "string",
-                  "description": "Determine whether the match should be case sensitive, applies to both 'matchPattern' and 'statePattern'",
-                  "pattern": "(^\\$[a-zA-Z0-9_]+:(true|false)$|(^true|false$))"
+                  "description": "Determine whether the a match or state should be ignore case sensitivity  'matchPattern' and 'statePattern' or none when empty'",
+                  "pattern": "(^\\$[a-zA-Z0-9_]+:((matchPattern\\sstatePattern|matchPattern|statePattern).*)$|(^(matchPattern\\sstatePattern|matchPattern|statePattern)))"
                 },
                 "behavior": {
                   "type": "string",

--- a/src/modules/compliance/tests/CMakeLists.txt
+++ b/src/modules/compliance/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(compliancetests
     ComplianceTest.cpp
     EngineTest.cpp
     EvaluatorTest.cpp
+    FactExistenceValidatorTest.cpp
     OptionalTest.cpp
     RegexFallbackTest.cpp
     RegexTest.cpp

--- a/src/modules/compliance/tests/FactExistenceValidatorTest.cpp
+++ b/src/modules/compliance/tests/FactExistenceValidatorTest.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "FactExistenceValidator.h"
+
+#include <gtest/gtest.h>
+
+using compliance::Error;
+using compliance::FactExistenceValidator;
+using compliance::Result;
+
+class FactExistenceValidatorTest : public ::testing::Test
+{
+};
+
+TEST_F(FactExistenceValidatorTest, MapBehavior)
+{
+    auto result = compliance::FactExistenceValidator::MapBehavior("all_exist");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::AllExist);
+
+    result = compliance::FactExistenceValidator::MapBehavior("any_exist");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::AnyExist);
+
+    result = compliance::FactExistenceValidator::MapBehavior("at_least_one_exists");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+
+    result = compliance::FactExistenceValidator::MapBehavior("none_exist");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::NoneExist);
+
+    result = compliance::FactExistenceValidator::MapBehavior("only_one_exists");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+
+    result = compliance::FactExistenceValidator::MapBehavior("invalid_value");
+    ASSERT_FALSE(result.HasValue());
+}
+
+TEST_F(FactExistenceValidatorTest, AllExist_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AllExist);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+
+    // Already done, Finish should not affact the state
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AllExist_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AllExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaUnmet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AllExist_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AllExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AnyExist_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AnyExist);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AnyExist_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AnyExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AnyExist_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AnyExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AtLeastOneExists_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AtLeastOneExists_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, AtLeastOneExists_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::AtLeastOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, NoneExist_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, NoneExist_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, NoneExist_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, OnlyOneExists_1)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}
+
+TEST_F(FactExistenceValidatorTest, OnlyOneExists_2)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.Finish();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+    // Already done, should not change state anymore
+    validator.CriteriaMet();
+    ASSERT_EQ(validator.Result(), compliance::Status::Compliant);
+}
+
+TEST_F(FactExistenceValidatorTest, OnlyOneExists_3)
+{
+    FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::OnlyOneExists);
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaUnmet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_FALSE(validator.Done());
+    validator.CriteriaMet();
+    ASSERT_TRUE(validator.Done());
+    ASSERT_EQ(validator.Result(), compliance::Status::NonCompliant);
+}

--- a/src/modules/compliance/tests/FactExistenceValidatorTest.cpp
+++ b/src/modules/compliance/tests/FactExistenceValidatorTest.cpp
@@ -169,9 +169,9 @@ TEST_F(FactExistenceValidatorTest, NoneExist_3)
     FactExistenceValidator validator(compliance::FactExistenceValidator::Behavior::NoneExist);
     ASSERT_FALSE(validator.Done());
     validator.CriteriaUnmet();
-    ASSERT_FALSE(validator.Done());
+    ASSERT_TRUE(validator.Done());
     validator.CriteriaUnmet();
-    ASSERT_FALSE(validator.Done());
+    ASSERT_TRUE(validator.Done());
     validator.Finish();
     ASSERT_TRUE(validator.Done());
     ASSERT_EQ(validator.Result(), compliance::Status::Compliant);

--- a/src/modules/compliance/tests/procedures/FileRegexMatchTest.cpp
+++ b/src/modules/compliance/tests/procedures/FileRegexMatchTest.cpp
@@ -150,7 +150,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_1)
     mArgs["matchOperation"] = "pattern match";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
 TEST_F(FileRegexMatchTest, Audit_Match_2)
@@ -160,6 +160,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_2)
     mArgs["filenamePattern"] = "1";
     mArgs["matchPattern"] = "test";
     mArgs["matchOperation"] = "pattern match";
+    mArgs["behavior"] = "none_exist";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
@@ -174,7 +175,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_3)
     mArgs["matchOperation"] = "pattern match";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::Compliant);
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
 TEST_F(FileRegexMatchTest, Audit_Match_4)
@@ -186,7 +187,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_4)
     mArgs["matchOperation"] = "pattern match";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
 TEST_F(FileRegexMatchTest, Audit_Match_5)
@@ -198,7 +199,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_5)
     mArgs["matchOperation"] = "pattern match";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
 TEST_F(FileRegexMatchTest, Audit_Match_6)
@@ -210,7 +211,7 @@ TEST_F(FileRegexMatchTest, Audit_Match_6)
     mArgs["matchOperation"] = "pattern match";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
 TEST_F(FileRegexMatchTest, Audit_CaseInsensitive_1)
@@ -223,7 +224,7 @@ TEST_F(FileRegexMatchTest, Audit_CaseInsensitive_1)
     mArgs["ignoreCase"] = "matchPattern";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
 TEST_F(FileRegexMatchTest, Audit_State_1)

--- a/src/modules/compliance/tests/procedures/FileRegexMatchTest.cpp
+++ b/src/modules/compliance/tests/procedures/FileRegexMatchTest.cpp
@@ -220,7 +220,7 @@ TEST_F(FileRegexMatchTest, Audit_CaseInsensitive_1)
     mArgs["filenamePattern"] = "1";
     mArgs["matchPattern"] = R"(^[[:space:]]*Te[a-z]t.*$)";
     mArgs["matchOperation"] = "pattern match";
-    mArgs["caseSensitive"] = "false";
+    mArgs["ignoreCase"] = "matchPattern";
     auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
@@ -239,6 +239,47 @@ TEST_F(FileRegexMatchTest, Audit_State_1)
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
+TEST_F(FileRegexMatchTest, Audit_State_2_CaseInsensitve)
+{
+    MakeTempfile("key=foo");
+    mArgs["path"] = mTempdir;
+    mArgs["filenamePattern"] = "1";
+    mArgs["matchPattern"] = R"(^key=.*$)";
+    mArgs["statePattern"] = R"(^key=FoO$)";
+    mArgs["behavior"] = "all_exist";
+    mArgs["ignoreCase"] = "statePattern";
+    auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(FileRegexMatchTest, Audit_State_2_CaseInsensitveBoth)
+{
+    MakeTempfile("key=foo");
+    mArgs["path"] = mTempdir;
+    mArgs["filenamePattern"] = "1";
+    mArgs["matchPattern"] = R"(^Key=.*$)";
+    mArgs["statePattern"] = R"(^Key=FoO$)";
+    mArgs["behavior"] = "all_exist";
+    mArgs["ignoreCase"] = "matchPattern statePattern";
+    auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(FileRegexMatchTest, Audit_State_2_CaseInsensitveBothDiffetnArg)
+{
+    MakeTempfile("key=foo");
+    mArgs["path"] = mTempdir;
+    mArgs["filenamePattern"] = "1";
+    mArgs["matchPattern"] = R"(^Key=.*$)";
+    mArgs["statePattern"] = R"(^Key=FoO$)";
+    mArgs["behavior"] = "all_exist";
+    mArgs["ignoreCase"] = "statePattern matchPattern";
+    auto result = AuditFileRegexMatch(mArgs, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}
 TEST_F(FileRegexMatchTest, Audit_State_2)
 {
     MakeTempfile("key=foo");

--- a/src/modules/test/recipes/compliance/FileRegexMatch.json
+++ b/src/modules/test/recipes/compliance/FileRegexMatch.json
@@ -16,14 +16,16 @@
           "path": "$PATH",
           "filenamePattern": "$FILENAME",
           "matchOperation": "$OPERATION",
-          "matchPattern": "$PATTERN"
+          "matchPattern": "$PATTERN",
+          "behavior": "$BEHAVIOR"
         }
       },
       "parameters": {
         "OPERATION": "pattern match",
         "PATTERN": ".*",
         "PATH": "/tmp",
-        "FILENAME": "testfile"
+        "FILENAME": "testfile",
+        "BEHAVIOR": "all_exist"
       }
     }
   },
@@ -34,7 +36,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '.*' matched line 1 in file '\/tmp\/testfile' } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
   {
     "ObjectType": "Desired",
@@ -46,7 +48,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'foo' matched line 1 in file '\/tmp\/testfile' } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -61,7 +63,32 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'f.*o' matched line 1 in file '\/tmp\/testfile' } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
+  },
+
+
+
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PATTERN=f.*O"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "{ FileRegexMatch: pattern 'f.*O' did not match line 1 in file '\/tmp\/testfile' } == FALSE"
+  },
+
+  {
+    "RunCommand": "echo foooOx > /tmp/testfile"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -79,8 +106,6 @@
     "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
-
-
   {
     "RunCommand": "echo foooOx > /tmp/testfile"
   },
@@ -88,7 +113,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'f.*O' matched line 1 in file '\/tmp\/testfile' } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -104,7 +129,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 in file '\/etc\/passwd' } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' did not match line 2 in file '\/etc\/passwd' } == FALSE"
   },
 
 
@@ -119,7 +144,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+$' did not match line 1 in file '\/etc\/passwd' } == FALSE"
   },
 
 
@@ -134,7 +159,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 in file '\/etc\/passwd' } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -152,7 +177,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 in file '\/tmp\/passwd' } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
   {
     "RunCommand": "echo '#testuser::1111:1111::/home/someuser:/bin/sh' > /tmp/passwd"
@@ -161,11 +186,43 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' did not match line 1 in file '\/tmp\/passwd' } == FALSE"
   },
 
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "Compliance",
+    "ObjectName": "initTest",
+    "Payload": "PATH=/tmp/non-existing-dir FILENAME='^passwd$' PATTERN=^[^:#]+:: BEHAVIOR=none_exist"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
+  },
+  {
+    "RunCommand": "mkdir -p /tmp/non-existing-dir"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ FileRegexMatch: No files matched the filename pattern '^passwd$' } == TRUE"
+  },
+  {
+    "RunCommand": "echo 'not the searched pattern' >   /tmp/non-existing-dir/passwd"
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "Compliance",
+    "ObjectName": "auditTest",
+    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+::' did not match line 1 in file '\/tmp\/non-existing-dir\/passwd' } == TRUE"
+  },
 
-
+  {
+    "RunCommand": "rm -rf /tmp/non-existing-dir"
+  },
   {
     "RunCommand": "rm -f /tmp/passwd"
   },

--- a/src/modules/test/recipes/compliance/FileRegexMatch.json
+++ b/src/modules/test/recipes/compliance/FileRegexMatch.json
@@ -13,7 +13,8 @@
     "Payload": {
       "audit": {
         "FileRegexMatch": {
-          "filename": "$PATH",
+          "path": "$PATH",
+          "filenamePattern": "$FILENAME",
           "matchOperation": "$OPERATION",
           "matchPattern": "$PATTERN"
         }
@@ -21,7 +22,8 @@
       "parameters": {
         "OPERATION": "pattern match",
         "PATTERN": ".*",
-        "PATH": "/tmp/testfile"
+        "PATH": "/tmp",
+        "FILENAME": "testfile"
       }
     }
   },
@@ -32,7 +34,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '.*' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '.*' matched line 1 in file '\/tmp\/testfile' } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -44,7 +46,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'foo' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern 'foo' matched line 1 in file '\/tmp\/testfile' } == FALSE"
   },
 
 
@@ -59,7 +61,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'f.*o' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*o' matched line 1 in file '\/tmp\/testfile' } == FALSE"
   },
 
 
@@ -86,7 +88,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'f.*O' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*O' matched line 1 in file '\/tmp\/testfile' } == FALSE"
   },
 
 
@@ -96,13 +98,13 @@
     "ObjectType": "Desired",
     "ComponentName": "Compliance",
     "ObjectName": "initTest",
-    "Payload": "PATH=/etc/passwd PATTERN=^root:x:[0-9]+:[0-9]+"
+    "Payload": "PATH=/etc FILENAME='^passwd$' PATTERN=^root:x:[0-9]+:[0-9]+"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 in file '\/etc\/passwd' } == FALSE"
   },
 
 
@@ -111,7 +113,7 @@
     "ObjectType": "Desired",
     "ComponentName": "Compliance",
     "ObjectName": "initTest",
-    "Payload": "PATH=/etc/passwd PATTERN=^root:x:[0-9]+:[0-9]+$"
+    "Payload": "PATH=/etc FILENAME='^passwd$' PATTERN=^root:x:[0-9]+:[0-9]+$"
   },
   {
     "ObjectType": "Reported",
@@ -126,13 +128,13 @@
     "ObjectType": "Desired",
     "ComponentName": "Compliance",
     "ObjectName": "initTest",
-    "Payload": "PATH=/etc/passwd PATTERN=^[^:#]+:.*"
+    "Payload": "PATH=/etc FILENAME='^passwd$' PATTERN=^[^:#]+:.*"
   },
   {
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 in file '\/etc\/passwd' } == FALSE"
   },
 
 
@@ -141,7 +143,7 @@
     "ObjectType": "Desired",
     "ComponentName": "Compliance",
     "ObjectName": "initTest",
-    "Payload": "PATH=/tmp/passwd PATTERN=^[^:#]+::"
+    "Payload": "PATH=/tmp FILENAME='^passwd$' PATTERN=^[^:#]+::"
   },
   {
     "RunCommand": "echo testuser::1111:1111::/home/someuser:/bin/sh > /tmp/passwd"
@@ -150,7 +152,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 } == FALSE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 in file '\/tmp\/passwd' } == FALSE"
   },
   {
     "RunCommand": "echo '#testuser::1111:1111::/home/someuser:/bin/sh' > /tmp/passwd"

--- a/src/modules/test/recipes/compliance/FileRegexMatch.json
+++ b/src/modules/test/recipes/compliance/FileRegexMatch.json
@@ -32,7 +32,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '.*' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '.*' matched line 1 } == FALSE"
   },
   {
     "ObjectType": "Desired",
@@ -44,7 +44,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern 'foo' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern 'foo' matched line 1 } == FALSE"
   },
 
 
@@ -59,7 +59,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern 'f.*o' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*o' matched line 1 } == FALSE"
   },
 
 
@@ -74,7 +74,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern 'f.*O' did not match any line } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -86,7 +86,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern 'f.*O' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern 'f.*O' matched line 1 } == FALSE"
   },
 
 
@@ -102,7 +102,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+' matched line 1 } == FALSE"
   },
 
 
@@ -117,7 +117,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^root:x:[0-9]+:[0-9]+$' did not match any line } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 
@@ -132,7 +132,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+:.*' matched line 1 } == FALSE"
   },
 
 
@@ -150,7 +150,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 } == TRUE"
+    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' matched line 1 } == FALSE"
   },
   {
     "RunCommand": "echo '#testuser::1111:1111::/home/someuser:/bin/sh' > /tmp/passwd"
@@ -159,7 +159,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: pattern '^[^:#]+::' did not match any line } == FALSE"
+    "Payload": "PASS{ FileRegexMatch:  } == TRUE"
   },
 
 


### PR DESCRIPTION
## Description
Rework and rebase #997 

procedure used to test the state pattern against the full line. In general, the state pattern should match against a captured value with a given instance. **The instance is for now skipped and will be added later based on actual needs, for now it defaults to 1.** <- **WARNING**

*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [ ] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
