### PR TITLE
Avoid spurious 'Validator finished with 1 errors' message

### DIFF
--- a/src/modules/complianceengine/src/lib/procedures/FileRegexMatch.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/FileRegexMatch.cpp
@@ -210,6 +210,7 @@ AUDIT_FN(FileRegexMatch, "path:A directory name contining files to check:M", "fi
     auto dirCloser = std::unique_ptr<DIR, int (*)(DIR*)>(dir, closedir);
 
     int matchCount = 0;
+    int mismatchCount = 0;
     int fileCount = 0;
     int errorCount = 0;
     struct dirent* entry = nullptr;
@@ -237,6 +238,10 @@ AUDIT_FN(FileRegexMatch, "path:A directory name contining files to check:M", "fi
         {
             matchCount++;
         }
+        else
+        {
+            mismatchCount++;
+        }
     }
 
     if (nullptr == entry && errno != 0)
@@ -249,21 +254,31 @@ AUDIT_FN(FileRegexMatch, "path:A directory name contining files to check:M", "fi
     // This is a direct mapping mapping of OVAL ExistenceEnumerator
     // see https://oval.mitre.org/language/version5.9/ovalsc/documentation/oval-common-schema.html#ExistenceEnumeration for details
 
+    OsConfigLogInfo(context.GetLogHandle(), "Validating pattern matching results, behavior: %s, matched: %d, mismatched: %d, errors: %d",
+        behavior.c_str(), matchCount, mismatchCount, errorCount);
+    if (matchCount + mismatchCount + errorCount != fileCount)
+    {
+        return Error("Counters mismatch");
+    }
+
     if ("all_exist" == behavior)
     {
+        if (mismatchCount > 0)
+        {
+            return indicators.NonCompliant("At least one file did not match the pattern");
+        }
+
         if (errorCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d errors", errorCount);
-            return Error("Validator finished with " + std::to_string(errorCount) + " errors", EINVAL);
+            return Error("Error occurred during pattern matching", EINVAL);
         }
-        if ((matchCount == fileCount) && (fileCount > 0))
+
+        if (matchCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d matches", matchCount);
             return indicators.Compliant("All " + std::to_string(fileCount) + " files matched the pattern");
         }
         else
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d matches out of %d files", matchCount, fileCount);
             return indicators.NonCompliant("Expected all files to match, but only " + std::to_string(matchCount) + " out of " +
                                            std::to_string(fileCount) + " matched");
         }
@@ -272,8 +287,7 @@ AUDIT_FN(FileRegexMatch, "path:A directory name contining files to check:M", "fi
     {
         if ((matchCount == 0) && (errorCount > 0))
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d errors", errorCount);
-            return Error("Validator finished with " + std::to_string(errorCount) + " errors", EINVAL);
+            return Error("Error occurred during pattern matching", EINVAL);
         }
         return indicators.Compliant("Found " + std::to_string(matchCount) + " matches");
     }
@@ -281,13 +295,11 @@ AUDIT_FN(FileRegexMatch, "path:A directory name contining files to check:M", "fi
     {
         if (matchCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d matches", matchCount);
             return indicators.Compliant("At least one file matched, found " + std::to_string(matchCount) + " matches");
         }
         if (errorCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d errors", errorCount);
-            return Error("Validator finished with " + std::to_string(errorCount) + " errors", EINVAL);
+            return Error("Error occurred during pattern matching", EINVAL);
         }
         return indicators.NonCompliant("Expected at least one file to match, but none did");
     }
@@ -295,35 +307,32 @@ AUDIT_FN(FileRegexMatch, "path:A directory name contining files to check:M", "fi
     {
         if (matchCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d matches", matchCount);
             return indicators.NonCompliant("Expected no files to match, but " + std::to_string(matchCount) + " matched");
         }
 
         if (errorCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d errors", errorCount);
-            return Error("Validator finished with " + std::to_string(errorCount) + " errors", EINVAL);
+            return Error("Error occurred during pattern matching", EINVAL);
         }
-        OsConfigLogInfo(context.GetLogHandle(), "Validator finished with no matches");
         return indicators.Compliant("No files matched the pattern");
     }
     else if ("only_one_exists" == behavior)
     {
         if (matchCount == 1 && errorCount == 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d matches", matchCount);
             return indicators.Compliant("Exactly one file matched the pattern");
         }
-        else if (matchCount > 1)
+
+        if (matchCount > 1)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d matches", matchCount);
             return indicators.NonCompliant("Expected only one file to match, but " + std::to_string(matchCount) + " matched");
         }
-        else if (errorCount > 0)
+
+        if (errorCount > 0)
         {
-            OsConfigLogInfo(context.GetLogHandle(), "Validator finished with %d errors", errorCount);
-            return Error("Validator finished with " + std::to_string(errorCount) + " errors", EINVAL);
+            return Error("Error occurred during pattern matching", EINVAL);
         }
+
         return indicators.NonCompliant("Expected exactly one file to match, but none did");
     }
     else

--- a/src/modules/complianceengine/tests/procedures/FileRegexMatchTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/FileRegexMatchTest.cpp
@@ -454,7 +454,7 @@ TEST_F(FileRegexMatchTest, Audit_FilenamePattern_3)
     CompactListFormatter formatter;
     auto payload = formatter.Format(mIndicators);
     ASSERT_TRUE(payload.HasValue());
-    EXPECT_NE(payload.Value().find("[NonCompliant] Expected all files to match, but only 1 out of 3 matched"), std::string::npos);
+    EXPECT_NE(payload.Value().find("[NonCompliant] At least one file did not match the pattern"), std::string::npos);
 }
 
 TEST_F(FileRegexMatchTest, Audit_FilenamePattern_4)

--- a/src/modules/test/recipes/complianceengine/FileRegexMatch.json
+++ b/src/modules/test/recipes/complianceengine/FileRegexMatch.json
@@ -78,7 +78,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: Expected all files to match, but only 0 out of 1 matched } == FALSE"
+    "Payload": "{ FileRegexMatch: At least one file did not match the pattern } == FALSE"
   },
 
   {
@@ -144,7 +144,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: Expected all files to match, but only 0 out of 1 matched } == FALSE"
+    "Payload": "{ FileRegexMatch: At least one file did not match the pattern } == FALSE"
   },
 
 
@@ -186,7 +186,7 @@
     "ObjectType": "Reported",
     "ComponentName": "ComplianceEngine",
     "ObjectName": "auditTest",
-    "Payload": "{ FileRegexMatch: Expected all files to match, but only 0 out of 1 matched } == FALSE"
+    "Payload": "{ FileRegexMatch: At least one file did not match the pattern } == FALSE"
   },
 
   {


### PR DESCRIPTION
## Description

Fix issue with invalid message reporting by compliance engine.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
