### PR TITLE
Improve the reason for the EnsureAuditdServiceIsRunning ASB rule audit when auditd and auoms are both active

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -1807,8 +1807,15 @@ static char* AuditEnsureLocalLoginWarningBannerIsConfigured(OsConfigLogHandle lo
 static char* AuditEnsureAuditdServiceIsRunning(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckDaemonActive(g_auditd, &reason, log);
-    CheckDaemonNotActive(g_auoms, &reason, log);
+    bool auditdActive = CheckDaemonActive(g_auditd, &reason, log);
+    bool auomsActive = CheckDaemonNotActive(g_auoms, &reason, log);
+
+    if (auditActive && auomsActive)
+    {
+        FREE_MEMORY(reason);
+        reason = FormatAllocateString("'%s' is active and collides with '%s', %s", g_auoms, g_auditd, g_remediationIsNotPossible);
+    }
+    
     return reason;
 }
 


### PR DESCRIPTION
## Description

What was happening here is that the auditd active was checked first and passed, and then auoms not active was checked next and this failed, resetting the reason to failure and forgetting the initial successful reason of auditd found active. So in the end reason was: 'auoms is active', which looked confusing to some self-hosters. 
 
Supplemented this particular case when both auditd and auoms are active at the same time with a reason phrase like this:
 
'auoms' is active and collides with 'auditd', automatic remediation is not possible'
 
We already had this comment in source:
 
// The auoms service is part of Microsoft's Operations Management Suite (OMS) and is used for collecting audit events.
// Conflicts between auoms and auditd can arise because both services attempt to manage and collect audit events.
// One of the recommended mitigation strategies is Single Service Usage: use either auoms or auditd, but not both.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
