### PR TITLE
Add UFW status detection

### DIFF
--- a/src/modules/complianceengine/src/lib/NetworkTools.cpp
+++ b/src/modules/complianceengine/src/lib/NetworkTools.cpp
@@ -32,7 +32,7 @@ Result<std::vector<OpenPort>> GetOpenPorts(ContextInterface& context)
     }
     std::vector<OpenPort> openPorts;
     std::istringstream stream(result.Value());
-    OsConfigLogError(context.GetLogHandle(), "ss command output: %s ", result.Value().c_str());
+    OsConfigLogDebug(context.GetLogHandle(), "ss command output: %s ", result.Value().c_str());
     std::string line;
     while (std::getline(stream, line))
     {
@@ -57,7 +57,7 @@ Result<std::vector<OpenPort>> GetOpenPorts(ContextInterface& context)
         }
         else
         {
-            OsConfigLogError(context.GetLogHandle(), "Unsupported netid: %s", netid.c_str());
+            OsConfigLogInfo(context.GetLogHandle(), "Unsupported netid: %s", netid.c_str());
             continue;
         }
         size_t pos = local.rfind(':');


### PR DESCRIPTION
## Description

Avoid failing with errors when the service is inactive. We fail some rules in case the UFW is inactive, the output of `ufw status verbose` command becomes:
```
Status: inactive
```
This PR adds handling for this situation and the following minor changes:
- downgrades some log messages from errors which were most likely missed during code review

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `dev` branch prior to this PR submission.
- [ ] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [ ] I submitted this PR against the `dev` branch.
