### PR TITLE
Fixed broken git checkout on universal nrp test

### DIFF
--- a/.github/workflows/universalnrp-test.yml
+++ b/.github/workflows/universalnrp-test.yml
@@ -159,8 +159,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        submodules: recursive
-        clean: true
+        with:
+          submodules: recursive
+          clean: true
 
       - uses: actions/download-artifact@v4
         id: download


### PR DESCRIPTION
## Description

* Fixed broken Universal NRP Test - images still must be updated to have Git v2.18+ but this unblocks the workflow

PR #1116 broke the tests

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [X] I added unit-tests to validate my changes. All unit tests are passing.
- [X] I have merged the latest `dev` branch prior to this PR submission.
- [X] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [X] I submitted this PR against the `dev` branch.
