### PR TITLE
assessor: extract CLI and MOF iteration into a testable library

### DIFF
--- a/src/modules/complianceengine/src/assessor/CMakeLists.txt
+++ b/src/modules/complianceengine/src/assessor/CMakeLists.txt
@@ -12,9 +12,13 @@ SET(CMAKE_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE} CACHE STRING "" FORCE)
 
 project(compliance-engine-assessor)
 set(target_name compliance-engine-assessor)
+set(lib_name compliance-engine-assessor-lib)
 
-set(SOURCES
-    Main.cpp
+# Library: parser + CLI options + formatters. Split out from the binary so
+# unit tests can link the same object code as the shipping tool without
+# rebuilding it or duplicating sources.
+set(LIB_SOURCES
+    CliOptions.cpp
     Mof.cpp
     BenchmarkFormatter.cpp
     CompactListFormatter.cpp
@@ -23,20 +27,30 @@ set(SOURCES
     NestedListFormatter.cpp
 )
 
-add_executable(${target_name} ${SOURCES})
+add_library(${lib_name} STATIC ${LIB_SOURCES})
 
-target_include_directories(${target_name} PUBLIC
+target_include_directories(${lib_name} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${MODULES_INC_DIR}
     )
 
-target_link_libraries(${target_name}
-    ${CMAKE_DL_LIBS}
+target_link_libraries(${lib_name} PUBLIC
     logging
     commonutils
     parsonlib
     complianceenginelib
     )
 
+add_executable(${target_name} Main.cpp)
+
+target_link_libraries(${target_name}
+    ${CMAKE_DL_LIBS}
+    ${lib_name}
+    )
+
 include(GNUInstallDirs)
 install(TARGETS ${target_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if (BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/modules/complianceengine/src/assessor/CliOptions.cpp
+++ b/src/modules/complianceengine/src/assessor/CliOptions.cpp
@@ -42,10 +42,9 @@ Result<Options> ParseCommandLine(const int argc, char* argv[])
 #endif
 
     const auto* short_opts = "hVvdel:s:f:";
-    const option long_opts[] = { {"help", no_argument, nullptr, 'h'}, {"version", no_argument, nullptr, 'V'},
-        {"verbose", no_argument, nullptr, 'v'}, {"debug", no_argument, nullptr, 'd'}, {"continue-on-error", no_argument, nullptr, 'e'},
-        {"log-file", required_argument, nullptr, 'l'}, {"section", required_argument, nullptr, 's'}, {"format", required_argument, nullptr, 'f'},
-        {nullptr, 0, nullptr, 0} };
+    const option long_opts[] = {{"help", no_argument, nullptr, 'h'}, {"version", no_argument, nullptr, 'V'}, {"verbose", no_argument, nullptr, 'v'},
+        {"debug", no_argument, nullptr, 'd'}, {"continue-on-error", no_argument, nullptr, 'e'}, {"log-file", required_argument, nullptr, 'l'},
+        {"section", required_argument, nullptr, 's'}, {"format", required_argument, nullptr, 'f'}, {nullptr, 0, nullptr, 0}};
 
     auto result = Options{};
     int opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);

--- a/src/modules/complianceengine/src/assessor/CliOptions.cpp
+++ b/src/modules/complianceengine/src/assessor/CliOptions.cpp
@@ -19,6 +19,7 @@ void PrintHelp(const std::string& programName)
     std::cout << "\t-V, --version\tShow software version and exit.\n";
     std::cout << "\t-v, --verbose\tRun in verbose mode.\n";
     std::cout << "\t-d, --debug\tRun in debug mode.\n";
+    std::cout << "\t-e, --continue-on-error\tSkip rules that fail due to engine errors and continue processing. Returns 1 if any error occurred.\n";
     std::cout << "\t-l, --log-file\tSpecify a log file. Default: print log entries to standard output.\n";
     std::cout << "\t-s, --section\tProcess only specific sections. Default: process all available rules.\n";
     std::cout << "\n";

--- a/src/modules/complianceengine/src/assessor/CliOptions.cpp
+++ b/src/modules/complianceengine/src/assessor/CliOptions.cpp
@@ -1,0 +1,145 @@
+#include <CliOptions.hpp>
+#include <algorithm>
+#include <getopt.h>
+#include <iostream>
+#include <string>
+
+namespace ComplianceEngine
+{
+namespace Assessor
+{
+
+using std::string;
+
+void PrintHelp(const std::string& programName)
+{
+    std::cout << "Usage: " + programName + "\n\n";
+    std::cout << "Available optinos:\n";
+    std::cout << "\t-h, --help\tShow help and exit.\n";
+    std::cout << "\t-V, --version\tShow software version and exit.\n";
+    std::cout << "\t-v, --verbose\tRun in verbose mode.\n";
+    std::cout << "\t-d, --debug\tRun in debug mode.\n";
+    std::cout << "\t-l, --log-file\tSpecify a log file. Default: print log entries to standard output.\n";
+    std::cout << "\t-s, --section\tProcess only specific sections. Default: process all available rules.\n";
+    std::cout << "\n";
+    std::cout << "Positional arguments:\n";
+    std::cout << "\tcommand\t\tDetermine whether to run in audit or remediation mode. Allowed values: {audit|remediate}.\n";
+    std::cout << "\tfilename\tProcess the specified MOF file. Optional: if skipped or the value is -, the program reads standard input\n";
+}
+
+// Command line parser using getopt_long.
+//
+// Resets getopt's global parser state on entry so this function can be safely
+// called more than once per process (notably from unit tests). The shipping
+// binary calls it exactly once, so the reset is a no-op there.
+Result<Options> ParseCommandLine(const int argc, char* argv[])
+{
+    optind = 0;
+#ifdef optreset
+    optreset = 1;
+    optind = 1;
+#endif
+
+    const auto* short_opts = "hVvdl:s:f:";
+    const option long_opts[] = {{"help", no_argument, nullptr, 'h'}, {"version", no_argument, nullptr, 'V'}, {"verbose", no_argument, nullptr, 'v'},
+        {"debug", no_argument, nullptr, 'd'}, {"log-file", required_argument, nullptr, 'l'}, {"section", required_argument, nullptr, 's'},
+        {"format", required_argument, nullptr, 'f'}, {nullptr, 0, nullptr, 0}};
+
+    auto result = Options{};
+    int opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
+    while (opt != -1)
+    {
+        switch (opt)
+        {
+            case 'h':
+                result.command = Command::Help;
+                return result;
+            case 'V':
+                result.command = Command::Version;
+                return result;
+            case 'v':
+                result.verbose = true;
+                break;
+            case 'd':
+                result.debug = true;
+                break;
+            case 'l':
+                result.logFile = std::string(optarg);
+                break;
+            case 's':
+                result.section = std::string(optarg);
+                break;
+            case 'f': {
+                auto formatArg = std::string(optarg);
+                std::transform(formatArg.begin(), formatArg.end(), formatArg.begin(), ::tolower);
+                if (formatArg == "nested-list")
+                {
+                    result.format = Format::NestedList;
+                }
+                else if (formatArg == "compact-list")
+                {
+                    result.format = Format::CompactList;
+                }
+                else if (formatArg == "json")
+                {
+                    result.format = Format::Json;
+                }
+                else if (formatArg == "debug")
+                {
+                    result.format = Format::Debug;
+                }
+                else
+                {
+                    return Error("Invalid format: " + formatArg);
+                }
+                break;
+            }
+            default:
+                return Error("Unknown option.");
+        }
+
+        opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
+    }
+
+    // After options, parse the positional arguments
+    if (optind < argc)
+    {
+        const std::string arg = argv[optind];
+        if (arg == "audit")
+        {
+            result.command = Command::Audit;
+        }
+        else if (arg == "remediate")
+        {
+            result.command = Command::Remediate;
+        }
+        else
+        {
+            return Error("Invalid command: '" + arg + "'. Must be 'audit' or 'remediate'.");
+        }
+        ++optind;
+    }
+    else
+    {
+        return Error("Missing required command: 'audit' or 'remediate'.");
+    }
+
+    // Input filename
+    if (optind < argc)
+    {
+        const std::string arg = argv[optind];
+        result.input = arg;
+        ++optind;
+    }
+
+    // End of positional arguments
+    if (optind < argc)
+    {
+        return Error("Too many arguments provided.");
+    }
+
+    return result;
+}
+
+} // namespace Assessor
+} // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/assessor/CliOptions.cpp
+++ b/src/modules/complianceengine/src/assessor/CliOptions.cpp
@@ -40,10 +40,11 @@ Result<Options> ParseCommandLine(const int argc, char* argv[])
     optind = 1;
 #endif
 
-    const auto* short_opts = "hVvdl:s:f:";
-    const option long_opts[] = {{"help", no_argument, nullptr, 'h'}, {"version", no_argument, nullptr, 'V'}, {"verbose", no_argument, nullptr, 'v'},
-        {"debug", no_argument, nullptr, 'd'}, {"log-file", required_argument, nullptr, 'l'}, {"section", required_argument, nullptr, 's'},
-        {"format", required_argument, nullptr, 'f'}, {nullptr, 0, nullptr, 0}};
+    const auto* short_opts = "hVvdel:s:f:";
+    const option long_opts[] = { {"help", no_argument, nullptr, 'h'}, {"version", no_argument, nullptr, 'V'},
+        {"verbose", no_argument, nullptr, 'v'}, {"debug", no_argument, nullptr, 'd'}, {"continue-on-error", no_argument, nullptr, 'e'},
+        {"log-file", required_argument, nullptr, 'l'}, {"section", required_argument, nullptr, 's'}, {"format", required_argument, nullptr, 'f'},
+        {nullptr, 0, nullptr, 0} };
 
     auto result = Options{};
     int opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);

--- a/src/modules/complianceengine/src/assessor/CliOptions.cpp
+++ b/src/modules/complianceengine/src/assessor/CliOptions.cpp
@@ -65,6 +65,9 @@ Result<Options> ParseCommandLine(const int argc, char* argv[])
             case 'd':
                 result.debug = true;
                 break;
+            case 'e':
+                result.continueOnError = true;
+                break;
             case 'l':
                 result.logFile = std::string(optarg);
                 break;

--- a/src/modules/complianceengine/src/assessor/CliOptions.hpp
+++ b/src/modules/complianceengine/src/assessor/CliOptions.hpp
@@ -1,0 +1,48 @@
+#ifndef COMPLIANCE_ENGINE_ASSESSOR_CLI_OPTIONS_HPP
+#define COMPLIANCE_ENGINE_ASSESSOR_CLI_OPTIONS_HPP
+
+#include <Optional.h>
+#include <Result.h>
+#include <string>
+
+namespace ComplianceEngine
+{
+namespace Assessor
+{
+
+enum class Command
+{
+    Help,
+    Version,
+    Audit,
+    Remediate
+};
+
+enum class Format
+{
+    NestedList,
+    CompactList,
+    Json,
+    Debug
+};
+
+struct Options
+{
+    bool verbose = false;
+    bool debug = false;
+    bool continueOnError = false;
+    Optional<std::string> logFile;
+    Optional<Format> format;
+    Command command = Command::Help;
+    std::string input;
+    Optional<std::string> section;
+};
+
+void PrintHelp(const std::string& programName);
+
+Result<Options> ParseCommandLine(int argc, char* argv[]);
+
+} // namespace Assessor
+} // namespace ComplianceEngine
+
+#endif // COMPLIANCE_ENGINE_ASSESSOR_CLI_OPTIONS_HPP

--- a/src/modules/complianceengine/src/assessor/Main.cpp
+++ b/src/modules/complianceengine/src/assessor/Main.cpp
@@ -1,4 +1,5 @@
 #include <AssessorContext.h>
+#include <CliOptions.hpp>
 #include <CompactListFormatter.hpp>
 #include <DebugFormatter.hpp>
 #include <Engine.h>
@@ -7,10 +8,7 @@
 #include <Mof.hpp>
 #include <NestedListFormatter.hpp>
 #include <Optional.h>
-#include <algorithm>
-#include <cassert>
 #include <fstream>
-#include <getopt.h>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -24,6 +22,11 @@ using ComplianceEngine::Optional;
 using ComplianceEngine::PayloadFormatter;
 using ComplianceEngine::Result;
 using ComplianceEngine::Status;
+using ComplianceEngine::Assessor::Command;
+using ComplianceEngine::Assessor::Format;
+using ComplianceEngine::Assessor::Options;
+using ComplianceEngine::Assessor::ParseCommandLine;
+using ComplianceEngine::Assessor::PrintHelp;
 using ComplianceEngine::BenchmarkFormatters::BenchmarkFormatter;
 using ComplianceEngine::BenchmarkFormatters::CompactListFormatter;
 using ComplianceEngine::BenchmarkFormatters::DebugFormatter;
@@ -33,162 +36,6 @@ using ComplianceEngine::MOF::Resource;
 using std::ifstream;
 using std::istream;
 using std::string;
-
-namespace
-{
-enum class Command
-{
-    Help,
-    Version,
-    Audit,
-    Remediate
-};
-
-enum class Format
-{
-    NestedList,
-    CompactList,
-    Json,
-    Debug
-};
-
-struct Options
-{
-    bool verbose = false;
-    bool debug = false;
-    bool continueOnError = false;
-    Optional<string> logFile;
-    Optional<Format> format;
-    Command command = Command::Help;
-    std::string input;
-    Optional<string> section;
-};
-
-void PrintHelp(const std::string& programName)
-{
-    std::cout << "Usage: " + programName + "\n\n";
-    std::cout << "Available optinos:\n";
-    std::cout << "\t-h, --help\tShow help and exit.\n";
-    std::cout << "\t-V, --version\tShow software version and exit.\n";
-    std::cout << "\t-v, --verbose\tRun in verbose mode.\n";
-    std::cout << "\t-d, --debug\tRun in debug mode.\n";
-    std::cout << "\t-e, --continue-on-error\tSkip rules that fail due to engine errors and continue processing. Returns 1 if any error occurred.\n";
-    std::cout << "\t-l, --log-file\tSpecify a log file. Default: print log entries to standard output.\n";
-    std::cout << "\t-s, --section\tProcess only specific sections. Default: process all available rules.\n";
-    std::cout << "\n";
-    std::cout << "Positional arguments:\n";
-    std::cout << "\tcommand\t\tDetermine whether to run in audit or remediation mode. Allowed values: {audit|remediate}.\n";
-    std::cout << "\tfilename\tProcess the specified MOF file. Optional: if skipped or the value is -, the program reads standard input\n";
-}
-
-// Command line parser using getopt_long
-Result<Options> ParseCommandLine(const int argc, char* argv[])
-{
-    const auto* short_opts = "hVvdel:s:f:";
-    const option long_opts[] = {{"help", no_argument, nullptr, 'h'}, {"version", no_argument, nullptr, 'V'}, {"verbose", no_argument, nullptr, 'v'},
-        {"debug", no_argument, nullptr, 'd'}, {"continue-on-error", no_argument, nullptr, 'e'}, {"log-file", required_argument, nullptr, 'l'},
-        {"section", required_argument, nullptr, 's'}, {"format", required_argument, nullptr, 'f'}, {nullptr, 0, nullptr, 0}};
-
-    auto result = Options{};
-    int opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
-    while (opt != -1)
-    {
-        switch (opt)
-        {
-            case 'h':
-                result.command = Command::Help;
-                return result;
-            case 'V':
-                result.command = Command::Version;
-                return result;
-            case 'v':
-                result.verbose = true;
-                break;
-            case 'd':
-                result.debug = true;
-                break;
-            case 'e':
-                result.continueOnError = true;
-                break;
-            case 'l':
-                result.logFile = std::string(optarg);
-                break;
-            case 's':
-                result.section = std::string(optarg);
-                break;
-            case 'f': {
-                auto formatArg = std::string(optarg);
-                std::transform(formatArg.begin(), formatArg.end(), formatArg.begin(), ::tolower);
-                if (formatArg == "nested-list")
-                {
-                    result.format = Format::NestedList;
-                }
-                else if (formatArg == "compact-list")
-                {
-                    result.format = Format::CompactList;
-                }
-                else if (formatArg == "json")
-                {
-                    result.format = Format::Json;
-                }
-                else if (formatArg == "debug")
-                {
-                    result.format = Format::Debug;
-                }
-                else
-                {
-                    return Error("Invalid format: " + formatArg);
-                }
-                break;
-            }
-            default:
-                return Error("Unknown option.");
-        }
-
-        opt = getopt_long(argc, argv, short_opts, long_opts, nullptr);
-    }
-
-    // After options, parse the positional arguments
-    if (optind < argc)
-    {
-        const std::string arg = argv[optind];
-        if (arg == "audit")
-        {
-            result.command = Command::Audit;
-        }
-        else if (arg == "remediate")
-        {
-            result.command = Command::Remediate;
-        }
-        else
-        {
-            return Error("Invalid command: '" + arg + "'. Must be 'audit' or 'remediate'.");
-        }
-        ++optind;
-    }
-    else
-    {
-        return Error("Missing required command: 'audit' or 'remediate'.");
-    }
-
-    // Input filename
-    if (optind < argc)
-    {
-        const std::string arg = argv[optind];
-        result.input = arg;
-        ++optind;
-    }
-
-    // End of positional arguments
-    if (optind < argc)
-    {
-        return Error("Too many arguments provided.");
-    }
-
-    return result;
-}
-
-} // anonymous namespace
 
 int main(int argc, char* argv[])
 {

--- a/src/modules/complianceengine/src/assessor/tests/CMakeLists.txt
+++ b/src/modules/complianceengine/src/assessor/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+include(GoogleTest)
+find_package(GTest CONFIG REQUIRED)
+
+add_executable(compliance-engine-assessor-tests
+    CliOptionsTest.cpp
+    MofTest.cpp
+)
+
+target_link_libraries(compliance-engine-assessor-tests
+    GTest::gtest
+    GTest::gtest_main
+    pthread
+    compliance-engine-assessor-lib
+)
+
+gtest_discover_tests(compliance-engine-assessor-tests XML_OUTPUT_DIR ${GTEST_OUTPUT_DIR})

--- a/src/modules/complianceengine/src/assessor/tests/CliOptionsTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/CliOptionsTest.cpp
@@ -1,0 +1,75 @@
+// Smoke tests for the extracted CLI options library. Verifies the lib links
+// and that ParseCommandLine accepts the same inputs the binary does today.
+// Behavioural hardening (duplicate-flag rejection, empty-optarg rejection,
+// breaking renames) lands in follow-up PRs along with their own tests.
+
+#include <CliOptions.hpp>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using ComplianceEngine::Assessor::Command;
+using ComplianceEngine::Assessor::Format;
+using ComplianceEngine::Assessor::ParseCommandLine;
+
+namespace
+{
+struct ArgvHelper
+{
+    std::vector<std::string> storage;
+    std::vector<char*> pointers;
+
+    explicit ArgvHelper(std::initializer_list<std::string> args)
+        : storage(args)
+    {
+        pointers.reserve(storage.size() + 1);
+        for (auto& s : storage)
+        {
+            pointers.push_back(&s[0]);
+        }
+        pointers.push_back(nullptr);
+    }
+
+    int Argc() const
+    {
+        return static_cast<int>(storage.size());
+    }
+    char** Argv()
+    {
+        return pointers.data();
+    }
+};
+} // namespace
+
+TEST(CliOptionsSmokeTest, HelpIsRecognised)
+{
+    ArgvHelper a{"prog", "-h"};
+    auto result = ParseCommandLine(a.Argc(), a.Argv());
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value().command, Command::Help);
+}
+
+TEST(CliOptionsSmokeTest, AuditWithInputFilename)
+{
+    ArgvHelper a{"prog", "audit", "/tmp/x.mof"};
+    auto result = ParseCommandLine(a.Argc(), a.Argv());
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value().command, Command::Audit);
+    EXPECT_EQ(result.Value().input, "/tmp/x.mof");
+}
+
+TEST(CliOptionsSmokeTest, FormatJsonIsParsed)
+{
+    ArgvHelper a{"prog", "-f", "json", "audit"};
+    auto result = ParseCommandLine(a.Argc(), a.Argv());
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_TRUE(result.Value().format.HasValue());
+    EXPECT_EQ(result.Value().format.Value(), Format::Json);
+}
+
+TEST(CliOptionsSmokeTest, MissingCommandIsError)
+{
+    ArgvHelper a{"prog"};
+    auto result = ParseCommandLine(a.Argc(), a.Argv());
+    EXPECT_FALSE(result.HasValue());
+}

--- a/src/modules/complianceengine/src/assessor/tests/CliOptionsTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/CliOptionsTest.cpp
@@ -67,6 +67,14 @@ TEST(CliOptionsSmokeTest, FormatJsonIsParsed)
     EXPECT_EQ(result.Value().format.Value(), Format::Json);
 }
 
+TEST(CliOptionsSmokeTest, ContinueOnErrorIsParsed)
+{
+    ArgvHelper a{"prog", "-e", "audit"};
+    auto result = ParseCommandLine(a.Argc(), a.Argv());
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_TRUE(result.Value().continueOnError);
+}
+
 TEST(CliOptionsSmokeTest, MissingCommandIsError)
 {
     ArgvHelper a{"prog"};

--- a/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
@@ -1,0 +1,59 @@
+// Smoke tests for the MOF parser library. Verifies the lib links and that
+// ParseSingleEntry accepts a well-formed MOF body. The MOF stream iterator
+// (ParseAll), bounded-line reader, and adversarial-input tests land in the
+// MOF parser-rework PR along with their own tests.
+
+#include <Mof.hpp>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+using ComplianceEngine::MOF::Resource;
+
+namespace
+{
+constexpr const char* kValidBody = R"(    ResourceID = "Some Rule";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/1";
+    ProcedureObjectName = "procedureMyRule";
+    ProcedureObjectValue = "base64data==";
+    InitObjectName = "initMyRule";
+    ReportedObjectName = "auditMyRule";
+    DesiredObjectValue = "mask=0600";
+};
+)";
+} // namespace
+
+TEST(MofSmokeTest, ParseSingleEntryHappyPath)
+{
+    std::istringstream s(kValidBody);
+    auto result = Resource::ParseSingleEntry(s);
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    EXPECT_EQ(result.Value().resourceID, "Some Rule");
+    EXPECT_EQ(result.Value().ruleName, "MyRule");
+    EXPECT_EQ(result.Value().procedure, "base64data==");
+    EXPECT_TRUE(result.Value().hasInitAudit);
+    ASSERT_TRUE(result.Value().payload.HasValue());
+    EXPECT_EQ(result.Value().payload.Value(), "mask=0600");
+    EXPECT_EQ(result.Value().benchmarkInfo.section, "1.1.1");
+}
+
+TEST(MofSmokeTest, JsonEscapedDesiredObjectValue)
+{
+    // Production MOFs use JSON for DesiredObjectValue with MOF-escaped inner
+    // quotes. Verifies pr1's GetValue escape handling is preserved through
+    // the library extraction.
+    const std::string body =
+        "    ResourceID = \"Some Rule\";\n"
+        "    PayloadKey = \"/cis/rhel/8/v4.0.0/1/2/3\";\n"
+        "    ProcedureObjectName = \"procedureMyRule\";\n"
+        "    ProcedureObjectValue = \"base64data==\";\n"
+        "    InitObjectName = \"initMyRule\";\n"
+        "    ReportedObjectName = \"auditMyRule\";\n"
+        "    DesiredObjectValue = \"{\\\"mountPoint\\\":\\\"/tmp\\\"}\";\n"
+        "};\n";
+    std::istringstream s(body);
+    auto result = Resource::ParseSingleEntry(s);
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    ASSERT_TRUE(result.Value().payload.HasValue());
+    EXPECT_EQ(result.Value().payload.Value(), "{\"mountPoint\":\"/tmp\"}");
+}


### PR DESCRIPTION
## Description

assessor: extract CLI options and parser into a testable library

Mechanically split the assessor binary into a static library plus a thin
binary, so unit tests can link the same object code as the shipping tool
without rebuilding it or duplicating sources. No behaviour change for the
binary: same flags (including -l for --log-file), same error messages,
same help text, same parse logic.

Changes:
  * New static library compliance-engine-assessor-lib containing CliOptions,
    Mof, and the formatters. Binary now contains only Main.cpp and links
    the lib.
  * New CliOptions.{hpp,cpp} hold the previously file-scoped Command,
    Format, Options, ParseCommandLine, and PrintHelp from Main.cpp,
    moved verbatim into namespace ComplianceEngine::Assessor.
  * ParseCommandLine now resets getopt globals (optind=0, optreset where
    available) on entry. The shipping binary calls it once so the reset is
    a no-op there; tests need it to call the parser repeatedly without
    crashing on stale getopt state.
   * New tests/ subdirectory gated on BUILD_TESTS, with smoke tests for
    CliOptions (4) and Mof (2) that prove the lib links and the moved
    code still parses representative inputs.

Cleanups deferred to follow-ups:
  * CLI hardening (duplicate-flag rejection, empty-optarg rejection,
    PrintHelp ostream signature, breaking -l -> -L rename, "optinos"
    typo, --format documentation in help) — separate PR.
  * MOF parser rework (Mof::ParseAll iterator, kMaxLineLength bounds,
    dead SemVer removal) — separate PR.
  * Main.cpp hardening (umask, O_NOFOLLOW, dup2 stderr routing, payload
    guards) — separate PR (pr4).

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
