### PR TITLE
Fix for builds ./devops/scripts/run-module-tests.sh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+
+.git
+.gitignore
+
+# common junk
+**/.cache
+**/build
+**/out
+**/.venv
+**/*.o
+**/*.a
+**/*.so
+**/*.log
+
+# vcpkg artifacts
+external/vcpkg/buildtrees
+external/vcpkg/packages
+external/vcpkg/downloads
+external/vcpkg/installed

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -103,7 +103,6 @@ jobs:
         with:
           context: .
           file: ${{ steps.image.outputs.path }}/Dockerfile
-          build-contexts: dockerfiledir=${{ steps.image.outputs.path }}
           # Always push the new image. We use frozen checksums stored in test-matrix.json. A new-test-matrix.json will be dropped in the artifacts which can be used to update the existing file after confirming the CI works.
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/devops/docker/centos-7-amd64/Dockerfile
+++ b/devops/docker/centos-7-amd64/Dockerfile
@@ -6,7 +6,7 @@ ARG GIT_VERSION=2.14.0
 
 RUN rm /etc/yum.repos.d/*.repo
 # Docker context is at the root of the project
-COPY --from=dockerfiledir ./centos.repo /etc/yum.repos.d/centos.repo
+COPY devops/docker/centos-7-amd64/centos.repo /etc/yum.repos.d/centos.repo
 
 # Install dependencies needed for Git compilation and general build
 RUN yum install -y \

--- a/devops/docker/debian-10-amd64/Dockerfile
+++ b/devops/docker/debian-10-amd64/Dockerfile
@@ -3,11 +3,11 @@ FROM mcr.microsoft.com/mirror/docker/library/debian:buster
 ARG CMAKE_VERSION=v3.30.1
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN cat <<EOF >/etc/apt/sources.list
-deb http://archive.debian.org/debian/ buster main contrib non-free
-deb http://archive.debian.org/debian/ buster-proposed-updates main contrib non-free
-deb http://archive.debian.org/debian-security buster/updates main contrib non-free
-EOF
+RUN printf '%s\n' \
+'deb http://archive.debian.org/debian/ buster main contrib non-free' \
+'deb http://archive.debian.org/debian/ buster-proposed-updates main contrib non-free' \
+'deb http://archive.debian.org/debian-security buster/updates main contrib non-free' \
+ > /etc/apt/sources.list
 
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \

--- a/devops/docker/debian-9-amd64/Dockerfile
+++ b/devops/docker/debian-9-amd64/Dockerfile
@@ -4,11 +4,11 @@ ARG CMAKE_VERSION=v3.30.1
 ARG DEBIAN_FRONTEND=noninteractive
 
 # debian-9 is EOL, update sources.list to use snapshot.debian.org mirrors
-RUN cat <<EOF > /etc/apt/sources.list
-deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20220622T000000Z stretch main
-deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20220622T000000Z stretch/updates main
-deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20220622T000000Z stretch-updates main
-EOF
+RUN printf '%s\n' \
+  'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20220622T000000Z stretch main' \
+  'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20220622T000000Z stretch/updates main' \
+  'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20220622T000000Z stretch-updates main' \
+  > /etc/apt/sources.list
 
 RUN apt -y update && apt-get -y install software-properties-common
 RUN apt -y update && apt-get -y install \

--- a/devops/docker/rhel-7-amd64/Dockerfile
+++ b/devops/docker/rhel-7-amd64/Dockerfile
@@ -5,11 +5,11 @@ ARG GIT_VERSION=2.14.0
 FROM centos:centos7 AS centos
 
 RUN rm /etc/yum.repos.d/*.repo
-COPY --from=dockerfiledir ./centos.repo /etc/yum.repos.d/centos.repo
+COPY  devops/docker/rhel-7-amd64/centos.repo /etc/yum.repos.d/centos.repo
 
 RUN yum update -y
 RUN rm /etc/yum.repos.d/*.repo
-COPY --from=dockerfiledir ./centos.repo /etc/yum.repos.d/centos.repo
+COPY devops/docker/rhel-7-amd64//centos.repo /etc/yum.repos.d/centos.repo
 
 RUN yumdownloader rpm-build elfutils
 

--- a/devops/scripts/run-module-tests.sh
+++ b/devops/scripts/run-module-tests.sh
@@ -40,22 +40,22 @@ fi
 
 if [ -z "$DISTRO" ]; then
     shopt -s globstar nullglob
-    DISTROS=( "$BASEDIR"/devops/docker/**/Dockerfile )
+    DOCKERFILES=( "$BASEDIR"/devops/docker/**/Dockerfile )
 else
-    if [ ! -f "$BASEDIR/devops/docker/$DISTRO" ] ; then
-      echo "Unabel to read $BASEDIR/devops/docker/$DISTRO "
+    if [ ! -f "$BASEDIR/devops/docker/$DISTRO/Dockerfile" ] ; then
+      echo "Unabel to read $BASEDIR/devops/docker/$DISTRO/Dockerfile "
       exit 1
     fi
-    DISTROS=( "$BASEDIR/devops/docker/$DISTRO" )
+    DOCKERFILES=( "$BASEDIR/devops/docker/$DISTRO/Dockerfile" )
 fi
 
 
-for DISTRO in "${DISTROS[@]}"; do
-  DISTRO_NAME=${DISTRO%/Dockerfile}
+for DOCKERFILE in "${DOCKERFILES[@]}"; do
+  DISTRO_NAME=${DOCKERFILE%/Dockerfile}
   DISTRO_NAME=${DISTRO_NAME##${BASEDIR}/devops/docker/}
   IMGNAME=moduletest-$DISTRO_NAME:latest
   if [ -z "$NODOCKERBUIILD" ]; then
-  	docker build -t "$IMGNAME" -f "$DISTRO"  $PWD
+    docker build -t "$IMGNAME" -f "$DOCKERFILE"  $PWD
   fi
   if [ -z "$BUILDDIR" ]; then
   	BDIR="build-$DISTRO_NAME"

--- a/devops/scripts/run-module-tests.sh
+++ b/devops/scripts/run-module-tests.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 
 usage()
 {
@@ -9,17 +10,15 @@ usage()
   exit 2
 }
 
-PARSED_ARGUMENTS=$(getopt -a -n $0 -o b:d:u:xn --long basedir:,distro:,builddir:,no-docker-build,no-build -- "$@")
-VALID_ARGUMENTS=$?
-
-if [ "$VALID_ARGUMENTS" != "0" ]; then
-  usage
-fi
+PARSED_ARGUMENTS=$(getopt -a -n "$0" -o b:d:u:xnh --long basedir:,distro:,builddir:,no-docker-build,no-build,help -- "$@")
 
 BASEDIR=`pwd`
-
+NODOCKERBUIILD=''
+DISTRO=''
+NOBUILD=''
+BUILDDIR=''
 eval set -- "$PARSED_ARGUMENTS"
-while :
+while true
 do
   case "$1" in
     -b | --basedir)          BASEDIR="$2"      ; shift 2 ;;
@@ -27,30 +26,41 @@ do
     -u | --builddir)         BUILDDIR="$2"       ; shift 2 ;;
     -x | --no-docker-build)  NODOCKERBUIILD=1  ; shift ;;
     -n | --no-build)         NOBUILD=1         ; shift ;;
+    -h | --help)             usage             ; shift ;;
     --) shift; break ;;
     *) echo "Unexpected option: $1 - this should not happen."
        usage ;;
   esac
 done
 
+if [ $# -ne 0 ] ; then
+    echo "Unexpected option: $1 - this should not happen."
+    usage
+fi
 
 if [ -z "$DISTRO" ]; then
-	DISTROS=$(ls -d $BASEDIR/devops/docker/*)
+    shopt -s globstar nullglob
+    DISTROS=( "$BASEDIR"/devops/docker/**/Dockerfile )
 else
-	DISTROS="$BASEDIR/devops/docker/$DISTRO"
+    if [ ! -f "$BASEDIR/devops/docker/$DISTRO" ] ; then
+      echo "Unabel to read $BASEDIR/devops/docker/$DISTRO "
+      exit 1
+    fi
+    DISTROS=( "$BASEDIR/devops/docker/$DISTRO" )
 fi
 
 
-for DISTRO in $DISTROS; do
-  DISTRO_NAME=$(basename $DISTRO)
+for DISTRO in "${DISTROS[@]}"; do
+  DISTRO_NAME=${DISTRO%/Dockerfile}
+  DISTRO_NAME=${DISTRO_NAME##${BASEDIR}/devops/docker/}
   IMGNAME=moduletest-$DISTRO_NAME:latest
-  if [ -z "$NODOCKERBUILD" ]; then
-  	docker build -t $IMGNAME $DISTRO
+  if [ -z "$NODOCKERBUIILD" ]; then
+  	docker build -t "$IMGNAME" -f "$DISTRO"  $PWD
   fi
   if [ -z "$BUILDDIR" ]; then
   	BDIR="build-$DISTRO_NAME"
   else
   	BDIR="$BUILDDIR"
   fi
-  docker run -v $BASEDIR:/git/azure-osconfig -w /git/azure-osconfig $IMGNAME ./devops/scripts/run-module-tests-int.sh $BDIR $NOBUILD
+  docker run -v "$BASEDIR:/git/azure-osconfig" -w /git/azure-osconfig "$IMGNAME" ./devops/scripts/run-module-tests-int.sh "$BDIR" "$NOBUILD"
 done


### PR DESCRIPTION
## Description
Due recent changes run-module-tests.sh was not able to build containers localy.
Fix it by:
 - aligning run-module-tests.sh and .github/workflows/build-containers.yml 
 -  changed Heredoc `RUN cat` as it don't work with podman to printf
 -  change script run-module-tests.sh to stop on error
 - removed custom context from containers aka --dockerfiledir 
 -  Use .dockeringnore to limit amount of data copied into src

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
