### PR TITLE
Fix for ASB's EnsureSmbWithSambaIsDisabled

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -581,6 +581,7 @@ static const char* g_systemdJournald = "systemd-journald";
 static const char* g_allTelnetd = "*telnetd*";
 static const char* g_samba = "samba";
 static const char* g_smbd = "smbd";
+static const char* g_smb = "smb";
 static const char* g_rpcSvcgssd = "rpc.svcgssd";
 static const char* g_needSvcgssd = "NEED_SVCGSSD = yes";
 static const char* g_inetInterfacesLocalhost = "inet_interfaces localhost";
@@ -2536,7 +2537,7 @@ static char* AuditEnsureRshClientNotInstalled(OsConfigLogHandle log)
 static char* AuditEnsureSmbWithSambaIsDisabled(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    if (IsDaemonActive(g_smbd, log))
+    if (IsDaemonActive(g_smbd, log) || IsDaemonActive(g_smb, log))
     {
         RETURN_REASON_IF_NOT_ZERO(CheckLineFoundNotCommentedOut(g_etcSambaConf, '#', g_minSambaProtocol, &reason, log));
         CheckLineFoundNotCommentedOut(g_etcSambaConf, ';', g_minSambaProtocol, &reason, log);
@@ -4163,7 +4164,7 @@ static int RemediateEnsureSmbWithSambaIsDisabled(char* value, OsConfigLogHandle 
 
     UNUSED(value);
 
-    if (IsDaemonActive(g_smbd, log))
+    if (IsDaemonActive(g_smbd, log) || IsDaemonActive(g_smb, log))
     {
         if (0 == (status = ReplaceMarkedLinesInFile(g_etcSambaConf, smb1, NULL, '#', true, log)))
         {


### PR DESCRIPTION
## Description

Fix for ASB's EnsureSmbWithSambaIsDisabled, On some of the distros the Samba service is called 'smb', on others 'smbd'. We need to check for both and if any is active, then check the Samba configuration.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
