### PR TITLE
SystemdParameter: block parameter do not need `[]`, add  passOnNotFound to make audit succeed if no value is found 

### DIFF
--- a/src/modules/complianceengine/src/lib/ProcedureMap.cpp
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.cpp
@@ -83,8 +83,8 @@ const char* Bindings<PackageInstalledParams>::names[] = {"packageName", "minPack
 // SCE.h:18
 const char* Bindings<SCEParams>::names[] = {"scriptName", "ENVIRONMENT"};
 
-// SystemdConfig.h:52
-const char* Bindings<SystemdParameterParams>::names[] = {"parameter", "valueRegex", "op", "value", "file", "block", "dir"};
+// SystemdConfig.h:55
+const char* Bindings<SystemdParameterParams>::names[] = {"parameter", "valueRegex", "op", "value", "file", "block", "dir", "passOnNotFound"};
 
 // SystemdUnitState.h:28
 const char* Bindings<SystemdUnitStateParams>::names[] = {"unitName", "ActiveState", "LoadState", "UnitFileState", "Unit"};

--- a/src/modules/complianceengine/src/lib/ProcedureMap.h
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.h
@@ -505,9 +505,9 @@ template <>
 struct Bindings<SystemdParameterParams>
 {
     using T = SystemdParameterParams;
-    static constexpr size_t size = 7;
+    static constexpr size_t size = 8;
     static const char* names[];
-    static constexpr auto members = std::make_tuple(&T::parameter, &T::valueRegex, &T::op, &T::value, &T::file, &T::block, &T::dir);
+    static constexpr auto members = std::make_tuple(&T::parameter, &T::valueRegex, &T::op, &T::value, &T::file, &T::block, &T::dir, &T::passOnNotFound);
 };
 
 // Defines the bindings for the SystemdUnitStateParams structure.

--- a/src/modules/complianceengine/src/lib/procedures/SystemdConfig.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SystemdConfig.cpp
@@ -67,6 +67,7 @@ Result<bool> GetSystemdConfig(SystemdConfigMap_t& config, const std::string& fil
         std::string value = line.substr(eqSign + 1);
         config[std::make_pair(currentBlock, key)] = std::make_pair(value, currentConfig);
     }
+
     return true;
 }
 } // namespace
@@ -160,7 +161,9 @@ Result<Status> AuditSystemdParameter(const SystemdParameterParams& params, Indic
     SystemdConfigMap_t::const_iterator paramIt = config.end();
     if (params.block.HasValue())
     {
-        paramIt = config.find(std::make_pair(params.block.Value(), params.parameter));
+        auto block = params.block.Value();
+        block = "[" + block + "]";
+        paramIt = config.find(std::make_pair(block, params.parameter));
     }
     else
     {
@@ -176,10 +179,19 @@ Result<Status> AuditSystemdParameter(const SystemdParameterParams& params, Indic
 
     if (paramIt == config.end())
     {
+
+        assert(params.passOnNotFound.HasValue());
+        if (params.passOnNotFound.Value())
+        {
+            OsConfigLogInfo(log, "Parameter '%s' not found but Compliant due to passOnNotFound==true", params.parameter.c_str());
+            return indicators.Compliant("Parameter '" + params.parameter + "' not found but Compliant due to passOnNotFound==true");
+        }
         if (params.block.HasValue())
         {
-            OsConfigLogInfo(log, "Parameter '%s' not found in block '%s'", params.parameter.c_str(), params.block->c_str());
-            return indicators.NonCompliant("Parameter '" + params.parameter + "' not found in block '" + params.block.Value() + "'");
+            auto block = params.block.Value();
+            block = "[" + block + "]";
+            OsConfigLogInfo(log, "Parameter '%s' not found in block '%s'", params.parameter.c_str(), block.c_str());
+            return indicators.NonCompliant("Parameter '" + params.parameter + "' not found in block '" + block + "'");
         }
         else
         {

--- a/src/modules/complianceengine/src/lib/procedures/SystemdConfig.h
+++ b/src/modules/complianceengine/src/lib/procedures/SystemdConfig.h
@@ -49,6 +49,9 @@ struct SystemdParameterParams
 
     /// Directory to search for config files
     Optional<std::string> dir;
+
+    /// If the value is not found return Compliant
+    Optional<bool> passOnNotFound = false;
 };
 
 Result<Status> AuditSystemdParameter(const SystemdParameterParams& params, IndicatorsTree& indicators, ContextInterface& context);

--- a/src/modules/complianceengine/src/lib/procedures/SystemdConfig.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/SystemdConfig.schema.json
@@ -44,6 +44,10 @@
                 "dir": {
                   "type": "string",
                   "description": "Directory to search for config files"
+                },
+                "passOnNotFound": {
+                  "type": "string",
+                  "description": "If the value is not found return Compliant"
                 }
               }
             }

--- a/src/modules/complianceengine/tests/procedures/SystemdConfigTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SystemdConfigTest.cpp
@@ -643,7 +643,7 @@ TEST_F(SystemdConfigTest, BlockParameterFoundInCorrectBlock)
     params.parameter = "Restart";
     params.valueRegex = regex("^always$");
     params.file = "test.conf";
-    params.block = std::string("[Service]");
+    params.block = std::string("Service");
 
     auto result = AuditSystemdParameter(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -666,7 +666,7 @@ TEST_F(SystemdConfigTest, BlockParameterNotFoundInWrongBlock)
     params.parameter = "Restart";
     params.valueRegex = regex("^always$");
     params.file = "test.conf";
-    params.block = std::string("[Unit]");
+    params.block = std::string("Unit");
 
     auto result = AuditSystemdParameter(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -686,7 +686,7 @@ TEST_F(SystemdConfigTest, BlockParameterNotFoundInNonexistentBlock)
     params.parameter = "ExecStart";
     params.valueRegex = regex(".*");
     params.file = "test.conf";
-    params.block = std::string("[Install]");
+    params.block = std::string("Install");
 
     auto result = AuditSystemdParameter(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -709,7 +709,7 @@ TEST_F(SystemdConfigTest, SameParameterInDifferentBlocksWithBlockFilter)
     params.op = SystemdParameterOperator::Equal;
     params.value = std::string("stream");
     params.file = "test.conf";
-    params.block = std::string("[Socket]");
+    params.block = std::string("Socket");
 
     auto result = AuditSystemdParameter(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -755,7 +755,7 @@ TEST_F(SystemdConfigTest, BlockWithOperatorComparison)
     params.op = SystemdParameterOperator::GreaterOrEqual;
     params.value = std::string("1024");
     params.file = "test.conf";
-    params.block = std::string("[Service]");
+    params.block = std::string("Service");
 
     auto result = AuditSystemdParameter(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -778,6 +778,86 @@ TEST_F(SystemdConfigTest, ParameterWithoutBlockHeaderFoundWithoutBlockFilter)
     params.valueRegex = regex("^globalvalue$");
     params.file = "test.conf";
     // No block filter
+
+    auto result = AuditSystemdParameter(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(SystemdConfigTest, JournalCompressUsesPassOnNotFoundWhenOutputHasNoJournalSection)
+{
+    std::string systemdOutput = "# /etc/systemd/journald.conf\n";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config journald.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+
+    SystemdParameterParams params;
+    params.parameter = "Compress";
+    params.valueRegex = regex("^yes$");
+    params.file = "journald.conf";
+    params.block = std::string("Journal");
+    params.passOnNotFound = true;
+
+    auto result = AuditSystemdParameter(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(SystemdConfigTest, JournalCompressUsesPassOnNotFoundWhenJournalSectionHasNoCompressLine)
+{
+    std::string systemdOutput =
+        "# /etc/systemd/journald.conf\n"
+        "[Journal]\n"
+        "Storage=auto\n";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config journald.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+
+    SystemdParameterParams params;
+    params.parameter = "Compress";
+    params.valueRegex = regex("^yes$");
+    params.file = "journald.conf";
+    params.block = std::string("Journal");
+    params.passOnNotFound = true;
+
+    auto result = AuditSystemdParameter(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}
+
+TEST_F(SystemdConfigTest, JournalCompressWinsOverPassOnNotFound)
+{
+    std::string systemdOutput =
+        "# /etc/systemd/journald.conf\n"
+        "[Journal]\n"
+        "Compress=no\n";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config journald.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+
+    SystemdParameterParams params;
+    params.parameter = "Compress";
+    params.valueRegex = regex("^yes$");
+    params.file = "journald.conf";
+    params.block = std::string("Journal");
+    params.passOnNotFound = true;
+
+    auto result = AuditSystemdParameter(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+}
+
+TEST_F(SystemdConfigTest, FileParameterNotFoundButPassOnNotFound)
+{
+    std::string systemdOutput =
+        "# /etc/systemd/test.conf\n"
+        "OtherParam=value1\n"
+        "AnotherParam=value2\n";
+
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+
+    SystemdParameterParams params;
+    params.parameter = "TestParam";
+    params.valueRegex = regex(".*");
+    params.file = "test.conf";
+    params.passOnNotFound = true;
 
     auto result = AuditSystemdParameter(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());


### PR DESCRIPTION
## Description
SystemdParameter: block parameter do not need `[]`, add passOnNotFound to make audit succeed if no value is found (aka default is ok but we have no way of checking it) 




*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
