### PR TITLE
Add a prefix to a non-critical incompliance message

### DIFF
--- a/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
+++ b/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
@@ -114,8 +114,7 @@ int ComplianceEngineMmiGet(MMI_HANDLE clientSession, const char* componentName, 
             {
                 OsConfigLogError(engine.Log(), "ComplianceEngineMmiGet failed with a non-critical error: %s (errno: %d)",
                     result.Error().message.c_str(), result.Error().code);
-                result =
-                    ComplianceEngine::AuditResult(Status::NonCompliant, "ComplianceEngineMmiGet failed with a non-critical error: " + result.Error().message);
+                result = ComplianceEngine::AuditResult(Status::NonCompliant, "Audit failed with a non-critical error: " + result.Error().message);
             }
         }
 

--- a/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
+++ b/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
@@ -114,7 +114,8 @@ int ComplianceEngineMmiGet(MMI_HANDLE clientSession, const char* componentName, 
             {
                 OsConfigLogError(engine.Log(), "ComplianceEngineMmiGet failed with a non-critical error: %s (errno: %d)",
                     result.Error().message.c_str(), result.Error().code);
-                result = ComplianceEngine::AuditResult(Status::NonCompliant, result.Error().message);
+                result =
+                    ComplianceEngine::AuditResult(Status::NonCompliant, "ComplianceEngineMmiGet failed with a non-critical error: " + result.Error().message);
             }
         }
 

--- a/src/modules/test/recipes/complianceengine/ExecuteCommandGrep.json
+++ b/src/modules/test/recipes/complianceengine/ExecuteCommandGrep.json
@@ -59,7 +59,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "Command useradd evilhacker is not allowed"
+    "Payload": "ComplianceEngineMmiGet failed with a non-critical error: Command useradd evilhacker is not allowed"
   },
 
   {

--- a/src/modules/test/recipes/complianceengine/ExecuteCommandGrep.json
+++ b/src/modules/test/recipes/complianceengine/ExecuteCommandGrep.json
@@ -59,7 +59,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "ComplianceEngineMmiGet failed with a non-critical error: Command useradd evilhacker is not allowed"
+    "Payload": "Audit failed with a non-critical error: Command useradd evilhacker is not allowed"
   },
 
   {


### PR DESCRIPTION
## Description

We have a graceful way of handling non-critical incompliance messages in the `ComplianceEngineMmiGet` function. This functionality prevents from prematurely aborting audit runs and allows GC worker to continue evaluation if a single rule fails.

The Augmentation Engine parses the outputs reported in the reason field and used to match against a 'failed to' string. However, this is incorrect as the messages vary and rely strictly on the procedures' outputs.

This PR adds a static prefix that we can attach to instead of the 'failed to' which is too generic and can be used in compliant cases.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
