### PR TITLE
RootPathSecurity: invoke sudo with -n to avoid blocking on a tty

### DIFF
--- a/src/modules/complianceengine/src/lib/procedures/RootPathSecurity.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/RootPathSecurity.cpp
@@ -14,7 +14,10 @@ Result<Status> AuditRootPathSecurity(IndicatorsTree& indicators, ContextInterfac
     // Directory must not be world- or group-writable
     const int maxPerm = 0777 & ~0022;
     // We're using sudo to get the proper root login shell, with the whole environment loaded.
-    auto rootEnv = context.ExecuteCommand("sudo -Hiu root env");
+    // -n (non-interactive) prevents sudo from blocking on a password prompt when the caller
+    // lacks a cached credential; it fails immediately so the assessor reports NonCompliant
+    // instead of hanging on a tty.
+    auto rootEnv = context.ExecuteCommand("sudo -n -Hiu root env");
     if (!rootEnv.HasValue())
     {
         return indicators.NonCompliant("Failed to run sudo: " + rootEnv.Error().message);

--- a/src/modules/complianceengine/tests/procedures/RootPathSecurityTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/RootPathSecurityTest.cpp
@@ -37,7 +37,7 @@ protected:
 
 TEST_F(EnsureRootPathTest, AuditRootPathCompliant)
 {
-    EXPECT_CALL(mContext, ExecuteCommand("sudo -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:/usr/bin:/sbin:/usr/sbin")));
+    EXPECT_CALL(mContext, ExecuteCommand("sudo -n -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:/usr/bin:/sbin:/usr/sbin")));
 
     auto result = AuditRootPathSecurity(indicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -46,7 +46,7 @@ TEST_F(EnsureRootPathTest, AuditRootPathCompliant)
 
 TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantEmptyDirectory)
 {
-    EXPECT_CALL(mContext, ExecuteCommand("sudo -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin::/usr/bin:/sbin:/usr/sbin")));
+    EXPECT_CALL(mContext, ExecuteCommand("sudo -n -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin::/usr/bin:/sbin:/usr/sbin")));
 
     auto result = AuditRootPathSecurity(indicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -55,7 +55,7 @@ TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantEmptyDirectory)
 
 TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantTrailingColon)
 {
-    EXPECT_CALL(mContext, ExecuteCommand("sudo -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:/usr/bin:/sbin:/usr/sbin:")));
+    EXPECT_CALL(mContext, ExecuteCommand("sudo -n -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:/usr/bin:/sbin:/usr/sbin:")));
 
     auto result = AuditRootPathSecurity(indicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -64,7 +64,7 @@ TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantTrailingColon)
 
 TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantCurrentDirectory)
 {
-    EXPECT_CALL(mContext, ExecuteCommand("sudo -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:.:/usr/bin:/sbin:/usr/sbin")));
+    EXPECT_CALL(mContext, ExecuteCommand("sudo -n -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:.:/usr/bin:/sbin:/usr/sbin")));
 
     auto result = AuditRootPathSecurity(indicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -73,7 +73,7 @@ TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantCurrentDirectory)
 
 TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantDirectoryOwnership)
 {
-    EXPECT_CALL(mContext, ExecuteCommand("sudo -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=" + path + "/bin:/usr/bin:/sbin:/usr/sbin")));
+    EXPECT_CALL(mContext, ExecuteCommand("sudo -n -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=" + path + "/bin:/usr/bin:/sbin:/usr/sbin")));
 
     ASSERT_EQ(chmod(path.c_str(), 0755), 0);
     // Either we can do it and we're root, or we can't and we're not - either way, it won't be root owned.
@@ -86,7 +86,7 @@ TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantDirectoryOwnership)
 
 TEST_F(EnsureRootPathTest, AuditRootPathNonCompliantDirectoryPermissions)
 {
-    EXPECT_CALL(mContext, ExecuteCommand("sudo -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:/usr/bin:/sbin:/usr/sbin:" + path)));
+    EXPECT_CALL(mContext, ExecuteCommand("sudo -n -Hiu root env")).WillOnce(Return(Result<std::string>("PATH=/bin:/usr/bin:/sbin:/usr/sbin:" + path)));
 
     ASSERT_EQ(chmod(path.c_str(), 0777), 0);
 


### PR DESCRIPTION
## Description

The audit shells out via 'sudo -Hiu root env' to obtain root's login shell PATH. Without -n, sudo prompts for a password on the controlling tty when the caller lacks a cached credential, which silently hangs the compliance engine inside non-interactive pipelines and services.

Force non-interactive mode. Authentication failures now surface as a NonCompliant verdict ("Failed to retrieve root path") instead of a hang. Callers that already run as root (or have a sudo timestamp) are unaffected.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
