### PR TITLE
Hardening the FREE_MEMORY macro

### DIFF
--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -16,12 +16,20 @@
 
 #define UNUSED(a) (void)(a)
 
+#if defined(__x86_64__)
+#define VALID_MAX_ADDR 0x00007FFFFFFFFFFF
+#elif defined(__aarch64__)
+#define VALID_MAX_ADDR 0x0000FFFFFFFFFFFF
+#else
+#define VALID_MAX_ADDR UINTPTR_MAX
+#endif
+
 // Checks for null, misalignment, low addresses, and out-of-range values
 #define VALID(a) ((0 != (uintptr_t)(a)) &&\
     (0 != sizeof(void*)) &&\
     (0 == ((uintptr_t)(a) % sizeof(void*))) &&\
     ((uintptr_t)(a) >= 0x1000) &&\
-    ((uintptr_t)(a) <= ((UINTPTR_MAX == 0xFFFFFFFF) ? 0xC0000000 : 0x00007FFFFFFFFFFF)))
+    ((uintptr_t)(a) <= ((UINTPTR_MAX == 0xFFFFFFFF) ? 0xC0000000 : VALID_MAX_ADDR)))
 
 #define FREE_MEMORY(a) {\
     void* b = (a);\

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -15,10 +15,14 @@
 
 #define UNUSED(a) (void)(a)
 
+// Checks for null, misalignment, low addresses, and out-of-range values distinguishings between 32-bit and 64-bit via UINTPTR_MAX
+#define VALID(a) ((uintptr_t)(a) != 0 && ((uintptr_t)(a) % (0 == sizeof(void*))) && (uintptr_t)(a) >= 0x1000 && (uintptr_t)(a) <= ((UINTPTR_MAX == 0xFFFFFFFF) ? 0xC0000000 : 0x00007FFFFFFFFFFF))
+
 #define FREE_MEMORY(a) {\
-    if (NULL != a) {\
-        free(a);\
-        a = NULL;\
+    void* b = (a);\
+    (a) = NULL;\
+    if (VALID(b)) {\
+        free(b);\
     }\
 }\
 
@@ -48,6 +52,8 @@
 extern "C"
 {
 #endif
+
+int IsValidPointer(void* pointer);
 
 char* LoadStringFromFile(const char* fileName, bool stopAtEol, OsConfigLogHandle log);
 bool SavePayloadToFile(const char* fileName, const char* payload, const int payloadSizeBytes, OsConfigLogHandle log);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -16,8 +16,12 @@
 
 #define UNUSED(a) (void)(a)
 
-// Checks for null, misalignment, low addresses, and out-of-range values distinguishings between 32-bit and 64-bit via UINTPTR_MAX
-#define VALID(a) ((uintptr_t)(a) != 0 && ((uintptr_t)(a) % (0 == sizeof(void*))) && (uintptr_t)(a) >= 0x1000 && (uintptr_t)(a) <= ((UINTPTR_MAX == 0xFFFFFFFF) ? 0xC0000000 : 0x00007FFFFFFFFFFF))
+// Checks for null, misalignment, low addresses, and out-of-range values
+#define VALID(a) ((0 != (uintptr_t)(a)) &&\
+    (0 != sizeof(void*)) &&\
+    (0 == ((uintptr_t)(a) % sizeof(void*))) &&\
+    ((uintptr_t)(a) >= 0x1000) &&\
+    ((uintptr_t)(a) <= ((UINTPTR_MAX == 0xFFFFFFFF) ? 0xC0000000 : 0x00007FFFFFFFFFFF)))
 
 #define FREE_MEMORY(a) {\
     void* b = (a);\

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <time.h>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/src/common/commonutils/OtherUtils.c
+++ b/src/common/commonutils/OtherUtils.c
@@ -3,6 +3,11 @@
 
 #include "Internal.h"
 
+int IsValidPointer(void* pointer)
+{
+    return VALID(pointer) ? 1 : 0;
+}
+
 char* DuplicateString(const char* source)
 {
     if (NULL == source)

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3127,7 +3127,7 @@ TEST_F(CommonUtilsTest, IsValidPointer)
 
     for (int i = 0; i < 100; i++)
     {
-        p = (char*)(uintptr_t)rand();
+        p = (char*)(uintptr_t)(rand() % ((i > 0) ? i : 3));
         EXPECT_EQ(0, IsValidPointer(p));
     }
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3127,7 +3127,7 @@ TEST_F(CommonUtilsTest, IsValidPointer)
 
     for (int i = 0; i < 100; i++)
     {
-        p = (char*)(int)rand();
+        p = (char*)(uintptr_t)rand();
         EXPECT_EQ(0, IsValidPointer(p));
     }
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3102,10 +3102,7 @@ TEST_F(CommonUtilsTest, GetOptionFromBuffer)
 
 TEST_F(CommonUtilsTest, IsValidPointer)
 {
-    static char c = 'c';
     char* p = NULL;
-
-    EXPECT_EQ(0, IsValidPointer(&c));
 
     EXPECT_EQ(0, IsValidPointer(0));
     EXPECT_EQ(0, IsValidPointer(nullptr));

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3127,7 +3127,7 @@ TEST_F(CommonUtilsTest, IsValidPointer)
 
     for (int i = 0; i < 100; i++)
     {
-        p = (char*)rand();
+        p = (char*)((void*)rand());
         EXPECT_EQ(0, IsValidPointer(p));
     }
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3110,19 +3110,19 @@ TEST_F(CommonUtilsTest, IsValidPointer)
     EXPECT_EQ(0, IsValidPointer(0));
     EXPECT_EQ(0, IsValidPointer(nullptr));
 
-    EXPECT_NE(nullptr, p = malloc(1));
+    EXPECT_NE(nullptr, p = (char*)malloc(1));
     EXPECT_EQ(1, IsValidPointer(p));
 
     FREE_MEMORY(p);
     EXPECT_EQ(0, IsValidPointer(p));
 
-    p = 0x1000 - 1;
+    p = (char*)(0x1000 - 1);
     EXPECT_EQ(0, IsValidPointer(p));
 
     p = (char*)0x1;
     EXPECT_EQ(0, IsValidPointer(p));
 
-    p = 0x00007FFFFFFFFFFF + 1;
+    p = (char*)(0x00007FFFFFFFFFFF + 1);
     EXPECT_EQ(0, IsValidPointer(p));
 
     p = (char*)0xFFFFFFFFFFFFFFFF;

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3124,6 +3124,12 @@ TEST_F(CommonUtilsTest, IsValidPointer)
 
     p = (char*)0xFFFFFFFFFFFFFFFF;
     EXPECT_EQ(0, IsValidPointer(p));
+
+    for (int i = 0; i < 100; i++)
+    {
+        p = (char*)rand();
+        EXPECT_EQ(0, IsValidPointer(p));
+    }
 }
 
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3129,9 +3129,11 @@ TEST_F(CommonUtilsTest, IsValidPointer)
     {
         p = (char*)(uintptr_t)(rand() % ((i > 0) ? i : 3));
         EXPECT_EQ(0, IsValidPointer(p));
+
+        p = (char*)(uintptr_t)(rand() + 0x00007FFFFFFFFFFF);
+        EXPECT_EQ(0, IsValidPointer(p));
     }
 }
-
 
 TEST_F(CommonUtilsTest, LoggingOptions)
 {

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3127,7 +3127,7 @@ TEST_F(CommonUtilsTest, IsValidPointer)
 
     for (int i = 0; i < 100; i++)
     {
-        p = (char*)((void*)rand());
+        p = (char*)(int)rand();
         EXPECT_EQ(0, IsValidPointer(p));
     }
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -3100,6 +3100,36 @@ TEST_F(CommonUtilsTest, GetOptionFromBuffer)
     EXPECT_EQ(88, GetIntegerOptionFromBuffer("#This is a TestSetting test configuration for TestSetting\n#TestSetting=100\nTestSetting=88", "TestSetting", '=', '#', 10, nullptr));
 }
 
+TEST_F(CommonUtilsTest, IsValidPointer)
+{
+    static char c = 'c';
+    char* p = NULL;
+
+    EXPECT_EQ(0, IsValidPointer(&c));
+
+    EXPECT_EQ(0, IsValidPointer(0));
+    EXPECT_EQ(0, IsValidPointer(nullptr));
+
+    EXPECT_NE(nullptr, p = malloc(1));
+    EXPECT_EQ(1, IsValidPointer(p));
+
+    FREE_MEMORY(p);
+    EXPECT_EQ(0, IsValidPointer(p));
+
+    p = 0x1000 - 1;
+    EXPECT_EQ(0, IsValidPointer(p));
+
+    p = (char*)0x1;
+    EXPECT_EQ(0, IsValidPointer(p));
+
+    p = 0x00007FFFFFFFFFFF + 1;
+    EXPECT_EQ(0, IsValidPointer(p));
+
+    p = (char*)0xFFFFFFFFFFFFFFFF;
+    EXPECT_EQ(0, IsValidPointer(p));
+}
+
+
 TEST_F(CommonUtilsTest, LoggingOptions)
 {
     const char* emergency = "EMERGENCY";


### PR DESCRIPTION
## Description

Slight hardening FREE_MEMORY macro:
- Check for not just non-null, but also for: misalignment, low addresses, and out-of-range values.
- Reset pointer to null before freeing.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
