### PR TITLE
Adding more ASB test cases for last fixes

### DIFF
--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2871,7 +2871,7 @@ TEST_F(CommonUtilsTest, CheckFilePermissionsForAllRsyslogLogFiles)
         "$FileCreateMode 00640\n"
         "$FileCreateMode  00640\n"
         "$FileCreateMode 0600\n"
-        "$FileCreateMode 600";
+        "$FileCreateMode 600"
         "$FileCreateMode     600";
     const char* list = "00600,00640";
 
@@ -2884,14 +2884,14 @@ TEST_F(CommonUtilsTest, CheckFilePermissionsForAllRsyslogLogFiles)
     EXPECT_TRUE(CreateTestFile(m_path, testFile));
     EXPECT_EQ(0, CheckIntegerOptionFromFileEqualWithAny(m_path, "$FileCreateMode", ' ', modes, numberOfModes, nullptr, 8, nullptr));
     EXPECT_TRUE(Cleanup(m_path));
-    
+
     FREE_MEMORY(modes);
 }
 
 TEST_F(CommonUtilsTest, CheckPasswordCreationRequirements)
 {
     const char* list = "1,14,4,-1,-1,-1,-1";
-    
+
     int* values = NULL;
     int numberOfValues = 0;
 
@@ -2899,6 +2899,6 @@ TEST_F(CommonUtilsTest, CheckPasswordCreationRequirements)
     EXPECT_EQ(7, numberOfValues);
 
     EXPECT_EQ(0, CheckPasswordCreationRequirements(values[0], values[1], values[2], values[3], values[4], values[5], values[6], nullptr, nullptr));
-    
+
     FREE_MEMORY(values);
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2854,14 +2854,14 @@ TEST_F(CommonUtilsTest, CheckBootloadersHavePasswordProtectionEnabled)
         " ### END /etc/grub.d/01_users ###\n";
 
     EXPECT_TRUE(CreateTestFile(m_path, testFile));
-    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "password", nullptr, nullptr));
-    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "superusers", nullptr, nullptr));
-    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "password_pbkdf2", nullptr, nullptr));
-    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "GRUB2_PASSWORD", nullptr, nullptr));
-    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "pa$$word", nullptr, nullptr));
-    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "Test of a", nullptr, nullptr));
-    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "BEGIN", nullptr, nullptr));
-    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "END", nullptr, nullptr));
+    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "password", nullptr, nullptr));
+    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "superusers", nullptr, nullptr));
+    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "password_pbkdf2", nullptr, nullptr));
+    EXPECT_EQ(0, CheckLineFoundNotCommentedOut(m_path, '#', "GRUB2_PASSWORD", nullptr, nullptr));
+    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "pa$$word", nullptr, nullptr));
+    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "Test of a", nullptr, nullptr));
+    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "BEGIN", nullptr, nullptr));
+    EXPECT_EQ(EEXIST, CheckLineFoundNotCommentedOut(m_path, '#', "END", nullptr, nullptr));
     EXPECT_TRUE(Cleanup(m_path));
 }
 


### PR DESCRIPTION
## Description

Adding more ASB test cases for last fixes (for GRUB bootloader password options, rsyslog file access modes, and PAM password creation requirements, as the real audit go, so we can catch any regressions in the future).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
