### PR TITLE
Add osconfig-collaborators to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @Azure/osconfig-maintainers
+* @Azure/osconfig-collaborators


### PR DESCRIPTION
## Description

Add `osconfig-collaborators` to *CODEOWNERS*.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
