### PR TITLE
Minimal double free guard for FREE_MEMORY macro

### DIFF
--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -16,9 +16,10 @@
 #define UNUSED(a) (void)(a)
 
 #define FREE_MEMORY(a) {\
-    if (NULL != a) {\
-        free(a);\
-        a = NULL;\
+    void* b = (a);\
+    (a) = NULL;\
+    if (NULL != b) {\
+        free(b);\
     }\
 }\
 


### PR DESCRIPTION
## Description

Minimal double free guard for FREE_MEMORY macro. The only kept piece from PR #1150 as we want to keep the rule to check against NULL for freeing memory while we check against NULL for successful memory allocation. 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
