### PR TITLE
A minor fix to the EnsureRootPath test

### DIFF
--- a/src/modules/compliance/src/lib/procedures/EnsureRootPath.cpp
+++ b/src/modules/compliance/src/lib/procedures/EnsureRootPath.cpp
@@ -18,6 +18,7 @@ AUDIT_FN(EnsureRootPath)
 
     // Directory must not be world- or group-writable
     const int maxPerm = 0777 & ~0022;
+    // We're using sudo to get the proper root login shell, with the whole environment loaded.
     auto rootEnv = context.ExecuteCommand("sudo -Hiu root env");
     if (!rootEnv.HasValue())
     {

--- a/src/modules/compliance/tests/procedures/EnsureRootPathTest.cpp
+++ b/src/modules/compliance/tests/procedures/EnsureRootPathTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <string>
+#include <sys/param.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -19,16 +20,13 @@ class EnsureRootPathTest : public ::testing::Test
 protected:
     MockContext mContext;
     IndicatorsTree indicators;
-    const std::string pathTemplate = "/tmp/pathTestXXXXXX";
     std::string path;
 
     void SetUp() override
     {
-        char* tmppath = strdup(pathTemplate.c_str());
-        mkdtemp(tmppath);
-        ASSERT_TRUE(tmppath != nullptr);
+        char tmppath[MAXPATHLEN] = "/tmp/pathTestXXXXXX";
+        ASSERT_TRUE(nullptr != mkdtemp(tmppath));
         path = tmppath;
-        free(tmppath);
         indicators.Push("EnsureRootPath");
     }
 


### PR DESCRIPTION
## Description
- Eliminate static analysis detected potential memleak
- Add a comment about the sudo usage

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
