### PR TITLE
Gtest: Fix sign vs unsigned compile warning

### DIFF
--- a/src/modules/complianceengine/tests/BindingsTest.cpp
+++ b/src/modules/complianceengine/tests/BindingsTest.cpp
@@ -68,7 +68,7 @@ TEST_F(BindingsTest, ValidInput_1)
     EXPECT_EQ(params.patternValue.GetPattern(), string("te.*"));
     EXPECT_TRUE(regex_match("test", params.patternValue.GetRegex()));
     EXPECT_EQ(params.octalValue, 0755u);
-    ASSERT_EQ(params.separatedValue.items.size(), (size_t)3);
+    ASSERT_EQ(params.separatedValue.items.size(), 3u);
     EXPECT_EQ(params.separatedValue.items[0], "foo");
     EXPECT_EQ(params.separatedValue.items[1], "bar");
     EXPECT_EQ(params.separatedValue.items[2], "baz");
@@ -117,7 +117,7 @@ TEST_F(BindingsTest, MissingValues_1)
     EXPECT_EQ(params.patternValue.GetPattern(), string("te.*"));
     EXPECT_TRUE(regex_match("test", params.patternValue.GetRegex()));
     EXPECT_EQ(params.octalValue, 0755u);
-    ASSERT_EQ(params.separatedValue.items.size(), (size_t)3);
+    ASSERT_EQ(params.separatedValue.items.size(), 3u);
     EXPECT_EQ(params.separatedValue.items[0], "foo");
     EXPECT_EQ(params.separatedValue.items[1], "bar");
     EXPECT_EQ(params.separatedValue.items[2], "baz");
@@ -176,7 +176,7 @@ TEST_F(BindingsTest, InvalidValues_1)
     EXPECT_EQ(params.patternValue.GetPattern(), string("te.*"));
     EXPECT_TRUE(regex_match("test", params.patternValue.GetRegex()));
     EXPECT_EQ(params.octalValue, 0755u);
-    ASSERT_EQ(params.separatedValue.items.size(), (size_t)3);
+    ASSERT_EQ(params.separatedValue.items.size(), 3u);
     EXPECT_EQ(params.separatedValue.items[0], "foo");
     EXPECT_EQ(params.separatedValue.items[1], "bar");
     EXPECT_EQ(params.separatedValue.items[2], "baz");

--- a/src/modules/complianceengine/tests/BindingsTest.cpp
+++ b/src/modules/complianceengine/tests/BindingsTest.cpp
@@ -67,8 +67,8 @@ TEST_F(BindingsTest, ValidInput_1)
     EXPECT_TRUE(regex_match("test", params.regexValue));
     EXPECT_EQ(params.patternValue.GetPattern(), string("te.*"));
     EXPECT_TRUE(regex_match("test", params.patternValue.GetRegex()));
-    EXPECT_EQ(params.octalValue, 0755);
-    ASSERT_EQ(params.separatedValue.items.size(), 3);
+    EXPECT_EQ(params.octalValue, 0755u);
+    ASSERT_EQ(params.separatedValue.items.size(), (size_t)3);
     EXPECT_EQ(params.separatedValue.items[0], "foo");
     EXPECT_EQ(params.separatedValue.items[1], "bar");
     EXPECT_EQ(params.separatedValue.items[2], "baz");
@@ -116,8 +116,8 @@ TEST_F(BindingsTest, MissingValues_1)
     EXPECT_TRUE(regex_match("test", params.regexValue));
     EXPECT_EQ(params.patternValue.GetPattern(), string("te.*"));
     EXPECT_TRUE(regex_match("test", params.patternValue.GetRegex()));
-    EXPECT_EQ(params.octalValue, 0755);
-    ASSERT_EQ(params.separatedValue.items.size(), 3);
+    EXPECT_EQ(params.octalValue, 0755u);
+    ASSERT_EQ(params.separatedValue.items.size(), (size_t)3);
     EXPECT_EQ(params.separatedValue.items[0], "foo");
     EXPECT_EQ(params.separatedValue.items[1], "bar");
     EXPECT_EQ(params.separatedValue.items[2], "baz");
@@ -175,8 +175,8 @@ TEST_F(BindingsTest, InvalidValues_1)
     EXPECT_TRUE(regex_match("test", params.regexValue));
     EXPECT_EQ(params.patternValue.GetPattern(), string("te.*"));
     EXPECT_TRUE(regex_match("test", params.patternValue.GetRegex()));
-    EXPECT_EQ(params.octalValue, 0755);
-    ASSERT_EQ(params.separatedValue.items.size(), 3);
+    EXPECT_EQ(params.octalValue, 0755u);
+    ASSERT_EQ(params.separatedValue.items.size(), (size_t)3);
     EXPECT_EQ(params.separatedValue.items[0], "foo");
     EXPECT_EQ(params.separatedValue.items[1], "bar");
     EXPECT_EQ(params.separatedValue.items[2], "baz");

--- a/src/modules/complianceengine/tests/CMakeLists.txt
+++ b/src/modules/complianceengine/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+add_compile_options("-Wno-unused-const-variable")
+
 project(compliancetests)
 
 include(GoogleTest)

--- a/src/modules/complianceengine/tests/NetworkToolsTest.cpp
+++ b/src/modules/complianceengine/tests/NetworkToolsTest.cpp
@@ -55,7 +55,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ValidTCPPorts_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)(size_t)2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_STREAM, "127.0.0.1", 3306);

--- a/src/modules/complianceengine/tests/NetworkToolsTest.cpp
+++ b/src/modules/complianceengine/tests/NetworkToolsTest.cpp
@@ -55,7 +55,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ValidTCPPorts_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)(size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_STREAM, "127.0.0.1", 3306);
@@ -72,7 +72,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ValidUDPPorts_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 323);
@@ -90,7 +90,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_IPv6Addresses_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     VerifyOpenPort(ports[0], AF_INET6, SOCK_STREAM, "::", 22);
     VerifyOpenPort(ports[1], AF_INET6, SOCK_STREAM, "::1", 3306);
@@ -110,7 +110,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_MixedIPv4AndIPv6_ReturnsAllPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 4);
+    ASSERT_EQ(ports.size(), (size_t)4);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 80);
     VerifyOpenPort(ports[1], AF_INET6, SOCK_STREAM, "::", 80);
@@ -162,7 +162,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_MalformedLines_SkipsInvalidLines)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_STREAM, "127.0.0.1", 3306);
@@ -181,7 +181,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_UnsupportedProtocols_SkipsUnsupportedProto
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
@@ -200,7 +200,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_InvalidIPAddresses_SkipsInvalidAddresses)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
@@ -218,7 +218,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_PortsWithoutColon_SkipsInvalidFormat)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 53);
@@ -235,7 +235,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_HighPortNumbers_HandlesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 2);
+    ASSERT_EQ(ports.size(), (size_t)2);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 65535);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 32768);
@@ -257,7 +257,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_RealWorldSSOutput_ParsesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 5);
+    ASSERT_EQ(ports.size(), (size_t)5);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_DGRAM, "127.0.0.53", 53);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 323);
@@ -278,7 +278,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_WildcardAddress_ConvertsToZeros)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 80);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
@@ -297,7 +297,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_InterfaceSpecificIPv4_ParsesInterfaceCorre
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "192.168.1.100", 22);
     EXPECT_EQ(ports[0].interface, "eth0");
@@ -321,7 +321,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_InterfaceSpecificIPv6_ParsesInterfaceCorre
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     VerifyOpenPort(ports[0], AF_INET6, SOCK_STREAM, "fe80::1", 22);
     EXPECT_EQ(ports[0].interface, "eth0");
@@ -346,7 +346,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_MixedWildcardAndInterface_ParsesBoth)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 4);
+    ASSERT_EQ(ports.size(), (size_t)4);
 
     // Wildcard addresses should have empty interface
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 80);
@@ -375,7 +375,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_IPv6WildcardWithInterface_ParsesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     // IPv6 wildcard
     VerifyOpenPort(ports[0], AF_INET6, SOCK_STREAM, "::", 22);
@@ -402,7 +402,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ComplexInterfaceNames_ParsesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "192.168.1.1", 80);
     EXPECT_EQ(ports[0].interface, "br-docker0");
@@ -426,7 +426,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_NoInterfaceSpecified_InterfaceEmpty)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), 3);
+    ASSERT_EQ(ports.size(), (size_t)3);
 
     // All should have empty interface names
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);

--- a/src/modules/complianceengine/tests/NetworkToolsTest.cpp
+++ b/src/modules/complianceengine/tests/NetworkToolsTest.cpp
@@ -55,7 +55,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ValidTCPPorts_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_STREAM, "127.0.0.1", 3306);
@@ -72,7 +72,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ValidUDPPorts_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 323);
@@ -90,7 +90,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_IPv6Addresses_ReturnsCorrectPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     VerifyOpenPort(ports[0], AF_INET6, SOCK_STREAM, "::", 22);
     VerifyOpenPort(ports[1], AF_INET6, SOCK_STREAM, "::1", 3306);
@@ -110,7 +110,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_MixedIPv4AndIPv6_ReturnsAllPorts)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)4);
+    ASSERT_EQ(ports.size(), 4u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 80);
     VerifyOpenPort(ports[1], AF_INET6, SOCK_STREAM, "::", 80);
@@ -162,7 +162,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_MalformedLines_SkipsInvalidLines)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_STREAM, "127.0.0.1", 3306);
@@ -181,7 +181,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_UnsupportedProtocols_SkipsUnsupportedProto
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
@@ -200,7 +200,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_InvalidIPAddresses_SkipsInvalidAddresses)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
@@ -218,7 +218,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_PortsWithoutColon_SkipsInvalidFormat)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 53);
@@ -235,7 +235,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_HighPortNumbers_HandlesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)2);
+    ASSERT_EQ(ports.size(), 2u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 65535);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 32768);
@@ -257,7 +257,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_RealWorldSSOutput_ParsesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)5);
+    ASSERT_EQ(ports.size(), 5u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_DGRAM, "127.0.0.53", 53);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "127.0.0.1", 323);
@@ -278,7 +278,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_WildcardAddress_ConvertsToZeros)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 80);
     VerifyOpenPort(ports[1], AF_INET, SOCK_DGRAM, "0.0.0.0", 53);
@@ -297,7 +297,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_InterfaceSpecificIPv4_ParsesInterfaceCorre
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "192.168.1.100", 22);
     EXPECT_EQ(ports[0].interface, "eth0");
@@ -321,7 +321,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_InterfaceSpecificIPv6_ParsesInterfaceCorre
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     VerifyOpenPort(ports[0], AF_INET6, SOCK_STREAM, "fe80::1", 22);
     EXPECT_EQ(ports[0].interface, "eth0");
@@ -346,7 +346,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_MixedWildcardAndInterface_ParsesBoth)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)4);
+    ASSERT_EQ(ports.size(), 4u);
 
     // Wildcard addresses should have empty interface
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 80);
@@ -375,7 +375,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_IPv6WildcardWithInterface_ParsesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     // IPv6 wildcard
     VerifyOpenPort(ports[0], AF_INET6, SOCK_STREAM, "::", 22);
@@ -402,7 +402,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_ComplexInterfaceNames_ParsesCorrectly)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "192.168.1.1", 80);
     EXPECT_EQ(ports[0].interface, "br-docker0");
@@ -426,7 +426,7 @@ TEST_F(NetworkToolsTest, GetOpenPorts_NoInterfaceSpecified_InterfaceEmpty)
 
     ASSERT_TRUE(result.HasValue());
     auto ports = result.Value();
-    ASSERT_EQ(ports.size(), (size_t)3);
+    ASSERT_EQ(ports.size(), 3u);
 
     // All should have empty interface names
     VerifyOpenPort(ports[0], AF_INET, SOCK_STREAM, "0.0.0.0", 22);

--- a/src/modules/complianceengine/tests/OptionalTest.cpp
+++ b/src/modules/complianceengine/tests/OptionalTest.cpp
@@ -113,7 +113,7 @@ TEST_F(OptionalTest, ArrowOperator)
 {
     auto opt = Optional<std::string>("foo");
     ASSERT_TRUE(opt.HasValue());
-    ASSERT_EQ(opt->size(), 3);
+    ASSERT_EQ(opt->size(), (size_t)3);
     opt->append("bar");
-    ASSERT_EQ(opt->size(), 6);
+    ASSERT_EQ(opt->size(), (size_t)6);
 }

--- a/src/modules/complianceengine/tests/OptionalTest.cpp
+++ b/src/modules/complianceengine/tests/OptionalTest.cpp
@@ -113,7 +113,7 @@ TEST_F(OptionalTest, ArrowOperator)
 {
     auto opt = Optional<std::string>("foo");
     ASSERT_TRUE(opt.HasValue());
-    ASSERT_EQ(opt->size(), (size_t)3);
+    ASSERT_EQ(opt->size(), 3u);
     opt->append("bar");
-    ASSERT_EQ(opt->size(), (size_t)6);
+    ASSERT_EQ(opt->size(), 6u);
 }

--- a/src/modules/complianceengine/tests/RegexFallbackTest.cpp
+++ b/src/modules/complianceengine/tests/RegexFallbackTest.cpp
@@ -22,7 +22,7 @@ TEST_F(RegexFallbackTest, NoMatch)
     bool result = regex_search(target, match, r);
     EXPECT_FALSE(result);
     ASSERT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), (size_t)0);
+    EXPECT_EQ(match.size(), 0u);
 }
 
 TEST_F(RegexFallbackTest, Match)
@@ -36,9 +36,9 @@ TEST_F(RegexFallbackTest, Match)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)1);
+    ASSERT_EQ(match.size(), 1u);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), (size_t)4);
+    EXPECT_EQ(match[0].length(), 4u);
 }
 
 TEST_F(RegexFallbackTest, MatchWithSubMatches_1)
@@ -50,7 +50,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_1)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)2);
+    ASSERT_EQ(match.size(), 2u);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), std::strlen("test"));
     EXPECT_EQ(match[1].matched, true);
@@ -66,7 +66,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_2)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)3);
+    ASSERT_EQ(match.size(), 3u);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
@@ -84,7 +84,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_3)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)4);
+    ASSERT_EQ(match.size(), 4u);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
@@ -94,7 +94,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_3)
     EXPECT_EQ(match[3].matched, true);
     EXPECT_EQ(match[3].length(), std::strlen("string"));
     EXPECT_EQ(match[100].matched, false);
-    EXPECT_EQ(match[100].length(), (size_t)0);
+    EXPECT_EQ(match[100].length(), 0u);
 }
 
 TEST_F(RegexFallbackTest, RangeLoop)
@@ -136,7 +136,7 @@ TEST_F(RegexFallbackTest, RegexMatch_1)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), (size_t)0);
+    EXPECT_EQ(match.size(), 0u);
     EXPECT_TRUE(match.empty());
 }
 
@@ -149,7 +149,7 @@ TEST_F(RegexFallbackTest, RegexMatch_2)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), (size_t)0);
+    EXPECT_EQ(match.size(), 0u);
     EXPECT_TRUE(match.empty());
 }
 

--- a/src/modules/complianceengine/tests/RegexFallbackTest.cpp
+++ b/src/modules/complianceengine/tests/RegexFallbackTest.cpp
@@ -22,7 +22,7 @@ TEST_F(RegexFallbackTest, NoMatch)
     bool result = regex_search(target, match, r);
     EXPECT_FALSE(result);
     ASSERT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), 0);
+    EXPECT_EQ(match.size(), (size_t)0);
 }
 
 TEST_F(RegexFallbackTest, Match)
@@ -36,9 +36,9 @@ TEST_F(RegexFallbackTest, Match)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 1);
+    ASSERT_EQ(match.size(), (size_t)1);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), 4);
+    EXPECT_EQ(match[0].length(), (size_t)4);
 }
 
 TEST_F(RegexFallbackTest, MatchWithSubMatches_1)
@@ -50,7 +50,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_1)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 2);
+    ASSERT_EQ(match.size(), (size_t)2);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), std::strlen("test"));
     EXPECT_EQ(match[1].matched, true);
@@ -66,7 +66,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_2)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 3);
+    ASSERT_EQ(match.size(), (size_t)3);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
@@ -84,7 +84,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_3)
     bool result = regex_search(target, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 4);
+    ASSERT_EQ(match.size(), (size_t)4);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
@@ -94,7 +94,7 @@ TEST_F(RegexFallbackTest, MatchWithSubMatches_3)
     EXPECT_EQ(match[3].matched, true);
     EXPECT_EQ(match[3].length(), std::strlen("string"));
     EXPECT_EQ(match[100].matched, false);
-    EXPECT_EQ(match[100].length(), 0);
+    EXPECT_EQ(match[100].length(), (size_t)0);
 }
 
 TEST_F(RegexFallbackTest, RangeLoop)
@@ -136,7 +136,7 @@ TEST_F(RegexFallbackTest, RegexMatch_1)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), 0);
+    EXPECT_EQ(match.size(), (size_t)0);
     EXPECT_TRUE(match.empty());
 }
 
@@ -149,7 +149,7 @@ TEST_F(RegexFallbackTest, RegexMatch_2)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), 0);
+    EXPECT_EQ(match.size(), (size_t)0);
     EXPECT_TRUE(match.empty());
 }
 

--- a/src/modules/complianceengine/tests/RegexTest.cpp
+++ b/src/modules/complianceengine/tests/RegexTest.cpp
@@ -21,7 +21,7 @@ TEST_F(RegexTest, NoMatch)
     bool result = regex_search(input, match, r);
     EXPECT_FALSE(result);
     ASSERT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), 0);
+    EXPECT_EQ(match.size(), (size_t)0);
 }
 
 TEST_F(RegexTest, Match)
@@ -35,9 +35,9 @@ TEST_F(RegexTest, Match)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 1);
+    ASSERT_EQ(match.size(), (size_t)1);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), 4);
+    EXPECT_EQ(match[0].length(), (ssize_t)4);
 }
 
 TEST_F(RegexTest, MatchWithSubMatches_1)
@@ -49,11 +49,11 @@ TEST_F(RegexTest, MatchWithSubMatches_1)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 2);
+    ASSERT_EQ(match.size(), (size_t)2);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), std::strlen("test"));
+    EXPECT_EQ(match[0].length(), (ssize_t)std::strlen("test"));
     EXPECT_EQ(match[1].matched, true);
-    EXPECT_EQ(match[1].length(), std::strlen("test"));
+    EXPECT_EQ(match[1].length(), (ssize_t)std::strlen("test"));
 }
 
 TEST_F(RegexTest, MatchWithSubMatches_2)
@@ -65,13 +65,13 @@ TEST_F(RegexTest, MatchWithSubMatches_2)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 3);
+    ASSERT_EQ(match.size(), (size_t)3);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[0].length(), (ssize_t)std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
-    EXPECT_EQ(match[1].length(), std::strlen("test"));
+    EXPECT_EQ(match[1].length(), (ssize_t)std::strlen("test"));
     EXPECT_EQ(match[2].matched, true);
-    EXPECT_EQ(match[2].length(), std::strlen("string"));
+    EXPECT_EQ(match[2].length(), (ssize_t)std::strlen("string"));
 }
 
 TEST_F(RegexTest, MatchWithSubMatches_3)
@@ -83,15 +83,15 @@ TEST_F(RegexTest, MatchWithSubMatches_3)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), 4);
+    ASSERT_EQ(match.size(), (size_t)4);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), std::strlen("test string"));
+    EXPECT_EQ(match[0].length(), (ssize_t)std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
-    EXPECT_EQ(match[1].length(), std::strlen("test string"));
+    EXPECT_EQ(match[1].length(), (ssize_t)std::strlen("test string"));
     EXPECT_EQ(match[2].matched, true);
-    EXPECT_EQ(match[2].length(), std::strlen("test"));
+    EXPECT_EQ(match[2].length(), (ssize_t)std::strlen("test"));
     EXPECT_EQ(match[3].matched, true);
-    EXPECT_EQ(match[3].length(), std::strlen("string"));
+    EXPECT_EQ(match[3].length(), (ssize_t)std::strlen("string"));
     EXPECT_EQ(match[100].matched, false);
     EXPECT_EQ(match[100].length(), 0);
 }
@@ -135,7 +135,7 @@ TEST_F(RegexTest, RegexMatch_1)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), 0);
+    EXPECT_EQ(match.size(), (size_t)0);
     EXPECT_TRUE(match.empty());
 }
 
@@ -148,7 +148,7 @@ TEST_F(RegexTest, RegexMatch_2)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), 0);
+    EXPECT_EQ(match.size(), (size_t)0);
     EXPECT_TRUE(match.empty());
 }
 

--- a/src/modules/complianceengine/tests/RegexTest.cpp
+++ b/src/modules/complianceengine/tests/RegexTest.cpp
@@ -21,7 +21,7 @@ TEST_F(RegexTest, NoMatch)
     bool result = regex_search(input, match, r);
     EXPECT_FALSE(result);
     ASSERT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), (size_t)0);
+    EXPECT_EQ(match.size(), 0u);
 }
 
 TEST_F(RegexTest, Match)
@@ -35,9 +35,9 @@ TEST_F(RegexTest, Match)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)1);
+    ASSERT_EQ(match.size(), 1u);
     EXPECT_EQ(match[0].matched, true);
-    EXPECT_EQ(match[0].length(), (ssize_t)4);
+    EXPECT_EQ(match[0].length(), 4u);
 }
 
 TEST_F(RegexTest, MatchWithSubMatches_1)
@@ -49,7 +49,7 @@ TEST_F(RegexTest, MatchWithSubMatches_1)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)2);
+    ASSERT_EQ(match.size(), 2u);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), (ssize_t)std::strlen("test"));
     EXPECT_EQ(match[1].matched, true);
@@ -65,7 +65,7 @@ TEST_F(RegexTest, MatchWithSubMatches_2)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)3);
+    ASSERT_EQ(match.size(), 3u);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), (ssize_t)std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
@@ -83,7 +83,7 @@ TEST_F(RegexTest, MatchWithSubMatches_3)
     bool result = regex_search(input, match, r);
     EXPECT_TRUE(result);
     ASSERT_TRUE(match.ready());
-    ASSERT_EQ(match.size(), (size_t)4);
+    ASSERT_EQ(match.size(), 4u);
     EXPECT_EQ(match[0].matched, true);
     EXPECT_EQ(match[0].length(), (ssize_t)std::strlen("test string"));
     EXPECT_EQ(match[1].matched, true);
@@ -135,7 +135,7 @@ TEST_F(RegexTest, RegexMatch_1)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), (size_t)0);
+    EXPECT_EQ(match.size(), 0u);
     EXPECT_TRUE(match.empty());
 }
 
@@ -148,7 +148,7 @@ TEST_F(RegexTest, RegexMatch_2)
     bool result = regex_match(target, match, r);
     EXPECT_FALSE(result);
     EXPECT_TRUE(match.ready());
-    EXPECT_EQ(match.size(), (size_t)0);
+    EXPECT_EQ(match.size(), 0u);
     EXPECT_TRUE(match.empty());
 }
 

--- a/src/modules/complianceengine/tests/ResultTest.cpp
+++ b/src/modules/complianceengine/tests/ResultTest.cpp
@@ -112,7 +112,7 @@ TEST_F(ResultTest, ArrowOperator)
 {
     auto result = Result<std::string>("foo");
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result->size(), (size_t)3);
+    ASSERT_EQ(result->size(), 3u);
     result->append("bar");
-    ASSERT_EQ(result->size(), (size_t)6);
+    ASSERT_EQ(result->size(), 6u);
 }

--- a/src/modules/complianceengine/tests/ResultTest.cpp
+++ b/src/modules/complianceengine/tests/ResultTest.cpp
@@ -112,7 +112,7 @@ TEST_F(ResultTest, ArrowOperator)
 {
     auto result = Result<std::string>("foo");
     ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result->size(), 3);
+    ASSERT_EQ(result->size(), (size_t)3);
     result->append("bar");
-    ASSERT_EQ(result->size(), 6);
+    ASSERT_EQ(result->size(), (size_t)6);
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
@@ -156,7 +156,7 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 2);
+    ASSERT_EQ(root->indicators.size(), 2u);
     EXPECT_EQ(root->indicators[0].message, string("User 9999 does not have a valid shell, but the account is locked"));
     EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
 }
@@ -173,7 +173,7 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 2);
+    ASSERT_EQ(root->indicators.size(), 2u);
     EXPECT_EQ(root->indicators[0].message, string("User 9999 does not have a valid shell, but the account is locked"));
     EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureDefaultShellTimeoutIsConfiguredTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureDefaultShellTimeoutIsConfiguredTest.cpp
@@ -47,7 +47,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoSpecialFiles)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not set"));
 }
@@ -62,7 +62,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, IncorrectValue)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is set to an incorrect value in ") + path);
 }
@@ -77,7 +77,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoReadonly)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not readonly in ") + path);
 }
@@ -92,7 +92,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoExport)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not exported in ") + path);
 }
@@ -107,7 +107,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, ProperlyConfigured)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::Compliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT variable is properly defined"));
 }
@@ -122,7 +122,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, MultipleEntries)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is set multiple times in ") + path);
 }
@@ -139,7 +139,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, MultipleEntriesInDifferentFile
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)1);
+    ASSERT_GE(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is set in multiple locations"));
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureDefaultShellTimeoutIsConfiguredTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureDefaultShellTimeoutIsConfiguredTest.cpp
@@ -47,7 +47,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoSpecialFiles)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), (size_t)(size_t)1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not set"));
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureDefaultShellTimeoutIsConfiguredTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureDefaultShellTimeoutIsConfiguredTest.cpp
@@ -47,7 +47,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoSpecialFiles)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)(size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not set"));
 }
@@ -62,7 +62,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, IncorrectValue)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is set to an incorrect value in ") + path);
 }
@@ -77,7 +77,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoReadonly)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not readonly in ") + path);
 }
@@ -92,7 +92,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, NoExport)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is not exported in ") + path);
 }
@@ -107,7 +107,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, ProperlyConfigured)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::Compliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT variable is properly defined"));
 }
@@ -122,7 +122,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, MultipleEntries)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is set multiple times in ") + path);
 }
@@ -139,7 +139,7 @@ TEST_F(EnsureDefaultShellTimeoutIsConfiguredTest, MultipleEntriesInDifferentFile
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_GE(root->indicators.size(), 1);
+    ASSERT_GE(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators.back().status, Status::NonCompliant);
     EXPECT_EQ(root->indicators.back().message, string("TMOUT is set in multiple locations"));
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureDefaultUserUmaskIsConfiguredTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureDefaultUserUmaskIsConfiguredTest.cpp
@@ -290,7 +290,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, Precedence_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 2);
+    ASSERT_EQ(root->indicators.size(), (size_t)2);
     EXPECT_EQ(root->indicators[0].message, string("umask is incorrectly set in ") + filename1);
     EXPECT_EQ(root->indicators[1].message, string("umask is correctly set in ") + filename2);
 }
@@ -306,7 +306,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, Precedence_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 1);
+    ASSERT_EQ(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators[0].message, string("umask is correctly set in ") + filename1);
 }
 
@@ -320,7 +320,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, CorrectValue_PAM_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 1);
+    ASSERT_EQ(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators[0].message, string("umask is correctly set in ") + filename);
 }
 
@@ -334,7 +334,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, CorrectValue_PAM_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 1);
+    ASSERT_EQ(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators[0].message, string("umask is correctly set in ") + filename);
 }
 
@@ -348,7 +348,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, IncorrectValue_PAM_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 1);
+    ASSERT_EQ(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators[0].message, string("umask is incorrectly set in ") + filename);
 }
 
@@ -362,6 +362,6 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, IncorrectValue_PAM_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), 1);
+    ASSERT_EQ(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators[0].message, string("umask is incorrectly set in ") + filename);
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureDefaultUserUmaskIsConfiguredTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureDefaultUserUmaskIsConfiguredTest.cpp
@@ -290,7 +290,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, Precedence_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), (size_t)2);
+    ASSERT_EQ(root->indicators.size(), 2u);
     EXPECT_EQ(root->indicators[0].message, string("umask is incorrectly set in ") + filename1);
     EXPECT_EQ(root->indicators[1].message, string("umask is correctly set in ") + filename2);
 }
@@ -306,7 +306,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, Precedence_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), (size_t)1);
+    ASSERT_EQ(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators[0].message, string("umask is correctly set in ") + filename1);
 }
 
@@ -320,7 +320,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, CorrectValue_PAM_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), (size_t)1);
+    ASSERT_EQ(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators[0].message, string("umask is correctly set in ") + filename);
 }
 
@@ -334,7 +334,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, CorrectValue_PAM_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), (size_t)1);
+    ASSERT_EQ(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators[0].message, string("umask is correctly set in ") + filename);
 }
 
@@ -348,7 +348,7 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, IncorrectValue_PAM_1)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), (size_t)1);
+    ASSERT_EQ(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators[0].message, string("umask is incorrectly set in ") + filename);
 }
 
@@ -362,6 +362,6 @@ TEST_F(EnsureDefaultUserUmaskIsConfiguredTest, IncorrectValue_PAM_2)
 
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
-    ASSERT_EQ(root->indicators.size(), (size_t)1);
+    ASSERT_EQ(root->indicators.size(), 1u);
     EXPECT_EQ(root->indicators[0].message, string("umask is incorrectly set in ") + filename);
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureFilePermissionsTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureFilePermissionsTest.cpp
@@ -145,9 +145,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongOwner)
     ASSERT_EQ(result.Value(), Status::Compliant);
     struct stat st;
     ASSERT_EQ(stat(params.filename.c_str(), &st), 0);
-    ASSERT_EQ(st.st_uid, 0);
-    ASSERT_EQ(st.st_gid, 0);
-    ASSERT_EQ(st.st_mode & 0777, 0610);
+    ASSERT_EQ(st.st_uid, 0u);
+    ASSERT_EQ(st.st_gid, 0u);
+    ASSERT_EQ(st.st_mode & 0777, 0610u);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditWrongGroup)
@@ -187,9 +187,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongGroup)
     ASSERT_EQ(result.Value(), Status::Compliant);
     struct stat st;
     ASSERT_EQ(stat(params.filename.c_str(), &st), 0);
-    ASSERT_EQ(st.st_uid, 0);
-    ASSERT_EQ(st.st_gid, 0);
-    ASSERT_EQ(st.st_mode & 0777, 0610);
+    ASSERT_EQ(st.st_uid, 0u);
+    ASSERT_EQ(st.st_gid, 0u);
+    ASSERT_EQ(st.st_mode & 0777, 0610u);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditWrongPermissions)
@@ -229,9 +229,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongPermissions)
     ASSERT_EQ(result.Value(), Status::Compliant);
     struct stat st;
     ASSERT_EQ(stat(params.filename.c_str(), &st), 0);
-    ASSERT_EQ(st.st_uid, 0);
-    ASSERT_EQ(st.st_gid, 0);
-    ASSERT_EQ(st.st_mode & 0777, 0610);
+    ASSERT_EQ(st.st_uid, 0u);
+    ASSERT_EQ(st.st_gid, 0u);
+    ASSERT_EQ(st.st_mode & 0777, 0610u);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditWrongMask)
@@ -271,9 +271,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateWrongMask)
     ASSERT_EQ(result.Value(), Status::Compliant);
     struct stat st;
     ASSERT_EQ(stat(params.filename.c_str(), &st), 0);
-    ASSERT_EQ(st.st_uid, 0);
-    ASSERT_EQ(st.st_gid, 0);
-    ASSERT_EQ(st.st_mode & 0777, 0610);
+    ASSERT_EQ(st.st_uid, 0u);
+    ASSERT_EQ(st.st_gid, 0u);
+    ASSERT_EQ(st.st_mode & 0777, 0610u);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditAllWrong)
@@ -311,9 +311,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateAllWrong)
     ASSERT_EQ(result.Value(), Status::Compliant);
     struct stat st;
     ASSERT_EQ(stat(params.filename.c_str(), &st), 0);
-    ASSERT_EQ(st.st_uid, 0);
-    ASSERT_EQ(st.st_gid, 0);
-    ASSERT_EQ(st.st_mode & 0777, 0610);
+    ASSERT_EQ(st.st_uid, 0u);
+    ASSERT_EQ(st.st_gid, 0u);
+    ASSERT_EQ(st.st_mode & 0777, 0610u);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditAllOk)
@@ -350,9 +350,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateAllOk)
     ASSERT_EQ(result.Value(), Status::Compliant);
     struct stat st;
     ASSERT_EQ(stat(params.filename.c_str(), &st), 0);
-    ASSERT_EQ(st.st_uid, 0);
-    ASSERT_EQ(st.st_gid, 0);
-    ASSERT_EQ(st.st_mode & 0777, 0610);
+    ASSERT_EQ(st.st_uid, 0u);
+    ASSERT_EQ(st.st_gid, 0u);
+    ASSERT_EQ(st.st_mode & 0777, 0610u);
 }
 
 TEST_F(EnsureFilePermissionsTest, AuditBadFileOwner)
@@ -533,9 +533,9 @@ TEST_F(EnsureFilePermissionsTest, RemediateCollectionNonCompliantFile)
     for (const auto& file : files)
     {
         ASSERT_EQ(stat(file.c_str(), &st), 0);
-        ASSERT_EQ(st.st_uid, 0);
-        ASSERT_EQ(st.st_gid, 0);
-        ASSERT_EQ(st.st_mode & 0777, 0644);
+        ASSERT_EQ(st.st_uid, 0u);
+        ASSERT_EQ(st.st_gid, 0u);
+        ASSERT_EQ(st.st_mode & 0777, 0644u);
     }
 }
 

--- a/src/modules/complianceengine/tests/procedures/EnsureLogfileAccessTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureLogfileAccessTest.cpp
@@ -274,7 +274,7 @@ TEST_F(EnsureLogfileAccessTest, RemediateIncorrectPermissions)
     ASSERT_EQ(stat(filePath.c_str(), &statInfo), 0);
 
     // Check that mask is now 640
-    EXPECT_EQ(statInfo.st_mode & 0777, 0640);
+    EXPECT_EQ(statInfo.st_mode & 0777, 0640u);
     // Owner should be root(0) or syslog(101)
     EXPECT_TRUE(statInfo.st_uid == 0 || statInfo.st_uid == 101);
     // Group should be root(0) or adm(4)
@@ -335,7 +335,7 @@ TEST_F(EnsureLogfileAccessTest, RemediateMultipleFiles)
         std::string filePath = testDir + "/" + file;
         struct stat statInfo;
         ASSERT_EQ(stat(filePath.c_str(), &statInfo), 0);
-        EXPECT_EQ(statInfo.st_mode & 0777, 0640);
+        EXPECT_EQ(statInfo.st_mode & 0777, 0640u);
     }
 }
 
@@ -362,7 +362,7 @@ TEST_F(EnsureLogfileAccessTest, RemediateIgnoresSpecialFiles)
     // Group should be root(0) or adm(4)
     EXPECT_TRUE(statInfo.st_gid == 0 || statInfo.st_gid == 4);
     // Mask should be 640
-    EXPECT_EQ(statInfo.st_mode & 0777, 0640);
+    EXPECT_EQ(statInfo.st_mode & 0777, 0640u);
 
     // Verify symlink and directory are unchanged
     std::string linkPath = testDir + "/link.log";


### PR DESCRIPTION
The number in C++ is signed int, when compared with .size() that returns size_t it raises signg vs unsinged warning

The C++ std::strlen returns size_t but the regex smatch .length() returns difference_type_t which is of ssize_t. Use explicic casts as all std::strlen of ststic string are lower then size_t::max.

The stat's mode function return unsiged int, use it in test as well

The gtest library has some unused constant values, turn off that warning as it creates compile time wrarning.

## Description

*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
