### PR TITLE
Add parameters to ensure account without shells are locked 

### DIFF
--- a/src/modules/complianceengine/src/lib/CMakeLists.txt
+++ b/src/modules/complianceengine/src/lib/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(complianceenginelib STATIC
     Result.cpp
     StringTools.cpp
     SystemdCatConfig.cpp
+    Users.cpp
     UsersIterator.cpp
     ${PROCEDURES}
     )

--- a/src/modules/complianceengine/src/lib/ProcedureMap.cpp
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.cpp
@@ -8,7 +8,7 @@ namespace ComplianceEngine
 // AuditdRulesCheck.h:22
 const char* Bindings<AuditAuditdRulesCheckParams>::names[] = {"searchItem", "excludeOption", "requiredOptions"};
 
-// EnsureAccountsWithoutShellAreLocked.h:20
+// EnsureAccountsWithoutShellAreLocked.h:19
 const char* Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>::names[] = {"excludeUsers", "skip_below_uid_min"};
 
 // EnsureApparmorProfiles.h:15

--- a/src/modules/complianceengine/src/lib/ProcedureMap.cpp
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.cpp
@@ -8,6 +8,9 @@ namespace ComplianceEngine
 // AuditdRulesCheck.h:22
 const char* Bindings<AuditAuditdRulesCheckParams>::names[] = {"searchItem", "excludeOption", "requiredOptions"};
 
+// EnsureAccountsWithoutShellAreLocked.h:20
+const char* Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>::names[] = {"excludeUsers", "skip_below_uid_min"};
+
 // EnsureApparmorProfiles.h:15
 const char* Bindings<AuditEnsureApparmorProfilesParams>::names[] = {"enforce"};
 

--- a/src/modules/complianceengine/src/lib/ProcedureMap.h
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.h
@@ -250,6 +250,16 @@ struct Bindings<AuditAuditdRulesCheckParams>
     static constexpr auto members = std::make_tuple(&T::searchItem, &T::excludeOption, &T::requiredOptions);
 };
 
+// Defines the bindings for the AuditEnsureAccountsWithoutShellAreLockedParams structure.
+template <>
+struct Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>
+{
+    using T = AuditEnsureAccountsWithoutShellAreLockedParams;
+    static constexpr size_t size = 2;
+    static const char* names[];
+    static constexpr auto members = std::make_tuple(&T::excludeUsers, &T::skip_below_uid_min);
+};
+
 // Defines the bindings for the AuditEnsureApparmorProfilesParams structure.
 template <>
 struct Bindings<AuditEnsureApparmorProfilesParams>

--- a/src/modules/complianceengine/src/lib/StringTools.cpp
+++ b/src/modules/complianceengine/src/lib/StringTools.cpp
@@ -62,7 +62,7 @@ Result<unsigned int> TryStringToUint(const std::string& str, int base)
     }
     if (try_int.Value() < 0)
     {
-        return Error("Invalid integer value (should be positive): " + try_int.Value());
+        return Error("Invalid integer value (should be positive): " + std::to_string(try_int.Value()));
     }
 
     return Result<unsigned int>(try_int.Value());

--- a/src/modules/complianceengine/src/lib/StringTools.cpp
+++ b/src/modules/complianceengine/src/lib/StringTools.cpp
@@ -53,4 +53,18 @@ Result<int> TryStringToInt(const std::string& str, int base)
         return Error("Integer value out of range: " + str, ERANGE);
     }
 }
+Result<unsigned int> TryStringToUint(const std::string& str, int base)
+{
+    auto try_int = TryStringToInt(str, base);
+    if (!try_int.HasValue())
+    {
+        return try_int.Error();
+    }
+    if (try_int.Value() < 0)
+    {
+        return Error("Invalid integer value (should be positive): " + try_int.Value());
+    }
+
+    return Result<unsigned int>(try_int.Value());
+}
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/StringTools.h
+++ b/src/modules/complianceengine/src/lib/StringTools.h
@@ -11,6 +11,7 @@ namespace ComplianceEngine
 std::string EscapeForShell(const std::string& str);
 std::string TrimWhiteSpaces(const std::string& str);
 Result<int> TryStringToInt(const std::string& str, int base = 10);
+Result<unsigned int> TryStringToUint(const std::string& str, int base = 10);
 } // namespace ComplianceEngine
 
 #endif // COMPLIANCEENGINE_STRING_TOOLS_H

--- a/src/modules/complianceengine/src/lib/Users.cpp
+++ b/src/modules/complianceengine/src/lib/Users.cpp
@@ -4,15 +4,14 @@
 
 namespace ComplianceEngine
 {
-int GetUidMin(ContextInterface& context)
+Result<int> GetUidMin(ContextInterface& context)
 {
-    const int defaultUidMin = 1000;
     const std::string prefix = "UID_MIN ";
     auto loginDefsResult = context.GetFileContents("/etc/login.defs");
     if (!loginDefsResult.HasValue() || loginDefsResult.Value().empty())
     {
-        OsConfigLogWarning(context.GetLogHandle(), "Failed to read /etc/login.defs, using default UID_MIN");
-        return defaultUidMin;
+        OsConfigLogWarning(context.GetLogHandle(), "Failed to read /etc/login.defs");
+        return Error("Failed to read /etc/login.defs");
     }
     std::stringstream ss(loginDefsResult.Value());
     std::string line;
@@ -23,18 +22,14 @@ int GetUidMin(ContextInterface& context)
         {
             auto value = line.substr(prefix.length());
             value = TrimWhiteSpaces(value);
-            try
+            auto result = TryStringToInt(value);
+            if (!result.HasValue())
             {
-                return std::stoi(value);
+                OsConfigLogWarning(context.GetLogHandle(), "Invalid UID_MIN value in /etc/login.defs %s", result.Error().message.c_str());
             }
-            catch (const std::exception&)
-            {
-                OsConfigLogWarning(context.GetLogHandle(), "Invalid UID_MIN value in /etc/login.defs, using default");
-                return defaultUidMin;
-            }
+            return result;
         }
     }
-    OsConfigLogWarning(context.GetLogHandle(), "UID_MIN not found in /etc/login.defs, using default");
-    return defaultUidMin;
+    return Error("Could not get UID_MIN find value");
 }
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/Users.cpp
+++ b/src/modules/complianceengine/src/lib/Users.cpp
@@ -4,7 +4,7 @@
 
 namespace ComplianceEngine
 {
-Result<int> GetUidMin(ContextInterface& context)
+Result<unsigned int> GetUidMin(ContextInterface& context)
 {
     const std::string prefix = "UID_MIN ";
     auto loginDefsResult = context.GetFileContents("/etc/login.defs");
@@ -22,7 +22,7 @@ Result<int> GetUidMin(ContextInterface& context)
         {
             auto value = line.substr(prefix.length());
             value = TrimWhiteSpaces(value);
-            auto result = TryStringToInt(value);
+            auto result = TryStringToUint(value);
             if (!result.HasValue())
             {
                 OsConfigLogWarning(context.GetLogHandle(), "Invalid UID_MIN value in /etc/login.defs %s", result.Error().message.c_str());

--- a/src/modules/complianceengine/src/lib/Users.cpp
+++ b/src/modules/complianceengine/src/lib/Users.cpp
@@ -1,0 +1,40 @@
+#include <CommonContext.h>
+#include <StringTools.h>
+#include <Users.h>
+
+namespace ComplianceEngine
+{
+int GetUidMin(ContextInterface& context)
+{
+    const int defaultUidMin = 1000;
+    const std::string prefix = "UID_MIN ";
+    auto loginDefsResult = context.GetFileContents("/etc/login.defs");
+    if (!loginDefsResult.HasValue() || loginDefsResult.Value().empty())
+    {
+        OsConfigLogWarning(context.GetLogHandle(), "Failed to read /etc/login.defs, using default UID_MIN");
+        return defaultUidMin;
+    }
+    std::stringstream ss(loginDefsResult.Value());
+    std::string line;
+    while (std::getline(ss, line))
+    {
+        line = TrimWhiteSpaces(line);
+        if (line.length() > prefix.length() && line.substr(0, prefix.length()) == prefix)
+        {
+            auto value = line.substr(prefix.length());
+            value = TrimWhiteSpaces(value);
+            try
+            {
+                return std::stoi(value);
+            }
+            catch (const std::exception&)
+            {
+                OsConfigLogWarning(context.GetLogHandle(), "Invalid UID_MIN value in /etc/login.defs, using default");
+                return defaultUidMin;
+            }
+        }
+    }
+    OsConfigLogWarning(context.GetLogHandle(), "UID_MIN not found in /etc/login.defs, using default");
+    return defaultUidMin;
+}
+} // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/Users.h
+++ b/src/modules/complianceengine/src/lib/Users.h
@@ -1,0 +1,6 @@
+#include <ContextInterface.h>
+
+namespace ComplianceEngine
+{
+int GetUidMin(ContextInterface& context);
+} // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/Users.h
+++ b/src/modules/complianceengine/src/lib/Users.h
@@ -1,6 +1,8 @@
+#include "Result.h"
+
 #include <ContextInterface.h>
 
 namespace ComplianceEngine
 {
-int GetUidMin(ContextInterface& context);
+Result<int> GetUidMin(ContextInterface& context);
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/Users.h
+++ b/src/modules/complianceengine/src/lib/Users.h
@@ -1,8 +1,7 @@
-#include "Result.h"
-
 #include <ContextInterface.h>
+#include <Result.h>
 
 namespace ComplianceEngine
 {
-Result<int> GetUidMin(ContextInterface& context);
+Result<unsigned int> GetUidMin(ContextInterface& context);
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/procedures/AuditdRulesCheck.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/AuditdRulesCheck.cpp
@@ -227,13 +227,20 @@ Result<Status> AuditAuditdRulesCheck(const AuditAuditdRulesCheckParams& params, 
         }
     }
     auto uidMin = GetUidMin(context);
+    if (!uidMin.HasValue())
+    {
+        const int defaultUidMin = 1000;
+        uidMin = defaultUidMin;
+        OsConfigLogWarning(context.GetLogHandle(), "UID_MIN not found in /etc/login.defs, using default ");
+    }
+
     std::vector<std::pair<regex, std::string>> requiredOptions;
     for (auto option : params.requiredOptions.items)
     {
         option = TrimWhiteSpaces(option);
         if (!option.empty())
         {
-            option = ReplaceAuidPlaceholder(option, uidMin);
+            option = ReplaceAuidPlaceholder(option, uidMin.Value());
             try
             {
                 requiredOptions.push_back(std::make_pair(regex(option, std::regex_constants::icase | std::regex_constants::extended), option));

--- a/src/modules/complianceengine/src/lib/procedures/AuditdRulesCheck.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/AuditdRulesCheck.cpp
@@ -7,6 +7,7 @@
 #include <Regex.h>
 #include <StringTools.h>
 #include <Telemetry.h>
+#include <Users.h>
 #include <fstream>
 #include <fts.h>
 #include <iostream>
@@ -20,40 +21,6 @@ namespace ComplianceEngine
 {
 namespace
 {
-int GetUidMin(ContextInterface& context)
-{
-    const int defaultUidMin = 1000;
-    const std::string prefix = "UID_MIN ";
-    auto loginDefsResult = context.GetFileContents("/etc/login.defs");
-    if (!loginDefsResult.HasValue() || loginDefsResult.Value().empty())
-    {
-        OsConfigLogWarning(context.GetLogHandle(), "Failed to read /etc/login.defs, using default UID_MIN");
-        return defaultUidMin;
-    }
-    std::stringstream ss(loginDefsResult.Value());
-    std::string line;
-    while (std::getline(ss, line))
-    {
-        line = TrimWhiteSpaces(line);
-        if (line.length() > prefix.length() && line.substr(0, prefix.length()) == prefix)
-        {
-            auto value = line.substr(prefix.length());
-            value = TrimWhiteSpaces(value);
-            try
-            {
-                return std::stoi(value);
-            }
-            catch (const std::exception&)
-            {
-                OsConfigLogWarning(context.GetLogHandle(), "Invalid UID_MIN value in /etc/login.defs, using default");
-                return defaultUidMin;
-            }
-        }
-    }
-    OsConfigLogWarning(context.GetLogHandle(), "UID_MIN not found in /etc/login.defs, using default");
-    return defaultUidMin;
-}
-
 std::string ReplaceAuidPlaceholder(const std::string& option, int uidMin)
 {
     regex auidRegex(R"(-F auid>=[0-9]+\b)");

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -21,7 +21,7 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
     ContextInterface& context)
 {
     Result<unsigned int> uidMin = Error("Uninitialised UID_MIN");
-    if (params.skip_below_uid_min.HasValue() && params.skip_below_uid_min)
+    if (params.skip_below_uid_min.HasValue() && params.skip_below_uid_min.Value())
     {
         uidMin = GetUidMin(context);
     }

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -16,8 +16,10 @@ namespace ComplianceEngine
 using std::set;
 using std::string;
 
-Result<Status> AuditEnsureAccountsWithoutShellAreLocked(IndicatorsTree& indicators, ContextInterface& context)
+Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
+    ContextInterface& context)
 {
+    (void)params;
     const auto validShells = ListValidShells(context);
     if (!validShells.HasValue())
     {

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -7,6 +7,7 @@
 #include <PasswordEntriesIterator.h>
 #include <Result.h>
 #include <Telemetry.h>
+#include <Users.h>
 #include <UsersIterator.h>
 #include <set>
 #include <shadow.h>
@@ -19,7 +20,12 @@ using std::string;
 Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
     ContextInterface& context)
 {
-    (void)params;
+    Result<unsigned int> uidMin = Error("Uninitazlied UID_MIN");
+    if (params.skip_below_uid_min)
+    {
+        uidMin = GetUidMin(context);
+    }
+
     const auto validShells = ListValidShells(context);
     if (!validShells.HasValue())
     {
@@ -68,6 +74,31 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
         if (0 == strcmp(user.pw_name, "root"))
         {
             continue;
+        }
+        bool shouldSkip = false;
+        if (params.excludeUsers.HasValue())
+        {
+            for (const auto& excludeUser : params.excludeUsers->items)
+            {
+                if (0 == strcmp(user.pw_name, excludeUser.c_str()))
+                {
+                    OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's on exclude list ", user.pw_name);
+                    shouldSkip = true;
+                    break;
+                }
+            }
+        }
+        if (shouldSkip)
+        {
+            continue;
+        }
+        if (params.skip_below_uid_min && uidMin.HasValue())
+        {
+            if (user.pw_uid < uidMin.Value())
+            {
+                OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's id %d is lower than UID_MIN %d", user.pw_name, user.pw_uid, uidMin.Value());
+                continue;
+            }
         }
 
         if (lockedUsers.find(user.pw_name) == lockedUsers.end())

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -21,7 +21,7 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
     ContextInterface& context)
 {
     Result<unsigned int> uidMin = Error("Uninitazlied UID_MIN");
-    if (params.skip_below_uid_min)
+    if (params.skip_below_uid_min.HasValue() && params.skip_below_uid_min)
     {
         uidMin = GetUidMin(context);
     }

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -20,7 +20,7 @@ using std::string;
 Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
     ContextInterface& context)
 {
-    Result<unsigned int> uidMin = Error("Uninitazlied UID_MIN");
+    Result<unsigned int> uidMin = Error("Uninitialised UID_MIN");
     if (params.skip_below_uid_min.HasValue() && params.skip_below_uid_min)
     {
         uidMin = GetUidMin(context);

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -16,7 +16,7 @@ struct AuditEnsureAccountsWithoutShellAreLockedParams
     /// List of users to be excluded from check
     Optional<Separated<std::string, ':'>> excludeUsers;
     /// Parse /etc/login.defs and skip users with uid below UID_MIN
-    bool skip_below_uid_min = false;
+    Optional<bool> skip_below_uid_min = false;
 };
 Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
     ContextInterface& context);

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -12,7 +12,6 @@ namespace ComplianceEngine
 
 struct AuditEnsureAccountsWithoutShellAreLockedParams
 {
-
     /// List of users to be excluded from check
     Optional<Separated<std::string, ','>> excludeUsers;
     /// Parse /etc/login.defs and skip users with uid below UID_MIN

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -14,7 +14,7 @@ struct AuditEnsureAccountsWithoutShellAreLockedParams
 {
 
     /// List of users to be excluded from check
-    Optional<Separated<std::string, ':'>> excludeUsers;
+    Optional<Separated<std::string, ','>> excludeUsers;
     /// Parse /etc/login.defs and skip users with uid below UID_MIN
     Optional<bool> skip_below_uid_min = false;
 };

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -5,9 +5,20 @@
 #define COMPLIANCEENGINE_PROCEDURES_ENSURE_ACCOUNTS_WITHOUT_SHELL_ARE_LOCKED_H
 
 #include <Evaluator.h>
+#include <Separated.h>
 
 namespace ComplianceEngine
 {
-Result<Status> AuditEnsureAccountsWithoutShellAreLocked(IndicatorsTree& indicators, ContextInterface& context);
+
+struct AuditEnsureAccountsWithoutShellAreLockedParams
+{
+
+    /// List of users to be excluded from check
+    Separated<std::string, ':'> excludeUsers;
+    /// Parse /etc/login.defs and skip users with uid below UID_MIN
+    bool skip_below_uid_min = false;
+};
+Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
+    ContextInterface& context);
 } // namespace ComplianceEngine
 #endif // COMPLIANCEENGINE_PROCEDURES_ENSURE_ACCOUNTS_WITHOUT_SHELL_ARE_LOCKED_H

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -14,7 +14,7 @@ struct AuditEnsureAccountsWithoutShellAreLockedParams
 {
 
     /// List of users to be excluded from check
-    Separated<std::string, ':'> excludeUsers;
+    Optional<Separated<std::string, ':'>> excludeUsers;
     /// Parse /etc/login.defs and skip users with uid below UID_MIN
     bool skip_below_uid_min = false;
 };

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
@@ -12,9 +12,21 @@
           "properties": {
             "EnsureAccountsWithoutShellAreLocked": {
               "type": "object",
-              "required": [],
+              "required": [
+                "excludeUsers",
+                "skip_below_uid_min"
+              ],
               "additionalProperties": false,
-              "properties": {}
+              "properties": {
+                "excludeUsers": {
+                  "type": "string",
+                  "description": "List of users to be excluded from check"
+                },
+                "skip_below_uid_min": {
+                  "type": "string",
+                  "description": "Parse /etc/login.defs and skip users with uid below UID_MIN"
+                }
+              }
             }
           }
         }

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
@@ -12,9 +12,7 @@
           "properties": {
             "EnsureAccountsWithoutShellAreLocked": {
               "type": "object",
-              "required": [
-                "skip_below_uid_min"
-              ],
+              "required": [],
               "additionalProperties": false,
               "properties": {
                 "excludeUsers": {

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
@@ -13,7 +13,6 @@
             "EnsureAccountsWithoutShellAreLocked": {
               "type": "object",
               "required": [
-                "excludeUsers",
                 "skip_below_uid_min"
               ],
               "additionalProperties": false,

--- a/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
@@ -44,15 +44,21 @@ protected:
     {
     }
 
-    string CreateTestShadowFile(string username, string password)
+    string CreateShadowEntry(string username, string password)
     {
         auto content = std::move(username);
         content += ":" + password;
         content += ":::::::";
+        return content;
+    }
+
+    string CreateTestShadowFile(string username, string password)
+    {
+        auto content = CreateShadowEntry(username, password);
         return mContext.MakeTempfile(std::move(content));
     }
 
-    string CreateTestPasswdFile(string username, string password, string shell)
+    string CreatePasswordEntry(string username, string password, string shell)
     {
         auto content = std::move(username);
         content += ":" + password;
@@ -60,6 +66,11 @@ protected:
         content += ":" + std::to_string(9999);
         content += ":::";
         content += shell;
+        return content;
+    }
+    string CreateTestPasswdFile(string username, string password, string shell)
+    {
+        auto content = CreatePasswordEntry(username, password, shell);
         return mContext.MakeTempfile(std::move(content));
     }
 };
@@ -83,6 +94,7 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, NoEtcPasswdFile)
 
 TEST_F(EnsureAccountsWithoutShellAreLockedTest, ValidShell_RegularPassword)
 {
+
     auto filename = CreateTestShadowFile("testuser", "$y$");
     mContext.SetSpecialFilePath("/etc/shadow", filename);
     AuditEnsureAccountsWithoutShellAreLockedParams params;
@@ -267,5 +279,33 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, SkipTestUser)
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
     ASSERT_EQ(root->indicators.size(), 1u);
+    EXPECT_EQ(root->indicators[0].message, string("All non-root users without a login shell are locked"));
+}
+
+TEST_F(EnsureAccountsWithoutShellAreLockedTest, ExcludeTwoUsers)
+{
+    // auto filename = CreateTestShadowFile("testuser", "$y$");
+    auto user1 = CreateShadowEntry("u,ser1", "$y$");
+    auto user2 = CreateShadowEntry("us,er2", "$y$");
+    auto content = user1 + "\n" + user2;
+    auto filename = mContext.MakeTempfile(std::move(content));
+    mContext.SetSpecialFilePath("/etc/shadow", filename);
+
+    // filename = CreateTestPasswdFile("user1", "$y$", "/bin/x");
+    user1 = CreatePasswordEntry("u,ser1", "$y$", "/bin/x");
+    user2 = CreatePasswordEntry("us,er2", "$y$", "/bin/x");
+    content = user1 + "\n" + user2;
+    filename = mContext.MakeTempfile(std::move(content));
+    mContext.SetSpecialFilePath("/etc/passwd", filename);
+
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    params.excludeUsers = {{"u,ser1", "us,er2"}};
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+
+    const auto* root = mIndicators.GetRootNode();
+    ASSERT_NE(nullptr, root);
+    ASSERT_EQ(root->indicators.size(), (size_t)1);
     EXPECT_EQ(root->indicators[0].message, string("All non-root users without a login shell are locked"));
 }

--- a/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
@@ -6,9 +6,11 @@
 
 #include <EnsureAccountsWithoutShellAreLocked.h>
 #include <Optional.h>
+#include <Separated.h>
 #include <fstream>
 
 using ComplianceEngine::AuditEnsureAccountsWithoutShellAreLocked;
+using ComplianceEngine::AuditEnsureAccountsWithoutShellAreLockedParams;
 using ComplianceEngine::CompactListFormatter;
 using ComplianceEngine::Error;
 using ComplianceEngine::IndicatorsTree;
@@ -17,6 +19,9 @@ using ComplianceEngine::Result;
 using ComplianceEngine::Status;
 using std::map;
 using std::string;
+using ::testing::Return;
+
+static const char* cLoginDefsPath = "/etc/login.defs";
 
 class EnsureAccountsWithoutShellAreLockedTest : public ::testing::Test
 {
@@ -62,7 +67,8 @@ protected:
 TEST_F(EnsureAccountsWithoutShellAreLockedTest, NoEtcShadowFile)
 {
     mContext.SetSpecialFilePath("/etc/shadow", "/tmp/somenonexistentfilename");
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_FALSE(result.HasValue());
 }
 
@@ -70,7 +76,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, NoEtcPasswdFile)
 {
     mContext.SetSpecialFilePath("/etc/shadow", "/tmp/somenonexistentfilename");
     mContext.SetSpecialFilePath("/etc/passwd", "/tmp/somenonexistentfilename");
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_FALSE(result.HasValue());
 }
 
@@ -78,7 +85,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, ValidShell_RegularPassword)
 {
     auto filename = CreateTestShadowFile("testuser", "$y$");
     mContext.SetSpecialFilePath("/etc/shadow", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
@@ -89,7 +97,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, ValidShell_NoPassword)
     mContext.SetSpecialFilePath("/etc/passwd", filename);
     filename = CreateTestShadowFile("testuser", "");
     mContext.SetSpecialFilePath("/etc/shadow", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
@@ -98,7 +107,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, ValidShell_LockedUser_1)
 {
     auto filename = CreateTestShadowFile("testuser", "!");
     mContext.SetSpecialFilePath("/etc/shadow", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
@@ -107,7 +117,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, ValidShell_LockedUser_2)
 {
     auto filename = CreateTestShadowFile("testuser", "*");
     mContext.SetSpecialFilePath("/etc/shadow", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
@@ -118,7 +129,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_RegularPassword)
     mContext.SetSpecialFilePath("/etc/shadow", filename);
     filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
     mContext.SetSpecialFilePath("/etc/passwd", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 
@@ -134,7 +146,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_NoPassword)
     mContext.SetSpecialFilePath("/etc/shadow", filename);
     filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
     mContext.SetSpecialFilePath("/etc/passwd", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 
@@ -150,7 +163,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_1)
     mContext.SetSpecialFilePath("/etc/shadow", filename);
     filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
     mContext.SetSpecialFilePath("/etc/passwd", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 
@@ -167,7 +181,8 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_2)
     mContext.SetSpecialFilePath("/etc/shadow", filename);
     filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
     mContext.SetSpecialFilePath("/etc/passwd", filename);
-    auto result = AuditEnsureAccountsWithoutShellAreLocked(mIndicators, mContext);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 
@@ -176,4 +191,81 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_2)
     ASSERT_EQ(root->indicators.size(), 2u);
     EXPECT_EQ(root->indicators[0].message, string("User 9999 does not have a valid shell, but the account is locked"));
     EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
+}
+
+TEST_F(EnsureAccountsWithoutShellAreLockedTest, SkipBelowUidMin_GetUidMinError)
+{
+    auto filename = CreateTestShadowFile("testuser", "*");
+    mContext.SetSpecialFilePath("/etc/shadow", filename);
+    filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
+    mContext.SetSpecialFilePath("/etc/passwd", filename);
+    EXPECT_CALL(mContext, GetFileContents(cLoginDefsPath)).WillOnce(Return(Result<string>(Error("Failed to load file contents"))));
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    params.skip_below_uid_min = true;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+
+    const auto* root = mIndicators.GetRootNode();
+    ASSERT_NE(nullptr, root);
+    ASSERT_EQ(root->indicators.size(), 2u);
+    EXPECT_EQ(root->indicators[0].message, string("User 9999 does not have a valid shell, but the account is locked"));
+    EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
+}
+
+TEST_F(EnsureAccountsWithoutShellAreLockedTest, SkipBelowUidMin_NoIUidMin)
+{
+    auto filename = CreateTestShadowFile("testuser", "*");
+    mContext.SetSpecialFilePath("/etc/shadow", filename);
+    filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
+    mContext.SetSpecialFilePath("/etc/passwd", filename);
+    EXPECT_CALL(mContext, GetFileContents(cLoginDefsPath)).WillOnce(Return(Result<string>("# EMPTY FILE")));
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    params.skip_below_uid_min = true;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+
+    const auto* root = mIndicators.GetRootNode();
+    ASSERT_NE(nullptr, root);
+    ASSERT_EQ(root->indicators.size(), 2u);
+    EXPECT_EQ(root->indicators[0].message, string("User 9999 does not have a valid shell, but the account is locked"));
+    EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
+}
+
+TEST_F(EnsureAccountsWithoutShellAreLockedTest, SkipBelowUidMin)
+{
+    auto filename = CreateTestShadowFile("testuser", "$y$");
+    mContext.SetSpecialFilePath("/etc/shadow", filename);
+    filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
+    mContext.SetSpecialFilePath("/etc/passwd", filename);
+    EXPECT_CALL(mContext, GetFileContents(cLoginDefsPath)).WillOnce(Return(Result<string>("UID_MIN 10001")));
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    params.skip_below_uid_min = true;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+
+    const auto* root = mIndicators.GetRootNode();
+    ASSERT_NE(nullptr, root);
+    ASSERT_EQ(root->indicators.size(), 1u);
+    EXPECT_EQ(root->indicators[0].message, string("All non-root users without a login shell are locked"));
+}
+
+TEST_F(EnsureAccountsWithoutShellAreLockedTest, SkipTestUser)
+{
+    auto filename = CreateTestShadowFile("testuser", "$y$");
+    mContext.SetSpecialFilePath("/etc/shadow", filename);
+    filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
+    mContext.SetSpecialFilePath("/etc/passwd", filename);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    params.excludeUsers = {{"testuser"}};
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+
+    const auto* root = mIndicators.GetRootNode();
+    ASSERT_NE(nullptr, root);
+    ASSERT_EQ(root->indicators.size(), 1u);
+    EXPECT_EQ(root->indicators[0].message, string("All non-root users without a login shell are locked"));
 }

--- a/src/modules/test/recipes/complianceengine/EnsureAccountsWithoutShellAreLocked.json
+++ b/src/modules/test/recipes/complianceengine/EnsureAccountsWithoutShellAreLocked.json
@@ -10,6 +10,7 @@
     "Payload": {
       "audit": {
         "EnsureAccountsWithoutShellAreLocked": {
+            "skip_below_uid_min": "false"
         }
       }
     }

--- a/src/modules/test/recipes/complianceengine/EnsureAccountsWithoutShellAreLocked.json
+++ b/src/modules/test/recipes/complianceengine/EnsureAccountsWithoutShellAreLocked.json
@@ -10,7 +10,6 @@
     "Payload": {
       "audit": {
         "EnsureAccountsWithoutShellAreLocked": {
-            "skip_below_uid_min": "false"
         }
       }
     }


### PR DESCRIPTION
## Description
To accommodate for various distribution checks extend AccountsWithoutShellAreLocked with parameters
1. Skip users with uid below UID_MIN from login_defs
2. Skip user names with names from parameter 

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
