### PR TITLE
Load configuration from json config file in Compliance Engine initialization

### DIFF
--- a/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
+++ b/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
@@ -36,7 +36,7 @@ static constexpr const char* cModuleTestClientName = "ModuleTestClient";
 static constexpr const char* cNRPClientName = "ComplianceEngine";
 OsConfigLogHandle g_log = nullptr;
 static const std::set<int> g_criticalErrors = {ENOMEM};
-static const std::string g_configurationFile = "/etc/osconfig/osconfig.json";
+static constexpr const char* g_configurationFile = "/etc/osconfig/osconfig.json";
 } // namespace
 
 // This function is called in library constructor by BaselineInitialize
@@ -57,11 +57,11 @@ void ComplianceEngineInitialize(OsConfigLogHandle log)
             SetLoggingLevel(GetLoggingLevelFromJsonConfig(jsonConfiguration.c_str(), log));
             SetMaxLogSize(GetMaxLogSizeFromJsonConfig(jsonConfiguration.c_str(), log));
             SetMaxLogSizeDebugMultiplier(GetMaxLogSizeDebugMultiplierFromJsonConfig(jsonConfiguration.c_str(), log));
-            OsConfigLogInfo(g_log, "Configuration file loaded successfully: %s", g_configurationFile.c_str());
+            OsConfigLogInfo(g_log, "Configuration file loaded successfully: %s", g_configurationFile);
         }
     }
 
-    RestrictFileAccessToCurrentAccountOnly(g_configurationFile.c_str());
+    RestrictFileAccessToCurrentAccountOnly(g_configurationFile);
 }
 
 // This function is called in library destructor by BaselineInitialize

--- a/src/modules/complianceengine/src/so/ComplianceEngineModule.c
+++ b/src/modules/complianceengine/src/so/ComplianceEngineModule.c
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 #include "ComplianceEngineInterface.h"
+#include "Logging.h"
 
 #include <Mmi.h>
 #include <assert.h>
 #include <stddef.h>
 
 static OsConfigLogHandle gLog = NULL;
+static const char* gComplianceEngineModuleName = "OSConfig ComplianceEngine module";
 static const char* gLogFile = "/var/log/osconfig_complianceengine.log";
 static const char* gRolledLogFile = "/var/log/osconfig_complianceengine.bak";
 
@@ -16,6 +18,7 @@ void __attribute__((constructor)) InitModule(void)
     gLog = OpenLog(gLogFile, gRolledLogFile);
     assert(NULL != gLog);
     ComplianceEngineInitialize(gLog);
+    OsConfigLogInfo(gLog, "%s initialized", gComplianceEngineModuleName);
 }
 
 void __attribute__((destructor)) DestroyModule(void)


### PR DESCRIPTION
## Description

Loading JSON configuration file was missing for Compliance Engine module. It's done the same way as it was for Security Baseline module.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
