### PR TITLE
Added missing vcpkg build dependencies for telemetry - openssl, curl

### DIFF
--- a/devops/docker/almalinux-9-amd64/Dockerfile
+++ b/devops/docker/almalinux-9-amd64/Dockerfile
@@ -11,6 +11,8 @@ RUN dnf install -y \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build \
     tar \
     unzip \

--- a/devops/docker/amazonlinux-2-amd64/Dockerfile
+++ b/devops/docker/amazonlinux-2-amd64/Dockerfile
@@ -12,6 +12,8 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build \
     tar \
     unzip \

--- a/devops/docker/azurelinux-3-amd64/Dockerfile
+++ b/devops/docker/azurelinux-3-amd64/Dockerfile
@@ -14,6 +14,8 @@ RUN tdnf install -y \
     jq \
     ninja-build \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rapidjson-devel \
     rpm-build \
     shadow-utils \

--- a/devops/docker/centos-7-amd64/Dockerfile
+++ b/devops/docker/centos-7-amd64/Dockerfile
@@ -4,23 +4,39 @@ FROM centos:7
 RUN rm /etc/yum.repos.d/*.repo
 COPY centos.repo /etc/yum.repos.d/centos.repo
 
+# Install dependencies needed for Git compilation and general build
 RUN yum install -y \
     autoconf \
     curl \
     gcc \
     gcc-c++ \
-    git \
+    gettext-devel \
     jq \
     libcurl-devel \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-CPAN \
+    perl-devel \
+    perl-IPC-Cmd \
     rpm-build \
     tar \
     unzip \
-    zip
+    zip \
+    zlib-devel
 
 WORKDIR /git
+
+# Install Git 2.14.0 from source (required for vcpkg)
+RUN curl -L https://github.com/git/git/archive/v2.14.0.tar.gz | tar xz
+RUN cd git-2.14.0 && \
+    make configure && \
+    ./configure && \
+    make all -j$(nproc) && \
+    make install && \
+    hash -r && \
+    rm -rf /git/git-2.14.0
 
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7

--- a/devops/docker/centos-8-amd64/Dockerfile
+++ b/devops/docker/centos-8-amd64/Dockerfile
@@ -21,6 +21,8 @@ RUN yum update -y && yum install -y \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build \
     tar \
     unzip \

--- a/devops/docker/debian-10-amd64/Dockerfile
+++ b/devops/docker/debian-10-amd64/Dockerfile
@@ -9,22 +9,23 @@ EOF
 
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
-    git \
-    cmake \
+    bc \
     build-essential \
+    cmake \
     curl \
+    gcovr \
+    git \
+    jq \
     libcurl4-openssl-dev \
     libssl-dev \
-    uuid-dev \
-    rapidjson-dev \
     ninja-build \
+    pkg-config \
     python3-jsonschema \
-    wget \
-    gcovr \
-    jq \
-    bc \
+    rapidjson-dev \
     tar \
     unzip \
+    uuid-dev \
+    wget \
     zip
 
 WORKDIR /git

--- a/devops/docker/debian-11-amd64/Dockerfile
+++ b/devops/docker/debian-11-amd64/Dockerfile
@@ -2,23 +2,24 @@ FROM mcr.microsoft.com/mirror/docker/library/debian:bullseye
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
-    git \
-    cmake \
+    bc \
     build-essential \
+    cmake \
     curl \
+    file \
+    gcovr \
+    git \
+    jq \
     libcurl4-openssl-dev \
     libssl-dev \
-    uuid-dev \
-    rapidjson-dev \
     ninja-build \
+    pkg-config \
     python3-jsonschema \
-    wget \
-    gcovr \
-    jq \
-    bc \
-    file \
+    rapidjson-dev \
     tar \
     unzip \
+    uuid-dev \
+    wget \
     zip
 
 WORKDIR /git

--- a/devops/docker/debian-12-amd64/Dockerfile
+++ b/devops/docker/debian-12-amd64/Dockerfile
@@ -4,23 +4,24 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
-    git \
-    cmake \
+    bc \
     build-essential \
+    cmake \
     curl \
+    file \
+    gcovr \
+    git \
+    jq \
     libcurl4-openssl-dev \
     libssl-dev \
-    uuid-dev \
-    rapidjson-dev \
     ninja-build \
+    pkg-config \
     python3-jsonschema \
-    wget \
-    gcovr \
-    jq \
-    bc \
-    file \
+    rapidjson-dev \
     tar \
     unzip \
+    uuid-dev \
+    wget \
     zip
 
 WORKDIR /git

--- a/devops/docker/oraclelinux-7-amd64/Dockerfile
+++ b/devops/docker/oraclelinux-7-amd64/Dockerfile
@@ -5,15 +5,27 @@ RUN yum install -y \
     autoconf \
     gcc \
     gcc-c++ \
-    git \
+    gettext \
     jq \
     libcurl-devel \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build
 
 WORKDIR /git
+
+# Install Git 2.14.0 from source (required for vcpkg)
+RUN curl -L https://github.com/git/git/archive/v2.14.0.tar.gz | tar xz
+RUN cd git-2.14.0 && \
+    make configure && \
+    ./configure && \
+    make all -j$(nproc) && \
+    make install && \
+    hash -r && \
+    rm -rf /git/git-2.14.0
 
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7

--- a/devops/docker/oraclelinux-8-amd64/Dockerfile
+++ b/devops/docker/oraclelinux-8-amd64/Dockerfile
@@ -11,6 +11,8 @@ RUN yum install -y \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build
 
 WORKDIR /git

--- a/devops/docker/rhel-7-amd64/Dockerfile
+++ b/devops/docker/rhel-7-amd64/Dockerfile
@@ -20,15 +20,28 @@ RUN yum install -y --disableplugin=subscription-manager \
     curl \
     gcc \
     gcc-c++ \
-    git \
+    gettext \
+    libcurl-devel \
     libtool \
     make \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     tar \
     unzip \
     zip
 
 WORKDIR /git
+
+# Install Git 2.14.0 from source (required for vcpkg)
+RUN curl -L https://github.com/git/git/archive/v2.14.0.tar.gz | tar xz
+RUN cd git-2.14.0 && \
+    make configure && \
+    ./configure && \
+    make all -j$(nproc) && \
+    make install && \
+    hash -r && \
+    rm -rf /git/git-2.14.0
 
 # CMake
 RUN git clone https://github.com/Kitware/CMake --recursive -b v3.21.7

--- a/devops/docker/rhel-8-amd64/Dockerfile
+++ b/devops/docker/rhel-8-amd64/Dockerfile
@@ -14,6 +14,8 @@ RUN yum install -y --disableplugin=subscription-manager \
     ninja-build \
     openssl-devel \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build \
     tar \
     unzip \

--- a/devops/docker/rhel-9-amd64/Dockerfile
+++ b/devops/docker/rhel-9-amd64/Dockerfile
@@ -7,12 +7,14 @@ RUN yum install -y --disableplugin=subscription-manager \
     gcc-c++ \
     git \
     jq \
-    libtool \
     libcurl-devel \
+    libtool \
     make \
     ninja-build \
     openssl-devel \
     openssl-devel \
+    perl \
+    perl-IPC-Cmd \
     rpm-build \
     tar \
     unzip \

--- a/devops/docker/ubuntu-20.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-20.04-amd64/Dockerfile
@@ -3,24 +3,25 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
     apt-transport-https \
-    git \
-    cmake \
-    build-essential \
-    curl \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    uuid-dev \
-    libgtest-dev \
-    libgmock-dev \
-    rapidjson-dev \
-    ninja-build \
-    python3-jsonschema \
-    wget \
-    gcovr\
-    jq \
     bc \
+    build-essential \
+    cmake \
+    curl \
+    gcovr\
+    git \
+    jq \
+    libcurl4-openssl-dev \
+    libgmock-dev \
+    libgtest-dev \
+    libssl-dev \
+    ninja-build \
+    pkg-config \
+    python3-jsonschema \
+    rapidjson-dev \
     tar \
     unzip \
+    uuid-dev \
+    wget \
     zip
 
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb

--- a/devops/docker/ubuntu-22.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-22.04-amd64/Dockerfile
@@ -5,29 +5,30 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
     apt-transport-https \
-    git \
-    cmake \
-    build-essential \
-    curl \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    uuid-dev \
-    libgtest-dev \
-    libgmock-dev \
-    rapidjson-dev \
-    ninja-build \
-    python3-jsonschema \
-    wget \
-    gcovr\
-    jq \
     bc \
-    file \
-    libasan8 \
-    libubsan1 \
+    build-essential \
     clang \
     clang-tools \
+    cmake \
+    curl \
+    file \
+    gcovr\
+    git \
+    jq \
+    libasan8 \
+    libcurl4-openssl-dev \
+    libgmock-dev \
+    libgtest-dev \
+    libssl-dev \
+    libubsan1 \
+    ninja-build \
+    pkg-config \
+    python3-jsonschema \
+    rapidjson-dev \
     tar \
     unzip \
+    uuid-dev \
+    wget \
     zip
 
 WORKDIR /git

--- a/devops/docker/ubuntu-24.04-amd64/Dockerfile
+++ b/devops/docker/ubuntu-24.04-amd64/Dockerfile
@@ -5,27 +5,28 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \
     apt-transport-https \
-    git \
-    cmake \
-    build-essential \
-    curl \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    uuid-dev \
-    rapidjson-dev \
-    ninja-build \
-    python3-jsonschema \
-    wget \
-    gcovr\
-    jq \
     bc \
-    file \
-    libasan8 \
-    libubsan1 \
+    build-essential \
     clang \
     clang-tools \
+    cmake \
+    curl \
+    file \
+    gcovr\
+    git \
+    jq \
+    libasan8 \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libubsan1 \
+    ninja-build \
+    pkg-config \
+    python3-jsonschema \
+    rapidjson-dev \
     tar \
     unzip \
+    uuid-dev \
+    wget \
     zip
 
 WORKDIR /git


### PR DESCRIPTION
## Description

The new telemetry requires OpenSSL/cURL which depends on some build tooling being present:

* Updated Git to v2.14.0 in CentOS 7, Oracle Linux 7, and RHEL 7 (vcpkg dependency)
* Added Perl/Perl-IPC
* Added other misc missing build tooling (gexttext/pkgconfig/zlib) and cleanup

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR