### PR TITLE
Fix sanitizers unit tests workflow

### DIFF
--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -68,7 +68,7 @@ jobs:
           container: ${{ steps.container.outputs.id }}
           cmd: |
             mkdir build && cd build
-            cmake ../src -DCMAKE_C_COMPILER="/usr/bin/gcc" -DCMAKE_CXX_COMPILER="/usr/bin/g++" -DCMAKE_C_FLAGS="${{ env.SANITIZER_FLAGS }}" -DCMAKE_CXX_FLAGS="${{ env.SANITIZER_FLAGS }}" -DCMAKE_build-type=${{ env.BUILD_TYPE }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_ADAPTERS=ON -Duse_default_uuid=ON
+            cmake ../src -DCMAKE_C_COMPILER='/usr/bin/gcc' -DCMAKE_CXX_COMPILER='/usr/bin/g++' -DCMAKE_C_FLAGS='${{ env.SANITIZER_FLAGS }}' -DCMAKE_CXX_FLAGS='${{ env.SANITIZER_FLAGS }}' -DCMAKE_build-type=${{ env.BUILD_TYPE }} -Duse_prov_client=ON -Dhsm_type_symm_key=ON -DCOMPILE_WITH_STRICTNESS=ON -DBUILD_TESTS=ON -DBUILD_SAMPLES=ON -DBUILD_ADAPTERS=ON -Duse_default_uuid=ON
 
       - name: Build Azure OSConfig
         uses: ./.github/actions/container-exec

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,9 @@ if (BUILD_MODULES)
     add_subdirectory(modules)
 endif()
 
+message(STATUS "CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CPACK_PACKAGE_VENDOR ${OsConfigProjectVendor})

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -125,6 +125,12 @@ bool FileEndsInEol(const char* fileName, OsConfigLogHandle log)
     int status = 0;
     bool result = false;
 
+    if (NULL == fileName)
+    {
+        OsConfigLogError(log, "FileEndsInEol: invalid argument");
+        return false;
+    }
+
     if (0 == (status = stat(fileName, &statStruct)))
     {
         if (statStruct.st_size > 0)

--- a/src/modules/samples/cpp/src/lib/Sample.cpp
+++ b/src/modules/samples/cpp/src/lib/Sample.cpp
@@ -783,3 +783,11 @@ unsigned int Sample::GetMaxPayloadSizeBytes()
 {
     return m_maxPayloadSizeBytes;
 }
+
+void Sample::MmiFree(MMI_JSON_STRING payload)
+{
+    if (nullptr != payload)
+    {
+        delete[] payload;
+    }
+}

--- a/src/modules/samples/cpp/src/lib/Sample.h
+++ b/src/modules/samples/cpp/src/lib/Sample.h
@@ -110,6 +110,7 @@ public:
     virtual int Set(const char* componentName, const char* objectName, const MMI_JSON_STRING payload, const int payloadSizeBytes);
     virtual int Get(const char* componentName, const char* objectName, MMI_JSON_STRING* payload, int* payloadSizeBytes);
     virtual unsigned int GetMaxPayloadSizeBytes();
+    void MmiFree(MMI_JSON_STRING payload);
 
 private:
     static int SerializeStringEnumeration(rapidjson::Writer<rapidjson::StringBuffer>& writer, StringEnumeration value);

--- a/src/modules/samples/cpp/tests/SampleTests.cpp
+++ b/src/modules/samples/cpp/tests/SampleTests.cpp
@@ -63,7 +63,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedStringObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -77,7 +77,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedIntegerObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -91,7 +91,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedBooleanObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -121,7 +121,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -168,14 +168,14 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
 
         ASSERT_EQ(MMI_OK, session->Set(componentName, desiredObjectName, jsonPayloadWithNullMapValues, strlen(jsonPayloadWithNullMapValues)));
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadStringWithNullMapValues(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayloadWithNullMapValues, payloadStringWithNullMapValues.c_str());
     }
 
@@ -207,7 +207,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedArrayObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -219,12 +219,12 @@ namespace OSConfig::Platform::Tests
         MMI_JSON_STRING payload = nullptr;
 
         ASSERT_EQ(EINVAL, session->Set(invalidName.c_str(), desiredStringObjectName, jsonPayload, strlen(jsonPayload)));
-        delete[] payload;
+        session->MmiFree(payload);
         ASSERT_EQ(EINVAL, session->Set(componentName, invalidName.c_str(), jsonPayload, strlen(jsonPayload)));
 
         ASSERT_EQ(EINVAL, session->Get(invalidName.c_str(), reportedStringObjectName, &payload, &payloadSizeBytes));
         ASSERT_EQ(EINVAL, session->Get(componentName, invalidName.c_str(), &payload, &payloadSizeBytes));
-        delete[] payload;
+        session->MmiFree(payload);
     }
 
     TEST_F(CppSampleTests, SetInvalidPayloadString)

--- a/src/modules/samples/cpp/tests/SampleTests.cpp
+++ b/src/modules/samples/cpp/tests/SampleTests.cpp
@@ -63,6 +63,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedStringObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -76,6 +77,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedIntegerObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -89,6 +91,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedBooleanObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -118,6 +121,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -164,12 +168,14 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
 
         ASSERT_EQ(MMI_OK, session->Set(componentName, desiredObjectName, jsonPayloadWithNullMapValues, strlen(jsonPayloadWithNullMapValues)));
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadStringWithNullMapValues(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayloadWithNullMapValues, payloadStringWithNullMapValues.c_str());
     }
 
@@ -201,6 +207,7 @@ namespace OSConfig::Platform::Tests
         ASSERT_EQ(MMI_OK, session->Get(componentName, reportedArrayObjectName, &payload, &payloadSizeBytes));
 
         std::string payloadString(payload, payloadSizeBytes);
+        delete[] payload;
         ASSERT_STREQ(jsonPayload, payloadString.c_str());
     }
 
@@ -212,10 +219,12 @@ namespace OSConfig::Platform::Tests
         MMI_JSON_STRING payload = nullptr;
 
         ASSERT_EQ(EINVAL, session->Set(invalidName.c_str(), desiredStringObjectName, jsonPayload, strlen(jsonPayload)));
+        delete[] payload;
         ASSERT_EQ(EINVAL, session->Set(componentName, invalidName.c_str(), jsonPayload, strlen(jsonPayload)));
 
         ASSERT_EQ(EINVAL, session->Get(invalidName.c_str(), reportedStringObjectName, &payload, &payloadSizeBytes));
         ASSERT_EQ(EINVAL, session->Get(componentName, invalidName.c_str(), &payload, &payloadSizeBytes));
+        delete[] payload;
     }
 
     TEST_F(CppSampleTests, SetInvalidPayloadString)


### PR DESCRIPTION
## Description

Fix sanitizers unit tests workflow. Previously, we would pass wrong arguments to the cmake command due to double quote escaping.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
