### PR TITLE
Fix compliance message in EnsureFilePermissions

### DIFF
--- a/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
+++ b/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
@@ -154,11 +154,8 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, con
                 << std::oct << perms;
             return indicators.NonCompliant(oss.str());
         }
-        else
-        {
-            OsConfigLogDebug(log, "Permissions are correct");
-        }
 
+        OsConfigLogDebug(log, "Permissions are correct");
         std::ostringstream oss;
         oss << filename << " matches expected permissions " << std::oct << perms;
         indicators.Compliant(oss.str());
@@ -172,16 +169,15 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, con
                 << " should not be set";
             return indicators.NonCompliant(oss.str());
         }
-        else
-        {
-            OsConfigLogDebug(log, "Mask is correct");
-        }
+
+        OsConfigLogDebug(log, "Mask is correct");
+        std::ostringstream oss;
+        oss << filename << " mask matches expected mask " << std::oct << mask;
+        indicators.Compliant(oss.str());
     }
 
     OsConfigLogDebug(log, "File '%s' has correct permissions", filename.c_str());
-    std::ostringstream oss;
-    oss << filename << " mask matches expected mask " << std::oct << mask;
-    return indicators.Compliant(oss.str());
+    return indicators.Compliant("File '" + filename + "' has correct permissions and ownership");
 }
 
 Result<Status> RemediateEnsureFilePermissionsHelper(const std::string& filename, const std::map<std::string, std::string>& args,

--- a/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
+++ b/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
@@ -155,7 +155,7 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, con
             return indicators.NonCompliant(oss.str());
         }
 
-        OsConfigLogDebug(log, "Permissions are correct");
+        OsConfigLogDebug(log, "%s permissions are correct", filename.c_str());
         std::ostringstream oss;
         oss << filename << " matches expected permissions " << std::oct << perms;
         indicators.Compliant(oss.str());
@@ -170,7 +170,7 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, con
             return indicators.NonCompliant(oss.str());
         }
 
-        OsConfigLogDebug(log, "Mask is correct");
+        OsConfigLogDebug(log, "%s mask is correct", filename.c_str());
         std::ostringstream oss;
         oss << filename << " mask matches expected mask " << std::oct << mask;
         indicators.Compliant(oss.str());

--- a/src/modules/test/recipes/complianceengine/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/complianceengine/EnsureFilePermissions.json
@@ -53,7 +53,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 777, \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 777, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
 
 
@@ -68,7 +68,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 777, \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 777, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0777\/-rwxrwxrwx)'"
@@ -85,7 +85,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 644, \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 644, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "ObjectType": "Desired",
@@ -97,7 +97,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 644, \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 644, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
 
 
@@ -167,7 +167,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile mask matches expected mask 0, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "ObjectType": "Desired",
@@ -191,7 +191,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile mask matches expected mask 177 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile mask matches expected mask 177, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
 
 
@@ -209,7 +209,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile mask matches expected mask 177 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile mask matches expected mask 177, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0600\/-rw-------)'"
@@ -260,7 +260,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'bar', \/tmp\/testfile mask matches expected mask 133 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'bar', /tmp/testfile mask matches expected mask 133, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0644\/-rw-r--r--)' | grep root | grep bar"
@@ -290,7 +290,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'foo', \/tmp\/testfile group matches expected value 'bar', \/tmp\/testfile mask matches expected mask 177 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'foo', /tmp/testfile group matches expected value 'bar', /tmp/testfile mask matches expected mask 177, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0600\/-rw-------)' | grep foo | grep bar"
@@ -351,7 +351,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 777, \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 777, /tmp/testfile mask matches expected mask 0, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
 
 
@@ -384,7 +384,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 333, \/tmp\/testfile mask matches expected mask 444 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 333, /tmp/testfile mask matches expected mask 444, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (0333\/--wx-wx-wx)'"
@@ -402,7 +402,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 1000, \/tmp\/testfile mask matches expected mask 0 } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissions: /tmp/testfile owner matches expected value 'root', /tmp/testfile group matches expected value 'root', /tmp/testfile matches expected permissions 1000, /tmp/testfile mask matches expected mask 0, File '/tmp/testfile' has correct permissions and ownership } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testfile | grep 'Access: (1333\/--wx-wx-wt)'"
@@ -450,7 +450,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "PASS{ EnsureFilePermissionsCollection: \/tmp\/testdir\/test1.log matches expected permissions 666, \/tmp\/testdir\/test1.log mask matches expected mask 0, All matching files in '\/tmp\/testdir' match expected permissions } == TRUE"
+    "Payload": "PASS{ EnsureFilePermissionsCollection: /tmp/testdir/test1.log matches expected permissions 666, File '/tmp/testdir/test1.log' has correct permissions and ownership, All matching files in '/tmp/testdir' match expected permissions } == TRUE"
   },
   {
     "RunCommand": "stat /tmp/testdir/test1.log | grep 'Access: (0666\/-rw-rw-rw-)'"


### PR DESCRIPTION
## Description

If no 'mask' argument is provided, we currently show spurious compliant message, e.g.: '/etc/crontab mask matches expected mask 0'.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
