### PR TITLE
Telemetry:Tests: Disable Telemetry tests that fails when build -DBUILD_TELEMETRY=0

### DIFF
--- a/src/common/tests/TelemetryUT.cpp
+++ b/src/common/tests/TelemetryUT.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <sys/stat.h>
 
+#ifdef BUILD_TELEMETRY
 class TelemetryTest : public ::testing::Test
 {
 protected:
@@ -71,3 +72,4 @@ TEST_F(TelemetryTest, CleanupResetsTelemetryState)
     EXPECT_EQ(0, stat(TELEMETRY_TMP_FILE_NAME, &fileInfo));
     EXPECT_EQ(0, remove(TELEMETRY_TMP_FILE_NAME));
 }
+#endif


### PR DESCRIPTION


## Description

Telemetry:Tests: Disable Telemetry tests that fails when build -DBUILD_TELEMETRY=0

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
