### PR TITLE
ASB fix for several rules that need to check system files and data that can have commented out lines

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -2209,7 +2209,7 @@ static char* AuditEnsureFilePermissionsForAllRsyslogLogFiles(OsConfigLogHandle l
     if ((0 == ConvertStringToIntegers(g_desiredEnsureFilePermissionsForAllRsyslogLogFiles ? g_desiredEnsureFilePermissionsForAllRsyslogLogFiles :
         g_defaultEnsureFilePermissionsForAllRsyslogLogFiles, ',', &modes, &numberOfModes, 8, log)) && (numberOfModes > 0))
     {
-        CheckIntegerOptionFromFileEqualWithAny(g_etcRsyslogConf, g_fileCreateMode, ' ', modes, numberOfModes, &reason, 8, log);
+        CheckIntegerOptionFromFileEqualWithAny(g_etcRsyslogConf, g_fileCreateMode, ' ', '#', modes, numberOfModes, &reason, 8, log);
     }
     else
     {

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -130,10 +130,10 @@ int SetEnsurePasswordReuseIsLimited(int remember, OsConfigLogHandle log);
 int EnableVirtualMemoryRandomization(OsConfigLogHandle log);
 int RemoveDotsFromPath(OsConfigLogHandle log);
 
-char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, OsConfigLogHandle log);
-int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, int base, OsConfigLogHandle log);
-int CheckIntegerOptionFromFileEqualWithAny(const char* fileName, const char* option, char separator, int* values, int numberOfValues, char** reason, int base, OsConfigLogHandle log);
-int CheckIntegerOptionFromFileLessOrEqualWith(const char* fileName, const char* option, char separator, int value, char** reason, int base, OsConfigLogHandle log);
+char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, char commentCharacter, OsConfigLogHandle log);
+int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, char commentCharacter, int base, OsConfigLogHandle log);
+int CheckIntegerOptionFromFileEqualWithAny(const char* fileName, const char* option, char separator, char commentCharacter, int* values, int numberOfValues, char** reason, int base, OsConfigLogHandle log);
+int CheckIntegerOptionFromFileLessOrEqualWith(const char* fileName, const char* option, char separator, char commentCharacter, int value, char** reason, int base, OsConfigLogHandle log);
 
 char* DuplicateString(const char* source);
 char* ConcatenateStrings(const char* first, const char* second);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -116,8 +116,8 @@ int CheckTextFoundInFolder(const char* directory, const char* text, const char* 
 int CheckLineNotFoundOrCommentedOut(const char* fileName, char commentMark, const char* text, char** reason, OsConfigLogHandle log);
 int CheckLineFoundNotCommentedOut(const char* fileName, char commentMark, const char* text, char** reason, OsConfigLogHandle log);
 int CheckTextFoundInCommandOutput(const char* command, const char* text, char** reason, OsConfigLogHandle log);
-char* GetStringOptionFromBuffer(const char* buffer, const char* option, char separator, OsConfigLogHandle log);
-int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char separator, int base, OsConfigLogHandle log);
+char* GetStringOptionFromBuffer(const char* buffer, const char* option, char separator, char commentCharacter, OsConfigLogHandle log);
+int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char separator, char commentCharacter, int base, OsConfigLogHandle log);
 int CheckTextNotFoundInCommandOutput(const char* command, const char* text, char** reason, OsConfigLogHandle log);
 int SetEtcConfValue(const char* file, const char* name, const char* value, OsConfigLogHandle log);
 int SetEtcLoginDefValue(const char* name, const char* value, OsConfigLogHandle log);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1733,25 +1733,29 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
     }
-    else if (NULL != (found = strstr(temp, option)))
+    else 
     {
-        OsConfigLogInfo(log, "#1## %s ####", found); ////////////////////////////
-        TruncateAtFirst(found, commentCharacter);
-        OsConfigLogInfo(log, "#2## %s ####", found); ////////////////////////////
-        RemovePrefixUpTo(found, separator);
-        OsConfigLogInfo(log, "#3## %s ####", found); ////////////////////////////
-        RemovePrefix(found, separator);
-        OsConfigLogInfo(log, "#4## %s ####", found); ////////////////////////////
-        RemovePrefixBlanks(found);
-        RemoveTrailingBlanks(found);
-        TruncateAtFirst(found, EOL);
-        TruncateAtFirst(found, ' ');
+        OsConfigLogInfo(log, "#1## %s ####", temp); ////////////////////////////
+        TruncateAtFirst(temp, commentCharacter);
 
-        OsConfigLogInfo(log, "GetStringOptionFromBuffer: found '%s' for '%s'", found, option);
-
-        if (NULL == (result = DuplicateString(found)))
+        if (NULL != (found = strstr(temp, option)))
         {
-            OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate result string (%d)", errno);
+            OsConfigLogInfo(log, "#2## %s ####", found); ////////////////////////////
+            RemovePrefixUpTo(found, separator);
+            OsConfigLogInfo(log, "#3## %s ####", found); ////////////////////////////
+            RemovePrefix(found, separator);
+            OsConfigLogInfo(log, "#4## %s ####", found); ////////////////////////////
+            RemovePrefixBlanks(found);
+            RemoveTrailingBlanks(found);
+            TruncateAtFirst(found, EOL);
+            TruncateAtFirst(found, ' ');
+
+            OsConfigLogInfo(log, "GetStringOptionFromBuffer: found '%s' for '%s'", found, option);
+
+            if (NULL == (result = DuplicateString(found)))
+            {
+                OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate result string (%d)", errno);
+            }
         }
     }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1715,7 +1715,7 @@ int CheckTextNotFoundInCommandOutput(const char* command, const char* text, char
     return result;
 }
 
-char* GetStringOptionFromBuffer(const char* buffer, const char* option, char separator, OsConfigLogHandle log)
+char* GetStringOptionFromBuffer(const char* buffer, const char* option, char separator, char commentCharacter, OsConfigLogHandle log)
 {
     char* found = NULL;
     char* temp = NULL;
@@ -1752,7 +1752,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     return result;
 }
 
-int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char separator, int base, OsConfigLogHandle log)
+int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char separator, char commentCharacter, int base, OsConfigLogHandle log)
 {
     char* stringValue = NULL;
     int value = INT_ENOENT;

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1735,7 +1735,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     }
     else if (commentCharacter == temp[0])
     {
-        OsConfigLogInfo(log, "GetStringOptionFromBuffer: entire line is commented out", errno);
+        OsConfigLogInfo(log, "GetStringOptionFromBuffer: entire line is commented out");
     }
     else if (NULL != (found = strstr(temp, option)))
     {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1769,7 +1769,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
             OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' is found but commented out with '%c'", option, commentCharacter);
         }
 
-        if ((found + 1) > (temp + strlen(temp)))
+        if ((found += 1) > (temp + strlen(temp)))
         {
             break;
         }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1735,9 +1735,13 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     }
     else if (NULL != (found = strstr(temp, option)))
     {
+        OsConfigLogInfo(log, "#1## %s ####", found); ////////////////////////////
         TruncateAtFirst(found, commentCharacter);
+        OsConfigLogInfo(log, "#2## %s ####", found); ////////////////////////////
         RemovePrefixUpTo(found, separator);
+        OsConfigLogInfo(log, "#3## %s ####", found); ////////////////////////////
         RemovePrefix(found, separator);
+        OsConfigLogInfo(log, "#4## %s ####", found); ////////////////////////////
         RemovePrefixBlanks(found);
         RemoveTrailingBlanks(found);
         TruncateAtFirst(found, EOL);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1735,7 +1735,9 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
         return result;
     }
     
-    while (NULL != (found = strstr(temp, option)))
+    found = temp;
+
+    while (NULL != (found = strstr(found, option)))
     {
         lineStart = found;
         while ((lineStart > temp) && (*(lineStart - 1)) != '\n')
@@ -1765,6 +1767,11 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
         else
         {
             OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' for '%s' is found but commented out with '%c'", found, option, commentCharacter);
+        }
+
+        if ((found += strlen(found)) > temp)
+        {
+            break;
         }
     }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1740,7 +1740,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     while (NULL != (found = strstr(found, option)))
     {
         lineStart = found;
-        while ((lineStart > temp) && (*(lineStart - 1)) != '\n')
+        while ((lineStart > temp) && (*(lineStart - 1)) != EOL)
         {
             lineStart--;
         }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1719,12 +1719,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
 {
     char* found = NULL;
     char* temp = NULL;
-    char* comment = NULL;
     char* result = NULL;
-    int offset = 0;
-
-
-    UNUSED(commentCharacter);
 
     if ((NULL == buffer) || (NULL == option))
     {
@@ -1736,7 +1731,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
     }
-    else 
+    else
     {
         TruncateAtFirst(temp, commentCharacter);
         if (NULL != (found = strstr(temp, option)))

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1733,8 +1733,13 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
     }
+    else if (commentCharacter == temp[0])
+    {
+        OsConfigLogInfo(log, "GetStringOptionFromBuffer: entire line is commented out", errno);
+    }
     else if (NULL != (found = strstr(temp, option)))
     {
+        TruncateAtFirst(found, commentCharacter);
         RemovePrefixUpTo(found, separator);
         RemovePrefix(found, separator);
         RemovePrefixBlanks(found);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1810,7 +1810,7 @@ int GetIntegerOptionFromFile(const char* fileName, const char* option, char sepa
         }
         else
         {
-            if (INT_ENOENT != (result = GetIntegerOptionFromBuffer(contents, option, separator, base, log)))
+            if (INT_ENOENT != (result = GetIntegerOptionFromBuffer(contents, option, separator, '#', base, log)))
             {
                 if (8 == base)
                 {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1768,7 +1768,7 @@ int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char sepa
     return value;
 }
 
-char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, OsConfigLogHandle log)
+char* GetStringOptionFromFile(const char* fileName, const char* option, char separator, char commentCharacter, OsConfigLogHandle log)
 {
     char* contents = NULL;
     char* result = NULL;
@@ -1781,7 +1781,7 @@ char* GetStringOptionFromFile(const char* fileName, const char* option, char sep
         }
         else
         {
-            if (NULL != (result = GetStringOptionFromBuffer(contents, option, separator, '#', log)))
+            if (NULL != (result = GetStringOptionFromBuffer(contents, option, separator, commentCharacter, log)))
             {
                 OsConfigLogInfo(log, "GetStringOptionFromFile: found '%s' in '%s' for '%s'", result, fileName, option);
             }
@@ -1797,7 +1797,7 @@ char* GetStringOptionFromFile(const char* fileName, const char* option, char sep
     return result;
 }
 
-int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, int base, OsConfigLogHandle log)
+int GetIntegerOptionFromFile(const char* fileName, const char* option, char separator, char commentCharacter, int base, OsConfigLogHandle log)
 {
     char* contents = NULL;
     int result = INT_ENOENT;
@@ -1810,7 +1810,7 @@ int GetIntegerOptionFromFile(const char* fileName, const char* option, char sepa
         }
         else
         {
-            if (INT_ENOENT != (result = GetIntegerOptionFromBuffer(contents, option, separator, '#', base, log)))
+            if (INT_ENOENT != (result = GetIntegerOptionFromBuffer(contents, option, separator, commentCharacter, base, log)))
             {
                 if (8 == base)
                 {
@@ -1833,7 +1833,7 @@ int GetIntegerOptionFromFile(const char* fileName, const char* option, char sepa
     return result;
 }
 
-int CheckIntegerOptionFromFileEqualWithAny(const char* fileName, const char* option, char separator, int* values, int numberOfValues, char** reason, int base, OsConfigLogHandle log)
+int CheckIntegerOptionFromFileEqualWithAny(const char* fileName, const char* option, char separator, char commentCharacter, int* values, int numberOfValues, char** reason, int base, OsConfigLogHandle log)
 {
     int valueFromFile = INT_ENOENT;
     int i = 0;
@@ -1845,7 +1845,7 @@ int CheckIntegerOptionFromFileEqualWithAny(const char* fileName, const char* opt
         return EINVAL;
     }
 
-    if (INT_ENOENT != (valueFromFile = GetIntegerOptionFromFile(fileName, option, separator, base, log)))
+    if (INT_ENOENT != (valueFromFile = GetIntegerOptionFromFile(fileName, option, separator, commentCharacter, base, log)))
     {
         for (i = 0; i < numberOfValues; i++)
         {
@@ -1884,12 +1884,12 @@ int CheckIntegerOptionFromFileEqualWithAny(const char* fileName, const char* opt
     return result;
 }
 
-int CheckIntegerOptionFromFileLessOrEqualWith(const char* fileName, const char* option, char separator, int value, char** reason, int base, OsConfigLogHandle log)
+int CheckIntegerOptionFromFileLessOrEqualWith(const char* fileName, const char* option, char separator, char commentCharacter, int value, char** reason, int base, OsConfigLogHandle log)
 {
     int valueFromFile = INT_ENOENT;
     int result = ENOENT;
 
-    if (INT_ENOENT != (valueFromFile = GetIntegerOptionFromFile(fileName, option, separator, base, log)))
+    if (INT_ENOENT != (valueFromFile = GetIntegerOptionFromFile(fileName, option, separator, commentCharacter, base, log)))
     {
         if (valueFromFile <= value)
         {

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1733,10 +1733,6 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
     }
-    else if (commentCharacter == temp[0])
-    {
-        OsConfigLogInfo(log, "GetStringOptionFromBuffer: entire line is commented out");
-    }
     else if (NULL != (found = strstr(temp, option)))
     {
         TruncateAtFirst(found, commentCharacter);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1719,6 +1719,8 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
 {
     char* found = NULL;
     char* temp = NULL;
+    char* lineStart = NULL;
+    char* comment = NULL;
     char* result = NULL;
 
     if ((NULL == buffer) || (NULL == option))
@@ -1731,10 +1733,15 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
     }
-    else
+    else if (NULL != (found = strstr(temp, option)))
     {
-        TruncateAtFirst(temp, commentCharacter);
-        if (NULL != (found = strstr(temp, option)))
+        lineStart = found;
+        while ((lineStart > temp) && (*(lineStart - 1)) != '\n')
+        {
+            lineStart--;
+        }
+
+        if ((NULL == (comment = strchr(lineStart, commentCharacter))) || (comment > found))
         {
             TruncateAtFirst(temp, commentCharacter);
             RemovePrefixUpTo(found, separator);
@@ -1750,6 +1757,10 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
             {
                 OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate result string (%d)", errno);
             }
+        }
+        else
+        {
+            OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' for '%s' is found but commented out with '%s'", found, option, commentCharacter);
         }
     }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1760,7 +1760,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
         }
         else
         {
-            OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' for '%s' is found but commented out with '%s'", found, option, commentCharacter);
+            OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' for '%s' is found but commented out with '%c'", found, option, commentCharacter);
         }
     }
 

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1766,10 +1766,10 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
         }
         else
         {
-            OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' for '%s' is found but commented out with '%c'", found, option, commentCharacter);
+            OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' is found but commented out with '%c'", option, commentCharacter);
         }
 
-        if ((found + 1) > temp)
+        if ((found + 1) > (temp + strlen(temp)))
         {
             break;
         }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1734,7 +1734,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
         return result;
     }
-    
+
     found = temp;
 
     while (NULL != (found = strstr(found, option)))
@@ -1769,7 +1769,7 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
             OsConfigLogInfo(log, "GetStringOptionFromBuffer: '%s' for '%s' is found but commented out with '%c'", found, option, commentCharacter);
         }
 
-        if ((found += strlen(found)) > temp)
+        if ((found + 1) > temp)
         {
             break;
         }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1719,7 +1719,10 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
 {
     char* found = NULL;
     char* temp = NULL;
+    char* comment = NULL;
     char* result = NULL;
+    int offset = 0;
+
 
     UNUSED(commentCharacter);
 
@@ -1735,16 +1738,12 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     }
     else 
     {
-        OsConfigLogInfo(log, "#1## %s ####", temp); ////////////////////////////
         TruncateAtFirst(temp, commentCharacter);
-
         if (NULL != (found = strstr(temp, option)))
         {
-            OsConfigLogInfo(log, "#2## %s ####", found); ////////////////////////////
+            TruncateAtFirst(temp, commentCharacter);
             RemovePrefixUpTo(found, separator);
-            OsConfigLogInfo(log, "#3## %s ####", found); ////////////////////////////
             RemovePrefix(found, separator);
-            OsConfigLogInfo(log, "#4## %s ####", found); ////////////////////////////
             RemovePrefixBlanks(found);
             RemoveTrailingBlanks(found);
             TruncateAtFirst(found, EOL);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1781,7 +1781,7 @@ char* GetStringOptionFromFile(const char* fileName, const char* option, char sep
         }
         else
         {
-            if (NULL != (result = GetStringOptionFromBuffer(contents, option, separator, log)))
+            if (NULL != (result = GetStringOptionFromBuffer(contents, option, separator, '#', log)))
             {
                 OsConfigLogInfo(log, "GetStringOptionFromFile: found '%s' in '%s' for '%s'", result, fileName, option);
             }

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1721,6 +1721,8 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     char* temp = NULL;
     char* result = NULL;
 
+    UNUSED(commentCharacter);
+
     if ((NULL == buffer) || (NULL == option))
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer called with invalid arguments");
@@ -1757,7 +1759,7 @@ int GetIntegerOptionFromBuffer(const char* buffer, const char* option, char sepa
     char* stringValue = NULL;
     int value = INT_ENOENT;
 
-    if (NULL != (stringValue = GetStringOptionFromBuffer(buffer, option, separator, log)))
+    if (NULL != (stringValue = GetStringOptionFromBuffer(buffer, option, separator, commentCharacter, log)))
     {
         value = strtol(stringValue, NULL, base);
         FREE_MEMORY(stringValue);

--- a/src/common/commonutils/FileUtils.c
+++ b/src/common/commonutils/FileUtils.c
@@ -1732,8 +1732,10 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
     if (NULL == (temp = DuplicateString(buffer)))
     {
         OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate buffer string failed (%d)", errno);
+        return result;
     }
-    else if (NULL != (found = strstr(temp, option)))
+    
+    while (NULL != (found = strstr(temp, option)))
     {
         lineStart = found;
         while ((lineStart > temp) && (*(lineStart - 1)) != '\n')
@@ -1757,6 +1759,8 @@ char* GetStringOptionFromBuffer(const char* buffer, const char* option, char sep
             {
                 OsConfigLogError(log, "GetStringOptionFromBuffer: failed to duplicate result string (%d)", errno);
             }
+
+            break;
         }
         else
         {

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -552,7 +552,7 @@ int RemoveDotsFromPath(OsConfigLogHandle log)
                 continue;
             }
 
-            if (NULL != (currentPath = GetStringOptionFromFile(pathLocations[i].location, pathLocations[i].path, ' ', log)))
+            if (NULL != (currentPath = GetStringOptionFromFile(pathLocations[i].location, pathLocations[i].path, ' ', '#', log)))
             {
                 if (NULL != (newPath = RemoveCharacterFromString(currentPath, dot[0], log)))
                 {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -247,8 +247,8 @@ int CheckLockoutForFailedPasswordAttempts(const char* fileName, const char* pamS
             }
             else if ((NULL != strstr(line, auth)) && (NULL != strstr(line, pamSo)) &&
                 (NULL != (authValue = GetStringOptionFromBuffer(line, auth, ' ', log))) && (0 == strcmp(authValue, required)) &&
-                (0 <= (deny = GetIntegerOptionFromBuffer(line, "deny", '=', 10, log))) && (deny <= 5) &&
-                (0 < (unlockTime = GetIntegerOptionFromBuffer(line, "unlock_time", '=', 10, log))))
+                (0 <= (deny = GetIntegerOptionFromBuffer(line, "deny", '=', '#', 10, log))) && (deny <= 5) &&
+                (0 < (unlockTime = GetIntegerOptionFromBuffer(line, "unlock_time", '=', '#', 10, log))))
             {
                 OsConfigLogInfo(log, "CheckLockoutForFailedPasswordAttempts: '%s %s %s' found uncommented with 'deny' set to %d and 'unlock_time' set to %d in '%s'",
                     auth, required, pamSo, deny, unlockTime, fileName);
@@ -472,12 +472,12 @@ static int CheckRequirementsForCommonPassword(int retry, int minlen, int dcredit
             {
                 found = true;
 
-                if ((retry == (retryOption = GetIntegerOptionFromBuffer(line, "retry", '=', 10, log))) &&
-                    (minlen == (minlenOption = GetIntegerOptionFromBuffer(line, "minlen", '=', 10, log))) &&
-                    (dcredit == (dcreditOption = GetIntegerOptionFromBuffer(line, "dcredit", '=', 10, log))) &&
-                    (ucredit == (ucreditOption = GetIntegerOptionFromBuffer(line, "ucredit", '=', 10, log))) &&
-                    (ocredit == (ocreditOption = GetIntegerOptionFromBuffer(line, "ocredit", '=', 10, log))) &&
-                    (lcredit == (lcreditOption = GetIntegerOptionFromBuffer(line, "lcredit", '=', 10, log))))
+                if ((retry == (retryOption = GetIntegerOptionFromBuffer(line, "retry", '=', '#', 10, log))) &&
+                    (minlen == (minlenOption = GetIntegerOptionFromBuffer(line, "minlen", '=', '#', 10, log))) &&
+                    (dcredit == (dcreditOption = GetIntegerOptionFromBuffer(line, "dcredit", '=', '#', 10, log))) &&
+                    (ucredit == (ucreditOption = GetIntegerOptionFromBuffer(line, "ucredit", '=', '#', 10, log))) &&
+                    (ocredit == (ocreditOption = GetIntegerOptionFromBuffer(line, "ocredit", '=', '#', 10, log))) &&
+                    (lcredit == (lcreditOption = GetIntegerOptionFromBuffer(line, "lcredit", '=', '#', 10, log))))
                 {
                     OsConfigLogInfo(log, "CheckRequirementsForCommonPassword: '%s' contains uncommented '%s %s' with "
                         "the expected password creation requirements (retry: %d, minlen: %d, dcredit: %d, ucredit: %d, ocredit: %d, lcredit: %d)",
@@ -599,7 +599,7 @@ static int CheckPasswordRequirementFromBuffer(const char* buffer, const char* op
         return INT_ENOENT;
     }
 
-    if (desired == (value = GetIntegerOptionFromBuffer(buffer, option, separator, 10, log)))
+    if (desired == (value = GetIntegerOptionFromBuffer(buffer, option, separator, '#', 10, log)))
     {
         if (comment == buffer[0])
         {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -246,7 +246,7 @@ int CheckLockoutForFailedPasswordAttempts(const char* fileName, const char* pamS
                 continue;
             }
             else if ((NULL != strstr(line, auth)) && (NULL != strstr(line, pamSo)) &&
-                (NULL != (authValue = GetStringOptionFromBuffer(line, auth, ' ', log))) && (0 == strcmp(authValue, required)) &&
+                (NULL != (authValue = GetStringOptionFromBuffer(line, auth, ' ', '#', log))) && (0 == strcmp(authValue, required)) &&
                 (0 <= (deny = GetIntegerOptionFromBuffer(line, "deny", '=', '#', 10, log))) && (deny <= 5) &&
                 (0 < (unlockTime = GetIntegerOptionFromBuffer(line, "unlock_time", '=', '#', 10, log))))
             {

--- a/src/common/commonutils/PassUtils.c
+++ b/src/common/commonutils/PassUtils.c
@@ -76,21 +76,21 @@ int CheckEnsurePasswordReuseIsLimited(int remember, char** reason, OsConfigLogHa
     {
         // On Debian-based systems '/etc/pam.d/common-password' is expected to exist
         status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdCommonPassword, '#', g_remember, reason, log)) &&
-            (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdCommonPassword, g_remember, '=', remember, reason, 10, log))) ? 0 : ENOENT;
+            (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdCommonPassword, g_remember, '=', '#', remember, reason, 10, log))) ? 0 : ENOENT;
     }
 
     if (status && (0 == CheckFileExists(g_etcPamdSystemAuth, NULL, log)))
     {
         // On Red Hat-based systems '/etc/pam.d/system-auth' is expected to exist
         status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdSystemAuth, '#', g_remember, reason, log)) &&
-            (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemAuth, g_remember, '=', remember, reason, 10, log))) ? 0 : ENOENT;
+            (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemAuth, g_remember, '=', '#', remember, reason, 10, log))) ? 0 : ENOENT;
     }
 
     if (status && (0 == CheckFileExists(g_etcPamdSystemAuth, NULL, log)))
     {
         // On Azure Linux '/etc/pam.d/system-password' is expected to exist
         status = ((0 == CheckLineFoundNotCommentedOut(g_etcPamdSystemPassword, '#', g_remember, reason, log)) &&
-            (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemPassword, g_remember, '=', remember, reason, 10, log))) ? 0 : ENOENT;
+            (0 == CheckIntegerOptionFromFileLessOrEqualWith(g_etcPamdSystemPassword, g_remember, '=', '#', remember, reason, 10, log))) ? 0 : ENOENT;
     }
 
     if (status)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1865,6 +1865,7 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
         "Test2:     12 $!    test test\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"
+        "#$FileCreateMode 00777\n"
         "$FileCreateMode 00644";
 
     char* value = nullptr;
@@ -3058,7 +3059,7 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", '=', '#', nullptr));
-    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\n#TestSetting=123", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#TestSetting=123", "TestSetting", '=', '#', nullptr));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3051,19 +3051,40 @@ TEST_F(CommonUtilsTest, AddIfMissingAdmGroupAndSyslogUser)
     EXPECT_EQ(0, AddIfMissingSyslogSystemUser(nullptr));
 }
 
-TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
+TEST_F(CommonUtilsTest, GetOptionFromBuffer)
 {
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer(nullptr, "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromBuffer(nullptr, "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("TestSetting =   TestValue", nullptr, '=', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromBuffer("TestSetting =   TestValue", nullptr, '=', '#', 10, nullptr));
+
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("TestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(0, GetIntegerOptionFromBuffer("TestSetting =   TestValue", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_STREQ("123", GetStringOptionFromBuffer("TestSetting     =   123", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(123, GetIntegerOptionFromBuffer("TestSetting     =   123", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_STREQ("345", GetStringOptionFromBuffer("#This is a test configuration\nTestSetting  =345", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(345, GetIntegerOptionFromBuffer("#This is a test configuration\nTestSetting  =345", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromBuffer("This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', 10, nullptr));
+
     EXPECT_STREQ("12", GetStringOptionFromBuffer("This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(12, GetIntegerOptionFromBuffer("This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_STREQ("1", GetStringOptionFromBuffer("  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(1, GetIntegerOptionFromBuffer("  TestSetting=1#2  ", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_STREQ("", GetStringOptionFromBuffer("  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(0, GetIntegerOptionFromBuffer("  TestSetting=#12  ", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer(" This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromBuffer(" This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', 10, nullptr));
+
     EXPECT_STREQ("88", GetStringOptionFromBuffer("#This is a TestSetting test configuration for TestSetting\n#TestSetting=100\nTestSetting=88", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(88, GetIntegerOptionFromBuffer("#This is a TestSetting test configuration for TestSetting\n#TestSetting=100\nTestSetting=88", "TestSetting", '=', '#', 10, nullptr));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -2778,7 +2778,7 @@ TEST_F(CommonUtilsTest, CheckFilePermissionsForAllRsyslogLogFiles)
     const char* testFiles[] = {
         "$FileCreateMode 00640",
         "$FileCreateMode  00640\n",
-        "# This is a test for $FileCreateMode\n",
+        "# This is a test for\n   $FileCreateMode 0640\n",
         "$FileCreateMode 0600\n"
         "$FileCreateMode 600",
         "$FileCreateMode     600"

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3052,12 +3052,12 @@ TEST_F(CommonUtilsTest, AddIfMissingAdmGroupAndSyslogUser)
 
 TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
 {
-    EXPECT_EQ(nullptr, GetStringOptionFromBuffer(nullptr, "TestSetting", ' ', '#', nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", nullptr, ' ', '#', nullptr));
-    EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", ' ', '#', nullptr));
-    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", ' ', '#', nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", ' ', '#', nullptr));
-    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\n#TestSetting=123", "TestSetting", ' ', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer(nullptr, "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", nullptr, '=', '#', nullptr));
+    EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", '=', '#', nullptr));
+    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\n#TestSetting=123", "TestSetting", '=', '#', nullptr));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1865,7 +1865,6 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
         "Test2:     12 $!    test test\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"
-        "#$FileCreateMode 00777\n"
         "$FileCreateMode 00644";
 
     char* value = nullptr;

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3060,7 +3060,7 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
     EXPECT_STREQ("12", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ(1, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("1", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1854,14 +1854,14 @@ TEST_F(CommonUtilsTest, CheckTextFoundInCommandOutput)
     EXPECT_EQ(0, CheckTextNotFoundInCommandOutput("echo Test123", "4", nullptr, nullptr));
 }
 
-/*TEST_F(CommonUtilsTest, GetOptionFromFile)
+TEST_F(CommonUtilsTest, GetOptionFromFile)
 {
     const char* testFile =
         "FooEntry1:test\n"
         " Test1=abc foo=123  \n"
         "FooEntry2  =     234\n"
         "FooEntry3 :     2 3 4\n"
-        "abc Test4 0456 # rt 4 $"
+        "abc Test4 0456 # rt 4 $\n"
         "Test2:     12 $!    test test\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"
@@ -1929,7 +1929,7 @@ TEST_F(CommonUtilsTest, CheckTextFoundInCommandOutput)
     EXPECT_EQ(0644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', '#', 8, nullptr));
 
     EXPECT_TRUE(Cleanup(m_path));
-}*/
+}
 
 TEST_F(CommonUtilsTest, CheckLockoutForFailedPasswordAttempts)
 {
@@ -3064,83 +3064,6 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_STREQ("", GetStringOptionFromBuffer("  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer(" This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("88", GetStringOptionFromBuffer("#This is a TestSetting test configuration for TestSetting\n#TestSetting=100\nTestSetting=88", "TestSetting", '=', '#', nullptr));
-}
-
-TEST_F(CommonUtilsTest, GetOptionFromFile)
-{
-    const char* testFile =
-        "FooEntry1:test\n"
-        " Test1=abc foo=123  \n"
-        "FooEntry2  =     234\n"
-        "FooEntry3 :     2 3 4\n"
-        "abc Test4 0456 # rt 4 $\n"
-        "Test2:     12 $!    test test\n"
-        "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
-        "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"
-        "$FileCreateMode 00644";
-
-    char* value = nullptr;
-
-    EXPECT_TRUE(CreateTestFile(m_path, testFile));
-
-    EXPECT_EQ(nullptr, GetStringOptionFromFile(nullptr, nullptr, ':', '#', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile(nullptr, nullptr, ':', '#', 10, nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromFile(m_path, nullptr, ':', '#', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile(m_path, nullptr, ':', '#', 10, nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromFile(nullptr, "Test1", ':', '#', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile(nullptr, "Test1", ':', '#', 8, nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromFile("~does_not_exist", "Test", '=', '#', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile("~does_not_exist", "Test", '=', '#', 10, nullptr));
-
-    EXPECT_STREQ("test", value = GetStringOptionFromFile(m_path, "FooEntry1:", ':', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_STREQ("test", value = GetStringOptionFromFile(m_path, "FooEntry1", ':', '#', nullptr));
-    FREE_MEMORY(value);
-
-    EXPECT_STREQ("abc", value = GetStringOptionFromFile(m_path, "Test1=", '=', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_STREQ("abc", value = GetStringOptionFromFile(m_path, "Test1", '=', '#', nullptr));
-    FREE_MEMORY(value);
-
-    EXPECT_STREQ("234", value = GetStringOptionFromFile(m_path, "FooEntry2", '=', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(234, GetIntegerOptionFromFile(m_path, "FooEntry2", '=', '#', 10, nullptr));
-
-    EXPECT_STREQ("2", value = GetStringOptionFromFile(m_path, "FooEntry3 :", ':', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_STREQ("2", value = GetStringOptionFromFile(m_path, "FooEntry3", ':', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(2, GetIntegerOptionFromFile(m_path, "FooEntry3 :", ':', '#', 10, nullptr));
-    EXPECT_EQ(2, GetIntegerOptionFromFile(m_path, "FooEntry3", ':', '#', 10, nullptr));
-
-    EXPECT_STREQ("0456", value = GetStringOptionFromFile(m_path, "Test4", ' ', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(456, GetIntegerOptionFromFile(m_path, "Test4", ' ', '#', 10, nullptr));
-
-    EXPECT_STREQ("12", value = GetStringOptionFromFile(m_path, "Test2:", ':', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_STREQ("12", value = GetStringOptionFromFile(m_path, "Test2", ':', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(12, GetIntegerOptionFromFile(m_path, "Test2:", ':', '#', 10, nullptr));
-    EXPECT_EQ(12, GetIntegerOptionFromFile(m_path, "Test2", ':', '#', 10, nullptr));
-
-    EXPECT_STREQ("5", value = GetStringOptionFromFile(m_path, "remember=", '=', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_STREQ("5", value = GetStringOptionFromFile(m_path, "remember", '=', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember=", '=', '#', 10, nullptr));
-    EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember", '=', '#', 10, nullptr));
-
-    EXPECT_STREQ("-1", value = GetStringOptionFromFile(m_path, "remembering", '=', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(-1, GetIntegerOptionFromFile(m_path, "remembering", '=', '#', 10, nullptr));
-
-    EXPECT_STREQ("00644", value = GetStringOptionFromFile(m_path, "$FileCreateMode", ' ', '#', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(00644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', '#', 8, nullptr));
-    EXPECT_EQ(0644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', '#', 8, nullptr));
-
-    EXPECT_TRUE(Cleanup(m_path));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3058,7 +3058,7 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", nullptr, '=', '#', nullptr));
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", '=', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
     EXPECT_STREQ(12, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(1, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3073,7 +3073,7 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
         " Test1=abc foo=123  \n"
         "FooEntry2  =     234\n"
         "FooEntry3 :     2 3 4\n"
-        "abc Test4 0456 # rt 4 $"
+        "abc Test4 0456 # rt 4 $\n"
         "Test2:     12 $!    test test\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1871,62 +1871,62 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
 
     EXPECT_TRUE(CreateTestFile(m_path, testFile));
 
-    EXPECT_EQ(nullptr, GetStringOptionFromFile(nullptr, nullptr, ':', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile(nullptr, nullptr, ':', 10, nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromFile(m_path, nullptr, ':', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile(m_path, nullptr, ':', 10, nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromFile(nullptr, "Test1", ':', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile(nullptr, "Test1", ':', 8, nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromFile("~does_not_exist", "Test", '=', nullptr));
-    EXPECT_EQ(-999, GetIntegerOptionFromFile("~does_not_exist", "Test", '=', 10, nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromFile(nullptr, nullptr, ':', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromFile(nullptr, nullptr, ':', '#', 10, nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromFile(m_path, nullptr, ':', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromFile(m_path, nullptr, ':', '#', 10, nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromFile(nullptr, "Test1", ':', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromFile(nullptr, "Test1", ':', '#', 8, nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromFile("~does_not_exist", "Test", '=', '#', nullptr));
+    EXPECT_EQ(-999, GetIntegerOptionFromFile("~does_not_exist", "Test", '=', '#', 10, nullptr));
 
-    EXPECT_STREQ("test", value = GetStringOptionFromFile(m_path, "FooEntry1:", ':', nullptr));
+    EXPECT_STREQ("test", value = GetStringOptionFromFile(m_path, "FooEntry1:", ':', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_STREQ("test", value = GetStringOptionFromFile(m_path, "FooEntry1", ':', nullptr));
-    FREE_MEMORY(value);
-
-    EXPECT_STREQ("abc", value = GetStringOptionFromFile(m_path, "Test1=", '=', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_STREQ("abc", value = GetStringOptionFromFile(m_path, "Test1", '=', nullptr));
+    EXPECT_STREQ("test", value = GetStringOptionFromFile(m_path, "FooEntry1", ':', '#', nullptr));
     FREE_MEMORY(value);
 
-    EXPECT_STREQ("234", value = GetStringOptionFromFile(m_path, "FooEntry2", '=', nullptr));
+    EXPECT_STREQ("abc", value = GetStringOptionFromFile(m_path, "Test1=", '=', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_EQ(234, GetIntegerOptionFromFile(m_path, "FooEntry2", '=', 10, nullptr));
+    EXPECT_STREQ("abc", value = GetStringOptionFromFile(m_path, "Test1", '=', '#', nullptr));
+    FREE_MEMORY(value);
 
-    EXPECT_STREQ("2", value = GetStringOptionFromFile(m_path, "FooEntry3 :", ':', nullptr));
+    EXPECT_STREQ("234", value = GetStringOptionFromFile(m_path, "FooEntry2", '=', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_STREQ("2", value = GetStringOptionFromFile(m_path, "FooEntry3", ':', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(2, GetIntegerOptionFromFile(m_path, "FooEntry3 :", ':', 10, nullptr));
-    EXPECT_EQ(2, GetIntegerOptionFromFile(m_path, "FooEntry3", ':', 10, nullptr));
+    EXPECT_EQ(234, GetIntegerOptionFromFile(m_path, "FooEntry2", '=', '#', 10, nullptr));
 
-    EXPECT_STREQ("0456", value = GetStringOptionFromFile(m_path, "Test4", ' ', nullptr));
+    EXPECT_STREQ("2", value = GetStringOptionFromFile(m_path, "FooEntry3 :", ':', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_EQ(456, GetIntegerOptionFromFile(m_path, "Test4", ' ', 10, nullptr));
+    EXPECT_STREQ("2", value = GetStringOptionFromFile(m_path, "FooEntry3", ':', '#', nullptr));
+    FREE_MEMORY(value);
+    EXPECT_EQ(2, GetIntegerOptionFromFile(m_path, "FooEntry3 :", ':', '#', 10, nullptr));
+    EXPECT_EQ(2, GetIntegerOptionFromFile(m_path, "FooEntry3", ':', '#', 10, nullptr));
 
-    EXPECT_STREQ("12", value = GetStringOptionFromFile(m_path, "Test2:", ':', nullptr));
+    EXPECT_STREQ("0456", value = GetStringOptionFromFile(m_path, "Test4", ' ', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_STREQ("12", value = GetStringOptionFromFile(m_path, "Test2", ':', nullptr));
-    FREE_MEMORY(value);
-    EXPECT_EQ(12, GetIntegerOptionFromFile(m_path, "Test2:", ':', 10, nullptr));
-    EXPECT_EQ(12, GetIntegerOptionFromFile(m_path, "Test2", ':', 10, nullptr));
+    EXPECT_EQ(456, GetIntegerOptionFromFile(m_path, "Test4", ' ', '#', 10, nullptr));
 
-    EXPECT_STREQ("5", value = GetStringOptionFromFile(m_path, "remember=", '=', nullptr));
+    EXPECT_STREQ("12", value = GetStringOptionFromFile(m_path, "Test2:", ':', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_STREQ("5", value = GetStringOptionFromFile(m_path, "remember", '=', nullptr));
+    EXPECT_STREQ("12", value = GetStringOptionFromFile(m_path, "Test2", ':', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember=", '=', 10, nullptr));
-    EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember", '=', 10, nullptr));
+    EXPECT_EQ(12, GetIntegerOptionFromFile(m_path, "Test2:", ':', '#', 10, nullptr));
+    EXPECT_EQ(12, GetIntegerOptionFromFile(m_path, "Test2", ':', '#', 10, nullptr));
+
+    EXPECT_STREQ("5", value = GetStringOptionFromFile(m_path, "remember=", '=', '#', nullptr));
+    FREE_MEMORY(value);
+    EXPECT_STREQ("5", value = GetStringOptionFromFile(m_path, "remember", '=', '#', nullptr));
+    FREE_MEMORY(value);
+    EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember=", '=', '#', 10, nullptr));
+    EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember", '=', '#', 10, nullptr));
 
     EXPECT_STREQ("-1", value = GetStringOptionFromFile(m_path, "remembering", '=', nullptr));
     FREE_MEMORY(value);
-    EXPECT_EQ(-1, GetIntegerOptionFromFile(m_path, "remembering", '=', 10, nullptr));
+    EXPECT_EQ(-1, GetIntegerOptionFromFile(m_path, "remembering", '=', '#', 10, nullptr));
 
-    EXPECT_STREQ("00644", value = GetStringOptionFromFile(m_path, "$FileCreateMode", ' ', nullptr));
+    EXPECT_STREQ("00644", value = GetStringOptionFromFile(m_path, "$FileCreateMode", ' ', '#', nullptr));
     FREE_MEMORY(value);
-    EXPECT_EQ(00644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', 8, nullptr));
-    EXPECT_EQ(0644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', 8, nullptr));
+    EXPECT_EQ(00644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', '#', 8, nullptr));
+    EXPECT_EQ(0644, GetIntegerOptionFromFile(m_path, "$FileCreateMode", ' ', '#', 8, nullptr));
 
     EXPECT_TRUE(Cleanup(m_path));
 }
@@ -2777,6 +2777,7 @@ TEST_F(CommonUtilsTest, CheckFilePermissionsForAllRsyslogLogFiles)
     const char* testFiles[] = {
         "$FileCreateMode 00640",
         "$FileCreateMode  00640\n",
+        "# This is a test for $FileCreateMode\n",
         "$FileCreateMode 0600\n"
         "$FileCreateMode 600",
         "$FileCreateMode     600"
@@ -2793,7 +2794,7 @@ TEST_F(CommonUtilsTest, CheckFilePermissionsForAllRsyslogLogFiles)
     for (int i = 0; i < testFilesSize; i++)
     {
         EXPECT_TRUE(CreateTestFile(m_path, testFiles[i]));
-        EXPECT_EQ(0, CheckIntegerOptionFromFileEqualWithAny(m_path, "$FileCreateMode", ' ', modes, numberOfModes, nullptr, 8, nullptr));
+        EXPECT_EQ(0, CheckIntegerOptionFromFileEqualWithAny(m_path, "$FileCreateMode", ' ', '#', modes, numberOfModes, nullptr, 8, nullptr));
         EXPECT_TRUE(Cleanup(m_path));
     }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3050,6 +3050,16 @@ TEST_F(CommonUtilsTest, AddIfMissingAdmGroupAndSyslogUser)
     EXPECT_EQ(0, AddIfMissingSyslogSystemUser(nullptr));
 }
 
+TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
+{
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer(nullptr, "TestSetting", ' ', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", nullptr, ' ', '#', nullptr));
+    EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", ' ', '#', nullptr));
+    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", ' ', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", ' ', '#', nullptr));
+    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\n#TestSetting=123", "TestSetting", ' ', '#', nullptr));
+}
+
 TEST_F(CommonUtilsTest, LoggingOptions)
 {
     const char* emergency = "EMERGENCY";

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3061,7 +3061,7 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
     EXPECT_STREQ("12", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("1", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
 }
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3059,7 +3059,7 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", '=', '#', nullptr));
-    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#TestSetting=123", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(12, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3059,7 +3059,10 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSetting", '=', '#', nullptr));
-    EXPECT_STREQ(12, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(12, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(1, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1865,7 +1865,6 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
         "Test2:     12 $!    test test\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"
-        "#$FileCreateMode 00777\n"
         "$FileCreateMode 00644";
 
     char* value = nullptr;
@@ -3058,9 +3057,10 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("TestSetting =   TestValue", nullptr, '=', '#', nullptr));
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("TestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("123", GetStringOptionFromBuffer("TestSetting     =   123", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("345", GetStringOptionFromBuffer("#This is a test configuration\nTestSetting  =345", "TestSetting", '=', '#', nullptr));
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
     EXPECT_STREQ("12", GetStringOptionFromBuffer("This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ("1", GetStringOptionFromBuffer("T  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("1", GetStringOptionFromBuffer("  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("", GetStringOptionFromBuffer("  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer(" This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1865,6 +1865,7 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
         "Test2:     12 $!    test test\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remember=5\n"
         "password [success=1 default=ignore] pam_unix.so obscure sha512 remembering   = -1\n"
+        "#$FileCreateMode 00777\n"
         "$FileCreateMode 00644";
 
     char* value = nullptr;

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3059,7 +3059,7 @@ TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
     EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
-    EXPECT_STREQ(12, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("12", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(1, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
     EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3055,14 +3055,14 @@ TEST_F(CommonUtilsTest, AddIfMissingAdmGroupAndSyslogUser)
 TEST_F(CommonUtilsTest, GetStringOptionFromBuffer)
 {
     EXPECT_EQ(nullptr, GetStringOptionFromBuffer(nullptr, "TestSetting", '=', '#', nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", nullptr, '=', '#', nullptr));
-    EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ("123", GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "TestSetting", '=', '#', nullptr));
-    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
-    EXPECT_STREQ("12", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ("1", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ("", GetStringOptionFromBuffer("# This is a test configuration\n  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
-    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer("# This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("TestSetting =   TestValue", nullptr, '=', '#', nullptr));
+    EXPECT_STREQ("TestValue", GetStringOptionFromBuffer("TestSetting =   TestValue", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("123", GetStringOptionFromBuffer("TestSetting     =   123", "TestSetting", '=', '#', nullptr));
+    EXPECT_EQ(nullptr, GetStringOptionFromBuffer("This is a test configuration\nTestSetting     =   123", "AnotherSomething", '=', '#', nullptr));
+    EXPECT_STREQ("12", GetStringOptionFromBuffer("This is a test configuration\n  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("1", GetStringOptionFromBuffer("T  TestSetting=1#2  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ("", GetStringOptionFromBuffer("  TestSetting=#12  ", "TestSetting", '=', '#', nullptr));
+    EXPECT_STREQ(nullptr, GetStringOptionFromBuffer(" This is a test configuration\n#  TestSetting=12  ", "TestSetting", '=', '#', nullptr));
 }
 
 TEST_F(CommonUtilsTest, LoggingOptions)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1919,7 +1919,7 @@ TEST_F(CommonUtilsTest, GetOptionFromFile)
     EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember=", '=', '#', 10, nullptr));
     EXPECT_EQ(5, GetIntegerOptionFromFile(m_path, "remember", '=', '#', 10, nullptr));
 
-    EXPECT_STREQ("-1", value = GetStringOptionFromFile(m_path, "remembering", '=', nullptr));
+    EXPECT_STREQ("-1", value = GetStringOptionFromFile(m_path, "remembering", '=', '#', nullptr));
     FREE_MEMORY(value);
     EXPECT_EQ(-1, GetIntegerOptionFromFile(m_path, "remembering", '=', '#', 10, nullptr));
 


### PR DESCRIPTION
## Description

ASB fix for several rules that need to check system files and data that can have commented out lines. Such as EnsurePasswordCreationRequirements, for example. For these, it may happen that the line is commented out, fully or partially. So, this fix addresses this, and also adds new test cases to validate the new functionality.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
