### PR TITLE
Fix 'Counters mismatch' error on dangling symlink

### DIFF
--- a/src/modules/complianceengine/src/lib/procedures/FileRegexMatch.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/FileRegexMatch.cpp
@@ -158,8 +158,7 @@ Result<Status> AuditFileRegexMatch(const AuditFileRegexMatchParams& params, Indi
             if (0 != stat((params.path + "/" + entry->d_name).c_str(), &st))
             {
                 const int status = errno;
-                OsConfigLogInfo(context.GetLogHandle(), "Failed to stat file '%s/%s': %s", params.path.c_str(), entry->d_name, strerror(status));
-                errorCount++;
+                OsConfigLogInfo(context.GetLogHandle(), "Failed to stat symlink target '%s/%s': %s", params.path.c_str(), entry->d_name, strerror(status));
                 continue;
             }
 

--- a/src/modules/complianceengine/tests/procedures/FileRegexMatchTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/FileRegexMatchTest.cpp
@@ -588,3 +588,24 @@ TEST_F(FileRegexMatchTest, Audit_SymlinkFollow_Directory)
     ASSERT_TRUE(result.HasValue());
     EXPECT_EQ(result.Value(), Status::Compliant);
 }
+
+TEST_F(FileRegexMatchTest, Audit_SymlinkFollow_DanglingLink)
+{
+    MakeTempfile("test");
+    const auto targetFilename = mTempfiles.back();
+    const auto linkFilename = targetFilename + ".link";
+
+    AuditFileRegexMatchParams params;
+    params.path = mTempdir;
+    params.filenamePattern = regex(".*\\.link");
+    params.matchOperation = Operation::Match;
+    params.matchPattern = R"(^foo$)"; // pattern mismatch against 'test'
+    params.behavior = Behavior::AtLeastOneExists;
+
+    ASSERT_EQ(0, symlink(targetFilename.c_str(), linkFilename.c_str()));
+    EXPECT_EQ(0, unlink(targetFilename.c_str()));
+    auto result = AuditFileRegexMatch(params, mIndicators, mContext);
+    EXPECT_EQ(0, unlink(linkFilename.c_str()));
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::NonCompliant);
+}


### PR DESCRIPTION
## Description

Fix an issue that the compliance engine FileRegexMatch procedure fails with error if a dangling symlink exists.
The dangling symlink error works properly, but the counter should not be bumped there.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
