### PR TITLE
EnumerateUsers can crash for blank lines in passwd (#1253)

### DIFF
--- a/src/common/commonutils/UserUtils.c
+++ b/src/common/commonutils/UserUtils.c
@@ -409,6 +409,8 @@ int EnumerateUsers(SimplifiedUser** userList, unsigned int* size, char** reason,
             }
 
             endpwent();
+
+            *size = i;
         }
         else
         {
@@ -889,7 +891,7 @@ int RemoveUser(SimplifiedUser* user, OsConfigLogHandle log)
     char* command = NULL;
     int status = 0;
 
-    if (NULL == user)
+    if ((NULL == user) || (NULL == user->username))
     {
         OsConfigLogError(log, "RemoveUser: invalid argument");
         OSConfigTelemetryStatusTrace("user", EINVAL);


### PR DESCRIPTION
## Description

Cherry picked from commit 803e5a91c6b1e1b604127d8bed24022ee70f2e03

ASB can crash during EnumerateUsers when there are blank lines in /etc/passwd. Fix is to adjust the number of enumerated user accounts to what getpwent returns. Also, an extra guard against crash for null username in RemoveUser is added.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
