### PR TITLE
Splitting the policy packages for SSH and ASB into Get and Set parts

### DIFF
--- a/src/adapters/mc/asb/CMakeLists.txt
+++ b/src/adapters/mc/asb/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(OsConfigResourceAsb
 # SO binary name must match the universal class name in MOF with a "lib" prefix added
 set_target_properties(OsConfigResourceAsb PROPERTIES OUTPUT_NAME libOsConfigResource)
 
-# Create the policy artifacts ZIP packages for the Azure Security Baseline for Linux
+# Create the policy artifacts ZIP packages for the Azure Security Baseline for Linux (Get and Set)
 
-# For Audit:
+# For Audit (Get):
 
 add_custom_target(stage_create_asb_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
@@ -40,7 +40,7 @@ add_custom_target(create_asb_zip ALL
     DEPENDS stage_create_asb_zip
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)
 
-# For Remediation:
+# For Remediation (Set):
 
 add_custom_target(stage_create_asb_zip_set
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging

--- a/src/adapters/mc/asb/CMakeLists.txt
+++ b/src/adapters/mc/asb/CMakeLists.txt
@@ -30,6 +30,7 @@ add_custom_target(stage_create_asb_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.mof" ${PROJECT_BINARY_DIR}/Staging/
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${PROJECT_BINARY_DIR}/Staging/SetAzureLinuxBaseline.mof
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OsConfigResourceAsb> ${PROJECT_BINARY_DIR}/Staging/Modules/DscNativeResources/OsConfigResource/libOsConfigResource.so
     DEPENDS OsConfigResourceAsb)
 

--- a/src/adapters/mc/asb/CMakeLists.txt
+++ b/src/adapters/mc/asb/CMakeLists.txt
@@ -24,6 +24,8 @@ set_target_properties(OsConfigResourceAsb PROPERTIES OUTPUT_NAME libOsConfigReso
 
 # Create the policy artifacts ZIP packages for the Azure Security Baseline for Linux
 
+# For Audit:
+
 add_custom_target(stage_create_asb_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
@@ -37,10 +39,13 @@ add_custom_target(create_asb_zip ALL
     DEPENDS stage_create_asb_zip
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)
 
+# For Remediation:
+
 add_custom_target(stage_create_asb_zip_set
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.mof" ${PROJECT_BINARY_DIR}/Staging/SetAzureLinuxBaseline.mof
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${PROJECT_BINARY_DIR}/Staging/AzureLinuxBaseline.mof
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OsConfigResourceAsb> ${PROJECT_BINARY_DIR}/Staging/Modules/DscNativeResources/OsConfigResource/libOsConfigResource.so
     DEPENDS OsConfigResourceAsb)
 

--- a/src/adapters/mc/asb/CMakeLists.txt
+++ b/src/adapters/mc/asb/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(OsConfigResourceAsb
 # SO binary name must match the universal class name in MOF with a "lib" prefix added
 set_target_properties(OsConfigResourceAsb PROPERTIES OUTPUT_NAME libOsConfigResource)
 
-# Create the policy artifacts ZIP package for the Azure Security Baseline for Linux
+# Create the policy artifacts ZIP packages for the Azure Security Baseline for Linux
 
 add_custom_target(stage_create_asb_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
@@ -35,4 +35,17 @@ add_custom_target(create_asb_zip ALL
     BYPRODUCTS ${OsConfigRootBinaryDir}/AzureLinuxBaseline.zip
     COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${OsConfigRootBinaryDir}/AzureLinuxBaseline.zip" --format=zip .
     DEPENDS stage_create_asb_zip
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)
+
+add_custom_target(stage_create_asb_zip_set
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/AzureLinuxBaseline.mof" ${PROJECT_BINARY_DIR}/Staging/SetAzureLinuxBaseline.mof
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OsConfigResourceAsb> ${PROJECT_BINARY_DIR}/Staging/Modules/DscNativeResources/OsConfigResource/libOsConfigResource.so
+    DEPENDS OsConfigResourceAsb)
+
+add_custom_target(create_asb_zip_set ALL
+    BYPRODUCTS ${OsConfigRootBinaryDir}/SetAzureLinuxBaseline.zip
+    COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${OsConfigRootBinaryDir}/SetAzureLinuxBaseline.zip" --format=zip .
+    DEPENDS stage_create_asb_zip_set
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)

--- a/src/adapters/mc/ssh/CMakeLists.txt
+++ b/src/adapters/mc/ssh/CMakeLists.txt
@@ -24,6 +24,8 @@ set_target_properties(OsConfigResourceSsh PROPERTIES OUTPUT_NAME libOsConfigReso
 
 # Create the policy artifacts ZIP packages for SSH Posture Control
 
+# For Audit:
+
 add_custom_target(stage_create_ssh_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
@@ -37,10 +39,13 @@ add_custom_target(create_ssh_zip ALL
     DEPENDS stage_create_ssh_zip
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)
 
+# For Remediation:
+
 add_custom_target(stage_create_ssh_zip_set
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.mof" ${PROJECT_BINARY_DIR}/Staging/SetLinuxSshServerSecurityBaseline.mof
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${PROJECT_BINARY_DIR}/Staging/LinuxSshServerSecurityBaseline.mof
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OsConfigResourceSsh> ${PROJECT_BINARY_DIR}/Staging/Modules/DscNativeResources/OsConfigResource/libOsConfigResource.so
     DEPENDS OsConfigResourceSsh)
 

--- a/src/adapters/mc/ssh/CMakeLists.txt
+++ b/src/adapters/mc/ssh/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(OsConfigResourceSsh
 # SO binary name must match the universal class name in MOF with a "lib" prefix added
 set_target_properties(OsConfigResourceSsh PROPERTIES OUTPUT_NAME libOsConfigResource)
 
-# Create the policy artifacts ZIP packages for SSH Posture Control
+# Create the policy artifacts ZIP packages for SSH Posture Control (Get and Set)
 
-# For Audit:
+# For Audit (Get):
 
 add_custom_target(stage_create_ssh_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
@@ -40,7 +40,7 @@ add_custom_target(create_ssh_zip ALL
     DEPENDS stage_create_ssh_zip
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)
 
-# For Remediation:
+# For Remediation (Set):
 
 add_custom_target(stage_create_ssh_zip_set
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging

--- a/src/adapters/mc/ssh/CMakeLists.txt
+++ b/src/adapters/mc/ssh/CMakeLists.txt
@@ -30,6 +30,7 @@ add_custom_target(stage_create_ssh_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.mof" ${PROJECT_BINARY_DIR}/Staging/
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${PROJECT_BINARY_DIR}/Staging/SetLinuxSshServerSecurityBaseline.mof
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OsConfigResourceSsh> ${PROJECT_BINARY_DIR}/Staging/Modules/DscNativeResources/OsConfigResource/libOsConfigResource.so
     DEPENDS OsConfigResourceSsh)
 

--- a/src/adapters/mc/ssh/CMakeLists.txt
+++ b/src/adapters/mc/ssh/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(OsConfigResourceSsh
 # SO binary name must match the universal class name in MOF with a "lib" prefix added
 set_target_properties(OsConfigResourceSsh PROPERTIES OUTPUT_NAME libOsConfigResource)
 
-# Create the policy artifacts ZIP package for SSH Posture Control
+# Create the policy artifacts ZIP packages for SSH Posture Control
 
 add_custom_target(stage_create_ssh_zip
     COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
@@ -35,4 +35,17 @@ add_custom_target(create_ssh_zip ALL
     BYPRODUCTS ${OsConfigRootBinaryDir}/LinuxSshServerSecurityBaseline.zip
     COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${OsConfigRootBinaryDir}/LinuxSshServerSecurityBaseline.zip" --format=zip .
     DEPENDS stage_create_ssh_zip
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)
+
+add_custom_target(stage_create_ssh_zip_set
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/Staging
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.metaconfig.json" ${PROJECT_BINARY_DIR}/Staging/
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/LinuxSshServerSecurityBaseline.mof" ${PROJECT_BINARY_DIR}/Staging/SetLinuxSshServerSecurityBaseline.mof
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:OsConfigResourceSsh> ${PROJECT_BINARY_DIR}/Staging/Modules/DscNativeResources/OsConfigResource/libOsConfigResource.so
+    DEPENDS OsConfigResourceSsh)
+
+add_custom_target(create_ssh_zip_set ALL
+    BYPRODUCTS ${OsConfigRootBinaryDir}/SetLinuxSshServerSecurityBaseline.zip
+    COMMAND ${CMAKE_COMMAND} -E tar "cfv" "${OsConfigRootBinaryDir}/SetLinuxSshServerSecurityBaseline.zip" --format=zip .
+    DEPENDS stage_create_ssh_zip_set
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Staging/)


### PR DESCRIPTION
## Description

Splitting the policy packages for SSH and ASB into Get and Set parts. We need this cherry picked to main to allow us to release the package updates for 2506.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
