### PR TITLE
Hardening ASB's enumeration of user's groups

### DIFF
--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -518,7 +518,7 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
 
         listSize = sizeof(SimplifiedGroup)* numberOfGroups;
 
-        if (NULL == (*groupList = malloc(listSize))
+        if (NULL == (*groupList = malloc(listSize)))
         {
             OsConfigLogError(log, "EnumerateUserGroups: out of memory");
             status = ENOMEM;

--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -455,6 +455,7 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
     int numberOfGroups = MAX_GROUPS_USER_CAN_BE_IN;
     struct group* groupEntry = NULL;
     size_t groupNameLength = 0;
+    size_t listSize = numberOfGroups * sizeof(gid_t);
     int i = 0;
     int getGroupListResult = 0;
     int status = 0;
@@ -473,35 +474,40 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
     *groupList = NULL;
     *size = 0;
 
-    if (NULL == (groupIds = malloc(numberOfGroups * sizeof(gid_t))))
+    if (NULL == (groupIds = malloc(listSize)))
     {
         OsConfigLogError(log, "EnumerateUserGroups: out of memory allocating list of %d group identifiers", numberOfGroups);
         numberOfGroups = 0;
         status = ENOMEM;
     }
-    else if (-1 == (getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups)))
+    else
     {
-        OsConfigLogDebug(log, "EnumerateUserGroups: first call to getgrouplist for user %u (%u) returned %d and %d", user->userId, user->groupId, getGroupListResult, numberOfGroups);
-        FREE_MEMORY(groupIds);
-
-        if (0 < numberOfGroups)
+        memset(groupIds, 0, listSize);
+        if (-1 == (getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups)))
         {
-            if (NULL != (groupIds = malloc(numberOfGroups * sizeof(gid_t))))
+            OsConfigLogDebug(log, "EnumerateUserGroups: first call to getgrouplist for user %u (%u) returned %d and %d", user->userId, user->groupId, getGroupListResult, numberOfGroups);
+            FREE_MEMORY(groupIds);
+
+            if (0 < numberOfGroups)
             {
-                getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups);
-                OsConfigLogDebug(log, "EnumerateUserGroups: second call to getgrouplist for user '%u' (%u) returned %d and %d", user->userId, user->groupId, getGroupListResult, numberOfGroups);
+                if (NULL != (groupIds = malloc(listSize)))
+                {
+                    memset(groupIds, 0, listSize);
+                    getGroupListResult = getgrouplist(user->username, user->groupId, groupIds, &numberOfGroups);
+                    OsConfigLogDebug(log, "EnumerateUserGroups: second call to getgrouplist for user '%u' (%u) returned %d and %d", user->userId, user->groupId, getGroupListResult, numberOfGroups);
+                }
+                else
+                {
+                    OsConfigLogError(log, "EnumerateUserGroups: out of memory allocating list of %d group identifiers", numberOfGroups);
+                    numberOfGroups = 0;
+                    status = ENOMEM;
+                }
             }
             else
             {
-                OsConfigLogError(log, "EnumerateUserGroups: out of memory allocating list of %d group identifiers", numberOfGroups);
-                numberOfGroups = 0;
-                status = ENOMEM;
+                OsConfigLogInfo(log, "EnumerateUserGroups: first call to getgrouplist for user %u (%u) returned -1 and %d groups", user->userId, user->groupId, numberOfGroups);
+                status = ENOENT;
             }
-        }
-        else
-        {
-            OsConfigLogInfo(log, "EnumerateUserGroups: first call to getgrouplist for user %u (%u) returned -1 and %d groups", user->userId, user->groupId, numberOfGroups);
-            status = ENOENT;
         }
     }
 
@@ -510,13 +516,17 @@ int EnumerateUserGroups(SimplifiedUser* user, SimplifiedGroup** groupList, unsig
         OsConfigLogDebug(log, "EnumerateUserGroups: user %u ('%s', gid: %u) is in %d group%s",
             user->userId, IsSystemAccount(user) ? user->username : g_redacted, user->groupId, numberOfGroups, (1 == numberOfGroups) ? "" : "s");
 
-        if (NULL == (*groupList = malloc(sizeof(SimplifiedGroup) * numberOfGroups)))
+        listSize = sizeof(SimplifiedGroup)* numberOfGroups;
+
+        if (NULL == (*groupList = malloc(listSize))
         {
             OsConfigLogError(log, "EnumerateUserGroups: out of memory");
             status = ENOMEM;
         }
         else
         {
+            memset(*groupList, 0, listSize);
+
             *size = numberOfGroups;
 
             for (i = 0; i < numberOfGroups; i++)


### PR DESCRIPTION
## Description

Hardening ASB's enumeration of user's groups -- we allocate memory sometimes in excess and sometimes some of that memory remained uninitialized at the end -- now we are making sure that all the allocated memory is set to 0s so we will not risk to attempt to free an invalid pointer on release. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
