### PR TITLE
Improve EnsureFilePermissions mask mismatch indicator

### DIFF
--- a/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
+++ b/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
@@ -9,6 +9,7 @@
 #include <fnmatch.h>
 #include <fts.h>
 #include <grp.h>
+#include <iomanip>
 #include <iostream>
 #include <pwd.h>
 #include <string.h>
@@ -166,7 +167,7 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, con
         {
             std::ostringstream oss;
             oss << "Invalid permissions on '" << filename << "' - are " << std::oct << (statbuf.st_mode & displayMask) << " should be set to "
-                << std::oct << (statbuf.st_mode & ~mask & displayMask) << " or more restrictive";
+                << std::oct << std::setw(3) << std::setfill('0') << (statbuf.st_mode & ~mask & displayMask) << " or a more restrictive value";
             return indicators.NonCompliant(oss.str());
         }
 

--- a/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
+++ b/src/modules/complianceengine/src/lib/FilePermissionsHelpers.cpp
@@ -165,8 +165,8 @@ Result<Status> AuditEnsureFilePermissionsHelper(const std::string& filename, con
         if (0 != (statbuf.st_mode & mask))
         {
             std::ostringstream oss;
-            oss << "Invalid permissions on '" << filename << "' - are " << std::oct << (statbuf.st_mode & displayMask) << " while " << std::oct << mask
-                << " should not be set";
+            oss << "Invalid permissions on '" << filename << "' - are " << std::oct << (statbuf.st_mode & displayMask) << " should be set to "
+                << std::oct << (statbuf.st_mode & ~mask & displayMask) << " or more restrictive";
             return indicators.NonCompliant(oss.str());
         }
 

--- a/src/modules/test/recipes/complianceengine/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/complianceengine/EnsureFilePermissions.json
@@ -179,7 +179,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions on '\/tmp\/testfile' - are 777 while 177 should not be set } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions on '\/tmp\/testfile' - are 777 should be set to 600 or more restrictive } == FALSE"
   },
 
 
@@ -336,7 +336,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 0, Invalid permissions on '\/tmp\/testfile' - are 777 while 777 should not be set } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 0, Invalid permissions on '\/tmp\/testfile' - are 777 should be set to 0 or more restrictive } == FALSE"
   },
 
 

--- a/src/modules/test/recipes/complianceengine/EnsureFilePermissions.json
+++ b/src/modules/test/recipes/complianceengine/EnsureFilePermissions.json
@@ -179,7 +179,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions on '\/tmp\/testfile' - are 777 should be set to 600 or more restrictive } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', Invalid permissions on '\/tmp\/testfile' - are 777 should be set to 600 or a more restrictive value } == FALSE"
   },
 
 
@@ -336,7 +336,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 0, Invalid permissions on '\/tmp\/testfile' - are 777 should be set to 0 or more restrictive } == FALSE"
+    "Payload": "{ EnsureFilePermissions: \/tmp\/testfile owner matches expected value 'root', \/tmp\/testfile group matches expected value 'root', \/tmp\/testfile matches expected permissions 0, Invalid permissions on '\/tmp\/testfile' - are 777 should be set to 000 or a more restrictive value } == FALSE"
   },
 
 


### PR DESCRIPTION
## Description

Improve indicator content for EnsureFilePermissions rule.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
