### PR TITLE
Switch passwd to chpasswd in module test

### DIFF
--- a/src/modules/test/recipes/complianceengine/EnsureShadowContains.json
+++ b/src/modules/test/recipes/complianceengine/EnsureShadowContains.json
@@ -59,7 +59,7 @@
     "RunCommand": "usermod securitybaselinetest -f 3 -e 2025-01-01"
   },
   {
-    "RunCommand": "printf \"DFC&Dhduf9823ds!@#$\nDFC&Dhduf9823ds!@#$\" | passwd securitybaselinetest"
+    "RunCommand": "echo \"securitybaselinetest:DFC&Dhduf9823ds!@#$\" | chpasswd"
   },
   {
     "RunCommand": "cat /etc/shadow | grep securitybaselinetest"


### PR DESCRIPTION
## Description

EnsureShadowContains module test fails from time to time because the passwd utility reports token manipulation errors. Switch to chpasswd.

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `dev` branch prior to this PR submission.
- [ ] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [ ] I submitted this PR against the `dev` branch.
