### PR TITLE
Hardening 2 ASB rules (EnsureAllRsyslogLogFilesAreOwnedByAdmGroup and EnsureAllRsyslogLogFilesAreOwnedBySyslogUser)

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3872,29 +3872,15 @@ static int RemediateEnsureLoggerConfigurationFilesAreRestricted(char* value, OsC
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    if (0 == CheckGroupExists("adm", NULL, log))
-    {
-        return SetEtcConfValue(g_etcRsyslogConf, "$FileGroup", "adm", log);
-    }
-    else
-    {
-        OsConfigLogInfo(log, "Manually add group 'adm', %s", g_remediationIsNotPossible);
-        return 0;
-    }
+    CheckGroupExists("adm", NULL, log);
+    return SetEtcConfValue(g_etcRsyslogConf, "$FileGroup", "adm", log);
 }
 
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    if (0 == CheckUserExists("syslog", NULL, log))
-    {
-        return SetEtcConfValue(g_etcRsyslogConf, "$FileOwner", "syslog", log);
-    }
-    else
-    {
-        OsConfigLogInfo(log, "Manually add user 'syslog', %s", g_remediationIsNotPossible);
-        return 0;
-    }
+    CheckUserExists("syslog", NULL, log);
+    return SetEtcConfValue(g_etcRsyslogConf, "$FileOwner", "syslog", log);
 }
 
 static int RemediateEnsureRsyslogNotAcceptingRemoteMessages(char* value, OsConfigLogHandle log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2234,7 +2234,8 @@ static char* AuditEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(OsConfigLogHandle l
     const char* fileGroup = "$FileGroup adm";
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckTextIsFoundInFile(g_etcRsyslogConf, fileGroup, &reason, log));
-    CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', fileGroup, &reason, log);
+    RETURN_REASON_IF_NOT_ZERO(CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', fileGroup, &reason, log));
+    CheckGroupExists("adm", &reason, log);
     return reason;
 }
 
@@ -2243,7 +2244,8 @@ static char* AuditEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(OsConfigLogHandle
     const char* fileOwner = "$FileOwner syslog";
     char* reason = NULL;
     RETURN_REASON_IF_NOT_ZERO(CheckTextIsFoundInFile(g_etcRsyslogConf, fileOwner, &reason, log));
-    CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', fileOwner, &reason, log);
+    RETURN_REASON_IF_NOT_ZERO(CheckLineFoundNotCommentedOut(g_etcRsyslogConf, '#', fileOwner, &reason, log));
+    CheckUserExists("syslog", &reason, log);
     return reason;
 }
 
@@ -3870,13 +3872,29 @@ static int RemediateEnsureLoggerConfigurationFilesAreRestricted(char* value, OsC
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetEtcConfValue(g_etcRsyslogConf, "$FileGroup", "adm", log);
+    if (0 == CheckGroupExists("adm", &reason, log))
+    {
+        return SetEtcConfValue(g_etcRsyslogConf, "$FileGroup", "adm", log);
+    }
+    else
+    {
+        OsConfigLogInfo(log, "Manually add group 'adm', %", g_remediationIsNotPossible);
+        return ENOENT;
+    }
 }
 
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetEtcConfValue(g_etcRsyslogConf, "$FileOwner", "syslog", log);
+    if (0 == CheckUserExists("syslog", &reason, log))
+    {
+        return SetEtcConfValue(g_etcRsyslogConf, "$FileOwner", "syslog", log);
+    }
+    else
+    {
+        OsConfigLogInfo(log, "Manually add user 'syslog', %", g_remediationIsNotPossible);
+        return ENOENT;
+    }
 }
 
 static int RemediateEnsureRsyslogNotAcceptingRemoteMessages(char* value, OsConfigLogHandle log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3879,7 +3879,7 @@ static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsCo
     else
     {
         OsConfigLogInfo(log, "Manually add group 'adm', %s", g_remediationIsNotPossible);
-        return ENOENT;
+        return 0;
     }
 }
 
@@ -3893,7 +3893,7 @@ static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, Os
     else
     {
         OsConfigLogInfo(log, "Manually add user 'syslog', %s", g_remediationIsNotPossible);
-        return ENOENT;
+        return 0;
     }
 }
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3872,7 +3872,7 @@ static int RemediateEnsureLoggerConfigurationFilesAreRestricted(char* value, OsC
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    if (0 == CheckGroupExists("adm", &reason, log))
+    if (0 == CheckGroupExists("adm", NULL, log))
     {
         return SetEtcConfValue(g_etcRsyslogConf, "$FileGroup", "adm", log);
     }
@@ -3886,7 +3886,7 @@ static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsCo
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    if (0 == CheckUserExists("syslog", &reason, log))
+    if (0 == CheckUserExists("syslog", NULL, log))
     {
         return SetEtcConfValue(g_etcRsyslogConf, "$FileOwner", "syslog", log);
     }

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3878,7 +3878,7 @@ static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsCo
     }
     else
     {
-        OsConfigLogInfo(log, "Manually add group 'adm', %", g_remediationIsNotPossible);
+        OsConfigLogInfo(log, "Manually add group 'adm', %s", g_remediationIsNotPossible);
         return ENOENT;
     }
 }
@@ -3892,7 +3892,7 @@ static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, Os
     }
     else
     {
-        OsConfigLogInfo(log, "Manually add user 'syslog', %", g_remediationIsNotPossible);
+        OsConfigLogInfo(log, "Manually add user 'syslog', %s", g_remediationIsNotPossible);
         return ENOENT;
     }
 }

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3152,7 +3152,7 @@ bool GroupExists(gid_t groupId, OsConfigLogHandle log)
 {
     bool result = false;
 
-    if (NULL != (groupEntry = getgrgid(groupId)))
+    if (NULL != getgrgid(groupId))
     {
         OsConfigLogInfo(log, "GroupExists: group %u exists", (unsigned int)groupId);
         result = true;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3152,7 +3152,7 @@ bool GroupExists(gid_t groupId, OsConfigLogHandle log)
 {
     bool result = false;
 
-    if (NULL != getgrgid(groupId))
+    if (NULL != (groupEntry = getgrgid(groupId)))
     {
         OsConfigLogInfo(log, "GroupExists: group %u exists", (unsigned int)groupId);
         result = true;
@@ -3164,6 +3164,63 @@ bool GroupExists(gid_t groupId, OsConfigLogHandle log)
     else
     {
         OsConfigLogInfo(log, "GroupExists: getgrgid(for gid: %u) failed (errno: %d, %s)", (unsigned int)groupId, errno, strerror(errno));
+    }
+
+    return result;
+}
+
+int CheckGroupExists(const char* name, char** reason, OsConfigLogHandle log)
+{
+    struct group* groupEntry = NULL;
+    int result = ENOENT;
+
+    if ((NULL != name) && (NULL != (groupEntry = getgrnam(name))))
+    {
+        OsConfigLogInfo(log, "CheckGroupExists: group %u exists", (unsigned int)groupEntry->gr_gid);
+        OsConfigCaptureSuccessReason(reason, "Group %u exists", (unsigned int)groupEntry->gr_gid);
+        result = 0;
+    }
+
+    if (0 != result)
+    {
+        OsConfigLogInfo(log, "CheckGroupExists: group '%s' does not exist (errno: %d)", name, errno);
+        OsConfigCaptureReason(reason, "Group '%s' does not exist (%d), automatic remediation is not possible", name, errno);
+    }
+
+    return result;
+}
+
+int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log)
+{
+    struct passwd* userEntry = NULL;
+    int result = ENOENT;
+
+    if (NULL != username)
+    {
+        setpwent();
+
+        while (NULL != (userEntry = getpwent()))
+        {
+            if (NULL == userEntry->pw_name)
+            {
+                continue;
+            }
+            else if (0 == strcmp(userEntry->pw_name, username))
+            {
+                OsConfigLogInfo(log, "UserExists: user %u exists", userEntry->pw_uid);
+                OsConfigCaptureSuccessReason(reason, "User %u exists", userEntry->pw_uid);
+                result = 0;
+                break;
+            }
+        }
+
+        endpwent();
+    }
+
+    if (0 != result)
+    {
+        OsConfigLogInfo(log, "UserExists: user '%s' does not exist", username);
+        OsConfigCaptureReason(reason, "User '%s' does not exist, automatic remediation is not possible", username);
     }
 
     return result;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3183,7 +3183,7 @@ int CheckGroupExists(const char* name, char** reason, OsConfigLogHandle log)
 
     if (0 != result)
     {
-        OsConfigLogInfo(log, "CheckGroupExists: group '%s' does not exist (errno: %d)", name, errno);
+        OsConfigLogInfo(log, "CheckGroupExists: group '%s' does not exist (errno: %d), automatic remediation is not possible", name, errno);
         OsConfigCaptureReason(reason, "Group '%s' does not exist (%d), automatic remediation is not possible", name, errno);
     }
 
@@ -3219,7 +3219,7 @@ int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log)
 
     if (0 != result)
     {
-        OsConfigLogInfo(log, "UserExists: user '%s' does not exist", username);
+        OsConfigLogInfo(log, "UserExists: user '%s' does not exist, automatic remediation is not possible", username);
         OsConfigCaptureReason(reason, "User '%s' does not exist, automatic remediation is not possible", username);
     }
 

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -121,8 +121,9 @@ int SetUsersRestrictedDotFiles(unsigned int* modes, unsigned int numberOfModes, 
 int CheckUserAccountsNotFound(const char* names, char** reason, OsConfigLogHandle log);
 int RemoveUserAccounts(const char* names, OsConfigLogHandle log);
 int RestrictSuToRootGroup(OsConfigLogHandle log);
-
 bool GroupExists(gid_t groupId, OsConfigLogHandle log);
+int CheckGroupExists(const char* name, char** reason, OsConfigLogHandle log);
+int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log);
 
 #ifdef __cplusplus
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2958,7 +2958,7 @@ TEST_F(CommonUtilsTest, GroupExists)
 
 TEST_F(CommonUtilsTest, CheckGroupExists)
 {
-    EXPECT_EQ(0, GroupExists("root", nullptr, nullptr));
+    EXPECT_EQ(0, CheckGroupExists("root", nullptr, nullptr));
     EXPECT_EQ(ENOENT, CheckGroupExists("root ", nullptr, nullptr));
     EXPECT_EQ(ENOENT, CheckGroupExists("my root", nullptr, nullptr));
     EXPECT_EQ(ENOENT, CheckGroupExists("-root", nullptr, nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2956,6 +2956,35 @@ TEST_F(CommonUtilsTest, GroupExists)
     EXPECT_FALSE(GroupExists(0xFFFFFFFF, nullptr));
 }
 
+TEST_F(CommonUtilsTest, CheckGroupExists)
+{
+    EXPECT_EQ(0, GroupExists("root", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckGroupExists("root ", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckGroupExists("my root", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckGroupExists("-root", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckGroupExists("", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckGroupExists(" ", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckGroupExists("abracadabra", nullptr, nullptr));
+}
+
+TEST_F(CommonUtilsTest, CheckUserExists)
+{
+    EXPECT_EQ(0, CheckUserExists("root", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists(nullptr, nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("0", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("abracadabra", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("nulluser", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("ghostaccount", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("testcaseonly", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("xyzzy", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("nobodyhere", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("fakeuser123", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("__void__", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("root ", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("  ", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckUserExists("1234567890123456789012345678901234567890123456789012345678901234567890", nullptr, nullptr));
+}
+
 TEST_F(CommonUtilsTest, FindTextInFolder)
 {
     const char* path = "/tmp/~test.conf";

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -16,7 +16,7 @@
   },
   {
     "RunCommand": "etent group adm >/dev/null || sudo groupadd -r adm"
-  }
+  },
   {
     "Action": "LoadModule",
     "Module": "securitybaseline.so"

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -15,6 +15,9 @@
     "RunCommand": "id -u syslog &>/dev/null || sudo useradd -r -s /usr/sbin/nologin -d /nonexistent syslog"
   },
   {
+    "RunCommand": "etent group adm >/dev/null || sudo groupadd -r adm"
+  }
+  {
     "Action": "LoadModule",
     "Module": "securitybaseline.so"
   },

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -12,6 +12,9 @@
     "RunCommand": "echo 'remember=5' > /tmp/~test.test"
   },
   {
+    "RunCommand": "id -u syslog &>/dev/null || sudo useradd -r -s /usr/sbin/nologin -d /nonexistent syslog"
+  },
+  {
     "Action": "LoadModule",
     "Module": "securitybaseline.so"
   },


### PR DESCRIPTION
## Description

This PR contains hardening for 2 ASB rules:

- EnsureAllRsyslogLogFilesAreOwnedByAdmGroup
- EnsureAllRsyslogLogFilesAreOwnedBySyslogUser

(both audit and remediation)

The hardening consists in checking if group 'adm' and user 'syslog' exist, and if not, to warn the user that automatic validation is not possible (we do not want to blindly create the group and/or account and risk breaking the local security).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
