### PR TITLE
Fix ASB user accounts enumeration for user accounts not found in shadow users database

### DIFF
--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -191,7 +191,7 @@ static bool IsUserNonLogin(SimplifiedUser* user)
 // We do this in order to log in full clear deviant accounts (that for example use a no-login shell while having UID above 1000)
 static bool IsSystemAccount(SimplifiedUser* user)
 {
-    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000) || (true == user->remoteOrFederated))) ? true : false;
+    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000) || user->remoteOrFederated)) ? true : false;
 }
 
 // Similar to determining if an user account is system, we identify a group to be system if either

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -340,6 +340,11 @@ static int CheckIfUserHasPassword(SimplifiedUser* user, OsConfigLogHandle log)
                 user->hasPassword = false;
         }
     }
+    else if (0 == errno)
+    {
+        OsConfigLogInfo(log, "CheckIfUserHasPassword: user %u is not found in shadow database (/etc/shadow), this may indicate a remote or federated user, assuming user has no password", user->userId);
+        user->hasPassword = false;
+    }
     else
     {
         OsConfigLogInfo(log, "CheckIfUserHasPassword: getspnam for user %u failed with %d (%s)", user->userId, errno, strerror(errno));

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -865,6 +865,11 @@ int RemoveUser(SimplifiedUser* user, OsConfigLogHandle log)
         OsConfigLogInfo(log, "RemoveUser: cannot remove user with uid 0 (%u, %u)", user->userId, user->groupId);
         return EPERM;
     }
+    else if (user->remoteOrFederated)
+    {
+        OsConfigLogInfo(log, "RemoveUser: cannot remove remote of federated user %u", user->userId);
+        return EPERM;
+    }
 
     if (NULL != (command = FormatAllocateString(commandTemplate, user->username)))
     {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -29,6 +29,7 @@ static void ResetUserEntry(SimplifiedUser* target)
         target->noLogin = false;
         target->cannotLogin = false;
         target->hasPassword = false;
+        target->remoteOrFederated = false;
         target->passwordEncryption = unknown;
         target->lastPasswordChange = 0;
         target->minimumPasswordAge = 0;
@@ -338,6 +339,7 @@ static int CheckIfUserHasPassword(SimplifiedUser* user, OsConfigLogHandle log)
             default:
                 OsConfigLogInfo(log, "CheckIfUserHasPassword: user %u appears to be missing password ('%c')", user->userId, control);
                 user->hasPassword = false;
+                user->remoteOrFederated = true;
         }
     }
     else if (0 == errno)
@@ -1352,6 +1354,10 @@ int RemoveUsersWithoutPasswords(OsConfigLogHandle log)
             else if (userList[i].cannotLogin)
             {
                 OsConfigLogInfo(log, "RemoveUsersWithoutPasswords: user %u cannot login with password", userList[i].userId);
+            }
+            else if (userList[i].remoteOrFederated)
+            {
+                OsConfigLogInfo(log, "RemoveUsersWithoutPasswords: user %u is a remote or federated user", userList[i].userId);
             }
             else
             {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -191,7 +191,7 @@ static bool IsUserNonLogin(SimplifiedUser* user)
 // We do this in order to log in full clear deviant accounts (that for example use a no-login shell while having UID above 1000)
 static bool IsSystemAccount(SimplifiedUser* user)
 {
-    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000) || user->remoteOrFederated)) ? true : false;
+    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000))) ? true : false;
 }
 
 // Similar to determining if an user account is system, we identify a group to be system if either
@@ -414,7 +414,6 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
         status = EPERM;
     }
 
-
     if (0 != status)
     {
         OsConfigLogInfo(log, "EnumerateUsers failed with %d", status);
@@ -426,11 +425,9 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
 
         for (i = 0; i < *size; i++)
         {
-            //OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
-            OsConfigLogInfo(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s', remote or federated: %u", i, (*userList)[i].userId,
+            OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
                 IsSystemAccount(&(*userList)[i]) ? (*userList)[i].username : g_redacted, (*userList)[i].groupId,
-                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : g_redacted, (*userList)[i].shell,
-                (true == (*userList)[i].remoteOrFederated) ? 1 : 0);//
+                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : g_redacted, (*userList)[i].shell);
         }
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -426,9 +426,11 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
 
         for (i = 0; i < *size; i++)
         {
-            OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
+            //OsConfigLogDebug(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s'", i, (*userList)[i].userId,
+            OsConfigLogInfo(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s', remote or federated: %u", i, (*userList)[i].userId,
                 IsSystemAccount(&(*userList)[i]) ? (*userList)[i].username : g_redacted, (*userList)[i].groupId,
-                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : g_redacted, (*userList)[i].shell);
+                IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : g_redacted, (*userList)[i].shell,
+                *userList)[i].remoteOrFederated ? 1 : 0);//
         }
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -430,7 +430,7 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
             OsConfigLogInfo(log, "EnumerateUsers(user %u): uid %d, name '%s', gid %d, home '%s', shell '%s', remote or federated: %u", i, (*userList)[i].userId,
                 IsSystemAccount(&(*userList)[i]) ? (*userList)[i].username : g_redacted, (*userList)[i].groupId,
                 IsSystemAccount(&(*userList)[i]) ? (*userList)[i].home : g_redacted, (*userList)[i].shell,
-                *userList)[i].remoteOrFederated ? 1 : 0);//
+                (true == (*userList)[i].remoteOrFederated) ? 1 : 0);//
         }
     }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -191,7 +191,7 @@ static bool IsUserNonLogin(SimplifiedUser* user)
 // We do this in order to log in full clear deviant accounts (that for example use a no-login shell while having UID above 1000)
 static bool IsSystemAccount(SimplifiedUser* user)
 {
-    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000))) ? true : false;
+    return (user && ((user->username && (0 == strcmp(user->username, g_root))) || IsUserNonLogin(user) || (user->userId < 1000) || (true == user->remoteOrFederated))) ? true : false;
 }
 
 // Similar to determining if an user account is system, we identify a group to be system if either

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -1314,6 +1314,11 @@ int CheckAllUsersHavePasswordsSet(char** reason, OsConfigLogHandle log)
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') cannot login with password",
                     userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
             }
+            else if (userList[i].remoteOrFederated)
+            {
+                OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s') is remote or federated",
+                    userList[i].userId, IsSystemAccount(&userList[i]) ? userList[i].username : g_redacted);
+            }
             else
             {
                 OsConfigLogInfo(log, "CheckAllUsersHavePasswordsSet: user %u ('%s')  not found to have a password set",

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -339,13 +339,13 @@ static int CheckIfUserHasPassword(SimplifiedUser* user, OsConfigLogHandle log)
             default:
                 OsConfigLogInfo(log, "CheckIfUserHasPassword: user %u appears to be missing password ('%c')", user->userId, control);
                 user->hasPassword = false;
-                user->remoteOrFederated = true;
         }
     }
     else if (0 == errno)
     {
         OsConfigLogInfo(log, "CheckIfUserHasPassword: user %u is not found in shadow database (/etc/shadow), this may indicate a remote or federated user, assuming user has no password", user->userId);
         user->hasPassword = false;
+        user->remoteOrFederated = true;
     }
     else
     {

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -34,6 +34,7 @@ typedef struct SimplifiedUser
     bool noLogin;
     bool cannotLogin;
     bool hasPassword;
+    bool remoteOrFederated;
 
     // Encryption algorithm (cypher) used for password
     PasswordEncryption passwordEncryption;

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -6,6 +6,9 @@
     "RunCommand": "useradd securitybaselinetest2 && id securitybaselinetest2"
   },
   {
+    "RunCommand": "sudo useradd testuser_noshadow && id testuser_noshadow"
+  },
+  {
     "Action": "LoadModule",
     "Module": "securitybaseline.so"
   },
@@ -2652,10 +2655,9 @@
   {
     "Action": "UnloadModule"
   },
-
-
-
-  // cleanup
+  // --------------------------------------------------------------------------------
+  // Clean-up
+  // --------------------------------------------------------------------------------
   {
     "RunCommand": "userdel -f -r securitybaselinetest || true"
   },
@@ -2673,5 +2675,14 @@
   },
   {
     "RunCommand": "groupdel securitybaselinetest2 || true"
+  },
+  {
+    "RunCommand": "userdel -f -r testuser_noshadow || true"
+  },
+  {
+    "RunCommand": "rm -rf /home/testuser_noshadow || true"
+  },
+  {
+    "RunCommand": "groupdel testuser_noshadow || true"
   }
 ]

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -6,7 +6,7 @@
     "RunCommand": "useradd securitybaselinetest2 && id securitybaselinetest2"
   },
   {
-    "RunCommand": "sudo useradd testuser_noshadow && sudo passwd -u testuser_noshadow && sudo sed -i '/^testuser_noshadow:/d' /etc/shadow && id testuser_noshadow"
+    "RunCommand": "sudo useradd testuser_noshadow && echo 'testuser_noshadow:DummyPass123!' | sudo chpasswd && sudo sed -i '/^testuser_noshadow:/d' /etc/shadow && id testuser_noshadow"
   },
   {
     "Action": "LoadModule",

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -6,7 +6,7 @@
     "RunCommand": "useradd securitybaselinetest2 && id securitybaselinetest2"
   },
   {
-    "RunCommand": "sudo useradd testuser_noshadow && id testuser_noshadow"
+    "RunCommand": "sudo useradd testuser_noshadow && sudo passwd -u testuser_noshadow && sudo sed -i '/^testuser_noshadow:/d' /etc/shadow && id testuser_noshadow"
   },
   {
     "Action": "LoadModule",


### PR DESCRIPTION
## Description

Fix ASB user accounts enumeration for user accounts not found in shadow users database so it won't break when encountering such an account which could be remote or federated. The way this situation is detected is when getspnam returns NULL and errno is 0 (no error). When this happens, instead of flagging this as an error, we mark that user account as such to remember, and we assume the account does not have a password, while overall skipping it from being removed for that reason.

The PR also adds testing for such special user accounts via the ASB (SecurityBaseline module) test recipe.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
