### PR TITLE
Keep logfile permissions at 0640 from the creation

### DIFF
--- a/src/adapters/mc/OsConfigResource.c
+++ b/src/adapters/mc/OsConfigResource.c
@@ -115,10 +115,6 @@ void __attribute__((destructor)) Destroy()
     OsConfigLogInfo(GetLog(), "[OsConfigResource] SO library unloaded by host process %d", getpid());
 
     CloseLog(&g_log);
-
-    // When the NRP is done, allow others read-only (no write, search or execute) access to the NRP logs
-    SetFileAccess(LOG_FILE, 0, 0, 0644, NULL);
-    SetFileAccess(ROLLED_LOG_FILE, 0, 0, 0644, NULL);
 }
 
 static void LogOsConfigVersion(MI_Context* context)

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -133,9 +133,9 @@ void SetMaxLogSizeDebugMultiplier(unsigned int value)
     g_maxLogSizeDebugMultiplier = value;
 }
 
-static int RestrictFileAccessToCurrentAccountOnly(const char* fileName)
+static int RestrictLogFileAccess(const char* fileName)
 {
-    return chmod(fileName, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    return chmod(fileName, S_IRUSR | S_IWUSR | S_IRGRP);
 }
 
 OsConfigLogHandle OpenLog(const char* logFileName, const char* bakLogFileName)
@@ -154,12 +154,12 @@ OsConfigLogHandle OpenLog(const char* logFileName, const char* bakLogFileName)
     if (NULL != newLog->logFileName)
     {
         newLog->log = fopen(newLog->logFileName, "a");
-        RestrictFileAccessToCurrentAccountOnly(newLog->logFileName);
+        RestrictLogFileAccess(newLog->logFileName);
     }
 
     if (NULL != newLog->backLogFileName)
     {
-        RestrictFileAccessToCurrentAccountOnly(newLog->backLogFileName);
+        RestrictLogFileAccess(newLog->backLogFileName);
     }
 
     return newLog;
@@ -242,11 +242,11 @@ void TrimLog(OsConfigLogHandle log)
             log->log = fopen(log->logFileName, "a");
 
             // Reapply restrictions once the file is recreated (also for backup, if any):
-            RestrictFileAccessToCurrentAccountOnly(log->logFileName);
+            RestrictLogFileAccess(log->logFileName);
             if (NULL != log->backLogFileName)
             {
                 // Reapply restrictions to the backup file:
-                RestrictFileAccessToCurrentAccountOnly(log->backLogFileName);
+                RestrictLogFileAccess(log->backLogFileName);
             }
         }
     }


### PR DESCRIPTION
## Description

It's compliant behavior with CIS "Ensure access to all logfiles has been configured" rule.

Rename static function `RestrictFileAccessToCurrentAccountOnly` from `Logging.c` to `RestrictLogFileAccess` to not being misleading as we have the same name of the commonly used function in `CommonUtils.c`

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
