### PR TITLE
ASB fix for rules that search under '/etc/modprobe.d'

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -604,6 +604,7 @@ static const char* g_bootGrubUserCfg = "/boot/grub/user.cfg";
 static const char* g_bootGrub2UserCfg = "/boot/grub2/user.cfg";
 static const char* g_minSambaProtocol = "min protocol = SMB2";
 static const char* g_login = "login";
+static const char* g_conf = ".conf";
 
 static const char* g_remediationIsNotPossible = "automatic remediation is not possible";
 
@@ -1973,28 +1974,28 @@ static char* AuditEnsureIpv6ProtocolIsEnabled(OsConfigLogHandle log)
 static char* AuditEnsureDccpIsDisabled(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install dccp /bin/true", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install dccp /bin/true", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureSctpIsDisabled(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install sctp /bin/true", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install sctp /bin/true", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureDisabledSupportForRds(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install rds /bin/true", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install rds /bin/true", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureTipcIsDisabled(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install tipc /bin/true", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install tipc /bin/true", g_conf, &reason, log);
     return reason;
 }
 
@@ -2040,7 +2041,7 @@ static char* AuditEnsurePasswordReuseIsLimited(OsConfigLogHandle log)
 static char* AuditEnsureMountingOfUsbStorageDevicesIsDisabled(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install usb-storage /bin/true", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install usb-storage /bin/true", g_conf, &reason, log);
     return reason;
 }
 
@@ -2097,35 +2098,35 @@ static char* AuditEnsureLockoutForFailedPasswordAttempts(OsConfigLogHandle log)
 static char* AuditEnsureDisabledInstallationOfCramfsFileSystem(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install cramfs", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install cramfs", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureDisabledInstallationOfFreevxfsFileSystem(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install freevxfs", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install freevxfs", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureDisabledInstallationOfHfsFileSystem(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install hfs", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install hfs", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureDisabledInstallationOfHfsplusFileSystem(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install hfsplus", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install hfsplus", g_conf, &reason, log);
     return reason;
 }
 
 static char* AuditEnsureDisabledInstallationOfJffs2FileSystem(OsConfigLogHandle log)
 {
     char* reason = NULL;
-    CheckTextFoundInFolder(g_etcModProbeD, "install jffs2", &reason, log);
+    CheckTextFoundInFolder(g_etcModProbeD, "install jffs2", g_conf, &reason, log);
     return reason;
 }
 

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -110,9 +110,9 @@ int CheckTextIsNotFoundInFile(const char* fileName, const char* text, char** rea
 int CheckMarkedTextNotFoundInFile(const char* fileName, const char* text, const char* marker, char commentCharacter, char** reason, OsConfigLogHandle log);
 int CheckTextNotFoundInEnvironmentVariable(const char* variableName, const char* text, bool strictComparison, char** reason, OsConfigLogHandle log);
 int CheckSmallFileContainsText(const char* fileName, const char* text, char** reason, OsConfigLogHandle log);
-int FindTextInFolder(const char* directory, const char* text, OsConfigLogHandle log);
-int CheckTextNotFoundInFolder(const char* directory, const char* text, char** reason, OsConfigLogHandle log);
-int CheckTextFoundInFolder(const char* directory, const char* text, char** reason, OsConfigLogHandle log);
+int FindTextInFolder(const char* directory, const char* text, const char* extension, OsConfigLogHandle log);
+int CheckTextNotFoundInFolder(const char* directory, const char* text, const char* extension, char** reason, OsConfigLogHandle log);
+int CheckTextFoundInFolder(const char* directory, const char* text, const char* extension, char** reason, OsConfigLogHandle log);
 int CheckLineNotFoundOrCommentedOut(const char* fileName, char commentMark, const char* text, char** reason, OsConfigLogHandle log);
 int CheckLineFoundNotCommentedOut(const char* fileName, char commentMark, const char* text, char** reason, OsConfigLogHandle log);
 int CheckTextFoundInCommandOutput(const char* command, const char* text, char** reason, OsConfigLogHandle log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1485,7 +1485,7 @@ int CheckTextNotFoundInFolder(const char* directory, const char* text, const cha
     return result;
 }
 
-int CheckTextFoundInFolder(const char* directory, const char* text, char** reason, const char* extension, OsConfigLogHandle log)
+int CheckTextFoundInFolder(const char* directory, const char* text, const char* extension, char** reason, OsConfigLogHandle log)
 {
     int result = 0;
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1432,7 +1432,8 @@ int FindTextInFolder(const char* directory, const char* text, const char* extens
     {
         while (NULL != (entry = readdir(home)))
         {
-            if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..") && (extension && strstr(entry->d_name, extension)))
+            if (strcmp(entry->d_name, ".") && strcmp(entry->d_name, "..") &&
+                ((extension && strstr(entry->d_name, extension)) || (NULL == extension)))
             {
                 length = strlen(pathTemplate) + strlen(directory) + strlen(entry->d_name);
                 if (NULL == (path = malloc(length + 1)))

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3010,7 +3010,7 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
 
     EXPECT_EQ(0, CheckTextNotFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckTextFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
 
     EXPECT_TRUE(Cleanup(noConfPath));
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1765,47 +1765,6 @@ TEST_F(CommonUtilsTest, OtherOptionalTests)
     CheckOsAndKernelMatchDistro(nullptr, nullptr);
 }
 
-TEST_F(CommonUtilsTest, FindTextInFolder)
-{
-    const char* text = "Test = 123";
-
-    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, "a", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, ".conf", nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder("/foo/does_not_exist", "test", nullptr, nullptr));
-
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, ".conf", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
-
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, ".conf", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
-
-    FindTextInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr);
-    CheckTextFoundInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr, nullptr);
-    CheckTextNotFoundInFolder("/etc/modprobe.d", "~~~~ test123 ~~~~", nullptr, nullptr, nullptr);
-
-    EXPECT_TRUE(CreateTestFile(m_path, text));
-
-    EXPECT_EQ(0, FindTextInFolder("/tmp", "123", nullptr, nullptr));
-    EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", nullptr, nullptr));
-    EXPECT_EQ(0, FindTextInFolder("/tmp", text, nullptr, nullptr));
-
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
-
-    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", nullptr, nullptr, nullptr));
-    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", nullptr, nullptr, nullptr));
-    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
-
-    EXPECT_TRUE(Cleanup(m_path));
-}
-
 TEST_F(CommonUtilsTest, CheckLineNotFoundOrCommentedOut)
 {
     const char* testFile =
@@ -2995,6 +2954,47 @@ TEST_F(CommonUtilsTest, GroupExists)
     EXPECT_FALSE(GroupExists(-1, nullptr));
     EXPECT_FALSE(GroupExists(0xDEADBEEF, nullptr));
     EXPECT_FALSE(GroupExists(0xFFFFFFFF, nullptr));
+}
+
+TEST_F(CommonUtilsTest, FindTextInFolder)
+{
+    const char* text = "Test = 123";
+
+    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, "a", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, ".conf", nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder("/foo/does_not_exist", "test", nullptr, nullptr));
+
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, ".conf", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
+
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, ".conf", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
+
+    FindTextInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr);
+    CheckTextFoundInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr, nullptr);
+    CheckTextNotFoundInFolder("/etc/modprobe.d", "~~~~ test123 ~~~~", nullptr, nullptr, nullptr);
+
+    EXPECT_TRUE(CreateTestFile(m_path, text));
+
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "123", nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", text, nullptr, nullptr));
+
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
+
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(m_path));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2985,15 +2985,15 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
 
     EXPECT_TRUE(CreateTestFile(path, text));
 
-    EXPECT_EQ(0, FindTextInFolder("/tmp", "123", nullptr, nullptr));
-    EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", nullptr, nullptr));
-    EXPECT_EQ(0, FindTextInFolder("/tmp", text, nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "123", ".conf", nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", ".conf", nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", text, ".conf", nullptr));
 
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
 
-    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", nullptr, nullptr, nullptr));
-    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", nullptr, nullptr, nullptr));
-    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", ".conf", nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", ".conf", nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, ".conf", nullptr, nullptr));
 
     EXPECT_TRUE(Cleanup(path));
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1778,13 +1778,13 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, ".conf", nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, ".conf", nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
 
     EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, ".conf", nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, ".conf", nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
 
     FindTextInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr);

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2958,6 +2958,7 @@ TEST_F(CommonUtilsTest, GroupExists)
 
 TEST_F(CommonUtilsTest, FindTextInFolder)
 {
+    const char* path = "/tmp/~test.conf";
     const char* text = "Test = 123";
 
     EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, nullptr, nullptr, nullptr));
@@ -2982,7 +2983,7 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     CheckTextFoundInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr, nullptr);
     CheckTextNotFoundInFolder("/etc/modprobe.d", "~~~~ test123 ~~~~", nullptr, nullptr, nullptr);
 
-    EXPECT_TRUE(CreateTestFile(m_path, text));
+    EXPECT_TRUE(CreateTestFile(path, text));
 
     EXPECT_EQ(0, FindTextInFolder("/tmp", "123", nullptr, nullptr));
     EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", nullptr, nullptr));
@@ -2994,7 +2995,7 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", nullptr, nullptr, nullptr));
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
 
-    EXPECT_TRUE(Cleanup(m_path));
+    EXPECT_TRUE(Cleanup(path));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2959,6 +2959,7 @@ TEST_F(CommonUtilsTest, GroupExists)
 TEST_F(CommonUtilsTest, FindTextInFolder)
 {
     const char* path = "/tmp/~test.conf";
+    const char* noConfPath = "/tmp/~test";
     const char* text = "Test = 123";
 
     EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, nullptr, nullptr, nullptr));
@@ -2989,13 +2990,29 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", ".conf", nullptr));
     EXPECT_EQ(0, FindTextInFolder("/tmp", text, ".conf", nullptr));
 
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
-
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", ".conf", nullptr, nullptr));
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", ".conf", nullptr, nullptr));
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, ".conf", nullptr, nullptr));
 
+    EXPECT_EQ(0, CheckTextNotFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
+
     EXPECT_TRUE(Cleanup(path));
+
+    EXPECT_TRUE(CreateTestFile(noConfPath, text));
+
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "123", nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", text, nullptr, nullptr));
+
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
+
+    EXPECT_EQ(0, CheckTextNotFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(noConfPath));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2995,7 +2995,7 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, ".conf", nullptr, nullptr));
 
     EXPECT_EQ(0, CheckTextNotFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckTextFoundInFolder("/tmp", "ghost", ".conf", nullptr, nullptr));
 
     EXPECT_TRUE(Cleanup(path));
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1767,24 +1767,43 @@ TEST_F(CommonUtilsTest, OtherOptionalTests)
 
 TEST_F(CommonUtilsTest, FindTextInFolder)
 {
-    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, "a", nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, FindTextInFolder("/foo/does_not_exist", "test", nullptr));
+    const char* text = "Test = 123";
 
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, "a", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder(nullptr, "a", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder("/etc", nullptr, ".conf", nullptr));
+    EXPECT_EQ(EINVAL, FindTextInFolder("/foo/does_not_exist", "test", nullptr, nullptr));
 
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, "a", nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, nullptr));
-    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/etc", nullptr, nullptr, ".conf", nullptr));
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
 
-    FindTextInFolder("/etc/modprobe.d", "ac97", nullptr);
-    CheckTextFoundInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr);
-    CheckTextNotFoundInFolder("/etc/modprobe.d", "~~~~ test123 ~~~~", nullptr, nullptr);
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder(nullptr, "a", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/etc", nullptr, nullptr, ".conf", nullptr));
+    EXPECT_EQ(EINVAL, CheckTextFoundInFolder("/foo/does_not_exist", "test", nullptr, nullptr, nullptr));
+
+    FindTextInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr);
+    CheckTextFoundInFolder("/etc/modprobe.d", "ac97", nullptr, nullptr, nullptr);
+    CheckTextNotFoundInFolder("/etc/modprobe.d", "~~~~ test123 ~~~~", nullptr, nullptr, nullptr);
+
+    EXPECT_TRUE(CreateTestFile(m_path, text));
+
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "123", nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", "Test", nullptr, nullptr));
+    EXPECT_EQ(0, FindTextInFolder("/tmp", text, nullptr, nullptr));
+
+    EXPECT_EQ(EINVAL, CheckTextNotFoundInFolder("/tmp", "ghost", nullptr, nullptr, nullptr));
+
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "123", nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", "Test", nullptr, nullptr, nullptr));
+    EXPECT_EQ(0, CheckTextFoundInFolder("/tmp", text, nullptr, nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(m_path));
 }
 
 TEST_F(CommonUtilsTest, CheckLineNotFoundOrCommentedOut)


### PR DESCRIPTION
## Description

This PR includes a fix for all ASB rules that search under '/etc/modprobe.d'. This fixes a bug where no-op files such as README.md ones could fool us. The fix ensures that we only look at '.conf' files. Plus few other improvements and also extending the automation test cases accordingly.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
