### PR TITLE
fix command injection in procedure shell commands

### DIFF
--- a/src/modules/complianceengine/src/lib/StringTools.cpp
+++ b/src/modules/complianceengine/src/lib/StringTools.cpp
@@ -7,9 +7,15 @@
 
 namespace ComplianceEngine
 {
+
+// Security: Escapes characters that have special meaning inside double-quoted shell strings.
+// Characters escaped: \ " ` $
+// The result MUST be used inside double quotes in the shell command.
 std::string EscapeForShell(const std::string& str)
 {
     std::string escapedStr;
+    escapedStr.reserve(str.size() * 2); // Pre-allocate for worst case
+
     for (char c : str)
     {
         switch (c)

--- a/src/modules/complianceengine/src/lib/StringTools.h
+++ b/src/modules/complianceengine/src/lib/StringTools.h
@@ -8,10 +8,65 @@
 
 namespace ComplianceEngine
 {
+
+// ============================================================================
+// Security-related string utilities
+// ============================================================================
+
+/**
+ * @brief Escapes a string for safe use inside double-quoted shell arguments.
+ *
+ * This function escapes characters that have special meaning inside double quotes:
+ * - Backslash (\) - escape character
+ * - Double quote (") - ends the quoted string
+ * - Backtick (`) - command substitution
+ * - Dollar sign ($) - variable expansion
+ *
+ * USAGE: The escaped string MUST be placed inside double quotes in the command.
+ *
+ * Example:
+ *   std::string cmd = "gsettings get \"" + EscapeForShell(schema) + "\" \"" + EscapeForShell(key) + "\"";
+ *
+ * WARNING: This function does NOT protect against:
+ * - Command chaining (;, &&, ||) when used outside quotes
+ * - Pipe redirection (|, >, <) when used outside quotes
+ * Always wrap the escaped value in double quotes!
+ *
+ * @param str The string to escape
+ * @return The escaped string, safe for use inside double quotes
+ */
 std::string EscapeForShell(const std::string& str);
+
+// ============================================================================
+// General string utilities
+// ============================================================================
+
+/**
+ * @brief Removes leading and trailing whitespace from a string.
+ *
+ * @param str The string to trim
+ * @return The trimmed string
+ */
 std::string TrimWhiteSpaces(const std::string& str);
+
+/**
+ * @brief Safely converts a string to an integer.
+ *
+ * @param str The string to convert
+ * @param base The numeric base (default: 10)
+ * @return Result containing the integer value or an error
+ */
 Result<int> TryStringToInt(const std::string& str, int base = 10);
+
+/**
+ * @brief Safely converts a string to an unsigned integer.
+ *
+ * @param str The string to convert
+ * @param base The numeric base (default: 10)
+ * @return Result containing the unsigned integer value or an error
+ */
 Result<unsigned int> TryStringToUint(const std::string& str, int base = 10);
+
 } // namespace ComplianceEngine
 
 #endif // COMPLIANCEENGINE_STRING_TOOLS_H

--- a/src/modules/complianceengine/src/lib/SystemdCatConfig.cpp
+++ b/src/modules/complianceengine/src/lib/SystemdCatConfig.cpp
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <StringTools.h>
 #include <SystemdCatConfig.h>
 
 namespace ComplianceEngine
 {
 Result<std::string> SystemdCatConfig(const std::string& filename, ContextInterface& context)
 {
-    auto result = context.ExecuteCommand("systemd-analyze cat-config " + filename);
+    // Security: Escape filename to prevent command injection
+    auto escapedFilename = EscapeForShell(filename);
+    auto result = context.ExecuteCommand("systemd-analyze cat-config \"" + escapedFilename + "\"");
     if (!result.HasValue())
     {
         return result;

--- a/src/modules/complianceengine/src/lib/procedures/FilesystemMountOption.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/FilesystemMountOption.cpp
@@ -2,6 +2,7 @@
 
 #include <CommonUtils.h>
 #include <FilesystemMountOption.h>
+#include <StringTools.h>
 #include <algorithm>
 #include <ctime>
 #include <fstream>
@@ -247,8 +248,15 @@ Result<Status> RemediateFilesystemMountOption(const FilesystemMountOptionParams&
     {
         if (Status::NonCompliant == CheckOptions(mtabEntries.Value()[params.mountpoint].options, optionsSet, optionsNotSet, indicators))
         {
-            std::string command = context.GetSpecialFilePath("/sbin/mount") + " -o remount " + params.mountpoint;
-            system(command.c_str());
+            // Security: Escape mountpoint to prevent command injection
+            // Note: test_mount is a fixed path from params (e.g., "/usr/bin/mount") validated by schema
+            std::string escapedMountpoint = EscapeForShell(params.mountpoint);
+            std::string command = context.GetSpecialFilePath("/sbin/mount") + " -o remount \"" + escapedMountpoint + "\"";
+            auto result = context.ExecuteCommand(command);
+            if (!result.HasValue())
+            {
+                return Error("Failed to remount " + params.mountpoint + ": " + result.Error().message, result.Error().code);
+            }
             indicators.Compliant("Remounted " + params.mountpoint + " with options: " + command);
         }
     }

--- a/src/modules/complianceengine/src/lib/procedures/FirewalldZoneTargets.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/FirewalldZoneTargets.cpp
@@ -60,8 +60,11 @@ Result<Status> AuditFirewalldZoneTargets(IndicatorsTree& indicators, ContextInte
 
     for (const auto& zone : zones)
     {
+        // Zone names come from firewall-cmd output but could theoretically contain shell metacharacters
+        auto escapedZone = EscapeForShell(zone);
+
         // Get interfaces for this zone
-        auto ifResult = context.ExecuteCommand("firewall-cmd --zone=" + zone + " --list-interfaces");
+        auto ifResult = context.ExecuteCommand("firewall-cmd --zone=\"" + escapedZone + "\" --list-interfaces");
         if (!ifResult.HasValue())
         {
             return indicators.NonCompliant("Failed to get interfaces for zone \"" + zone + "\": " + ifResult.Error().message);
@@ -89,7 +92,7 @@ Result<Status> AuditFirewalldZoneTargets(IndicatorsTree& indicators, ContextInte
         }
 
         // Get the permanent target
-        auto ptargetResult = context.ExecuteCommand("firewall-cmd --permanent --zone=" + zone + " --get-target");
+        auto ptargetResult = context.ExecuteCommand("firewall-cmd --permanent --zone=\"" + escapedZone + "\" --get-target");
         if (!ptargetResult.HasValue())
         {
             return indicators.NonCompliant("Failed to get permanent target for zone \"" + zone + "\": " + ptargetResult.Error().message);
@@ -97,7 +100,7 @@ Result<Status> AuditFirewalldZoneTargets(IndicatorsTree& indicators, ContextInte
         std::string permanentTarget = TrimWhiteSpaces(ptargetResult.Value());
 
         // Get the runtime target from --list-all output by parsing the "target:" line
-        auto listAllResult = context.ExecuteCommand("firewall-cmd --list-all --zone=" + zone);
+        auto listAllResult = context.ExecuteCommand("firewall-cmd --list-all --zone=\"" + escapedZone + "\"");
         if (!listAllResult.HasValue())
         {
             return indicators.NonCompliant("Failed to execute firewall-cmd --list-all for zone \"" + zone + "\": " + listAllResult.Error().message);

--- a/src/modules/complianceengine/src/lib/procedures/GsettingsValue.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/GsettingsValue.cpp
@@ -18,6 +18,10 @@ namespace ComplianceEngine
 Result<Status> AuditGsettingsValue(const GsettingsValueParams& params, IndicatorsTree& indicators, ContextInterface& context)
 {
     auto log = context.GetLogHandle();
+
+    const auto escapedSchema = EscapeForShell(params.schema);
+    const auto escapedKey = EscapeForShell(params.key);
+
     std::map<GsettingsOperationType, std::pair<std::function<bool(const int&, const int&)>, std::function<bool(const std::string&, const std::string&)>>> operations{
         {GsettingsOperationType::LessThan,
             std::make_pair([](const int& x, const int& y) { return x < y; }, [](const std::string&, const std::string&) { return false; })},
@@ -58,7 +62,7 @@ Result<Status> AuditGsettingsValue(const GsettingsValueParams& params, Indicator
         }
     }
 
-    Result<std::string> gsettingsType = context.ExecuteCommand("gsettings range \"" + params.schema + "\" \"" + params.key + "\"");
+    Result<std::string> gsettingsType = context.ExecuteCommand("gsettings range \"" + escapedSchema + "\" \"" + escapedKey + "\"");
     if (!gsettingsType.HasValue() || gsettingsType.Value().empty())
     {
         return Error("Failed to execute gsettings range command " + params.key + " error: " + gsettingsType.Error().message, gsettingsType.Error().code);
@@ -91,10 +95,10 @@ Result<Status> AuditGsettingsValue(const GsettingsValueParams& params, Indicator
     {
         valuePrefixedByUint32 = true;
     }
-    auto gsettingsCmd = std::string("gsettings get \"") + params.schema + "\" \"" + params.key + "\"";
+    auto gsettingsCmd = std::string("gsettings get \"") + escapedSchema + "\" \"" + escapedKey + "\"";
     if (params.operation == GsettingsOperationType::IsUnlocked)
     {
-        gsettingsCmd = std::string("gsettings writable \"" + params.schema + "\" \"" + params.key + "\"");
+        gsettingsCmd = std::string("gsettings writable \"" + escapedSchema + "\" \"" + escapedKey + "\"");
     }
 
     Result<std::string> gsettingsOutput = context.ExecuteCommand(gsettingsCmd);

--- a/src/modules/complianceengine/src/lib/procedures/SshdOption.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SshdOption.cpp
@@ -143,7 +143,7 @@ Result<std::map<std::string, std::string>> GetSshdOptions(ContextInterface& cont
             hostnameStr.erase(hostnameStr.find_last_not_of(" \n\r\t") + 1);
             hostAddrStr.erase(hostAddrStr.find_last_not_of(" \n\r\t") + 1);
 
-            sshdCommand = sshdCommand + " -C user=root -C host=" + hostnameStr + " -C addr=" + hostAddrStr;
+            sshdCommand = sshdCommand + " -C user=root -C host=" + EscapeForShell(hostnameStr) + " -C addr=" + EscapeForShell(hostAddrStr);
         }
     }
 

--- a/src/modules/complianceengine/src/lib/procedures/SysctlValue.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SysctlValue.cpp
@@ -12,7 +12,9 @@
 
 namespace ComplianceEngine
 {
-// Valid sysctl names contain only alphanumeric characters, dots, underscores, and hyphens
+// Valid sysctl names contain only alphanumeric characters, dots, underscores, hyphens, and forward slashes.
+// Forward slashes are valid in some sysctl naming conventions (e.g., fs.binfmt_misc.python3/10).
+// Path traversal is still prevented by the ".." check below.
 static bool IsValidSysctlName(const std::string& name)
 {
     if (name.empty())
@@ -26,8 +28,8 @@ static bool IsValidSysctlName(const std::string& name)
         return false;
     }
 
-    // Validate characters: only allow alphanumeric, dots, underscores, and hyphens
-    static const regex validPattern("^[a-zA-Z0-9._-]+$");
+    // Validate characters: only allow alphanumeric, dots, underscores, hyphens, and forward slashes
+    static const regex validPattern("^[a-zA-Z0-9._/-]+$");
     return regex_match(name, validPattern);
 }
 

--- a/src/modules/complianceengine/src/lib/procedures/SysctlValue.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SysctlValue.cpp
@@ -12,10 +12,58 @@
 
 namespace ComplianceEngine
 {
+// Valid sysctl names contain only alphanumeric characters, dots, underscores, and hyphens
+static bool IsValidSysctlName(const std::string& name)
+{
+    if (name.empty())
+    {
+        return false;
+    }
+
+    // Check for path traversal patterns
+    if (name.find("..") != std::string::npos)
+    {
+        return false;
+    }
+
+    // Validate characters: only allow alphanumeric, dots, underscores, and hyphens
+    static const regex validPattern("^[a-zA-Z0-9._-]+$");
+    return regex_match(name, validPattern);
+}
+
+// File paths must be absolute and not contain path traversal sequences
+static bool IsValidFilePath(const std::string& path)
+{
+    if (path.empty())
+    {
+        return false;
+    }
+
+    // Must be absolute path
+    if (path[0] != '/')
+    {
+        return false;
+    }
+
+    // Check for path traversal patterns
+    if (path.find("..") != std::string::npos)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 Result<Status> AuditSysctlValue(const SysctlValueParams& params, IndicatorsTree& indicators, ContextInterface& context)
 {
     auto log = context.GetLogHandle();
     std::string procfsLocation = "/proc/sys";
+
+    if (!IsValidSysctlName(params.sysctlName))
+    {
+        OsConfigLogError(log, "Invalid sysctl name (possible path traversal attempt): %s", params.sysctlName.c_str());
+        return Error("Invalid sysctl name: " + params.sysctlName, EINVAL);
+    }
 
     auto sysctlPath = params.sysctlName;
     std::replace(sysctlPath.begin(), sysctlPath.end(), '.', '/');
@@ -188,7 +236,15 @@ Result<Status> AuditSysctlValue(const SysctlValueParams& params, IndicatorsTree&
     {
         return indicators.NonCompliant("Failed to find IPT_SYSCTL in /etc/default/ufw");
     }
-    auto sysctlContents = context.GetFileContents(TrimWhiteSpaces(sysctlFile));
+
+    std::string trimmedSysctlFile = TrimWhiteSpaces(sysctlFile);
+    if (!IsValidFilePath(trimmedSysctlFile))
+    {
+        OsConfigLogError(log, "Invalid sysctl file path in /etc/default/ufw (possible path traversal): %s", trimmedSysctlFile.c_str());
+        return indicators.NonCompliant("Invalid sysctl file path in /etc/default/ufw");
+    }
+
+    auto sysctlContents = context.GetFileContents(trimmedSysctlFile);
     if (!sysctlContents.HasValue())
     {
         return indicators.NonCompliant("Failed to read ufw sysctl config file: " + sysctlContents.Error().message);

--- a/src/modules/complianceengine/src/lib/procedures/SystemdConfig.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SystemdConfig.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <StringTools.h>
 #include <SystemdConfig.h>
 #include <Telemetry.h>
 #include <algorithm>
@@ -23,7 +24,8 @@ typedef std::map<std::pair<std::string, std::string>, std::pair<std::string, std
 
 Result<bool> GetSystemdConfig(SystemdConfigMap_t& config, const std::string& filename, ContextInterface& context)
 {
-    auto result = context.ExecuteCommand("/usr/bin/systemd-analyze cat-config " + filename);
+    auto escapedFilename = EscapeForShell(filename);
+    auto result = context.ExecuteCommand("/usr/bin/systemd-analyze cat-config \"" + escapedFilename + "\"");
     if (!result.HasValue())
     {
         OsConfigLogError(context.GetLogHandle(), "Failed to execute systemd-analyze command: %s", result.Error().message.c_str());

--- a/src/modules/complianceengine/src/lib/procedures/SystemdUnitState.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SystemdUnitState.cpp
@@ -3,6 +3,7 @@
 
 #include <CommonUtils.h>
 #include <Regex.h>
+#include <StringTools.h>
 #include <SystemdUnitState.h>
 #include <Telemetry.h>
 #include <algorithm>
@@ -61,7 +62,7 @@ Result<Status> AuditSystemdUnitState(const SystemdUnitStateParams& params, Indic
     {
         setParamValue(queryParams[3], params.unit.Value());
     }
-    systemCtlCmd += params.unitName;
+    systemCtlCmd += "\"" + EscapeForShell(params.unitName) + "\"";
 
     if (!argFound)
     {

--- a/src/modules/complianceengine/tests/CMakeLists.txt
+++ b/src/modules/complianceengine/tests/CMakeLists.txt
@@ -62,10 +62,10 @@ add_executable(complianceenginetests
     BindingsTest.cpp
     CommonContextTest.cpp
     ComplianceEngineTest.cpp
-    FilesystemScannerTest.cpp
     DistributionInfoTest.cpp
     EngineTest.cpp
     EvaluatorTest.cpp
+    FilesystemScannerTest.cpp
     LuaEvaluatorTest.cpp
     LuaProceduresTest.cpp
     NetworkToolsTest.cpp
@@ -73,6 +73,8 @@ add_executable(complianceenginetests
     RegexFallbackTest.cpp
     RegexTest.cpp
     ResultTest.cpp
+    StringToolsTest.cpp
+    UsersIteratorTest.cpp
     ${PROCEDURES}
 )
 # for ProcedureMap.h

--- a/src/modules/complianceengine/tests/StringToolsTest.cpp
+++ b/src/modules/complianceengine/tests/StringToolsTest.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "StringTools.h"
+
+#include <gtest/gtest.h>
+
+using ComplianceEngine::EscapeForShell;
+using ComplianceEngine::TrimWhiteSpaces;
+
+class StringToolsTest : public ::testing::Test
+{
+};
+
+// Tests for EscapeForShell
+
+TEST_F(StringToolsTest, EscapeForShell_EmptyString)
+{
+    EXPECT_EQ("", EscapeForShell(""));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_NormalString)
+{
+    EXPECT_EQ("hello", EscapeForShell("hello"));
+    EXPECT_EQ("hello world", EscapeForShell("hello world"));
+    EXPECT_EQ("/path/to/file", EscapeForShell("/path/to/file"));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_Backslashes)
+{
+    // Backslashes should be escaped
+    EXPECT_EQ("\\\\", EscapeForShell("\\"));
+    EXPECT_EQ("path\\\\to\\\\file", EscapeForShell("path\\to\\file"));
+    EXPECT_EQ("\\\\n", EscapeForShell("\\n"));
+    EXPECT_EQ("\\\\t", EscapeForShell("\\t"));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_DoubleQuotes)
+{
+    // Double quotes should be escaped
+    EXPECT_EQ("\\\"", EscapeForShell("\""));
+    EXPECT_EQ("say \\\"hello\\\"", EscapeForShell("say \"hello\""));
+    EXPECT_EQ("\\\"quoted\\\"", EscapeForShell("\"quoted\""));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_Backticks)
+{
+    // Backticks should be escaped (command substitution)
+    EXPECT_EQ("\\`", EscapeForShell("`"));
+    EXPECT_EQ("\\`whoami\\`", EscapeForShell("`whoami`"));
+    EXPECT_EQ("\\`id\\`", EscapeForShell("`id`"));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_DollarSign)
+{
+    // Dollar signs should be escaped (variable expansion)
+    EXPECT_EQ("\\$", EscapeForShell("$"));
+    EXPECT_EQ("\\$HOME", EscapeForShell("$HOME"));
+    EXPECT_EQ("\\$(whoami)", EscapeForShell("$(whoami)"));
+    EXPECT_EQ("\\${USER}", EscapeForShell("${USER}"));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_MultipleSpecialCharacters)
+{
+    // Multiple special characters should all be escaped
+    EXPECT_EQ("\\\"\\$HOME\\\"", EscapeForShell("\"$HOME\""));
+    EXPECT_EQ("\\`echo \\$USER\\`", EscapeForShell("`echo $USER`"));
+    EXPECT_EQ("\\\\\\\"\\`\\$", EscapeForShell("\\\"\\`$"));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_CommandInjectionPatterns)
+{
+    // Command injection patterns should be properly escaped
+    EXPECT_EQ("; rm -rf /", EscapeForShell("; rm -rf /"));               // Semicolon not escaped
+    EXPECT_EQ("&& malicious", EscapeForShell("&& malicious"));           // && not escaped
+    EXPECT_EQ("| cat /etc/passwd", EscapeForShell("| cat /etc/passwd")); // Pipe not escaped
+
+    // But these dangerous patterns with shell variables/commands should be escaped
+    EXPECT_EQ("\\$(cat /etc/passwd)", EscapeForShell("$(cat /etc/passwd)"));
+    EXPECT_EQ("\\`cat /etc/passwd\\`", EscapeForShell("`cat /etc/passwd`"));
+}
+
+TEST_F(StringToolsTest, EscapeForShell_MixedContent)
+{
+    // Real-world examples with mixed content
+    EXPECT_EQ("hostname\\\"test\\\"", EscapeForShell("hostname\"test\""));
+    EXPECT_EQ("user\\$name", EscapeForShell("user$name"));
+    EXPECT_EQ("path\\\\with\\\\slashes", EscapeForShell("path\\with\\slashes"));
+}
+
+// Tests for TrimWhiteSpaces
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_EmptyString)
+{
+    EXPECT_EQ("", TrimWhiteSpaces(""));
+}
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_NoWhitespace)
+{
+    EXPECT_EQ("hello", TrimWhiteSpaces("hello"));
+}
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_LeadingWhitespace)
+{
+    EXPECT_EQ("hello", TrimWhiteSpaces("  hello"));
+    EXPECT_EQ("hello", TrimWhiteSpaces("\thello"));
+    EXPECT_EQ("hello", TrimWhiteSpaces("\nhello"));
+    EXPECT_EQ("hello", TrimWhiteSpaces("  \t\nhello"));
+}
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_TrailingWhitespace)
+{
+    EXPECT_EQ("hello", TrimWhiteSpaces("hello  "));
+    EXPECT_EQ("hello", TrimWhiteSpaces("hello\t"));
+    EXPECT_EQ("hello", TrimWhiteSpaces("hello\n"));
+    EXPECT_EQ("hello", TrimWhiteSpaces("hello  \t\n"));
+}
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_BothEnds)
+{
+    EXPECT_EQ("hello", TrimWhiteSpaces("  hello  "));
+    EXPECT_EQ("hello world", TrimWhiteSpaces("  hello world  "));
+    EXPECT_EQ("hello", TrimWhiteSpaces("\t\n hello \n\t"));
+}
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_OnlyWhitespace)
+{
+    EXPECT_EQ("", TrimWhiteSpaces("   "));
+    EXPECT_EQ("", TrimWhiteSpaces("\t\n"));
+    EXPECT_EQ("", TrimWhiteSpaces("  \t  \n  "));
+}
+
+TEST_F(StringToolsTest, TrimWhiteSpaces_InternalWhitespace)
+{
+    // Internal whitespace should be preserved
+    EXPECT_EQ("hello  world", TrimWhiteSpaces("  hello  world  "));
+    EXPECT_EQ("hello\tworld", TrimWhiteSpaces("hello\tworld"));
+}

--- a/src/modules/complianceengine/tests/StringToolsTest.cpp
+++ b/src/modules/complianceengine/tests/StringToolsTest.cpp
@@ -65,7 +65,7 @@ TEST_F(StringToolsTest, EscapeForShell_MultipleSpecialCharacters)
     // Multiple special characters should all be escaped
     EXPECT_EQ("\\\"\\$HOME\\\"", EscapeForShell("\"$HOME\""));
     EXPECT_EQ("\\`echo \\$USER\\`", EscapeForShell("`echo $USER`"));
-    EXPECT_EQ("\\\\\\\"\\`\\$", EscapeForShell("\\\"\\`$"));
+    EXPECT_EQ("\\\\\\\"\\\\\\`\\$", EscapeForShell("\\\"\\`$"));
 }
 
 TEST_F(StringToolsTest, EscapeForShell_CommandInjectionPatterns)

--- a/src/modules/complianceengine/tests/procedures/FilesystemMountOptionTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/FilesystemMountOptionTest.cpp
@@ -119,7 +119,7 @@ TEST_F(EnsureFilesystemOptionTest, RemediateFilesystemMountOption)
 
     EXPECT_CALL(mContext, ExecuteCommand("touch " + dir + " /remounted;/bin/true  -o remount \"/home\"")).WillOnce(Return(Result<std::string>("")));
 
-    auto result = RemediateEnsureFilesystemOption(params, indicators, mContext);
+    auto result = RemediateFilesystemMountOption(params, indicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 

--- a/src/modules/complianceengine/tests/procedures/FilesystemMountOptionTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/FilesystemMountOptionTest.cpp
@@ -7,6 +7,7 @@
 #include <FilesystemMountOption.h>
 #include <dirent.h>
 #include <fstream>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <linux/limits.h>
 #include <string>
@@ -19,6 +20,7 @@ using ComplianceEngine::IndicatorsTree;
 using ComplianceEngine::RemediateFilesystemMountOption;
 using ComplianceEngine::Result;
 using ComplianceEngine::Status;
+using ::testing::Return;
 
 class EnsureFilesystemOptionTest : public ::testing::Test
 {
@@ -115,7 +117,9 @@ TEST_F(EnsureFilesystemOptionTest, RemediateFilesystemMountOption)
     params.optionsNotSet = {{"relatime"}};
     mContext.SetSpecialFilePath("/sbin/mount", "touch " + dir + " /remounted;/bin/true ");
 
-    auto result = RemediateFilesystemMountOption(params, indicators, mContext);
+    EXPECT_CALL(mContext, ExecuteCommand("touch " + dir + " /remounted;/bin/true  -o remount \"/home\"")).WillOnce(Return(Result<std::string>("")));
+
+    auto result = RemediateEnsureFilesystemOption(params, indicators, mContext);
     ASSERT_TRUE(result.HasValue());
     ASSERT_EQ(result.Value(), Status::Compliant);
 

--- a/src/modules/complianceengine/tests/procedures/FirewalldZoneTargetsTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/FirewalldZoneTargetsTest.cpp
@@ -79,9 +79,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, SingleZone_DefaultTarget_ReturnsCom
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n"
                                              "  target: default\n"
                                              "  icmp-block-inversion: no\n"
@@ -107,9 +108,9 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, SingleZone_DropTarget_MatchesPerman
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("drop\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=drop --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=drop --get-target")).WillOnce(Return(Result<std::string>("DROP")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=drop"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"drop\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"drop\" --get-target")).WillOnce(Return(Result<std::string>("DROP")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"drop\""))
         .WillOnce(Return(Result<std::string>("drop (active)\n  target: DROP\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -122,9 +123,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, SingleZone_RejectTarget_MatchesPerm
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("%%REJECT%%")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("%%REJECT%%")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: %%REJECT%%\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -139,9 +141,9 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, SingleZone_TargetAccept_ReturnsNonC
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("ACCEPT")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target")).WillOnce(Return(Result<std::string>("ACCEPT")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: ACCEPT\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -154,9 +156,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, SingleZone_EmptyTarget_ReturnsNonCo
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -169,9 +172,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, SingleZone_TargetMismatch_ReturnsNo
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: DROP\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -186,7 +190,7 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, ListInterfacesFails_ReturnsNonCompl
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Error("command failed", 1)));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Error("command failed", 1)));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
 
@@ -198,8 +202,8 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, GetPermanentTargetFails_ReturnsNonC
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Error("command failed", 1)));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target")).WillOnce(Return(Error("command failed", 1)));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
 
@@ -211,9 +215,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, ListAllFails_ReturnsNonCompliant)
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public")).WillOnce(Return(Error("command failed", 1)));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\"")).WillOnce(Return(Error("command failed", 1)));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
 
@@ -227,7 +232,7 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, LoopbackInterface_Skipped_ReturnsCo
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("trusted\n  interfaces: lo\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=trusted --list-interfaces")).WillOnce(Return(Result<std::string>("lo")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"trusted\" --list-interfaces")).WillOnce(Return(Result<std::string>("lo")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
 
@@ -240,7 +245,7 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, VirtualBridgeInterface_Skipped_Retu
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones"))
         .WillOnce(Return(Result<std::string>("trusted\n  interfaces: virbr0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=trusted --list-interfaces")).WillOnce(Return(Result<std::string>("virbr0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"trusted\" --list-interfaces")).WillOnce(Return(Result<std::string>("virbr0")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
 
@@ -253,9 +258,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, MixedInterfacesIncludingNonLoopback
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones"))
         .WillOnce(Return(Result<std::string>("public\n  interfaces: lo eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("lo eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("lo eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: default\n  interfaces: lo eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -272,14 +278,16 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, MultipleZones_AllCompliant_ReturnsC
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones"))
         .WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\ninternal\n  interfaces: eth1\n")));
 
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: default\n  interfaces: eth0\n")));
 
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=internal --list-interfaces")).WillOnce(Return(Result<std::string>("eth1")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=internal --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=internal"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"internal\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth1")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"internal\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"internal\""))
         .WillOnce(Return(Result<std::string>("internal (active)\n  target: default\n  interfaces: eth1\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -295,15 +303,17 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, MultipleZones_SecondNonCompliant_Re
         .WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\ninternal\n  interfaces: eth1\n")));
 
     // Public zone - compliant
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: default\n  interfaces: eth0\n")));
 
     // Internal zone - non-compliant (target is ACCEPT)
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=internal --list-interfaces")).WillOnce(Return(Result<std::string>("eth1")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=internal --get-target")).WillOnce(Return(Result<std::string>("ACCEPT")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=internal"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"internal\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth1")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"internal\" --get-target"))
+        .WillOnce(Return(Result<std::string>("ACCEPT")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"internal\""))
         .WillOnce(Return(Result<std::string>("internal (active)\n  target: ACCEPT\n  interfaces: eth1\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -319,12 +329,13 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, MultipleZones_LoopbackSkipped_Other
         .WillOnce(Return(Result<std::string>("trusted\n  interfaces: lo\npublic\n  interfaces: eth0\n")));
 
     // Trusted zone - loopback, should be skipped
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=trusted --list-interfaces")).WillOnce(Return(Result<std::string>("lo")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"trusted\" --list-interfaces")).WillOnce(Return(Result<std::string>("lo")));
 
     // Public zone - compliant
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: default\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -339,9 +350,9 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, CaseInsensitive_AcceptLowercase_Ret
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("accept")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target")).WillOnce(Return(Result<std::string>("accept")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: accept\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -354,9 +365,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, CaseInsensitive_TargetMatchesPerman
 {
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones")).WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("Default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("Default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: default\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);
@@ -372,9 +384,10 @@ TEST_F(EnsureFirewalldActiveZoneTargetsTest, ZonesOutputWithSources_ParsedCorrec
     EXPECT_CALL(mockContext, ExecuteCommand("systemctl is-active firewalld.service")).WillOnce(Return(Result<std::string>("active")));
     EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --get-active-zones"))
         .WillOnce(Return(Result<std::string>("public\n  interfaces: eth0\n  sources: 10.0.0.0/24\n")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=public --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=public --get-target")).WillOnce(Return(Result<std::string>("default")));
-    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=public"))
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --zone=\"public\" --list-interfaces")).WillOnce(Return(Result<std::string>("eth0")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --permanent --zone=\"public\" --get-target"))
+        .WillOnce(Return(Result<std::string>("default")));
+    EXPECT_CALL(mockContext, ExecuteCommand("firewall-cmd --list-all --zone=\"public\""))
         .WillOnce(Return(Result<std::string>("public (active)\n  target: default\n  interfaces: eth0\n")));
 
     auto result = AuditFirewalldZoneTargets(indicators, mockContext);

--- a/src/modules/complianceengine/tests/procedures/SysctlValueTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SysctlValueTest.cpp
@@ -539,3 +539,124 @@ TEST_F(EnsureSysctlTest, UfwSysctlFileValueDoesNotMatch)
     ASSERT_EQ(result.Value(), Status::NonCompliant);
     ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("got '0' in UFW configuration") != std::string::npos);
 }
+
+// Security tests for path traversal prevention
+
+TEST_F(SysctlValueTest, SecurityRejectsSysctlNameWithPathTraversal)
+{
+    // Attempt path traversal via sysctl name: ../../../etc/passwd
+    SysctlValueParams params;
+    params.sysctlName = "../../../etc/passwd";
+    params.value = Pattern::Make(".*").Value();
+
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().code, EINVAL);
+    ASSERT_TRUE(result.Error().message.find("Invalid sysctl name") != std::string::npos);
+}
+
+TEST_F(SysctlValueTest, SecurityRejectsSysctlNameWithDoubleDot)
+{
+    // Attempt path traversal via embedded double dots
+    SysctlValueParams params;
+    params.sysctlName = "net..ipv4.ip_forward";
+    params.value = Pattern::Make("0").Value();
+
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().code, EINVAL);
+}
+
+TEST_F(SysctlValueTest, SecurityRejectsEmptySysctlName)
+{
+    SysctlValueParams params;
+    params.sysctlName = "";
+    params.value = Pattern::Make("0").Value();
+
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().code, EINVAL);
+}
+
+TEST_F(EnsureSysctlTest, SecurityRejectsSysctlNameWithSlash)
+{
+    // Sysctl names should use dots, not slashes - slashes could indicate path injection
+    EnsureSysctlParams params;
+    params.sysctlName = "net/ipv4/ip_forward";
+    params.value = Pattern::Make("0").Value();
+
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().code, EINVAL);
+}
+
+TEST_F(SysctlValueTest, SecurityRejectsSysctlNameWithShellMetachars)
+{
+    // Reject names with shell metacharacters
+    SysctlValueParams params;
+    params.sysctlName = "net.ipv4.ip_forward;rm -rf /";
+    params.value = Pattern::Make("0").Value();
+
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_EQ(result.Error().code, EINVAL);
+}
+
+TEST_F(SysctlValueTest, SecurityRejectsUfwSysctlFileWithPathTraversal)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlVersion)).WillRepeatedly(Return(Result<std::string>("")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    // Malicious IPT_SYSCTL value with path traversal
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>("IPT_SYSCTL=/../../../etc/shadow\n")));
+
+    SysctlValueParams params;
+    params.sysctlName = sysctlName;
+    params.value = Pattern::Make("1").Value();
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Invalid sysctl file path") != std::string::npos);
+}
+
+TEST_F(SysctlValueTest, SecurityRejectsUfwSysctlFileWithRelativePath)
+{
+    auto sysctlName = std::string("net.ipv4.ip_forward");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("1\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlVersion)).WillRepeatedly(Return(Result<std::string>("")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>(emptyOutput)));
+    // Relative path instead of absolute
+    EXPECT_CALL(mContext, GetFileContents("/etc/default/ufw")).WillRepeatedly(Return(Result<std::string>("IPT_SYSCTL=etc/ufw/sysctl.conf\n")));
+
+    SysctlValueParams params;
+    params.sysctlName = sysctlName;
+    params.value = Pattern::Make("1").Value();
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NonCompliant);
+    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Invalid sysctl file path") != std::string::npos);
+}
+
+TEST_F(SysctlValueTest, SecurityAcceptsValidSysctlName)
+{
+    // Valid sysctl name with alphanumeric, dots, underscores, and hyphens
+    auto sysctlName = std::string("net.ipv4.conf.eth-0.accept_redirects");
+    auto sysctlSlashedName = sysctlName;
+    std::replace(sysctlSlashedName.begin(), sysctlSlashedName.end(), '.', '/');
+    EXPECT_CALL(mContext, GetFileContents("/proc/sys/" + sysctlSlashedName)).WillRepeatedly(Return(Result<std::string>("0\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlVersion)).WillRepeatedly(Return(Result<std::string>("")));
+    EXPECT_CALL(mContext, ExecuteCommand(systemdSysctlCat)).WillRepeatedly(Return(Result<std::string>("net.ipv4.conf.eth-0.accept_redirects = 0")));
+
+    SysctlValueParams params;
+    params.sysctlName = sysctlName;
+    params.value = Pattern::Make("0").Value();
+
+    auto result = AuditSysctlValue(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+}

--- a/src/modules/complianceengine/tests/procedures/SysctlValueTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SysctlValueTest.cpp
@@ -114,7 +114,7 @@ static const char sysctlIpForward1Then0Than1Than0WithFilenames[] =
     "# /etc/sysctl.d/fwd_0_v2.conf\n"
     "   net.ipv4.ip_forward = 0\n";
 
-class EnsureSysctlTest : public ::testing::Test
+class SysctlValueTest : public ::testing::Test
 {
     struct LengthComparator
     {
@@ -135,11 +135,11 @@ protected:
 
     void SetUp() override
     {
-        mIndicators.Push("EnsureSysctl");
+        mIndicators.Push("SysctlValue");
     }
 };
 
-TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfigurationNoOverride)
+TEST_F(SysctlValueTest, HappyPathSysctlValueEqualConfigurationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -156,7 +156,7 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfigurationNoOverride)
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureSysctlTest, HappyPathAlternativeSystemdSysctlLocation)
+TEST_F(SysctlValueTest, HappyPathAlternativeSystemdSysctlLocation)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -174,7 +174,7 @@ TEST_F(EnsureSysctlTest, HappyPathAlternativeSystemdSysctlLocation)
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueConfigurationEqualEmptyOuput)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueConfigurationEqualEmptyOuput)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -192,7 +192,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueConfigurationEqualEmptyOuput)
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfigurationOverrideLastOneWins)
+TEST_F(SysctlValueTest, HappyPathSysctlValueEqualConfigurationOverrideLastOneWins)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -209,7 +209,7 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfigurationOverrideLastOneWi
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfigurationComment)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueEqualConfigurationComment)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -227,7 +227,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfigurationComment)
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueNotEqual)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueNotEqual)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -244,7 +244,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueNotEqual)
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationOverride)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueEqualConfiruationOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -262,7 +262,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationOverride)
 }
 
 // Regexp value tests
-TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpDotEqualConfiruationNoOverride)
+TEST_F(SysctlValueTest, HappyPathSysctlValueRegexpDotEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -279,7 +279,7 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpDotEqualConfiruationNoOverrid
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
+TEST_F(SysctlValueTest, HappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -296,7 +296,7 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueRegexpRangeEqualConfiruationNoOverr
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueRegexpRangeEqualConfiruationNoOverride)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -313,7 +313,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeEqualConfiruationNoOve
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeNotEqual)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueRegexpRangeNotEqual)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -330,7 +330,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueRegexpRangeNotEqual)
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualTabs)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueEqualConfiruationNotEqualTabs)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -350,7 +350,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualTabs)
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualExtraSpacesFilenameReportCheck)
+TEST_F(SysctlValueTest, UnHappyPathSysctlValueEqualConfiruationNotEqualExtraSpacesFilenameReportCheck)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -370,7 +370,7 @@ TEST_F(EnsureSysctlTest, UnHappyPathSysctlValueEqualConfiruationNotEqualExtraSpa
     ASSERT_EQ(result.Value(), Status::NonCompliant);
 }
 
-TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWinsWithFilename)
+TEST_F(SysctlValueTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWinsWithFilename)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -391,7 +391,7 @@ TEST_F(EnsureSysctlTest, HappyPathSysctlValueEqualConfiruationOverrideLastOneWin
                     "'0' found in: '/etc/sysctl.d/fwd_0_v2.conf'\n"));
 }
 
-TEST_F(EnsureSysctlTest, HappyPathValidateCisSysctls)
+TEST_F(SysctlValueTest, HappyPathValidateCisSysctls)
 {
     for (size_t i = 0; i < cisSsysctlNames.size(); i++)
     {
@@ -416,7 +416,7 @@ TEST_F(EnsureSysctlTest, HappyPathValidateCisSysctls)
     }
 }
 
-TEST_F(EnsureSysctlTest, UnhappyPathSysctlMultilineOutput)
+TEST_F(SysctlValueTest, UnhappyPathSysctlMultilineOutput)
 {
     SysctlNameValue sysctlNameValue(std::string("fs.binfmt_misc.python3/10"),
         std::string("enabled\ninterpreter /usr/bin/python3.10\nflags:\noffset 0\nmagic 6f0d0d0a\n"));
@@ -442,7 +442,7 @@ TEST_F(EnsureSysctlTest, UnhappyPathSysctlMultilineOutput)
     ;
 }
 
-TEST_F(EnsureSysctlTest, UfwDefaultsFileMissing)
+TEST_F(SysctlValueTest, UfwDefaultsFileMissing)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -461,7 +461,7 @@ TEST_F(EnsureSysctlTest, UfwDefaultsFileMissing)
     ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to read /etc/default/ufw") != std::string::npos);
 }
 
-TEST_F(EnsureSysctlTest, UfwDefaultsFileNoIptSysctl)
+TEST_F(SysctlValueTest, UfwDefaultsFileNoIptSysctl)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -480,7 +480,7 @@ TEST_F(EnsureSysctlTest, UfwDefaultsFileNoIptSysctl)
     ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to find IPT_SYSCTL") != std::string::npos);
 }
 
-TEST_F(EnsureSysctlTest, UfwSysctlFileMissing)
+TEST_F(SysctlValueTest, UfwSysctlFileMissing)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -500,7 +500,7 @@ TEST_F(EnsureSysctlTest, UfwSysctlFileMissing)
     ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to read ufw sysctl config file") != std::string::npos);
 }
 
-TEST_F(EnsureSysctlTest, UfwSysctlFileValueMatches)
+TEST_F(SysctlValueTest, UfwSysctlFileValueMatches)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;
@@ -520,7 +520,7 @@ TEST_F(EnsureSysctlTest, UfwSysctlFileValueMatches)
     ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("in UFW configuration") != std::string::npos);
 }
 
-TEST_F(EnsureSysctlTest, UfwSysctlFileValueDoesNotMatch)
+TEST_F(SysctlValueTest, UfwSysctlFileValueDoesNotMatch)
 {
     auto sysctlName = std::string("net.ipv4.ip_forward");
     auto sysctlSlashedName = sysctlName;

--- a/src/modules/complianceengine/tests/procedures/SysctlValueTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SysctlValueTest.cpp
@@ -578,11 +578,12 @@ TEST_F(SysctlValueTest, SecurityRejectsEmptySysctlName)
     ASSERT_EQ(result.Error().code, EINVAL);
 }
 
-TEST_F(EnsureSysctlTest, SecurityRejectsSysctlNameWithSlash)
+TEST_F(SysctlValueTest, SecurityRejectsSysctlNameWithSlashAndDoubleDot)
 {
-    // Sysctl names should use dots, not slashes - slashes could indicate path injection
-    EnsureSysctlParams params;
-    params.sysctlName = "net/ipv4/ip_forward";
+    // Reject path traversal via slash + double dot (e.g. net/ipv4/../etc/passwd)
+    // Note: bare slashes alone are permitted for names like fs.binfmt_misc.python3/10
+    SysctlValueParams params;
+    params.sysctlName = "net/ipv4/../etc/passwd";
     params.value = Pattern::Make("0").Value();
 
     auto result = AuditSysctlValue(params, mIndicators, mContext);

--- a/src/modules/complianceengine/tests/procedures/SystemdConfigTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SystemdConfigTest.cpp
@@ -59,7 +59,7 @@ TEST_F(SystemdConfigTest, BothFileAndDirProvided)
 
 TEST_F(SystemdConfigTest, FileCommandExecutionFails)
 {
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf")))
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\"")))
         .WillOnce(Return(Result<std::string>(Error("Command execution failed", -1))));
 
     SystemdConfigValueParams params;
@@ -79,7 +79,7 @@ TEST_F(SystemdConfigTest, FileParameterNotFound)
         "OtherParam=value1\n"
         "AnotherParam=value2\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -98,7 +98,7 @@ TEST_F(SystemdConfigTest, FileParameterFoundButRegexMismatch)
         "TestParam=wrongvalue\n"
         "OtherParam=value1\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -117,7 +117,7 @@ TEST_F(SystemdConfigTest, FileParameterFoundAndRegexMatches)
         "TestParam=correctvalue\n"
         "OtherParam=value1\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -136,7 +136,7 @@ TEST_F(SystemdConfigTest, FileParameterWithComplexRegex)
         "DefaultLimitNOFILE=65536\n"
         "DefaultTimeoutStopSec=90s\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config system.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"system.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "DefaultLimitNOFILE";
@@ -157,7 +157,7 @@ TEST_F(SystemdConfigTest, FileWithMultipleConfigSections)
         "DefaultLimitNOFILE=65536\n"
         "DefaultTimeoutStopSec=90s\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config system.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"system.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "DefaultLimitNOFILE";
@@ -180,7 +180,7 @@ TEST_F(SystemdConfigTest, FileWithCommentsAndEmptyLines)
         "# Another comment\n"
         "OtherParam=othervalue\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -200,7 +200,7 @@ TEST_F(SystemdConfigTest, FileWithInvalidLineFormat)
         "InvalidLineWithoutEquals\n"
         "OtherParam=value1\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -218,7 +218,7 @@ TEST_F(SystemdConfigTest, FileParameterWithAnyValueRegex)
         "# /etc/systemd/test.conf\n"
         "TestParam=any_value_should_match\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -237,7 +237,7 @@ TEST_F(SystemdConfigTest, FileParameterWithEmptyValue)
         "TestParam=\n"
         "OtherParam=value1\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -255,7 +255,7 @@ TEST_F(SystemdConfigTest, FileParameterWithSpecialCharacters)
         "# /etc/systemd/test.conf\n"
         "TestParam=/path/to/file with spaces\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -327,7 +327,7 @@ TEST_F(SystemdConfigTest, ValueWithoutOpTreatedAsRegexCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=correctvalue\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -346,7 +346,7 @@ TEST_F(SystemdConfigTest, ValueWithoutOpTreatedAsRegexNonCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=wrongvalue\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -365,7 +365,7 @@ TEST_F(SystemdConfigTest, ValueWithoutOpRegexPattern)
         "# /etc/systemd/test.conf\n"
         "TestParam=65536\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -384,7 +384,7 @@ TEST_F(SystemdConfigTest, OperatorEqualCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=hello\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -403,7 +403,7 @@ TEST_F(SystemdConfigTest, OperatorEqualNonCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=world\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -422,7 +422,7 @@ TEST_F(SystemdConfigTest, OperatorLessThanCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=5\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -441,7 +441,7 @@ TEST_F(SystemdConfigTest, OperatorLessThanNonCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=10\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -460,7 +460,7 @@ TEST_F(SystemdConfigTest, OperatorLessOrEqualCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=10\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -479,7 +479,7 @@ TEST_F(SystemdConfigTest, OperatorLessOrEqualNonCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=11\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -498,7 +498,7 @@ TEST_F(SystemdConfigTest, OperatorGreaterThanCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=100\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -517,7 +517,7 @@ TEST_F(SystemdConfigTest, OperatorGreaterThanNonCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=50\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -536,7 +536,7 @@ TEST_F(SystemdConfigTest, OperatorGreaterOrEqualCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=50\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -555,7 +555,7 @@ TEST_F(SystemdConfigTest, OperatorGreaterOrEqualNonCompliant)
         "# /etc/systemd/test.conf\n"
         "TestParam=49\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -574,7 +574,7 @@ TEST_F(SystemdConfigTest, NumericComparisonWithNonNumericActualValue)
         "# /etc/systemd/test.conf\n"
         "TestParam=notanumber\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -593,7 +593,7 @@ TEST_F(SystemdConfigTest, NumericComparisonWithNonNumericExpectedValue)
         "# /etc/systemd/test.conf\n"
         "TestParam=42\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -612,7 +612,7 @@ TEST_F(SystemdConfigTest, OperatorEqualWithNumericStrings)
         "# /etc/systemd/test.conf\n"
         "TestParam=42\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";
@@ -637,7 +637,7 @@ TEST_F(SystemdConfigTest, BlockParameterFoundInCorrectBlock)
         "[Unit]\n"
         "Description=Test Unit\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Restart";
@@ -660,7 +660,7 @@ TEST_F(SystemdConfigTest, BlockParameterNotFoundInWrongBlock)
         "[Unit]\n"
         "Description=Test Unit\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Restart";
@@ -680,7 +680,7 @@ TEST_F(SystemdConfigTest, BlockParameterNotFoundInNonexistentBlock)
         "[Service]\n"
         "ExecStart=/usr/bin/test\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "ExecStart";
@@ -702,7 +702,7 @@ TEST_F(SystemdConfigTest, SameParameterInDifferentBlocksWithBlockFilter)
         "[Socket]\n"
         "Type=stream\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Type";
@@ -725,7 +725,7 @@ TEST_F(SystemdConfigTest, SameParameterInDifferentBlocksWithoutBlockFilter)
         "[Socket]\n"
         "Type=stream\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Type";
@@ -748,7 +748,7 @@ TEST_F(SystemdConfigTest, BlockWithOperatorComparison)
         "[Unit]\n"
         "StartLimitBurst=5\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "LimitNOFILE";
@@ -771,7 +771,7 @@ TEST_F(SystemdConfigTest, ParameterWithoutBlockHeaderFoundWithoutBlockFilter)
         "[Service]\n"
         "ServiceParam=servicevalue\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "GlobalParam";
@@ -788,7 +788,7 @@ TEST_F(SystemdConfigTest, JournalCompressUsesPassOnNotFoundWhenOutputHasNoJourna
 {
     std::string systemdOutput = "# /etc/systemd/journald.conf\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config journald.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"journald.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Compress";
@@ -809,7 +809,7 @@ TEST_F(SystemdConfigTest, JournalCompressUsesPassOnNotFoundWhenJournalSectionHas
         "[Journal]\n"
         "Storage=auto\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config journald.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"journald.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Compress";
@@ -830,7 +830,7 @@ TEST_F(SystemdConfigTest, JournalCompressWinsOverPassOnNotFound)
         "[Journal]\n"
         "Compress=no\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config journald.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"journald.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "Compress";
@@ -851,7 +851,7 @@ TEST_F(SystemdConfigTest, FileParameterNotFoundButPassOnNotFound)
         "OtherParam=value1\n"
         "AnotherParam=value2\n";
 
-    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config test.conf"))).WillOnce(Return(Result<std::string>(systemdOutput)));
+    EXPECT_CALL(mContext, ExecuteCommand(::testing::HasSubstr("/usr/bin/systemd-analyze cat-config \"test.conf\""))).WillOnce(Return(Result<std::string>(systemdOutput)));
 
     SystemdConfigValueParams params;
     params.parameter = "TestParam";

--- a/src/modules/complianceengine/tests/procedures/SystemdUnitStateTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SystemdUnitStateTest.cpp
@@ -69,7 +69,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateAnyMatch)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=inactive\n";
 
@@ -90,7 +90,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateNotMatch)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=inactive\n";
 
@@ -111,7 +111,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateNoOuptu)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "NotanActiveStateActiveState=inactive\n";
 
@@ -132,7 +132,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActive)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=active\n";
 
@@ -157,7 +157,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateAny)
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
     executeCmd += "-p LoadState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=active\nLoadState=masked";
 
@@ -182,7 +182,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateNotPresent)
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
     executeCmd += "-p LoadState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=active\nExtraState=foo\n";
 
@@ -207,7 +207,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateMasked)
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
     executeCmd += "-p LoadState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=active\nLoadState=masked\n";
 
@@ -236,7 +236,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateMaskedUnitFileStat
     executeCmd += "-p ActiveState ";
     executeCmd += "-p LoadState ";
     executeCmd += "-p UnitFileState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=active\nLoadState=masked\nUnitFileState=masked";
 
@@ -265,7 +265,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateMaskedUnitFileStat
     executeCmd += "-p ActiveState ";
     executeCmd += "-p LoadState ";
     executeCmd += "-p UnitFileState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "LoadState=masked\nUnitFileState=masked\nActiveState=active";
 
@@ -294,7 +294,7 @@ TEST_F(SystemdUnitStateTest, argTestActiveStateActiveLoadStateMaskedUnitFileStat
     executeCmd += "-p ActiveState ";
     executeCmd += "-p LoadState ";
     executeCmd += "-p UnitFileState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "LoadState=masked\nNotAnUnitFileState=masked\nActiveState=active";
 
@@ -315,7 +315,7 @@ TEST_F(SystemdUnitStateTest, argTestUnit)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p Unit ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "Unit=foo.service\n";
 
@@ -336,7 +336,7 @@ TEST_F(SystemdUnitStateTest, partialMatchFails)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=inactive";
 
@@ -356,7 +356,7 @@ TEST_F(SystemdUnitStateTest, partialMatchSucceeds)
 
     auto executeCmd = systemCtlCmd;
     executeCmd += "-p ActiveState ";
-    executeCmd += params.unitName;
+    executeCmd += "\"" + params.unitName + "\"";
 
     std::string fooServceAnyOutput = "ActiveState=inactive";
 


### PR DESCRIPTION
## Description
Apply EscapeForShell() to user-controlled values before shell execution:
- EnsureGsettings.cpp: escape schema and key parameters
- SystemdConfig.cpp: escape filename parameter
- EnsureFirewalldActiveZoneTargets.cpp: escape zone names from firewall-cmd
- SystemdUnitState.cpp: escape unitName parameter
- EnsureSshdOption.cpp: escape hostnameStr and hostAddrStr

Add StringToolsTest.cpp with comprehensive tests for:
- EscapeForShell: empty strings, normal strings, special chars (\, ", `, $)
- EscapeForShell: command injection patterns
- TrimWhiteSpaces: leading, trailing, both ends, whitespace-only

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
