### PR TITLE
Introduce a NotApplicable state in compliance engine

### DIFF
--- a/src/modules/complianceengine/src/lib/CommonContext.cpp
+++ b/src/modules/complianceengine/src/lib/CommonContext.cpp
@@ -27,6 +27,18 @@ Result<std::string> CommonContext::ExecuteCommand(const std::string& cmd) const
 
 Result<std::string> CommonContext::GetFileContents(const std::string& filePath) const
 {
+    struct stat st;
+    if (stat(filePath.c_str(), &st) != 0)
+    {
+        int status = errno;
+        if (ENOENT == status)
+        {
+            return Error("File not found: " + filePath, status);
+        }
+
+        return Error("Failed to stat file: " + std::string(strerror(status)), status);
+    }
+
     char* output = LoadStringFromFile(filePath.c_str(), false, mLog);
     if (output == nullptr)
     {

--- a/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
+++ b/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
@@ -186,7 +186,7 @@ int ComplianceEngineMmiGet(MMI_HANDLE clientSession, const char* componentName, 
         }
 
         auto payloadString = result.Value().payload;
-        if (result.Value().status == Status::Compliant)
+        if ((result.Value().status == Status::Compliant) || (result.Value().status == Status::NotApplicable))
         {
             payloadString = "PASS" + payloadString;
         }
@@ -281,8 +281,22 @@ int ComplianceEngineMmiSet(MMI_HANDLE clientSession, const char* componentName, 
             }
         }
 
+        std::string statusString;
+        switch (result.Value())
+        {
+            case Status::Compliant:
+                statusString = "compliant";
+                break;
+            case Status::NonCompliant:
+                statusString = "non-compliant";
+                break;
+            case Status::NotApplicable:
+                statusString = "not applicable";
+                break;
+        }
+
         OsConfigLogDebug(engine.Log(), "MmiSet(%p, %s, %s, %.*s, %d) returned %s", clientSession, componentName, objectName, payloadSizeBytes, payload,
-            payloadSizeBytes, result.Value() == Status::Compliant ? "compliant" : "non-compliant");
+            payloadSizeBytes, statusString.c_str());
         return MMI_OK;
     }
     catch (const std::exception& e)

--- a/src/modules/complianceengine/src/lib/Evaluator.cpp
+++ b/src/modules/complianceengine/src/lib/Evaluator.cpp
@@ -395,7 +395,7 @@ void NestedListFormatter::FormatNode(const IndicatorsTree::Node& node, std::ostr
         {
             compliantIndicatorsCount++;
         }
-        if (compliantIndicatorsCount > cMaxNodeIndicators)
+        if (compliantIndicatorsCount > cMaxNodeCompliantIndicators)
         {
             continue;
         }
@@ -435,7 +435,7 @@ void NestedListFormatter::FormatNode(const IndicatorsTree::Node& node, std::ostr
         {
             compliantIndicatorsCount++;
         }
-        if (compliantIndicatorsCount > cMaxNodeIndicators)
+        if (compliantIndicatorsCount > cMaxNodeCompliantIndicators)
         {
             continue;
         }

--- a/src/modules/complianceengine/src/lib/Evaluator.cpp
+++ b/src/modules/complianceengine/src/lib/Evaluator.cpp
@@ -159,6 +159,7 @@ Result<Status> Evaluator::EvaluateList(const json_value_t* value, const Action a
 
     const auto* array = json_value_get_array(value);
     size_t count = json_array_get_count(array);
+    Status accumulated = (listAction == ListAction::AnyOf) ? Status::NonCompliant : Status::Compliant;
     for (size_t i = 0; i < count; ++i)
     {
         const auto* subObject = json_array_get_object(array, i);
@@ -180,9 +181,14 @@ Result<Status> Evaluator::EvaluateList(const json_value_t* value, const Action a
             OsConfigLogDebug(mContext.GetLogHandle(), "Evaluation returned non-compliant status at index %zu", i);
             return Status::NonCompliant;
         }
+
+        if (result.Value() == Status::NotApplicable)
+        {
+            accumulated = Status::NotApplicable;
+        }
     }
 
-    return ((listAction == ListAction::AnyOf) ? Status::NonCompliant : Status::Compliant);
+    return accumulated;
 }
 
 Result<Status> Evaluator::EvaluateNot(const json_value_t* value, const Action action)
@@ -212,6 +218,12 @@ Result<Status> Evaluator::EvaluateNot(const json_value_t* value, const Action ac
     {
         OsConfigLogError(mContext.GetLogHandle(), "Evaluation failed: %s", result.Error().message.c_str());
         return result;
+    }
+
+    if (result.Value() == Status::NotApplicable)
+    {
+        OsConfigLogDebug(mContext.GetLogHandle(), "not: inner result is not-applicable, propagating");
+        return Status::NotApplicable;
     }
 
     if (result.Value() == Status::Compliant)
@@ -367,14 +379,13 @@ Result<Status> Evaluator::EvaluateBuiltinProcedure(const string& procedureName, 
     return result.Value();
 }
 
-static constexpr std::size_t cMaxNodeIndicators = 5;
-void NestedListFormatter::FormatNode(const IndicatorsTree::Node& node, std::ostringstream& result, int depth, const bool ignored)
-{
-    static const char* greenCompliant = "✅";
-    static const char* redNonCompliant = "❌";
-    static const char* greyCompliant = "✓";
-    static const char* greyNonCompliant = "🇽";
+const std::map<std::pair<Status, NestedListFormatter::Ignored>, const char*> NestedListFormatter::sEmojiMap = {
+    {{Status::Compliant, NestedListFormatter::Ignored::No}, "✅"}, {{Status::Compliant, NestedListFormatter::Ignored::Yes}, "✓"},
+    {{Status::NonCompliant, NestedListFormatter::Ignored::No}, "❌"}, {{Status::NonCompliant, NestedListFormatter::Ignored::Yes}, "🇽"},
+    {{Status::NotApplicable, NestedListFormatter::Ignored::No}, "➖"}, {{Status::NotApplicable, NestedListFormatter::Ignored::Yes}, "–"}};
 
+void NestedListFormatter::FormatNode(const IndicatorsTree::Node& node, std::ostringstream& result, int depth, const Ignored ignored)
+{
     std::size_t compliantIndicatorsCount = 0;
     for (std::size_t i = 0; i < node.children.size(); i++)
     {
@@ -393,25 +404,26 @@ void NestedListFormatter::FormatNode(const IndicatorsTree::Node& node, std::ostr
         {
             result << "\t";
         }
-        bool ign = ignored;
-        if (i + 1 != node.children.size() && node.procedureName == "anyOf" && node.status == Status::Compliant)
+        Ignored ign = ignored;
+        // Check if this child is not the last one and if we're in an alternative.
+        if (i + 1 != node.children.size() && node.procedureName == "anyOf")
         {
-            ign = true;
+            // In this case we know this child is not the last one,
+            // so it does not determine the result. If the status was compliant,
+            // it would have to be the last child.
+            assert(child->status != Status::Compliant);
+            ign = Ignored::Yes;
         }
 
-        if (node.procedureName == "not")
+        // Ignore the 'not' inner status only if it's results is determined, otherwise it'll be forwarded as not-applicable.
+        if (node.procedureName == "not" && child->status != Status::NotApplicable)
         {
-            ign = true;
+            ign = Ignored::Yes;
         }
 
-        if (ign)
-        {
-            result << (child->status == Status::Compliant ? greyCompliant : greyNonCompliant) << " " << child->procedureName << "\n";
-        }
-        else
-        {
-            result << (child->status == Status::Compliant ? greenCompliant : redNonCompliant) << " " << child->procedureName << "\n";
-        }
+        auto emoji = sEmojiMap.find({child->status, ign});
+        assert(emoji != sEmojiMap.end());
+        result << emoji->second << " " << child->procedureName << "\n";
         FormatNode(*child.get(), result, depth + 1, ign);
     }
 
@@ -432,28 +444,10 @@ void NestedListFormatter::FormatNode(const IndicatorsTree::Node& node, std::ostr
         {
             result << "\t";
         }
-        if (indicator.status == Status::Compliant)
-        {
-            if (ignored)
-            {
-                result << greyCompliant << " " << indicator.message << "\n";
-            }
-            else
-            {
-                result << greenCompliant << " " << indicator.message << "\n";
-            }
-        }
-        else
-        {
-            if (ignored)
-            {
-                result << greyNonCompliant << " " << indicator.message << "\n";
-            }
-            else
-            {
-                result << redNonCompliant << " " << indicator.message << "\n";
-            }
-        }
+
+        auto emoji = sEmojiMap.find({indicator.status, ignored});
+        assert(emoji != sEmojiMap.end());
+        result << emoji->second << " " << indicator.message << "\n";
     }
 }
 
@@ -462,8 +456,11 @@ Result<std::string> NestedListFormatter::Format(const IndicatorsTree& indicators
     std::ostringstream result;
     const auto* node = indicators.GetRootNode();
     assert(nullptr != node);
-    result << (node->status == Status::Compliant ? "✅ " : "❌ ") << node->procedureName << "\n";
-    FormatNode(*node, result, 1, false);
+    auto emoji = sEmojiMap.find({node->status, NestedListFormatter::Ignored::No});
+    // Keep the assert if in the future the Status enum has changed
+    assert(emoji != sEmojiMap.end());
+    result << emoji->second << " " << node->procedureName << "\n";
+    FormatNode(*node, result, 1, NestedListFormatter::Ignored::No);
     return result.str();
 }
 

--- a/src/modules/complianceengine/src/lib/Evaluator.h
+++ b/src/modules/complianceengine/src/lib/Evaluator.h
@@ -41,7 +41,15 @@ public:
 
 class NestedListFormatter : public PayloadFormatter
 {
-    static void FormatNode(const IndicatorsTree::Node& node, std::ostringstream& result, int depth, bool ignored);
+    enum class Ignored
+    {
+        No,
+        Yes
+    };
+    static const std::map<std::pair<Status, NestedListFormatter::Ignored>, const char*> sEmojiMap;
+    static constexpr std::size_t cMaxNodeIndicators = 5;
+
+    static void FormatNode(const IndicatorsTree::Node& node, std::ostringstream& result, int depth, Ignored ignored);
 
 public:
     ~NestedListFormatter() override = default;

--- a/src/modules/complianceengine/src/lib/Evaluator.h
+++ b/src/modules/complianceengine/src/lib/Evaluator.h
@@ -47,7 +47,11 @@ class NestedListFormatter : public PayloadFormatter
         Yes
     };
     static const std::map<std::pair<Status, NestedListFormatter::Ignored>, const char*> sEmojiMap;
-    static constexpr std::size_t cMaxNodeIndicators = 5;
+    // To prevent excessively large payloads, we limit the number of
+    // compliant indicators shown for each node. The non-compliant indicators
+    // are not limited as they are more critical for understanding
+    // the compliance failures.
+    static constexpr std::size_t cMaxNodeCompliantIndicators = 5;
 
     static void FormatNode(const IndicatorsTree::Node& node, std::ostringstream& result, int depth, Ignored ignored);
 

--- a/src/modules/complianceengine/src/lib/Indicators.cpp
+++ b/src/modules/complianceengine/src/lib/Indicators.cpp
@@ -26,6 +26,11 @@ Status IndicatorsTree::NonCompliant(std::string message) &
     return AddIndicator(std::move(message), Status::NonCompliant);
 }
 
+Status IndicatorsTree::NotApplicable(std::string message) &
+{
+    return AddIndicator(std::move(message), Status::NotApplicable);
+}
+
 const IndicatorsTree::Node* IndicatorsTree::GetRootNode() const noexcept
 {
     return mTreeRoot.get();

--- a/src/modules/complianceengine/src/lib/Indicators.h
+++ b/src/modules/complianceengine/src/lib/Indicators.h
@@ -71,6 +71,9 @@ struct IndicatorsTree
     // Add a non-compliant indicator to the current node in the evaluation stack.
     Status NonCompliant(std::string message) &;
 
+    // Add a not applicable indicator to the current node in the evaluation stack.
+    Status NotApplicable(std::string message = "This procedure is not applicable") &;
+
     // Get the root node of the tree.
     const Node* GetRootNode() const noexcept;
 

--- a/src/modules/complianceengine/src/lib/MmiResults.h
+++ b/src/modules/complianceengine/src/lib/MmiResults.h
@@ -11,7 +11,8 @@ namespace ComplianceEngine
 enum class Status
 {
     Compliant,
-    NonCompliant
+    NonCompliant,
+    NotApplicable
 };
 
 struct AuditResult

--- a/src/modules/complianceengine/src/lib/ProcedureMap.cpp
+++ b/src/modules/complianceengine/src/lib/ProcedureMap.cpp
@@ -92,10 +92,10 @@ const char* Bindings<SystemdUnitStateParams>::names[] = {"unitName", "ActiveStat
 // TestingProcedures.h:15
 const char* Bindings<TestingProcedureParams>::names[] = {"message"};
 
-// TestingProcedures.h:27
+// TestingProcedures.h:29
 const char* Bindings<TestingProcedureParametrizedParams>::names[] = {"result"};
 
-// TestingProcedures.h:36
+// TestingProcedures.h:38
 const char* Bindings<TestingProcedureGetParamValuesParams>::names[] = {"KEY1", "KEY2", "KEY3"};
 
 // UfwStatus.h:16
@@ -104,6 +104,7 @@ const char* Bindings<AuditUfwStatusParams>::names[] = {"statusRegex"};
 const ProcedureMap Evaluator::mProcedureMap = {
     {"AuditFailure", {MakeHandler(AuditAuditFailure), nullptr}},
     {"AuditGetParamValues", {MakeHandler(AuditAuditGetParamValues), nullptr}},
+    {"AuditNotApplicable", {MakeHandler(AuditAuditNotApplicable), nullptr}},
     {"AuditSuccess", {MakeHandler(AuditAuditSuccess), nullptr}},
     {"AuditdRulesCheck", {MakeHandler(AuditAuditdRulesCheck), nullptr}},
     {"EnsureAccountsWithoutShellAreLocked", {MakeHandler(AuditEnsureAccountsWithoutShellAreLocked), nullptr}},
@@ -147,6 +148,7 @@ const ProcedureMap Evaluator::mProcedureMap = {
     {"LoginDefsOption", {MakeHandler(AuditLoginDefsOption), nullptr}},
     {"PackageInstalled", {MakeHandler(AuditPackageInstalled), nullptr}},
     {"RemediationFailure", {nullptr, MakeHandler(RemediateRemediationFailure)}},
+    {"RemediationNotApplicable", {nullptr, MakeHandler(RemediateRemediationNotApplicable)}},
     {"RemediationParametrized", {nullptr, MakeHandler(RemediateRemediationParametrized)}},
     {"RemediationSuccess", {nullptr, MakeHandler(RemediateRemediationSuccess)}},
     {"SCE", {MakeHandler(AuditSCE), MakeHandler(RemediateSCE)}},

--- a/src/modules/complianceengine/src/lib/procedures/EnsureSysctl.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/EnsureSysctl.cpp
@@ -24,6 +24,11 @@ Result<Status> AuditEnsureSysctl(const EnsureSysctlParams& params, IndicatorsTre
     auto output = context.GetFileContents(procSysPath);
     if (!output.HasValue())
     {
+        if (output.Error().code == ENOENT)
+        {
+            return indicators.NotApplicable("Sysctl '" + params.sysctlName + "' not found in runtime configuration");
+        }
+
         return output.Error();
     }
     std::string sysctlOutput = output.Value();

--- a/src/modules/complianceengine/src/lib/procedures/TestingProcedures.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/TestingProcedures.cpp
@@ -18,12 +18,22 @@ Result<Status> RemediateRemediationFailure(const TestingProcedureParams& params,
     return Status::NonCompliant;
 }
 
+Result<Status> RemediateRemediationNotApplicable(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context)
+{
+    UNUSED(context);
+    if (params.message.HasValue())
+    {
+        return indicators.NotApplicable(params.message.Value());
+    }
+    return Status::NotApplicable;
+}
+
 Result<Status> RemediateRemediationSuccess(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context)
 {
     UNUSED(context);
     if (params.message.HasValue())
     {
-        return indicators.NonCompliant(params.message.Value());
+        return indicators.Compliant(params.message.Value());
     }
     return Status::Compliant;
 }
@@ -46,6 +56,16 @@ Result<Status> AuditAuditSuccess(const TestingProcedureParams& params, Indicator
         return indicators.Compliant(params.message.Value());
     }
     return Status::Compliant;
+}
+
+Result<Status> AuditAuditNotApplicable(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context)
+{
+    UNUSED(context);
+    if (params.message.HasValue())
+    {
+        return indicators.NotApplicable(params.message.Value());
+    }
+    return Status::NotApplicable;
 }
 
 Result<Status> RemediateRemediationParametrized(const TestingProcedureParametrizedParams& params, IndicatorsTree& indicators, ContextInterface& context)

--- a/src/modules/complianceengine/src/lib/procedures/TestingProcedures.h
+++ b/src/modules/complianceengine/src/lib/procedures/TestingProcedures.h
@@ -16,8 +16,10 @@ struct TestingProcedureParams
 
 Result<Status> RemediateRemediationFailure(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context);
 Result<Status> RemediateRemediationSuccess(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context);
+Result<Status> RemediateRemediationNotApplicable(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context);
 Result<Status> AuditAuditFailure(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context);
 Result<Status> AuditAuditSuccess(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context);
+Result<Status> AuditAuditNotApplicable(const TestingProcedureParams& params, IndicatorsTree& indicators, ContextInterface& context);
 
 struct TestingProcedureParametrizedParams
 {

--- a/src/modules/complianceengine/src/lib/procedures/TestingProcedures.schema.json
+++ b/src/modules/complianceengine/src/lib/procedures/TestingProcedures.schema.json
@@ -51,6 +51,26 @@
         {
           "type": "object",
           "required": [
+            "AuditNotApplicable"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "AuditNotApplicable": {
+              "type": "object",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "description": "The message to be logged"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
             "AuditSuccess"
           ],
           "additionalProperties": false,
@@ -80,6 +100,26 @@
           "additionalProperties": false,
           "properties": {
             "RemediationFailure": {
+              "type": "object",
+              "required": [],
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "description": "The message to be logged"
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "RemediationNotApplicable"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "RemediationNotApplicable": {
               "type": "object",
               "required": [],
               "additionalProperties": false,

--- a/src/modules/complianceengine/tests/EvaluatorTest.cpp
+++ b/src/modules/complianceengine/tests/EvaluatorTest.cpp
@@ -519,3 +519,149 @@ TEST_F(EvaluatorTest, ExecuteRemediation_Parameters_7)
     ASSERT_TRUE(result);
     EXPECT_EQ(result.Value(), Status::Compliant);
 }
+
+// ── Three-valued logic (3VL) tests ────────────────────────────────────────────
+
+// not(N/A) → N/A
+TEST_F(EvaluatorTest, ThreeValuedLogic_Not_NotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"not\":{\"AuditNotApplicable\":{}}}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// not(not(N/A)) → N/A  (double negation preserves N/A)
+TEST_F(EvaluatorTest, ThreeValuedLogic_Not_Not_NotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"not\":{\"not\":{\"AuditNotApplicable\":{}}}}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// allOf([N/A]) → N/A  (only N/A, no absorbing element)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AllOf_OnlyNotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"allOf\":[{\"AuditNotApplicable\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// allOf([Compliant, N/A]) → N/A  (N/A contaminates a passing allOf)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AllOf_Compliant_NotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"allOf\":[{\"AuditSuccess\":{}},{\"AuditNotApplicable\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// allOf([N/A, Compliant]) → N/A  (order must not matter)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AllOf_NotApplicable_Compliant)
+{
+    auto json = JsonWrapper::FromString("{\"allOf\":[{\"AuditNotApplicable\":{}},{\"AuditSuccess\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// allOf([NonCompliant, N/A]) → NonCompliant  (NC absorbs N/A in allOf)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AllOf_NonCompliant_NotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"allOf\":[{\"AuditFailure\":{}},{\"AuditNotApplicable\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NonCompliant);
+}
+
+// allOf([N/A, NonCompliant]) → NonCompliant  (absorbing element reached after N/A)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AllOf_NotApplicable_NonCompliant)
+{
+    auto json = JsonWrapper::FromString("{\"allOf\":[{\"AuditNotApplicable\":{}},{\"AuditFailure\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NonCompliant);
+}
+
+// anyOf([N/A]) → N/A  (only N/A, no absorbing element)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AnyOf_OnlyNotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"anyOf\":[{\"AuditNotApplicable\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// anyOf([NonCompliant, N/A]) → N/A  (N/A contaminates a failing anyOf)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AnyOf_NonCompliant_NotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"anyOf\":[{\"AuditFailure\":{}},{\"AuditNotApplicable\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// anyOf([N/A, NonCompliant]) → N/A  (order must not matter)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AnyOf_NotApplicable_NonCompliant)
+{
+    auto json = JsonWrapper::FromString("{\"anyOf\":[{\"AuditNotApplicable\":{}},{\"AuditFailure\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::NotApplicable);
+}
+
+// anyOf([Compliant, N/A]) → Compliant  (C absorbs N/A in anyOf)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AnyOf_Compliant_NotApplicable)
+{
+    auto json = JsonWrapper::FromString("{\"anyOf\":[{\"AuditSuccess\":{}},{\"AuditNotApplicable\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::Compliant);
+}
+
+// anyOf([N/A, Compliant]) → Compliant  (absorbing element reached after N/A)
+TEST_F(EvaluatorTest, ThreeValuedLogic_AnyOf_NotApplicable_Compliant)
+{
+    auto json = JsonWrapper::FromString("{\"anyOf\":[{\"AuditNotApplicable\":{}},{\"AuditSuccess\":{}}]}");
+    ASSERT_TRUE(json.HasValue());
+    Evaluator evaluator("test", json_value_get_object(json->get()), mParameters, mContext);
+
+    auto result = evaluator.ExecuteAudit(mFormatter);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(result.Value().status, Status::Compliant);
+}


### PR DESCRIPTION
## Description

Introduce a new state to Compliance Engine.

### Rationale

We've started with Machine Configuration as our main direction which only accepts the `Compliant` or `NonCompliant` states. However, there are many rules that could benefit from N/A state. So far we've followed the NRP interface from the bottom, but the idea of this PR is to use such state, but only switch from N/A to C at the NRP interface level.


### Most notable changes
- A new label to the `Status` enum
- A new set of emojis for NRP interface phrase formatting - `NestedListFormatter`
- The logic follows the 3VL (`Compliant` - True, `NonCompliant` - False, `NotApplicable` - Undefined)
- Added a sinlge use-case in the `EnsureSysctl` procedure - if running inside containers some `procfs` files may not exist

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
