### PR TITLE
AuditEnsureAccountsWithoutShellAreLockedParams: add additional optional parameter to exclude users with not valid shells

### DIFF
--- a/src/modules/complianceengine/src/lib/ProcedureMap.cpp
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.cpp
@@ -8,8 +8,8 @@ namespace ComplianceEngine
 // AuditdRulesCheck.h:22
 const char* Bindings<AuditAuditdRulesCheckParams>::names[] = {"searchItem", "excludeOption", "requiredOptions"};
 
-// EnsureAccountsWithoutShellAreLocked.h:19
-const char* Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>::names[] = {"excludeUsers", "skip_below_uid_min"};
+// EnsureAccountsWithoutShellAreLocked.h:21
+const char* Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>::names[] = {"excludeUsers", "skip_below_uid_min", "skip_not_valid_shells"};
 
 // EnsureApparmorProfiles.h:15
 const char* Bindings<AuditEnsureApparmorProfilesParams>::names[] = {"enforce"};

--- a/src/modules/complianceengine/src/lib/ProcedureMap.cpp
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.cpp
@@ -9,7 +9,7 @@ namespace ComplianceEngine
 const char* Bindings<AuditAuditdRulesCheckParams>::names[] = {"searchItem", "excludeOption", "requiredOptions"};
 
 // EnsureAccountsWithoutShellAreLocked.h:21
-const char* Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>::names[] = {"excludeUsers", "skip_below_uid_min", "skip_not_valid_shells"};
+const char* Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>::names[] = {"excludeUsers", "skip_below_uid_min", "skip_invalid_shells"};
 
 // EnsureApparmorProfiles.h:15
 const char* Bindings<AuditEnsureApparmorProfilesParams>::names[] = {"enforce"};

--- a/src/modules/complianceengine/src/lib/ProcedureMap.h
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.h
@@ -257,7 +257,7 @@ struct Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>
     using T = AuditEnsureAccountsWithoutShellAreLockedParams;
     static constexpr size_t size = 3;
     static const char* names[];
-    static constexpr auto members = std::make_tuple(&T::excludeUsers, &T::skip_below_uid_min, &T::skip_not_valid_shells);
+    static constexpr auto members = std::make_tuple(&T::excludeUsers, &T::skip_below_uid_min, &T::skip_invalid_shells);
 };
 
 // Defines the bindings for the AuditEnsureApparmorProfilesParams structure.

--- a/src/modules/complianceengine/src/lib/ProcedureMap.h
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.h
@@ -255,9 +255,9 @@ template <>
 struct Bindings<AuditEnsureAccountsWithoutShellAreLockedParams>
 {
     using T = AuditEnsureAccountsWithoutShellAreLockedParams;
-    static constexpr size_t size = 2;
+    static constexpr size_t size = 3;
     static const char* names[];
-    static constexpr auto members = std::make_tuple(&T::excludeUsers, &T::skip_below_uid_min);
+    static constexpr auto members = std::make_tuple(&T::excludeUsers, &T::skip_below_uid_min, &T::skip_not_valid_shells);
 };
 
 // Defines the bindings for the AuditEnsureApparmorProfilesParams structure.

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -27,6 +27,7 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
     }
 
     const auto validShells = ListValidShells(context);
+
     if (!validShells.HasValue())
     {
         OsConfigLogError(context.GetLogHandle(), "Failed to get valid shells: %s", validShells.Error().message.c_str());
@@ -79,10 +80,10 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
         bool shouldSkip = false;
         assert(params.skip_not_valid_shells.HasValue());
         if (params.skip_not_valid_shells.Value()))
-        {
-            OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's does not have valid shell %s", user.pw_name, user.pw_shell);
-            shouldSkip = true;
-        }
+            {
+                OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's does not have valid shell %s", user.pw_name, user.pw_shell);
+                shouldSkip = true;
+            }
 
         if (params.excludeUsers.HasValue())
         {

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -75,7 +75,14 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
         {
             continue;
         }
+
         bool shouldSkip = false;
+        if (params.skip_not_valid_shells.HasValue() && params.skip_not_valid_shells.Value())
+        {
+            OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's does not have valid shell %s", user.pw_name, user.pw_shell);
+            shouldSkip = true;
+        }
+
         if (params.excludeUsers.HasValue())
         {
             for (const auto& excludeUser : params.excludeUsers->items)

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -77,7 +77,8 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
         }
 
         bool shouldSkip = false;
-        if (params.skip_not_valid_shells.HasValue() && params.skip_not_valid_shells.Value())
+        assert(params.skip_not_valid_shells.HasValue());
+        if (params.skip_not_valid_shells.Value()))
         {
             OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's does not have valid shell %s", user.pw_name, user.pw_shell);
             shouldSkip = true;

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.cpp
@@ -78,12 +78,12 @@ Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccount
         }
 
         bool shouldSkip = false;
-        assert(params.skip_not_valid_shells.HasValue());
-        if (params.skip_not_valid_shells.Value()))
-            {
-                OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's does not have valid shell %s", user.pw_name, user.pw_shell);
-                shouldSkip = true;
-            }
+        assert(params.skip_invalid_shells.HasValue());
+        if (params.skip_invalid_shells.Value())
+        {
+            OsConfigLogDebug(context.GetLogHandle(), "Skip User '%s' as it's does not have valid shell %s", user.pw_name, user.pw_shell);
+            shouldSkip = true;
+        }
 
         if (params.excludeUsers.HasValue())
         {

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -19,6 +19,7 @@ struct AuditEnsureAccountsWithoutShellAreLockedParams
     /// Parse /etc/shells and if user does not have valid shell skip it
     Optional<bool> skip_invalid_shells = false;
 };
+
 Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
     ContextInterface& context);
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -16,6 +16,8 @@ struct AuditEnsureAccountsWithoutShellAreLockedParams
     Optional<Separated<std::string, ','>> excludeUsers;
     /// Parse /etc/login.defs and skip users with uid below UID_MIN
     Optional<bool> skip_below_uid_min = false;
+    /// Parse /etc/shells and if user does not have valid shell skip it
+    Optional<bool> skip_not_valid_shells = false;
 };
 Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
     ContextInterface& context);

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.h
@@ -17,7 +17,7 @@ struct AuditEnsureAccountsWithoutShellAreLockedParams
     /// Parse /etc/login.defs and skip users with uid below UID_MIN
     Optional<bool> skip_below_uid_min = false;
     /// Parse /etc/shells and if user does not have valid shell skip it
-    Optional<bool> skip_not_valid_shells = false;
+    Optional<bool> skip_invalid_shells = false;
 };
 Result<Status> AuditEnsureAccountsWithoutShellAreLocked(const AuditEnsureAccountsWithoutShellAreLockedParams& params, IndicatorsTree& indicators,
     ContextInterface& context);

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
@@ -23,7 +23,7 @@
                   "type": "string",
                   "description": "Parse /etc/login.defs and skip users with uid below UID_MIN"
                 },
-                "skip_not_valid_shells": {
+                "skip_invalid_shells": {
                   "type": "string",
                   "description": "Parse /etc/shells and if user does not have valid shell skip it"
                 }

--- a/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureAccountsWithoutShellAreLocked.schema.json
@@ -22,6 +22,10 @@
                 "skip_below_uid_min": {
                   "type": "string",
                   "description": "Parse /etc/login.defs and skip users with uid below UID_MIN"
+                },
+                "skip_not_valid_shells": {
+                  "type": "string",
+                  "description": "Parse /etc/shells and if user does not have valid shell skip it"
                 }
               }
             }

--- a/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
@@ -187,6 +187,24 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_1)
     EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
 }
 
+TEST_F(EnsureAccountsWithoutShellAreLockedTest, IngnoreInvalidShellUnlockedUser)
+{
+    auto filename = CreateTestShadowFile("testuser", "*");
+    mContext.SetSpecialFilePath("/etc/shadow", filename);
+    filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
+    mContext.SetSpecialFilePath("/etc/passwd", filename);
+    AuditEnsureAccountsWithoutShellAreLockedParams params;
+    params.skip_not_valid_shells = true;
+    auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+
+    const auto* root = mIndicators.GetRootNode();
+    ASSERT_NE(nullptr, root);
+    ASSERT_EQ(root->indicators.size(), 1u);
+    EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
+}
+
 TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_2)
 {
     auto filename = CreateTestShadowFile("testuser", "*");

--- a/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/EnsureAccountsWithoutShellAreLockedTest.cpp
@@ -194,7 +194,7 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, IngnoreInvalidShellUnlockedUser)
     filename = CreateTestPasswdFile("testuser", "$y$", "/bin/x");
     mContext.SetSpecialFilePath("/etc/passwd", filename);
     AuditEnsureAccountsWithoutShellAreLockedParams params;
-    params.skip_not_valid_shells = true;
+    params.skip_invalid_shells = true;
     auto result = AuditEnsureAccountsWithoutShellAreLocked(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
@@ -202,7 +202,7 @@ TEST_F(EnsureAccountsWithoutShellAreLockedTest, IngnoreInvalidShellUnlockedUser)
     const auto* root = mIndicators.GetRootNode();
     ASSERT_NE(nullptr, root);
     ASSERT_EQ(root->indicators.size(), 1u);
-    EXPECT_EQ(root->indicators[1].message, string("All non-root users without a login shell are locked"));
+    EXPECT_EQ(root->indicators[0].message, string("All non-root users without a login shell are locked"));
 }
 
 TEST_F(EnsureAccountsWithoutShellAreLockedTest, InvalidShell_LockedUser_2)


### PR DESCRIPTION
## Description

AuditEnsureAccountsWithoutShellAreLockedParams: add additional optional parameter to exclude users with not valid shells

Azure Linux3 in addition  to excluding UID_MIN also excludes users with not valid shell from failing compliance

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [ ] I added unit-tests to validate my changes. All unit tests are passing.
- [ ] I have merged the latest `dev` branch prior to this PR submission.
- [ ] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [ ] I submitted this PR against the `dev` branch.
