### PR TITLE
EnsureSysctl procedure fixes:

### DIFF
--- a/src/modules/complianceengine/src/lib/procedures/EnsureSysctl.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureSysctl.cpp
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <CommonUtils.h>
 #include <Evaluator.h>
 #include <Regex.h>
 #include <algorithm>
+#include <fstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -14,16 +15,23 @@ namespace ComplianceEngine
 {
 namespace
 {
-std::string TrimWhitesSpace(const std::string& str);
+std::string TrimWhiteSpaces(const std::string& str)
+{
+    auto start = std::find_if_not(str.begin(), str.end(), ::isspace);
+    auto end = std::find_if_not(str.rbegin(), str.rend(), ::isspace).base();
+    if (start < end)
+    {
+        return std::string(start, end);
+    }
+    return std::string();
+}
 } // anonymous namespace
 
-AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-Z0-9_-]+)$", "value:Regex that the value of sysctl has to match:M",
-    "test_procfs:Prefix for the /proc/sys from where sysctl will be read")
+AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-Z0-9_-]+)$", "value:Regex that the value of sysctl has to match:M")
 {
     auto log = context.GetLogHandle();
-    char* output = NULL;
     std::string procfsLocation = "/proc/sys";
-    std::string systemdSysctl = "/lib/systemd/systemd-sysctl";
+    std::string systemdSysctl = "/lib/systemd/systemd-sysctl --cat-config";
 
     auto it = args.find("sysctlName");
     if (it == args.end())
@@ -39,25 +47,18 @@ AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-
     }
     auto sysctlValue = std::move(it->second);
 
-    it = args.find("test_procfs");
-    if (it != args.end())
-    {
-        procfsLocation = std::move(it->second);
-    }
-
     auto sysctlPath = sysctlName;
     std::replace(sysctlPath.begin(), sysctlPath.end(), '.', '/');
     std::string procSysPath = procfsLocation + std::string("/") + sysctlPath;
 
-    output = LoadStringFromFile(procSysPath.c_str(), false, log);
-    if (output == NULL)
+    auto output = context.GetFileContents(procSysPath);
+    if (!output.HasValue())
     {
-        return indicators.NonCompliant("Failed to load sysctl value from '" + procSysPath + "'");
+        return output.Error();
     }
-    std::string sysctlOutput(output);
-    FREE_MEMORY(output);
+    std::string sysctlOutput = output.Value();
 
-    // remove newline caracter
+    // remove newline character
     if (*sysctlOutput.rbegin() == '\n')
     {
         sysctlOutput.erase(sysctlOutput.size() - 1);
@@ -76,32 +77,22 @@ AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-
 
     if (regex_search(sysctlOutput, valueRegex) == false)
     {
-        return indicators.NonCompliant("Expected '" + sysctlName + "' value: '" + sysctlValue + "' got '" + sysctlOutput + "'");
+        return indicators.NonCompliant("Expected '" + sysctlName + "' value: '" + sysctlValue + "' got '" + sysctlOutput + "' in runtime configuration");
     }
-    if (args.find("test_procfs") == args.end())
+    else
     {
-        struct stat statbuf;
-        if (0 != stat(systemdSysctl.c_str(), &statbuf))
-        {
-            systemdSysctl = std::string("/usr/lib/systemd/systemd-sysctl");
-            if (0 != stat(systemdSysctl.c_str(), &statbuf))
-            {
-                OsConfigLogError(log, "Failed to locate systemd-sysctl command");
-                return Error("Failed to locate systemd-sysctl command");
-            }
-        }
+        indicators.Compliant("Correct value for '" + sysctlName + "': '" + sysctlValue + "' in runtime configuration");
     }
-    systemdSysctl += " --cat-config";
+
     // systemd-sysclt shows all configs used by system that have sysctl's
-    if ((0 != ExecuteCommand(NULL, systemdSysctl.c_str(), false, false, 0, 0, &output, NULL, log)) || (output == NULL))
+    auto execResult = context.ExecuteCommand(systemdSysctl);
+    if (!execResult.HasValue())
     {
         OsConfigLogError(log, "Failed to execute systemd-sysctl command");
-        return Error("Failed to execute systemd-sysctl command");
+        return execResult.Error();
     }
-    std::string sysctlConfigs(output);
-    FREE_MEMORY(output);
 
-    std::istringstream configurations(sysctlConfigs);
+    std::istringstream configurations(execResult.Value());
     std::string line;
     std::string runSysctlValue;
     std::vector<std::string> sysctlConfigLines;
@@ -141,9 +132,9 @@ AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-
             }
 
             std::string name = line.substr(0, eqPos);
-            name = TrimWhitesSpace(name);
+            name = TrimWhiteSpaces(name);
             runSysctlValue = line.substr(eqPos + 1, line.size() - eqPos);
-            runSysctlValue = TrimWhitesSpace(runSysctlValue);
+            runSysctlValue = TrimWhiteSpaces(runSysctlValue);
 
             if (name == sysctlName)
             {
@@ -158,7 +149,7 @@ AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-
     // we found a match with correct value
     if (found && !invalid)
     {
-        return indicators.Compliant("Correct value for '" + sysctlName + "': '" + sysctlValue + "'");
+        return indicators.Compliant("Correct value for '" + sysctlName + "': '" + sysctlValue + "' in stored configuration");
     }
 
     // lines are iterated backwards so filename is before last value marked by lines
@@ -190,20 +181,52 @@ AUDIT_FN(EnsureSysctl, "sysctlName:Name of the sysctl:M:^([a-zA-Z0-9_]+[\\.a-zA-
         return indicators.NonCompliant("Expected '" + sysctlName + "' value: '" + sysctlValue + "' got '" + runSysctlValue + "' found in: '" +
                                        fileName + "'");
     }
-    return indicators.NonCompliant("Expected '" + sysctlName + "' value: '" + sysctlValue + "' not found in system");
-}
-
-namespace
-{
-std::string TrimWhitesSpace(const std::string& str)
-{
-    auto start = std::find_if_not(str.begin(), str.end(), ::isspace);
-    auto end = std::find_if_not(str.rbegin(), str.rend(), ::isspace).base();
-    if (start < end)
+    else
     {
-        return std::string(start, end);
+        indicators.NonCompliant("Expected '" + sysctlName + "' value: '" + sysctlValue + "' not found in stored sysctl configuration");
     }
-    return std::string();
+
+    auto ufwDefaults = context.GetFileContents("/etc/default/ufw");
+    if (!ufwDefaults.HasValue())
+    {
+        return indicators.NonCompliant("Failed to read /etc/default/ufw: " + ufwDefaults.Error().message);
+    }
+    std::istringstream iss(ufwDefaults.Value());
+    std::string sysctlFile;
+    while (std::getline(iss, line))
+    {
+        if (line.find("IPT_SYSCTL=", 0) == 0)
+        {
+            sysctlFile = line.substr(std::string("IPT_SYSCTL=").size());
+            break;
+        }
+    }
+    if (sysctlFile.empty())
+    {
+        return indicators.NonCompliant("Failed to find IPT_SYSCTL in /etc/default/ufw");
+    }
+    auto sysctlContents = context.GetFileContents(TrimWhiteSpaces(sysctlFile));
+    if (!sysctlContents.HasValue())
+    {
+        return indicators.NonCompliant("Failed to read ufw sysctl config file: " + sysctlContents.Error().message);
+    }
+    std::istringstream sysctlStream(sysctlContents.Value());
+    while (std::getline(sysctlStream, line))
+    {
+        if (line.find(sysctlPath + "=", 0) == 0)
+        {
+            auto value = line.substr(sysctlName.size() + 1);
+            if (regex_search(value, valueRegex))
+            {
+                return indicators.Compliant("Correct value for '" + sysctlName + "': '" + sysctlValue + "' in UFW configuration");
+            }
+            else
+            {
+                return indicators.NonCompliant("Expected '" + sysctlName + "' value: '" + sysctlValue + "' got '" + value + "' in UFW configuration");
+            }
+        }
+    }
+
+    return indicators.NonCompliant("Value not found in UFW configuration for '" + sysctlName + "'");
 }
-} // anonymous namespace
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/procedures/EnsureSysctl.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureSysctl.schema.json
@@ -26,10 +26,6 @@
                 "value": {
                   "type": "string",
                   "description": "Regex that the value of sysctl has to match"
-                },
-                "test_procfs": {
-                  "type": "string",
-                  "description": "Prefix for the /proc/sys from where sysctl will be read"
                 }
               }
             }

--- a/src/modules/complianceengine/tests/procedures/EnsureSysctlTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureSysctlTest.cpp
@@ -22,6 +22,7 @@ using ComplianceEngine::Error;
 using ComplianceEngine::IndicatorsTree;
 using ComplianceEngine::Result;
 using ComplianceEngine::Status;
+using ::testing::Return;
 
 bool startsWith(const std::string& str, const std::string& prefix)
 {
@@ -130,72 +131,26 @@ class EnsureSysctlTest : public ::testing::Test
     };
 
 protected:
-    char dirTemplate[PATH_MAX] = "/tmp/ensureSysctlTest.XXXXXX";
-    std::string dir;
-    std::set<std::string, LengthComparator> sysctlDirs;
-    std::set<std::string, LengthComparator> sysctlFiles;
     MockContext mContext;
     IndicatorsTree mIndicators;
     CompactListFormatter mFormatter;
 
     void SetUp() override
     {
-        dir = mkdtemp(dirTemplate);
-        ASSERT_TRUE(dir != "");
         mIndicators.Push("EnsureSysctl");
-    }
-
-    // sysctlName: is sysctl name in dot notation e.g net.net/ipv4/ip_forwardipv4.ip_forward
-    void CreateSysctlFile(std::string sysctlName, std::string data)
-    {
-        int ret;
-        std::replace(sysctlName.begin(), sysctlName.end(), '.', '/');
-        std::string path = dir + std::string("/") + sysctlName;
-
-        size_t pos = 0;
-        while ((pos = path.find('/', pos)) != std::string::npos)
-        {
-            auto pathPart = path.substr(0, pos);
-            pos++;
-            if (startsWith(dir, pathPart))
-            {
-                continue;
-            }
-            ret = ::mkdir(pathPart.c_str(), 0777);
-            ASSERT_TRUE((ret == 0) || (ret != 0 && (errno == EEXIST)))
-                << "ERROR creating directory " << pathPart << " errno " << errno << ": " << strerror(errno);
-            sysctlDirs.insert(pathPart);
-        }
-
-        std::ofstream sysctlFile(path);
-        sysctlFile << data;
-        sysctlFile.close();
-        sysctlFiles.insert(path);
-    }
-
-    void TearDown() override
-    {
-        for (auto& file : sysctlFiles)
-        {
-            unlink(file.c_str());
-        }
-        for (auto& dir : sysctlDirs)
-        {
-            rmdir(dir.c_str());
-        }
-        rmdir(dir.c_str());
     }
 };
 
 TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "0";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -205,42 +160,47 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationNoOverride)
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueConfigurationEqualEmptyOuput)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, emptyOutput, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>(Error("No such file or directory", -1))));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "0";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWins)
+TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfigurationOverrideLastOneWins)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1Then0Than1Than0, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward1Then0Than1Than0)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "0";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationComment)
+TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfigurationComment)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0Comment, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0Comment)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>(Error("No such file or directory", -1))));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "0";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -250,12 +210,13 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationComment)
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueNotEqual)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward1)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "0";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -265,12 +226,13 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueNotEqual)
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward1)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "0";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -281,12 +243,13 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationOverride)
 TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpDotEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = ".";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -296,12 +259,13 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpDotEqualConfiruationNoOverrid
 TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "[0]";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -311,12 +275,13 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpRangeEqualConfiruationNoOverr
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 0\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward1)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "[0]";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -326,12 +291,13 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeEqualConfiruationNoOve
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeNotEqual)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "[0]";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -341,12 +307,13 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeNotEqual)
 TEST_F(EnsureSysctlTest, UnHappyPathRegexError)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward1)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "(?)[1]";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_FALSE(result.HasValue());
@@ -357,16 +324,18 @@ TEST_F(EnsureSysctlTest, UnHappyPathRegexError)
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualTabs)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0FilenameTabs, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0FilenameTabs)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "1";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_EQ(mFormatter.Format(mIndicators).Value(),
-        std::string("[NonCompliant] Expected 'net.ipv4.ip_forward' value: '1' got '0' found in: '/etc/sysctl.d/foo.conf'\n"));
+        std::string("[Compliant] Correct value for 'net.ipv4.ip_forward': '1' in runtime configuration\n[NonCompliant] Expected 'net.ipv4.ip_forward' "
+                    "value: '1' got '0' found in: '/etc/sysctl.d/foo.conf'\n"));
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
@@ -374,16 +343,18 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualTabs)
 TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualExtraSpacesFilenameReportCheck)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward0FilenameExtraSpaces, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward0FilenameExtraSpaces)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "1";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
     ASSERT_EQ(mFormatter.Format(mIndicators).Value(),
-        std::string("[NonCompliant] Expected 'net.ipv4.ip_forward' value: '1' got '0' found in: '/etc/sysctl.d/foo.conf'\n"));
+        std::string("[Compliant] Correct value for 'net.ipv4.ip_forward': '1' in runtime configuration\n[NonCompliant] Expected 'net.ipv4.ip_forward' "
+                    "value: '1' got '0' found in: '/etc/sysctl.d/foo.conf'\n"));
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
@@ -391,19 +362,21 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualExtraSpa
 TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWinsWithFilename)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
-    CreateSysctlFile(sysctlName, sysctlName + " = 1\n");
-    AddMockCommand(systemdSysctlCat, true, sysctlIpForward1Then0Than1Than0WithFilenames, 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(sysctlIpForward1Then0Than1Than0WithFilenames)));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = "1";
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
 
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
     ASSERT_EQ(mFormatter.Format(mIndicators).Value(),
-        std::string("[NonCompliant] Expected 'net.ipv4.ip_forward' value: '1' got '0' found in: '/etc/sysctl.d/fwd_0_v2.conf'\n"));
+        std::string("[Compliant] Correct value for 'net.ipv4.ip_forward': '1' in runtime configuration\n[NonCompliant] Expected 'net.ipv4.ip_forward' "
+                    "value: '1' got '0' found in: '/etc/sysctl.d/fwd_0_v2.conf'\n"));
 }
 
 TEST_F(EnsureSysctlTest, HappyPathValidateCisSysctls)
@@ -414,12 +387,13 @@ TEST_F(EnsureSysctlTest, HappyPathValidateCisSysctls)
         auto value = cisSsysctlNames[i].value;
         auto cfgOuput = cisSsysctlNames[i].CfgOutput();
 
-        CreateSysctlFile(sysctlName, sysctlName + " = " + value + "\n");
-        AddMockCommand(systemdSysctlCat, true, cfgOuput.c_str(), 0);
+        auto sysctlSlashedName = sysctlName;
+        std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+        EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>(value + "\n")));
+        EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(cfgOuput.c_str())));
         std::map<std::string, std::string> args;
         args["sysctlName"] = sysctlName;
         args["value"] = value;
-        args["test_procfs"] = dir;
 
         auto result = AuditEnsureSysctl(args, mIndicators, mContext);
 
@@ -437,13 +411,13 @@ TEST_F(EnsureSysctlTest, UnhappyPathSysctlMultilineOutput)
     auto sysctlName = sysctlNameValue.name;
     auto value = sysctlNameValue.value;
     auto cfgOuput = sysctlNameValue.CfgOutput();
-
-    CreateSysctlFile(sysctlName, sysctlName + " = " + value + "\n");
-    AddMockCommand(systemdSysctlCat, true, cfgOuput.c_str(), 0);
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>(value + "\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(cfgOuput.c_str())));
     std::map<std::string, std::string> args;
     args["sysctlName"] = sysctlName;
     args["value"] = value;
-    args["test_procfs"] = dir;
 
     auto result = AuditEnsureSysctl(args, mIndicators, mContext);
 
@@ -452,4 +426,97 @@ TEST_F(EnsureSysctlTest, UnhappyPathSysctlMultilineOutput)
     ASSERT_EQ(result.Value(), Status::NonCompliant) << "HappyPathValidateSysctlNameAndValues FAILED: nr "
                                                     << " name '" << sysctlName << "'";
     ;
+}
+
+TEST_F(EnsureSysctlTest, UfwDefaultsFileMissing)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>(Error("No such file or directory", -1))));
+
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    auto result = AuditEnsureSysctl(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to read /etc/default/ufw") != std::string::npos);
+}
+
+TEST_F(EnsureSysctlTest, UfwDefaultsFileNoIptSysctl)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>("# No IPT_SYSCTL here\nFOO=bar\n")));
+
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    auto result = AuditEnsureSysctl(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to find IPT_SYSCTL") != std::string::npos);
+}
+
+TEST_F(EnsureSysctlTest, UfwSysctlFileMissing)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>("IPT_SYSCTL=/tmp/ufw-sysctl.conf\n")));
+    EXPECT_CALL(mContext, GetFileContents("/tmp/ufw-sysctl.conf")).WillRepeatedly(Return(Result<std::string>(Error("No such file or directory", -1))));
+
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    auto result = AuditEnsureSysctl(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to read ufw sysctl config file") != std::string::npos);
+}
+
+TEST_F(EnsureSysctlTest, UfwSysctlFileValueMatches)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>("IPT_SYSCTL=/tmp/ufw-sysctl.conf\n")));
+    EXPECT_CALL(mContext, GetFileContents("/tmp/ufw-sysctl.conf")).WillRepeatedly(Return(Result<std::string>("net/ipv4/ip_forward=1\n")));
+
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    auto result = AuditEnsureSysctl(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("in UFW configuration") != std::string::npos);
+}
+
+TEST_F(EnsureSysctlTest, UfwSysctlFileValueDoesNotMatch)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>("IPT_SYSCTL=/tmp/ufw-sysctl.conf\n")));
+    EXPECT_CALL(mContext, GetFileContents("/tmp/ufw-sysctl.conf")).WillRepeatedly(Return(Result<std::string>("net/ipv4/ip_forward=0\n")));
+
+    std::map<std::string, std::string> args;
+    args["sysctlName"] = sysctlName;
+    args["value"] = "1";
+    auto result = AuditEnsureSysctl(args, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("got '0' in UFW configuration") != std::string::npos);
 }

--- a/src/modules/test/recipes/compliance/EnsureSyctl.json
+++ b/src/modules/test/recipes/compliance/EnsureSyctl.json
@@ -3,98 +3,40 @@
     "Action": "LoadModule",
     "Module": "complianceengine.so"
   },
-  // Comment out test setup and acctuall test of EnsureSysctl due to problem seting  sysctl relably in github containtes
-  // {
-  //   "RunCommand": "sysctl net.ipv4.conf.default.log_martians=1 && test -f /etc/sysctl.d/99-sysctl.conf && cp /etc/sysctl.d/99-sysctl.conf /etc/sysctl.d/99-sysctl.conf.bak ||  true ; echo net.ipv4.conf.default.log_martians=1 >> /etc/sysctl.d/99-sysctl.conf"
-  // },
-  // {
-  //   "ObjectType": "Desired",
-  //   "ComponentName": "ComplianceEngine",
-  //   "ObjectName": "procedureTest",
-  //   "Payload": {
-  //     "audit": {
-  //       "EnsureSysctl": {
-  //         "sysctlName": "net.ipv4.conf.default.log_martians",
-  //         "value": "1"
-  //       }
-  //     },
-  //     "parameters": {
-  //     }
-  //   }
-  // },
-  // {
-  //   "ObjectType": "Reported",
-  //   "ComponentName": "ComplianceEngine",
-  //   "ObjectName": "auditTest",
-  //   "Payload": "PASS{ EnsureSysctl: Correct value for 'net.ipv4.conf.default.log_martians': '1' } == TRUE"
-  // },
-  // Comment out test setup and acctuall test of EnsureSysctl due to problem seting  sysctl relably in github containtes
-  // {
-  //   "RunCommand": "sysctl net.ipv4.conf.default.log_martians=0 && test -f /etc/sysctl.d/99-sysctl.conf.bak && { mv /etc/sysctl.d/99-sysctl.conf.bak /etc/sysctl.d/99-sysctl.conf ; } || { rm /etc/sysctl.d/99-sysctl.conf ; }"
-  // },
-
-   // {
-   //   "RunCommand": "sysctl net.ipv4.conf.default.log_martians=0"
-   // },
-   // {
-   //   "RunCommand": "test -f /etc/sysctl.d/99-sysctl.conf && cp /etc/sysctl.d/99-sysctl.conf /etc/sysctl.d/99-sysctl.conf.bak ||  true ; echo net.ipv4.conf.default.log_martians=0 >> /etc/sysctl.d/99-sysctl.conf"
-   // },
-   // {
-   //   "ObjectType": "Desired",
-   //   "ComponentName": "ComplianceEngine",
-   //   "ObjectName": "procedureTest",
-   //   "Payload": {
-   //     "audit": {
-   //       "EnsureSysctl": {
-   //         "sysctlName": "net.ipv4.conf.default.log_martians",
-   //         "value": "0"
-   //       }
-   //     },
-   //     "parameters": {
-   //     }
-   //   }
-   // },
-   // {
-   //   "ObjectType": "Reported",
-   //   "ComponentName": "ComplianceEngine",
-   //   "ObjectName": "auditTest",
-   //   "Payload": "PASS{ EnsureSysctl: Correct value for 'net.ipv4.conf.default.log_martians': '0' } == TRUE"
-
-   // },
-   // {
-   //    "RunCommand": "test -f /etc/sysctl.d/99-sysctl.conf.bak && { mv /etc/sysctl.d/99-sysctl.conf.bak /etc/sysctl.d/99-sysctl.conf ; } || { rm /etc/sysctl.d/99-sysctl.conf ; }"
-   // },
-   // {
-   //   "RunCommand": "test -f /etc/sysctl.d/99-sysctl.conf && cp /etc/sysctl.d/99-sysctl.conf /etc/sysctl.d/99-sysctl.conf.bak ||  true ; echo net.ipv4.conf.default.log_martians=1 >> /etc/sysctl.d/99-sysctl.conf"
-   // },
-   // {
-   //   "ObjectType": "Desired",
-   //   "ComponentName": "ComplianceEngine",
-   //   "ObjectName": "procedureTest",
-   //   "Payload": {
-   //     "audit": {
-   //       "EnsureSysctl": {
-   //         "sysctlName": "net.ipv4.conf.default.log_martians",
-   //         "value": "0"
-   //       }
-   //     },
-   //     "parameters": {
-   //     }
-   //   }
-   // },
-   // {
-   //   "ObjectType": "Reported",
-   //   "ComponentName": "ComplianceEngine",
-   //   "ObjectName": "auditTest",
-   //   "Payload": "{ EnsureSysctl: Expected 'net.ipv4.conf.default.log_martians' value: '0' got '1' found in: '\/etc\/sysctl.d\/99-sysctl.conf' } == FALSE"
-
-   // },
-   // {
-   //    "RunCommand": "test -f /etc/sysctl.d/99-sysctl.conf.bak && { mv /etc/sysctl.d/99-sysctl.conf.bak /etc/sysctl.d/99-sysctl.conf ; } || { rm /etc/sysctl.d/99-sysctl.conf ; }"
-   // },
-
-
-   {
-     "Action": "UnloadModule"
-   }
+  // We cannot assume anything about the settings on the test machine, but anyOf [x, not x] should always PASS unless there's an error.
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "ComplianceEngine",
+    "ObjectName": "procedureTest",
+    "Payload": {
+      "audit": {
+        "anyOf": [
+          {
+            "EnsureSysctl": {
+              "sysctlName": "net.ipv4.conf.default.log_martians",
+              "value": "1"
+            }
+          },
+          {
+            "not": {
+              "EnsureSysctl": {
+                "sysctlName": "net.ipv4.conf.default.log_martians",
+                "value": "1"
+              }
+            }
+          }
+        ]
+      },
+      "parameters": {}
+    }
+  },
+  {
+    "ObjectType": "Reported",
+    "ComponentName": "ComplianceEngine",
+    "ObjectName": "auditTest",
+    "Payload": "PASS*"
+  },
+  {
+    "Action": "UnloadModule"
+  }
 ]


### PR DESCRIPTION
## Description
 - Make the checks more verbose
 - Use context for proper mocking, get rid of fake procfs
 - Check ufw configuration if the value is missing in systemd-sysctl

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
