### PR TITLE
Move telemetry files and reduce events

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Source | Destination | Description
 [src/modules/configuration/](src/modules/configuration/) | /usr/lib/osconfig/configuration.so | The Configuration module binary
 [src/modules/securitybaseline/](src/modules/securitybaseline/) | /usr/lib/osconfig/securitybaseline.so | The SecurityBaseline module binary
 [src/modules/complianceengine/](src/modules/complianceengine/) | /usr/lib/osconfig/complianceengine.so | The ComplianceEngine module binary
+[src/common/telemetry/](src/common/telemetry/) | /var/lib/osconfig/telemetry | The OSConfig telemetry directory
 
 ### Enable and start OSConfig for the first time
 

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -5033,7 +5033,11 @@ int AsbMmiGet(const char* componentName, const char* objectName, char** payload,
         // For telemetry:
         OsConfigLogCritical(log, "TargetName: '%s', ComponentName: '%s', 'ObjectName:'%s', ObjectResult:'%s (%d)', Reason: '%.*s', Microseconds: %ld",
             g_prettyName, componentName, objectName, strerror(status), status, *payloadSizeBytes, *payload, GetPerfClockTime(&perfClock, log));
-        OSConfigTelemetryRuleComplete(componentName, objectName, status, GetPerfClockTime(&perfClock, log));
+
+        if (0 != status)
+        {
+            OSConfigTelemetryRuleComplete(componentName, objectName, status, GetPerfClockTime(&perfClock, log));
+        }
     }
 
     return status;
@@ -6022,7 +6026,11 @@ int AsbMmiSet(const char* componentName, const char* objectName, const char* pay
             // For telemetry:
             OsConfigLogCritical(log, "TargetName: '%s', ComponentName: '%s', 'ObjectName:'%s', ObjectResult:'%s (%d)', Microseconds: %ld",
                 g_prettyName, componentName, objectName, strerror(status), status, GetPerfClockTime(&perfClock, log));
-            OSConfigTelemetryRuleComplete(componentName, objectName, status, GetPerfClockTime(&perfClock, log));
+
+            if (0 != status)
+            {
+                OSConfigTelemetryRuleComplete(componentName, objectName, status, GetPerfClockTime(&perfClock, log));
+            }
         }
     }
 

--- a/src/common/telemetry/Telemetry.c
+++ b/src/common/telemetry/Telemetry.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static FILE* g_tmpFile = NULL;
@@ -54,6 +55,32 @@ char* GetCachedDistroName(void)
 
 void TelemetryInitialize(const OsConfigLogHandle log)
 {
+    if (false == DirectoryExists(OSCONFIG_DIRECTORY_NAME))
+    {
+        if (0 != mkdir(OSCONFIG_DIRECTORY_NAME, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
+        {
+            OsConfigLogError(log, "TelemetryInitialize: Failed to create directory: '%s' (%d, %s)", OSCONFIG_DIRECTORY_NAME, errno, strerror(errno));
+            return;
+        }
+        else
+        {
+            OsConfigLogInfo(log, "TelemetryInitialize: Created directory: %s", OSCONFIG_DIRECTORY_NAME);
+        }
+    }
+
+    if (false == DirectoryExists(TELEMETRY_DIRECTORY_NAME))
+    {
+        if (0 != mkdir(TELEMETRY_DIRECTORY_NAME, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
+        {
+            OsConfigLogError(log, "TelemetryInitialize: Failed to create directory: '%s' (%d, %s)", TELEMETRY_DIRECTORY_NAME, errno, strerror(errno));
+            return;
+        }
+        else
+        {
+            OsConfigLogInfo(log, "TelemetryInitialize: Created directory: %s", TELEMETRY_DIRECTORY_NAME);
+        }
+    }
+
     g_tmpFile = fopen(TELEMETRY_TMP_FILE_NAME, "a");
 
     if (NULL != g_tmpFile)

--- a/src/common/telemetry/Telemetry.h
+++ b/src/common/telemetry/Telemetry.h
@@ -24,7 +24,9 @@
 #include <version.h>
 
 #define TELEMETRY_BINARY_NAME "OSConfigTelemetry"
-#define TELEMETRY_TMP_FILE_NAME "/tmp/osconfig_telemetry.jsonl"
+#define OSCONFIG_DIRECTORY_NAME "/var/lib/osconfig"
+#define TELEMETRY_DIRECTORY_NAME "/var/lib/osconfig/telemetry"
+#define TELEMETRY_TMP_FILE_NAME "/var/lib/osconfig/telemetry/tmp.jsonl"
 
 // Ensure that TELEMETRY_COMMAND_TIMEOUT_SECONDS > TELEMETRY_TEARDOWN_TIMEOUT_SECONDS
 #define TELEMETRY_COMMAND_TIMEOUT_SECONDS (TELEMETRY_TEARDOWN_TIMEOUT_SECONDS + 2)

--- a/src/common/telemetry/lib/Telemetry.hpp
+++ b/src/common/telemetry/lib/Telemetry.hpp
@@ -25,7 +25,7 @@ public:
     static constexpr std::chrono::seconds CONFIG_DEFAULT_TEARDOWN_TIME{5};
     static constexpr const char* TELEMETRY_NAME = "OSConfigTelemetry";
     static constexpr const char* TELEMETRY_VERSION = "1.0.0";
-    static constexpr const char* TELEMETRY_CACHE_FILE_NAME = "/tmp/osconfig_telemetry.db";
+    static constexpr const char* TELEMETRY_CACHE_FILE_NAME = "/var/lib/osconfig/telemetry/cache.db";
     static constexpr const int TELEMETRY_CACHE_FILE_SIZE = 10 * 1024 * 1024;
     static constexpr const int TELEMETRY_RAM_QUEUE_SIZE = 2 * 1024 * 1024;
 

--- a/src/common/tests/TelemetryUT.cpp
+++ b/src/common/tests/TelemetryUT.cpp
@@ -27,6 +27,7 @@ protected:
     {
         TelemetryCleanup(NULL);
         remove(TELEMETRY_TMP_FILE_NAME);
+        rmdir(TELEMETRY_DIRECTORY_NAME);
     }
 };
 
@@ -36,6 +37,14 @@ TEST_F(TelemetryTest, InitCreatesTelemetryFile)
 
     struct stat fileInfo;
     EXPECT_EQ(0, stat(TELEMETRY_TMP_FILE_NAME, &fileInfo));
+}
+
+TEST_F(TelemetryTest, InitCreatesTelemetryDirectory)
+{
+    TelemetryInitialize(NULL);
+
+    struct stat dirInfo;
+    EXPECT_EQ(0, stat(TELEMETRY_DIRECTORY_NAME, &dirInfo));
 }
 
 TEST_F(TelemetryTest, AppendJsonWritesSingleLine)


### PR DESCRIPTION
## Description

1. Move temporary telemetry files to `/var/lib/osconfig`.
1. Remove calls to `OSConfigTelemetryRuleComplete` when the status does not indicate an error.
1. Update `README.md`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
