### PR TITLE
ASB fix for EnsureAllRsyslogLogFilesAreOwnedByAdmGroup and EnsureAllRsyslogLogFilesAreOwnedBySyslogUser remediations

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3872,14 +3872,14 @@ static int RemediateEnsureLoggerConfigurationFilesAreRestricted(char* value, OsC
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedByAdmGroup(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    CheckGroupExists("adm", NULL, log);
+    AddIfMissingAdmSystemGroup(log);
     return SetEtcConfValue(g_etcRsyslogConf, "$FileGroup", "adm", log);
 }
 
 static int RemediateEnsureAllRsyslogLogFilesAreOwnedBySyslogUser(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    CheckUserExists("syslog", NULL, log);
+    AddIfMissingSyslogSystemUser(log);
     return SetEtcConfValue(g_etcRsyslogConf, "$FileOwner", "syslog", log);
 }
 

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3228,8 +3228,8 @@ int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log)
 
 int AddIfMissingSyslogSystemUser(OsConfigLogHandle log)
 {
-    const char* commmand = "useradd -r -s /usr/sbin/nologin -d /nonexistent syslog";
-    result = 0;
+    const char* command = "useradd -r -s /usr/sbin/nologin -d /nonexistent syslog";
+    int result = 0;
 
     if (0 != (result = CheckUserExists("syslog", NULL, log)))
     {
@@ -3248,8 +3248,8 @@ int AddIfMissingSyslogSystemUser(OsConfigLogHandle log)
 
 int AddIfMissingAdmSystemGroup(OsConfigLogHandle log)
 {
-    const char* commmand = "groupadd -r adm";
-    result = 0;
+    const char* command = "groupadd -r adm";
+    int result = 0;
 
     if (0 != (result = CheckGroupExists("adm", NULL, log)))
     {

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3183,8 +3183,8 @@ int CheckGroupExists(const char* name, char** reason, OsConfigLogHandle log)
 
     if (0 != result)
     {
-        OsConfigLogInfo(log, "CheckGroupExists: group '%s' does not exist (errno: %d), automatic remediation is not possible", name, errno);
-        OsConfigCaptureReason(reason, "Group '%s' does not exist (%d), automatic remediation is not possible", name, errno);
+        OsConfigLogInfo(log, "CheckGroupExists: group '%s' does not exist (errno: %d)", name, errno);
+        OsConfigCaptureReason(reason, "Group '%s' does not exist (%d)", name, errno);
     }
 
     return result;
@@ -3219,8 +3219,8 @@ int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log)
 
     if (0 != result)
     {
-        OsConfigLogInfo(log, "UserExists: user '%s' does not exist, automatic remediation is not possible", username);
-        OsConfigCaptureReason(reason, "User '%s' does not exist, automatic remediation is not possible", username);
+        OsConfigLogInfo(log, "UserExists: user '%s' does not exist", username);
+        OsConfigCaptureReason(reason, "User '%s' does not exist", username);
     }
 
     return result;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -3225,3 +3225,43 @@ int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log)
 
     return result;
 }
+
+int AddIfMissingSyslogSystemUser(OsConfigLogHandle log)
+{
+    const char* commmand = "useradd -r -s /usr/sbin/nologin -d /nonexistent syslog";
+    result = 0;
+
+    if (0 != (result = CheckUserExists("syslog", NULL, log)))
+    {
+        if (0 != (result = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+        {
+            OsConfigLogInfo(log, "AddMissingSyslogSystemUser: useradd for user 'syslog' failed with %d (errno: %d, %s)", result, errno, strerror(errno));
+        }
+        else
+        {
+            OsConfigLogInfo(log, "AddMissingSyslogSystemUser: user 'syslog' successfully created");
+        }
+    }
+
+    return result;
+}
+
+int AddIfMissingAdmSystemGroup(OsConfigLogHandle log)
+{
+    const char* commmand = "groupadd -r adm";
+    result = 0;
+
+    if (0 != (result = CheckGroupExists("adm", NULL, log)))
+    {
+        if (0 != (result = ExecuteCommand(NULL, command, false, false, 0, 0, NULL, NULL, log)))
+        {
+            OsConfigLogInfo(log, "AddMissingAdmSystemGroup: groupadd for group 'adm' failed with %d (errno: %d, %s)", result, errno, strerror(errno));
+        }
+        else
+        {
+            OsConfigLogInfo(log, "AddMissingAdmSystemGroup: group 'adm' successfully created");
+        }
+    }
+
+    return result;
+}

--- a/src/common/commonutils/UserUtils.h
+++ b/src/common/commonutils/UserUtils.h
@@ -124,6 +124,8 @@ int RestrictSuToRootGroup(OsConfigLogHandle log);
 bool GroupExists(gid_t groupId, OsConfigLogHandle log);
 int CheckGroupExists(const char* name, char** reason, OsConfigLogHandle log);
 int CheckUserExists(const char* username, char** reason, OsConfigLogHandle log);
+int AddIfMissingSyslogSystemUser(OsConfigLogHandle log);
+int AddIfMissingAdmSystemGroup(OsConfigLogHandle log);
 
 #ifdef __cplusplus
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3044,6 +3044,12 @@ TEST_F(CommonUtilsTest, FindTextInFolder)
     EXPECT_TRUE(Cleanup(noConfPath));
 }
 
+TEST_F(CommonUtilsTest, AddIfMissingAdmGroupAndSyslogUser)
+{
+    EXPECT_EQ(0, AddIfMissingAdmSystemGroup(nullptr));
+    EXPECT_EQ(0, AddIfMissingSyslogSystemUser(nullptr));
+}
+
 TEST_F(CommonUtilsTest, LoggingOptions)
 {
     const char* emergency = "EMERGENCY";

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -12,12 +12,6 @@
     "RunCommand": "echo 'remember=5' > /tmp/~test.test"
   },
   {
-    "RunCommand": "id -u syslog &>/dev/null || sudo useradd -r -s /usr/sbin/nologin -d /nonexistent syslog"
-  },
-  {
-    "RunCommand": "etent group adm >/dev/null || sudo groupadd -r adm"
-  },
-  {
     "Action": "LoadModule",
     "Module": "securitybaseline.so"
   },


### PR DESCRIPTION
## Description

This PR adds fix for the ASB's EnsureAllRsyslogLogFilesAreOwnedByAdmGroup and EnsureAllRsyslogLogFilesAreOwnedBySyslogUser rules remediations:
- When the 'syslog' user does not exist, add it as a system, non-login user.
- When 'adm' does not exist, add it as a system group.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
