### PR TITLE
 Use opendir/fts directory traverse instead of find to search filesystem for modules

### DIFF
--- a/src/modules/complianceengine/src/lib/KernelModuleTools.cpp
+++ b/src/modules/complianceengine/src/lib/KernelModuleTools.cpp
@@ -33,6 +33,7 @@ Result<bool> SearchFilesystemForModuleName(std::string& moduleName, ContextInter
     {
         return Error("Failed to open /lib/modules directory");
     }
+    auto modulesDirDeleter = std::unique_ptr<DIR, int (*)(DIR*)>(modulesDir, closedir);
 
     std::vector<std::string> kernelModuleFileBasenames; // Collected file basenames (no directory prefix)
     bool moduleFound = false;
@@ -60,6 +61,7 @@ Result<bool> SearchFilesystemForModuleName(std::string& moduleName, ContextInter
             OsConfigLogError(context.GetLogHandle(), "Failed to open %s - errno %d", modulesVersionDir.c_str(), errno);
             continue;
         }
+        auto ftspDeleter = std::unique_ptr<FTS, int (*)(FTS*)>(fts, fts_close);
 
         FTSENT* node = nullptr;
         while (!moduleFound && (node = fts_read(fts)) != nullptr)
@@ -84,10 +86,7 @@ Result<bool> SearchFilesystemForModuleName(std::string& moduleName, ContextInter
                 }
             }
         }
-        fts_close(fts);
     }
-    closedir(modulesDir);
-
     return moduleFound;
 }
 

--- a/src/modules/complianceengine/src/lib/KernelModuleTools.cpp
+++ b/src/modules/complianceengine/src/lib/KernelModuleTools.cpp
@@ -2,8 +2,11 @@
 #include <Evaluator.h>
 #include <KernelModuleTools.h>
 #include <Regex.h>
+#include <dirent.h>
+#include <fts.h>
 #include <iostream>
 #include <string>
+#include <sys/stat.h>
 
 namespace ComplianceEngine
 {
@@ -24,42 +27,68 @@ static bool MultilineRegexSearch(const std::string& str, const regex& pattern)
 // Searches /lib/modules for moduleName, including overlay.ko modules and returns true if found
 Result<bool> SearchFilesystemForModuleName(std::string& moduleName, ContextInterface& context)
 {
-    // For all of the Kernel versions in /lib/modules find all the files in the kernel (modules) directory.
-    // TODO(wpk) replace this with std::filesystem when we can use C++17.
-    std::string findCmd = "find /lib/modules/ -maxdepth 1 -mindepth 1 -type d | while read i; do find \"$i\"/kernel/ -type f; done";
-    Result<std::string> findOutput = context.ExecuteCommand(findCmd);
-    if (!findOutput.HasValue())
+    std::string modulesDirPath = context.GetSpecialFilePath("/lib/modules");
+    DIR* modulesDir = opendir(modulesDirPath.c_str());
+    if (!modulesDir)
     {
-        return Error("Failed to execute find command");
+        return Error("Failed to open /lib/modules directory");
     }
-    std::istringstream findStream(findOutput.Value());
-    std::string line;
+
+    std::vector<std::string> kernelModuleFileBasenames; // Collected file basenames (no directory prefix)
     bool moduleFound = false;
-    while (std::getline(findStream, line))
+
+    struct dirent* entry = nullptr;
+    while ((entry = readdir(modulesDir)) != nullptr && !moduleFound)
     {
-        auto pos = line.find_last_of("/");
-        if (pos != std::string::npos)
+        if (entry->d_type != DT_DIR)
         {
-            line = line.substr(pos + 1);
+            continue;
         }
-        // We use find because modules can have postfixes like .ko.gz.
-        if (line.find(moduleName + ".ko") == 0)
+
+        std::string modulesVersionDir = modulesDirPath + "/" + entry->d_name + "/kernel";
+        struct stat st;
+        if (stat(modulesVersionDir.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))
         {
-            moduleFound = true;
-            break;
+            continue;
         }
-        if (line.find(moduleName + "_overlay.ko") == 0)
+
+        char* paths[] = {const_cast<char*>(modulesVersionDir.c_str()), nullptr};
+        // Use FTS_PHYSICAL to avoid following symlinks; omit FTS_NOCHDIR for portability.
+        FTS* fts = fts_open(paths, FTS_PHYSICAL, nullptr);
+        if (!fts)
         {
-            moduleFound = true;
-            moduleName = moduleName + "_overlay";
-            break;
+            OsConfigLogError(context.GetLogHandle(), "Failed to open %s - errno %d", modulesVersionDir.c_str(), errno);
+            continue;
         }
+
+        FTSENT* node = nullptr;
+        while (!moduleFound && (node = fts_read(fts)) != nullptr)
+        {
+            if (node->fts_info == FTS_F)
+            {
+                std::string baseName = node->fts_name;
+
+                std::string target = moduleName + ".ko";
+                std::string overlayTarget = moduleName + "_overlay.ko";
+
+                if (baseName.find(target) == 0)
+                {
+                    moduleFound = true;
+                    break;
+                }
+                if (baseName.find(overlayTarget) == 0)
+                {
+                    moduleFound = true;
+                    moduleName += "_overlay"; // preserve original behavior of tracking overlay variant
+                    break;
+                }
+            }
+        }
+        fts_close(fts);
     }
-    if (!moduleFound)
-    {
-        return false;
-    }
-    return true;
+    closedir(modulesDir);
+
+    return moduleFound;
 }
 
 Result<bool> IsKernelModuleLoaded(std::string moduleName, ContextInterface& context)

--- a/src/modules/complianceengine/src/lib/procedures/ExecuteCommandGrep.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/ExecuteCommandGrep.cpp
@@ -12,7 +12,8 @@ namespace ComplianceEngine
 {
 
 static const std::set<std::string> allowedCommands = {"nft list ruleset", "nft list chain", "nft list tables", "ip6tables -L -n",
-    "ip6tables -L INPUT -v -n", "ip6tables -L OUTPUT -v -n", "iptables -L -n", "iptables -L INPUT -v -n", "iptables -L OUTPUT -v -n", "uname", "ps -ef"};
+    "ip6tables -L INPUT -v -n", "ip6tables -L OUTPUT -v -n", "iptables -L -n", "iptables -L INPUT -v -n", "iptables -L OUTPUT -v -n", "uname", "ps -ef",
+    "ps -eZ", "sestatus", "journalctl", "arch"};
 
 AUDIT_FN(ExecuteCommandGrep, "command:Command to be executed:M", "awk:Awk transformation in the middle, optional", "regex:Regex to be matched:M",
     "type:Type of regex, P for Perl (default) or E for Extended")

--- a/src/modules/complianceengine/tests/MockContext.h
+++ b/src/modules/complianceengine/tests/MockContext.h
@@ -73,9 +73,8 @@ struct MockContext : public ComplianceEngine::ContextInterface
                 continue;
             }
             std::string child = path + "/" + ent->d_name;
-            struct stat st
-            {
-            };
+            struct stat st;
+
             if (0 == lstat(child.c_str(), &st))
             {
                 if (S_ISDIR(st.st_mode))

--- a/src/modules/complianceengine/tests/procedures/EnsureKernelModuleTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureKernelModuleTest.cpp
@@ -12,6 +12,7 @@
 #include <linux/limits.h>
 #include <string>
 #include <unistd.h>
+#include <vector>
 
 using ComplianceEngine::AuditEnsureKernelModuleUnavailable;
 using ComplianceEngine::Error;
@@ -19,19 +20,8 @@ using ComplianceEngine::IndicatorsTree;
 using ComplianceEngine::Result;
 using ComplianceEngine::Status;
 
-static const char findCommand[] = "find";
-static const char findPositiveOutput[] =
-    "/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/drivers/block/nbd.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/drivers/usb/"
-    "serial/hator.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/net/netfilter/xt_CT.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/"
-    "kernel/net/netfilter/xt_u32.ko\n";
-static const char findNegativeOutput[] =
-    "/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/drivers/block/nbd.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/drivers/usb/"
-    "serial/usbserial.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/net/netfilter/xt_CT.ko\n/lib/modules/"
-    "5.15.167.4-microsoft-standard-WSL2/kernel/net/netfilter/xt_u32.ko\n";
-static const char findOverlayedOutput[] =
-    "/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/drivers/block/nbd.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/drivers/usb/"
-    "serial/hator_overlay.ko\n/lib/modules/5.15.167.4-microsoft-standard-WSL2/kernel/net/netfilter/xt_CT.ko\n/lib/modules/"
-    "5.15.167.4-microsoft-standard-WSL2/kernel/net/netfilter/xt_u32.ko\n";
+// Test module directory layouts now created in a temporary directory using MockContext::SetSpecialFilePath
+// find* outputs removed due to refactor away from executing find command.
 
 static const char procModulesPath[] = "/proc/modules";
 static const char procModulesPositiveOutput[] =
@@ -75,30 +65,41 @@ TEST_F(EnsureKernelModuleTest, AuditNoArgument)
     ASSERT_EQ(result.Error().message, "No module name provided");
 }
 
-TEST_F(EnsureKernelModuleTest, FailedFindExecution)
+// Helper to create a fake /lib/modules tree
+static std::string CreateModulesTree(MockContext& ctx, const std::vector<std::string>& files)
 {
-    // Setup the expectation for the find command to fail
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand)))
-        .WillRepeatedly(::testing::Return(Result<std::string>(Error("Failed to execute find command", -1))));
-
-    // Setup the expectation for the proc modules read
-    EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesPositiveOutput)));
-
-    // Setup the expectation for the modprobe command
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(modprobeCommand))).WillRepeatedly(::testing::Return(Result<std::string>(modprobeNothingOutput)));
-
-    std::map<std::string, std::string> args;
-    args["moduleName"] = "hator";
-
-    auto result = AuditEnsureKernelModuleUnavailable(args, indicators, mContext);
-    ASSERT_FALSE(result.HasValue());
-    ASSERT_EQ(result.Error().message, "Failed to execute find command");
+    std::string root = ctx.GetTempdirPath() + "/modulesRoot";
+    if (::mkdir(root.c_str(), 0755) != 0)
+    {
+        ADD_FAILURE() << "Failed to create root dir: " << strerror(errno);
+        return "";
+    }
+    std::string versionDir = root + "/5.15.test";
+    if (::mkdir(versionDir.c_str(), 0755) != 0)
+    {
+        ADD_FAILURE() << "Failed to create version dir: " << strerror(errno);
+        return "";
+    }
+    std::string kernelDir = versionDir + "/kernel";
+    if (::mkdir(kernelDir.c_str(), 0755) != 0)
+    {
+        ADD_FAILURE() << "Failed to create kernel dir: " << strerror(errno);
+        return "";
+    }
+    for (const auto& f : files)
+    {
+        std::string full = kernelDir + "/" + f;
+        std::ofstream ofs(full);
+        ofs << "placeholder";
+        ofs.close();
+    }
+    ctx.SetSpecialFilePath("/lib/modules", root);
+    return root;
 }
 
 TEST_F(EnsureKernelModuleTest, FailedLsmodExecution)
 {
-    // Setup the expectation for the find command to succeed
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findPositiveOutput)));
+    CreateModulesTree(mContext, {"hator.ko", "nbd.ko"});
 
     // Setup the expectation for the proc modules read to fail
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath)))
@@ -117,8 +118,7 @@ TEST_F(EnsureKernelModuleTest, FailedLsmodExecution)
 
 TEST_F(EnsureKernelModuleTest, FailedModprobeExecution)
 {
-    // Setup the expectation for the find command to succeed
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findPositiveOutput)));
+    CreateModulesTree(mContext, {"hator.ko"});
 
     // Setup the expectation for the /proc/modules read to succeed
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesNegativeOutput)));
@@ -135,10 +135,9 @@ TEST_F(EnsureKernelModuleTest, FailedModprobeExecution)
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureKernelModuleTest, ModuleNotFoundInFind)
+TEST_F(EnsureKernelModuleTest, ModuleNotFoundInFilesystem)
 {
-    // Setup the expectation for the find command to return negative results
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findNegativeOutput)));
+    CreateModulesTree(mContext, {"usbserial.ko", "nbd.ko"});
 
     // Setup the expectation for the proc modules read
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesPositiveOutput)));
@@ -156,8 +155,7 @@ TEST_F(EnsureKernelModuleTest, ModuleNotFoundInFind)
 
 TEST_F(EnsureKernelModuleTest, ModuleFoundInProcModules)
 {
-    // Setup the expectation for the find command
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findPositiveOutput)));
+    CreateModulesTree(mContext, {"hator.ko"});
 
     // Setup the expectation for the proc modules read showing the module is loaded
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesPositiveOutput)));
@@ -175,8 +173,7 @@ TEST_F(EnsureKernelModuleTest, ModuleFoundInProcModules)
 
 TEST_F(EnsureKernelModuleTest, NoAlias)
 {
-    // Setup the expectation for the find command
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findPositiveOutput)));
+    CreateModulesTree(mContext, {"hator.ko"});
 
     // Setup the expectation for the proc modules read
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesPositiveOutput)));
@@ -194,8 +191,7 @@ TEST_F(EnsureKernelModuleTest, NoAlias)
 
 TEST_F(EnsureKernelModuleTest, NoBlacklist)
 {
-    // Setup the expectation for the find command
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findPositiveOutput)));
+    CreateModulesTree(mContext, {"hator.ko"});
 
     // Setup the expectation for the proc modules read
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesNegativeOutput)));
@@ -213,8 +209,7 @@ TEST_F(EnsureKernelModuleTest, NoBlacklist)
 
 TEST_F(EnsureKernelModuleTest, ModuleBlocked)
 {
-    // Setup the expectation for the find command
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findPositiveOutput)));
+    CreateModulesTree(mContext, {"hator.ko"});
 
     // Setup the expectation for the proc modules read
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesNegativeOutput)));
@@ -232,8 +227,7 @@ TEST_F(EnsureKernelModuleTest, ModuleBlocked)
 
 TEST_F(EnsureKernelModuleTest, OverlayedModuleNotBlocked)
 {
-    // Setup the expectation for the find command with overlayed output
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findOverlayedOutput)));
+    CreateModulesTree(mContext, {"hator_overlay.ko"});
 
     // Setup the expectation for the proc modules read
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesNegativeOutput)));
@@ -251,8 +245,7 @@ TEST_F(EnsureKernelModuleTest, OverlayedModuleNotBlocked)
 
 TEST_F(EnsureKernelModuleTest, OverlayedModuleBlocked)
 {
-    // Setup the expectation for the find command with overlayed output
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr(findCommand))).WillRepeatedly(::testing::Return(Result<std::string>(findOverlayedOutput)));
+    CreateModulesTree(mContext, {"hator_overlay.ko"});
 
     // Setup the expectation for the proc modules read
     EXPECT_CALL(mContext, GetFileContents(::testing::StrEq(procModulesPath))).WillRepeatedly(::testing::Return(Result<std::string>(procModulesNegativeOutput)));


### PR DESCRIPTION
## Description
 Use opendir/fts directory traverse instead of find to search filesystem for modules
Allow 'arch' command in ExecuteCommandGrep

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
