### PR TITLE
Temporarily disable Mariner 2 builds

### DIFF
--- a/.github/workflows/module-test.yml
+++ b/.github/workflows/module-test.yml
@@ -19,7 +19,6 @@ jobs:
             { os: azurelinux, version: 3, package-type: RPM },
             { os: debian, version: 11, package-type: DEB },
             { os: debian, version: 12, package-type: DEB },
-            { os: mariner, version: 2, package-type: RPM },
             { os: oraclelinux, version: 8, package-type: RPM },
             { os: rhel, version: 8, package-type: RPM },
             { os: rhel, version: 9, package-type: RPM },

--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -55,7 +55,6 @@ jobs:
               { "os": "azurelinux", "version": "3" },
               { "os": "debian", "version": "11" },
               { "os": "debian", "version": "12" },
-              { "os": "mariner", "version": "2" },
               { "os": "oraclelinux", "version": "8" },
               { "os": "rhel", "version": "8" },
               { "os": "rhel", "version": "9" },


### PR DESCRIPTION
## Description

Our CI is down for some time now due to consistent failures of Mariner 2 self-hosted VMs provisioning.
Disable temporarily - if it's possible to restore these machines then we can revert this PR.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
