### PR TITLE
Adding GMT offset to logged times

### DIFF
--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -200,7 +200,7 @@ char* GetFormattedTime(void)
     struct tm result = {0};
     time(&rawTime);
     timeInfo = localtime_r(&rawTime, &result);
-    strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S %z", timeInfo);
+    strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S %z (%Z)", timeInfo);
     return g_logTime;
 }
 

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -192,7 +192,7 @@ FILE* GetLogFile(OsConfigLogHandle log)
 
 static char g_logTime[TIME_FORMAT_STRING_LENGTH] = {0};
 
-// Returns the local date/time formatted as YYYY-MM-DD HH:MM:SS (for example: 2014-03-19 11:11:52)
+// Returns the local date/time with GMT offset, formatted as YYYY-MM-DD HH:MM:SS-GGGG (for example: 2025-09-26 15:49:55-0700)
 char* GetFormattedTime(void)
 {
     time_t rawTime = {0};

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -13,7 +13,7 @@
 #include <limits.h>
 #include "Logging.h"
 
-#define TIME_FORMAT_STRING_LENGTH 20
+#define TIME_FORMAT_STRING_LENGTH 64
 
 struct OsConfigLog
 {

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -200,7 +200,7 @@ char* GetFormattedTime(void)
     struct tm result = {0};
     time(&rawTime);
     timeInfo = localtime_r(&rawTime, &result);
-    strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S", timeInfo);
+    strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S %z", timeInfo);
     return g_logTime;
 }
 

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -200,7 +200,7 @@ char* GetFormattedTime(void)
     struct tm result = {0};
     time(&rawTime);
     timeInfo = localtime_r(&rawTime, &result);
-    strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S %z (%Z)", timeInfo);
+    strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S%z", timeInfo);
     printf("######################### %s #######################\n", g_logTime);/////////////
     return g_logTime;
 }

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -201,7 +201,6 @@ char* GetFormattedTime(void)
     time(&rawTime);
     timeInfo = localtime_r(&rawTime, &result);
     strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S%z", timeInfo);
-    printf("######################### %s #######################\n", g_logTime);/////////////
     return g_logTime;
 }
 

--- a/src/common/logging/Logging.c
+++ b/src/common/logging/Logging.c
@@ -201,6 +201,7 @@ char* GetFormattedTime(void)
     time(&rawTime);
     timeInfo = localtime_r(&rawTime, &result);
     strftime(g_logTime, ARRAY_SIZE(g_logTime), "%Y-%m-%d %H:%M:%S %z (%Z)", timeInfo);
+    printf("######################### %s #######################\n", g_logTime);/////////////
     return g_logTime;
 }
 


### PR DESCRIPTION
## Description

Adding GMT offset to logged times. We used to have this in the past and maybe it was not merged as it is still missing. This allows us to see real times from Virtual Machines especially that show time in GMT only.

Produces date and time stamps like this:

[2025-09-26 15:49:55-0700]

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
