### PR TITLE
Fixes for systemd unit audit

### DIFF
--- a/src/modules/compliance/tests/procedures/SystemdUnitStateTest.cpp
+++ b/src/modules/compliance/tests/procedures/SystemdUnitStateTest.cpp
@@ -299,3 +299,41 @@ TEST_F(SystemdUnitStateTest, argTestUnit)
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
+
+TEST_F(SystemdUnitStateTest, partialMatchFails)
+{
+
+    std::map<std::string, std::string> args;
+    args["unitName"] = "fooArg.service";
+    args["ActiveState"] = "active";
+
+    auto executeCmd = systemCtlCmd;
+    executeCmd += "-p ActiveState ";
+    executeCmd += args["unitName"];
+
+    std::string fooServceAnyOutput = "ActiveState=inactive";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(executeCmd))).WillOnce(::testing::Return(Result<std::string>(fooServceAnyOutput)));
+    auto result = AuditSystemdUnitState(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+}
+
+TEST_F(SystemdUnitStateTest, partialMatchSucceeds)
+{
+
+    std::map<std::string, std::string> args;
+    args["unitName"] = "fooArg.service";
+    args["ActiveState"] = ".*active";
+
+    auto executeCmd = systemCtlCmd;
+    executeCmd += "-p ActiveState ";
+    executeCmd += args["unitName"];
+
+    std::string fooServceAnyOutput = "ActiveState=inactive";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(executeCmd))).WillOnce(::testing::Return(Result<std::string>(fooServceAnyOutput)));
+    auto result = AuditSystemdUnitState(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}

--- a/src/modules/test/recipes/compliance/SystemdUnitState.json
+++ b/src/modules/test/recipes/compliance/SystemdUnitState.json
@@ -25,7 +25,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ SystemdUnitState: Success to match systemctl unit name 'foo.service' for name all params } == TRUE"
+    "Payload": "PASS{ SystemdUnitState: Successfully matched systemctl unit name 'foo.service' field 'LoadState' value 'not-found' with pattern 'not-found', Successfully matched systemctl unit name 'foo.service' field 'ActiveState' value 'inactive' with pattern 'inactive', Successfully matched systemctl unit name 'foo.service' field 'UnitFileState' value '' with pattern '' } == TRUE"
   },
 
   {
@@ -49,7 +49,7 @@
     "ObjectType": "Reported",
     "ComponentName": "Compliance",
     "ObjectName": "auditTest",
-    "Payload": "{ SystemdUnitState: Failed to match systemctl unit name 'foo.service' for name 'LoadState' for pattern 'active' for value 'not-found' } == FALSE"
+    "Payload": "{ SystemdUnitState: Failed to match systemctl unit name 'foo.service' field 'LoadState' value 'not-found' with pattern 'active' } == FALSE"
   },
   {
     "ObjectType": "Desired",


### PR DESCRIPTION
## Description
- Make systemd checks more verbose
- Strict match, not search, on the value

Note to reviewer: the test failures are there because it depends on #1035 


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
