### PR TITLE
SystemdUnitState: add Unit parameter

### DIFF
--- a/src/modules/compliance/src/lib/procedures/SystemdUnitState.cpp
+++ b/src/modules/compliance/src/lib/procedures/SystemdUnitState.cpp
@@ -17,8 +17,12 @@ namespace compliance
 
 // Documentation for dbus {ActiveState, LoadState, UnitFileState} possible values and meaning
 // https://www.freedesktop.org/wiki/Software/systemd/dbus/
+// man systemd.timer /Unit=
+// https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html
+// Unit=  # The unit to activate when this timer elapses.
 AUDIT_FN(SystemdUnitState, "unitName:Name of the systemd unit:M", "ActiveState:value of systemd ActiveState of unitName to match",
-    "LoadState:value of systemd LoadState of unitName to match", "UnitFileState:value of systemd UnitFileState of unitName to match")
+    "LoadState:value of systemd LoadState of unitName to match", "UnitFileState:value of systemd UnitFileState of unitName to match",
+    "Unit:value of systemd property Unit, used in systemd.timer, name of unit to run when timer elapses ")
 {
     struct systemdQueryParams
     {
@@ -31,7 +35,8 @@ AUDIT_FN(SystemdUnitState, "unitName:Name of the systemd unit:M", "ActiveState:v
         {
         }
     };
-    systemdQueryParams params[] = {systemdQueryParams("ActiveState"), systemdQueryParams("LoadState"), systemdQueryParams("UnitFileState")};
+    systemdQueryParams params[] = {
+        systemdQueryParams("ActiveState"), systemdQueryParams("LoadState"), systemdQueryParams("UnitFileState"), systemdQueryParams("Unit")};
     bool argFound = false;
     auto log = context.GetLogHandle();
     std::string systemCtlCmd = "systemctl show ";

--- a/src/modules/compliance/src/lib/procedures/SystemdUnitState.schema.json
+++ b/src/modules/compliance/src/lib/procedures/SystemdUnitState.schema.json
@@ -32,6 +32,10 @@
                 "UnitFileState": {
                   "type": "string",
                   "description": "value of systemd UnitFileState of unitName to match"
+                },
+                "Unit": {
+                  "type": "string",
+                  "description": "value of systemd property Unit, used in systemd.timer, name of unit to run when timer elapses"
                 }
               }
             }

--- a/src/modules/compliance/tests/procedures/SystemdUnitStateTest.cpp
+++ b/src/modules/compliance/tests/procedures/SystemdUnitStateTest.cpp
@@ -280,3 +280,22 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateMaskedUnitFileStat
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
+
+TEST_F(SystemdUnitStateTest, argTestUnit)
+{
+
+    std::map<std::string, std::string> args;
+    args["unitName"] = "fooTimer.timer";
+    args["Unit"] = "foo.service";
+
+    auto executeCmd = systemCtlCmd;
+    executeCmd += "-p Unit ";
+    executeCmd += args["unitName"];
+
+    std::string fooServceAnyOutput = "Unit=foo.service\n";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(executeCmd))).WillOnce(::testing::Return(Result<std::string>(fooServceAnyOutput)));
+    auto result = AuditSystemdUnitState(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}


### PR DESCRIPTION
## Description
SystemdUnitState: add Unit parameter 

This is to support Systemd.timer.
Systemd.timer has Unit= parameter which indicates systemd unit to activate when systemd.timer expires.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
