### PR TITLE
Fixing one remaining case in which ASB's EnsureCoreDumpsAreRestricted rule audit can end in audit failure without a reason phrase

### DIFF
--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -968,7 +968,7 @@ int CheckCoreDumpsHardLimitIsDisabledForAllUsers(char** reason, OsConfigLogHandl
         }
         else
         {
-            OsConfigCaptureReason(reason, "'*hard core 0' is not present uncommented in '/etc/security/limits.conf' or in a file under '/etc/security/limits.d/'");
+            OsConfigCaptureReason(reason, "'*hard core 0' is not present uncommented in '/etc/security/limits.conf' or in any file under '/etc/security/limits.d/'");
         }
 
         FREE_MEMORY(textResult);

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -968,7 +968,7 @@ int CheckCoreDumpsHardLimitIsDisabledForAllUsers(char** reason, OsConfigLogHandl
         }
         else
         {
-            OsConfigCaptureReason(reason, "'*hard core 0' is not present uncommented in in '/etc/security/limits.conf' or in a file under '/etc/security/limits.d/'");
+            OsConfigCaptureReason(reason, "'*hard core 0' is not present uncommented in '/etc/security/limits.conf' or in a file under '/etc/security/limits.d/'");
         }
 
         FREE_MEMORY(textResult);

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -968,6 +968,7 @@ int CheckCoreDumpsHardLimitIsDisabledForAllUsers(char** reason, OsConfigLogHandl
         }
         else
         {
+            OsConfigResetReason(reason);
             OsConfigCaptureReason(reason, "'*hard core 0' is not present uncommented in '/etc/security/limits.conf' or in any file under '/etc/security/limits.d/'");
         }
 

--- a/src/common/commonutils/DeviceInfoUtils.c
+++ b/src/common/commonutils/DeviceInfoUtils.c
@@ -966,6 +966,10 @@ int CheckCoreDumpsHardLimitIsDisabledForAllUsers(char** reason, OsConfigLogHandl
                 OsConfigCaptureReason(reason, "'*hard core 0' is not present in any file, or is commented out under '/etc/security/limits.d/'");
             }
         }
+        else
+        {
+            OsConfigCaptureReason(reason, "'*hard core 0' is not present uncommented in in '/etc/security/limits.conf' or in a file under '/etc/security/limits.d/'");
+        }
 
         FREE_MEMORY(textResult);
     }


### PR DESCRIPTION
## Description

Fixing one remaining case in which ASB's EnsureCoreDumpsAreRestricted rule audit can end in audit failure without a reason phrase.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
