### PR TITLE
Fix ASB EnsureSshMaxAuthTriesIsSet audit rule

### DIFF
--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -580,6 +580,39 @@ static int CheckSshLoginGraceTime(const char* value, char** reason, OsConfigLogH
     return status;
 }
 
+static int CheckSshMaxAuthTries(const char* value, char** reason, OsConfigLogHandle log)
+{
+    char* maxAuthTries = DuplicateStringToLowercase(g_sshMaxAuthTries);
+    int targetValue = atoi(value ? value : g_sshDefaultSshMaxAuthTries);
+    int actualValue = 0;
+    int status = 0;
+
+    if (0 == IsSshServerActive(log))
+    {
+        if (0 == (status = CheckSshOptionIsSetToInteger(maxAuthTries, NULL, &actualValue, reason, log)))
+        {
+            OsConfigResetReason(reason);
+
+            if (actualValue <= targetValue)
+            {
+                OsConfigCaptureSuccessReason(reason, "%s reports that '%s' is set to '%d' (that is %d or less)", g_sshMaxAuthTries, maxAuthTries, targetValue, actualValue);
+            }
+            else
+            {
+                OsConfigLogInfo(log, "CheckSshMaxAuthTries: 'maxauthtries' is not set to %d or less in SSH Server response (but to %d)", targetValue, actualValue);
+                OsConfigCaptureReason(reason, "'maxauthtries' is not set to a value of %d or less in SSH Server response (but to %d)", targetValue, actualValue);
+                status = ENOENT;
+            }
+        }
+    }
+
+    FREE_MEMORY(loginGraceTime);
+
+    OsConfigLogInfo(log, "CheckSshMaxAuthTries returning %d", status);
+
+    return status;
+}
+
 static int CheckSshWarningBanner(char** reason, OsConfigLogHandle log)
 {
     const char* banner = "banner";
@@ -1350,7 +1383,7 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, OsConfigL
     else if (0 == strcmp(name, g_auditEnsureSshMaxAuthTriesIsSetObject))
     {
         lowercase = DuplicateStringToLowercase(g_sshMaxAuthTries);
-        CheckSshOptionIsSet(lowercase, g_desiredSshMaxAuthTriesIsSet ? g_desiredSshMaxAuthTriesIsSet : g_sshDefaultSshMaxAuthTries, NULL, reason, log);
+        CheckSshMaxAuthTries(g_desiredSshMaxAuthTriesIsSet ? g_desiredSshMaxAuthTriesIsSet : g_sshDefaultSshMaxAuthTries, reason, log);
     }
     else if (0 == strcmp(name, g_auditEnsureAllowUsersIsConfiguredObject))
     {

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -606,7 +606,7 @@ static int CheckSshMaxAuthTries(const char* value, char** reason, OsConfigLogHan
         }
     }
 
-    FREE_MEMORY(loginGraceTime);
+    FREE_MEMORY(maxAuthTries);
 
     OsConfigLogInfo(log, "CheckSshMaxAuthTries returning %d", status);
 

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -231,13 +231,13 @@
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "initEnsureSshMaxAuthTriesIsSet",
-    "Payload": "6"
+    "Payload": "4"
   },
   {
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "remediateEnsureSshMaxAuthTriesIsSet",
-    "Payload": "6"
+    "Payload": "4"
   },
   {
     "ObjectType": "Desired",


### PR DESCRIPTION
## Description

This is a fix for following the ASB (and SSH) audit rule: { "Ensure that the SSH MaxAuthTries is configured (CIS: L1 - Server - 5.2.7)", "e7708534-5d98-406f-83ae-1de835b2906e", "EnsureSshMaxAuthTriesIsSet" }.

This rule allows for values lower or equal than the expected value to be set and to pass audit.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.