### PR TITLE
Create distinct context classess for assessor and GC module

### DIFF
--- a/src/modules/complianceengine/src/assessor/Main.cpp
+++ b/src/modules/complianceengine/src/assessor/Main.cpp
@@ -1,4 +1,4 @@
-#include <CommonContext.h>
+#include <AssessorContext.h>
 #include <CompactListFormatter.hpp>
 #include <DebugFormatter.hpp>
 #include <Engine.h>
@@ -17,7 +17,7 @@
 #include <version.h>
 
 using ComplianceEngine::Action;
-using ComplianceEngine::CommonContext;
+using ComplianceEngine::AssessorContext;
 using ComplianceEngine::Engine;
 using ComplianceEngine::Error;
 using ComplianceEngine::Optional;
@@ -262,7 +262,7 @@ int main(int argc, char* argv[])
         OsConfigLogInfo(logHandle, "Debug logging enabled");
     }
 
-    auto context = std::unique_ptr<CommonContext>(new CommonContext(logHandle));
+    auto context = std::unique_ptr<AssessorContext>(new AssessorContext(logHandle));
     Engine engine(std::move(context), std::move(payloadFormatter));
 
     auto error = benchmarkFormatter->Begin(options.command == Command::Audit ? Action::Audit : Action::Remediate);

--- a/src/modules/complianceengine/src/lib/AssessorContext.h
+++ b/src/modules/complianceengine/src/lib/AssessorContext.h
@@ -7,20 +7,42 @@
 #include "CommonContext.h"
 #include "Logging.h"
 
+#include <ftw.h>
+#include <stdexcept>
+#include <unistd.h>
+
 namespace ComplianceEngine
 {
-
-namespace
-{
-constexpr char assessorStatePath[] = "/tmp/compliance-engine";
-} // namespace
 
 class AssessorContext : public CommonContext
 {
 public:
     AssessorContext(OsConfigLogHandle log)
-        : CommonContext(log, assessorStatePath)
+        : CommonContext(log, CreateTempDir())
     {
+    }
+    AssessorContext(const AssessorContext&) = delete;
+    AssessorContext& operator=(const AssessorContext&) = delete;
+    AssessorContext(AssessorContext&&) = delete;
+    AssessorContext& operator=(AssessorContext&&) = delete;
+
+    ~AssessorContext() override
+    {
+        nftw(
+            GetStatePath().c_str(),
+            [](const char* fpath, const struct stat*, int typeflag, struct FTW*) -> int { return (typeflag == FTW_DP) ? rmdir(fpath) : unlink(fpath); },
+            64, FTW_DEPTH | FTW_PHYS);
+    }
+
+private:
+    static std::string CreateTempDir()
+    {
+        char tmpl[] = "/tmp/compliance-engine-assessor.XXXXXX";
+        if (mkdtemp(tmpl) == nullptr)
+        {
+            throw std::runtime_error("AssessorContext: failed to create temporary state directory");
+        }
+        return std::string(tmpl);
     }
 };
 

--- a/src/modules/complianceengine/src/lib/AssessorContext.h
+++ b/src/modules/complianceengine/src/lib/AssessorContext.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCEENGINE_ASSESSORCONTEXT_H
+#define COMPLIANCEENGINE_ASSESSORCONTEXT_H
+
+#include "CommonContext.h"
+#include "Logging.h"
+
+namespace ComplianceEngine
+{
+
+namespace
+{
+constexpr char assessorStatePath[] = "/tmp/compliance-engine";
+} // namespace
+
+class AssessorContext : public CommonContext
+{
+public:
+    AssessorContext(OsConfigLogHandle log)
+        : CommonContext(log, assessorStatePath)
+    {
+    }
+};
+
+} // namespace ComplianceEngine
+#endif // COMPLIANCEENGINE_ASSESSORCONTEXT_H

--- a/src/modules/complianceengine/src/lib/AssessorContext.h
+++ b/src/modules/complianceengine/src/lib/AssessorContext.h
@@ -30,7 +30,18 @@ public:
     {
         nftw(
             GetStatePath().c_str(),
-            [](const char* fpath, const struct stat*, int typeflag, struct FTW*) -> int { return (typeflag == FTW_DP) ? rmdir(fpath) : unlink(fpath); },
+            [](const char* fpath, const struct stat*, int typeflag, struct FTW*) -> int
+            {
+                if (typeflag == FTW_DP)
+                {
+                    (void)rmdir(fpath);
+                }
+                else
+                {
+                    (void)unlink(fpath);
+                }
+                return 0; // best-effort cleanup: keep walking even if a removal fails
+            },
             64, FTW_DEPTH | FTW_PHYS);
     }
 

--- a/src/modules/complianceengine/src/lib/AssessorContext.h
+++ b/src/modules/complianceengine/src/lib/AssessorContext.h
@@ -28,10 +28,10 @@ public:
 
     ~AssessorContext() override
     {
+        const std::string statePath = GetStatePath();
         nftw(
-            GetStatePath().c_str(),
-            [](const char* fpath, const struct stat*, int typeflag, struct FTW*) -> int
-            {
+            statePath.c_str(),
+            [](const char* fpath, const struct stat*, int typeflag, struct FTW*) -> int {
                 if (typeflag == FTW_DP)
                 {
                     (void)rmdir(fpath);

--- a/src/modules/complianceengine/src/lib/CMakeLists.txt
+++ b/src/modules/complianceengine/src/lib/CMakeLists.txt
@@ -143,6 +143,7 @@ add_library(complianceenginelib STATIC
     Engine.cpp
     Evaluator.cpp
     FileTreeWalk.cpp
+    GuestConfigurationContext.cpp
     FilesystemScanner.cpp
     GroupsIterator.cpp
     Indicators.cpp

--- a/src/modules/complianceengine/src/lib/CommonContext.cpp
+++ b/src/modules/complianceengine/src/lib/CommonContext.cpp
@@ -4,7 +4,6 @@
 #include "CommonContext.h"
 
 #include "CommonUtils.h"
-#include "ContextInterface.h"
 
 namespace ComplianceEngine
 {

--- a/src/modules/complianceengine/src/lib/CommonContext.cpp
+++ b/src/modules/complianceengine/src/lib/CommonContext.cpp
@@ -7,6 +7,9 @@
 
 namespace ComplianceEngine
 {
+constexpr char CommonContext::sFsCachePath[];
+constexpr char CommonContext::sLockPath[];
+
 CommonContext::~CommonContext() = default;
 
 Result<std::string> CommonContext::ExecuteCommand(const std::string& cmd) const

--- a/src/modules/complianceengine/src/lib/CommonContext.h
+++ b/src/modules/complianceengine/src/lib/CommonContext.h
@@ -8,7 +8,6 @@
 #include "Logging.h"
 #include "Result.h"
 
-#include <sstream>
 #include <string>
 
 namespace ComplianceEngine
@@ -16,7 +15,7 @@ namespace ComplianceEngine
 
 namespace
 {
-constexpr char fsCachePath[] = "/var/lib/GuestConfig/ComplianceEngineFSCache";
+constexpr char fsCachePath[] = "ComplianceEngineFSCache";
 constexpr char lockPath[] = "/run/complianceengine-fsscanner.lock";
 constexpr int softTimeout = 3600;
 constexpr int hardTimeout = 86400;
@@ -25,12 +24,17 @@ constexpr int scanWaitTime = 30;
 class CommonContext : public ContextInterface
 {
 public:
-    CommonContext(OsConfigLogHandle log)
+    CommonContext(OsConfigLogHandle log, const std::string& statePath)
         : mLog(log),
+          mStatePath(statePath),
           mFsScanner("/", fsCachePath, lockPath, softTimeout, hardTimeout, scanWaitTime)
     {
     }
     ~CommonContext() override;
+    CommonContext(const CommonContext&) = delete;
+    CommonContext& operator=(const CommonContext&) = delete;
+    CommonContext(CommonContext&&) = delete;
+    CommonContext& operator=(CommonContext&&) = delete;
 
     Result<std::string> ExecuteCommand(const std::string& cmd) const override;
     Result<std::string> GetFileContents(const std::string& filePath) const override;
@@ -45,8 +49,14 @@ public:
         return mFsScanner;
     }
 
+    std::string GetStatePath() const override
+    {
+        return mStatePath;
+    }
+
 private:
     OsConfigLogHandle mLog;
+    std::string mStatePath;
     FilesystemScanner mFsScanner;
 };
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/CommonContext.h
+++ b/src/modules/complianceengine/src/lib/CommonContext.h
@@ -13,21 +13,13 @@
 namespace ComplianceEngine
 {
 
-namespace
-{
-constexpr char fsCachePath[] = "ComplianceEngineFSCache";
-constexpr char lockPath[] = "/run/complianceengine-fsscanner.lock";
-constexpr int softTimeout = 3600;
-constexpr int hardTimeout = 86400;
-constexpr int scanWaitTime = 30;
-} // namespace
 class CommonContext : public ContextInterface
 {
 public:
     CommonContext(OsConfigLogHandle log, const std::string& statePath)
         : mLog(log),
           mStatePath(statePath),
-          mFsScanner("/", mStatePath + "/" + fsCachePath, lockPath, softTimeout, hardTimeout, scanWaitTime)
+          mFsScanner("/", mStatePath + "/" + sFsCachePath, sLockPath, sSoftTimeout, sHardTimeout, sScanWaitTime)
     {
     }
     ~CommonContext() override;
@@ -55,6 +47,12 @@ public:
     }
 
 private:
+    static constexpr char sFsCachePath[] = "ComplianceEngineFSCache";
+    static constexpr char sLockPath[] = "/run/complianceengine-fsscanner.lock";
+    static constexpr int sSoftTimeout = 3600;
+    static constexpr int sHardTimeout = 86400;
+    static constexpr int sScanWaitTime = 30;
+
     OsConfigLogHandle mLog;
     std::string mStatePath;
     FilesystemScanner mFsScanner;

--- a/src/modules/complianceengine/src/lib/CommonContext.h
+++ b/src/modules/complianceengine/src/lib/CommonContext.h
@@ -27,7 +27,7 @@ public:
     CommonContext(OsConfigLogHandle log, const std::string& statePath)
         : mLog(log),
           mStatePath(statePath),
-          mFsScanner("/", fsCachePath, lockPath, softTimeout, hardTimeout, scanWaitTime)
+          mFsScanner("/", mStatePath + "/" + fsCachePath, lockPath, softTimeout, hardTimeout, scanWaitTime)
     {
     }
     ~CommonContext() override;

--- a/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
+++ b/src/modules/complianceengine/src/lib/ComplianceEngineInterface.cpp
@@ -4,10 +4,10 @@
 #include "ComplianceEngineInterface.h"
 
 #include "BenchmarkInfo.h"
-#include "CommonContext.h"
 #include "CommonUtils.h"
 #include "DistributionInfo.h"
 #include "Engine.h"
+#include "GuestConfigurationContext.h"
 #include "JsonWrapper.h"
 #include "Logging.h"
 #include "Mmi.h"
@@ -74,7 +74,7 @@ void ComplianceEngineShutdown(void)
 
 MMI_HANDLE ComplianceEngineMmiOpen(const char* clientName, const unsigned int maxPayloadSizeBytes)
 {
-    auto context = std::unique_ptr<ComplianceEngine::CommonContext>(new ComplianceEngine::CommonContext(g_log));
+    auto context = std::unique_ptr<ComplianceEngine::GuestConfigurationContext>(new ComplianceEngine::GuestConfigurationContext(g_log));
     if (nullptr == context)
     {
         OsConfigLogError(g_log, "ComplianceEngineMmiOpen(%s, %u): failed to create context", clientName, maxPayloadSizeBytes);

--- a/src/modules/complianceengine/src/lib/ContextInterface.h
+++ b/src/modules/complianceengine/src/lib/ContextInterface.h
@@ -23,6 +23,9 @@ public:
     virtual std::string GetSpecialFilePath(const std::string& path) const = 0;
 
     virtual FilesystemScanner& GetFilesystemScanner() = 0;
+
+    // Returns the path to be used for storing state.
+    virtual std::string GetStatePath() const = 0;
 };
 } // namespace ComplianceEngine
 #endif // COMPLIANCEENGINE_CONTEXT_H

--- a/src/modules/complianceengine/src/lib/GuestConfigurationContext.cpp
+++ b/src/modules/complianceengine/src/lib/GuestConfigurationContext.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "GuestConfigurationContext.h"
+
+namespace ComplianceEngine
+{
+constexpr char GuestConfigurationContext::sStatePath[];
+} // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/GuestConfigurationContext.h
+++ b/src/modules/complianceengine/src/lib/GuestConfigurationContext.h
@@ -10,18 +10,16 @@
 namespace ComplianceEngine
 {
 
-namespace
-{
-constexpr char guestConfigStatePath[] = "/var/lib/GuestConfig";
-} // namespace
-
 class GuestConfigurationContext : public CommonContext
 {
 public:
     GuestConfigurationContext(OsConfigLogHandle log)
-        : CommonContext(log, guestConfigStatePath)
+        : CommonContext(log, sStatePath)
     {
     }
+
+private:
+    static constexpr char sStatePath[] = "/var/lib/GuestConfig";
 };
 
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/lib/GuestConfigurationContext.h
+++ b/src/modules/complianceengine/src/lib/GuestConfigurationContext.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#ifndef COMPLIANCEENGINE_GUESTCONFIGURATIONCONTEXT_H
+#define COMPLIANCEENGINE_GUESTCONFIGURATIONCONTEXT_H
+
+#include "CommonContext.h"
+#include "Logging.h"
+
+namespace ComplianceEngine
+{
+
+namespace
+{
+constexpr char guestConfigStatePath[] = "/var/lib/GuestConfig";
+} // namespace
+
+class GuestConfigurationContext : public CommonContext
+{
+public:
+    GuestConfigurationContext(OsConfigLogHandle log)
+        : CommonContext(log, guestConfigStatePath)
+    {
+    }
+};
+
+} // namespace ComplianceEngine
+#endif // COMPLIANCEENGINE_GUESTCONFIGURATIONCONTEXT_H

--- a/src/modules/complianceengine/src/lib/Users.cpp
+++ b/src/modules/complianceengine/src/lib/Users.cpp
@@ -1,6 +1,7 @@
 #include <CommonContext.h>
 #include <StringTools.h>
 #include <Users.h>
+#include <sstream>
 
 namespace ComplianceEngine
 {

--- a/src/modules/complianceengine/src/lib/procedures/PackageInstalled.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/PackageInstalled.cpp
@@ -453,7 +453,7 @@ Result<Status> AuditPackageInstalled(const PackageInstalledParams& params, Indic
     auto log = context.GetLogHandle();
 
     PackageCache cache;
-    auto cacheResult = LoadPackageCache(context.GetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache"));
+    auto cacheResult = LoadPackageCache(context.GetStatePath() + "/ComplianceEnginePackageCache");
     bool cacheValid = true;
     bool cacheStale = false;
     if (cacheResult.HasValue())
@@ -522,10 +522,10 @@ Result<Status> AuditPackageInstalled(const PackageInstalledParams& params, Indic
         if (cacheResult.HasValue())
         {
             cache = cacheResult.Value();
-            auto saveResult = SavePackageCache(cache, context.GetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache"));
+            auto saveResult = SavePackageCache(cache, context.GetStatePath() + "/ComplianceEnginePackageCache");
             if (saveResult.HasValue())
             {
-                OsConfigLogInfo(log, "Saved package cache to %s", context.GetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache").c_str());
+                OsConfigLogInfo(log, "Saved package cache to %s", (context.GetStatePath() + "/ComplianceEnginePackageCache").c_str());
             }
             else
             {

--- a/src/modules/complianceengine/src/lua-evaluator/Main.cpp
+++ b/src/modules/complianceengine/src/lua-evaluator/Main.cpp
@@ -1,4 +1,4 @@
-#include <CommonContext.h>
+#include <AssessorContext.h>
 #include <Logging.h>
 #include <LuaEvaluator.h>
 #include <Optional.h>
@@ -13,7 +13,7 @@
 #include <version.h>
 
 using ComplianceEngine::Action;
-using ComplianceEngine::CommonContext;
+using ComplianceEngine::AssessorContext;
 using ComplianceEngine::Error;
 using ComplianceEngine::IndicatorsTree;
 using ComplianceEngine::LuaEvaluator;
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
         OsConfigLogInfo(logHandle, "Debug logging enabled");
     }
 
-    auto context = std::unique_ptr<CommonContext>(new CommonContext(logHandle));
+    auto context = std::unique_ptr<AssessorContext>(new AssessorContext(logHandle));
     LuaEvaluator evaluator;
 
     ifstream file;

--- a/src/modules/complianceengine/tests/AssessorContextTest.cpp
+++ b/src/modules/complianceengine/tests/AssessorContextTest.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "AssessorContext.h"
+
+#include <fstream>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+
+class AssessorContextTest : public ::testing::Test
+{
+};
+
+TEST_F(AssessorContextTest, DirectoryCreatedOnConstruction)
+{
+    ComplianceEngine::AssessorContext ctx(nullptr);
+    struct stat st;
+    ASSERT_EQ(0, stat(ctx.GetStatePath().c_str(), &st));
+    EXPECT_TRUE(S_ISDIR(st.st_mode));
+}
+
+TEST_F(AssessorContextTest, DirectoryHasCorrectPrefix)
+{
+    ComplianceEngine::AssessorContext ctx(nullptr);
+    EXPECT_EQ(0u, ctx.GetStatePath().rfind("/tmp/compliance-engine-assessor.", 0));
+}
+
+TEST_F(AssessorContextTest, DirectoryPermissionsAre0700)
+{
+    ComplianceEngine::AssessorContext ctx(nullptr);
+    struct stat st;
+    ASSERT_EQ(0, stat(ctx.GetStatePath().c_str(), &st));
+    EXPECT_EQ(static_cast<mode_t>(0700), st.st_mode & 0777);
+}
+
+TEST_F(AssessorContextTest, EmptyDirectoryRemovedOnDestruction)
+{
+    std::string statePath;
+    {
+        ComplianceEngine::AssessorContext ctx(nullptr);
+        statePath = ctx.GetStatePath();
+        struct stat st;
+        ASSERT_EQ(0, stat(statePath.c_str(), &st));
+    }
+    struct stat st;
+    EXPECT_NE(0, stat(statePath.c_str(), &st));
+}
+
+TEST_F(AssessorContextTest, RecursiveRemovalOnDestruction)
+{
+    std::string statePath;
+    std::string subDir;
+    std::string topFile;
+    std::string nestedFile;
+
+    {
+        ComplianceEngine::AssessorContext ctx(nullptr);
+        statePath = ctx.GetStatePath();
+
+        subDir = statePath + "/subdir";
+        ASSERT_EQ(0, mkdir(subDir.c_str(), 0700));
+
+        topFile = statePath + "/file.txt";
+        std::ofstream(topFile) << "test";
+
+        nestedFile = subDir + "/nested.txt";
+        std::ofstream(nestedFile) << "nested";
+
+        // Confirm all exist before destruction
+        struct stat st;
+        ASSERT_EQ(0, stat(topFile.c_str(), &st));
+        ASSERT_EQ(0, stat(nestedFile.c_str(), &st));
+        ASSERT_EQ(0, stat(subDir.c_str(), &st));
+    }
+
+    struct stat st;
+    EXPECT_NE(0, stat(nestedFile.c_str(), &st)) << "nested file should be removed";
+    EXPECT_NE(0, stat(topFile.c_str(), &st)) << "top-level file should be removed";
+    EXPECT_NE(0, stat(subDir.c_str(), &st)) << "subdirectory should be removed";
+    EXPECT_NE(0, stat(statePath.c_str(), &st)) << "state directory itself should be removed";
+}
+
+TEST_F(AssessorContextTest, UniqueDirectoryPerInstance)
+{
+    ComplianceEngine::AssessorContext ctx1(nullptr);
+    ComplianceEngine::AssessorContext ctx2(nullptr);
+    EXPECT_NE(ctx1.GetStatePath(), ctx2.GetStatePath());
+}

--- a/src/modules/complianceengine/tests/CMakeLists.txt
+++ b/src/modules/complianceengine/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ foreach(proc ${GLOBBED_PROCEDURES})
 endforeach()
 
 add_executable(complianceenginetests
+    AssessorContextTest.cpp
     Base64Test.cpp
     BenchmarkInfoTest.cpp
     BindingsTest.cpp

--- a/src/modules/complianceengine/tests/CommonContextTest.cpp
+++ b/src/modules/complianceengine/tests/CommonContextTest.cpp
@@ -3,6 +3,9 @@
 
 #include "CommonContext.h"
 
+#include "AssessorContext.h"
+#include "GuestConfigurationContext.h"
+
 #include <fstream>
 #include <gtest/gtest.h>
 
@@ -22,7 +25,7 @@ protected:
 
 TEST_F(CommonContextTest, ExecuteCommand_Success)
 {
-    ComplianceEngine::CommonContext ctx(nullptr);
+    ComplianceEngine::CommonContext ctx(nullptr, "/tmp");
     auto result = ctx.ExecuteCommand("echo test");
     EXPECT_TRUE(result);
     EXPECT_NE(result.Value().find("test"), std::string::npos);
@@ -30,7 +33,7 @@ TEST_F(CommonContextTest, ExecuteCommand_Success)
 
 TEST_F(CommonContextTest, ExecuteCommand_Failure)
 {
-    ComplianceEngine::CommonContext ctx(nullptr);
+    ComplianceEngine::CommonContext ctx(nullptr, "/tmp");
     auto result = ctx.ExecuteCommand("someinvalidcommand");
     EXPECT_FALSE(result);
     auto err = result.Error();
@@ -39,14 +42,14 @@ TEST_F(CommonContextTest, ExecuteCommand_Failure)
 
 TEST_F(CommonContextTest, GetFileContents_NotFound)
 {
-    ComplianceEngine::CommonContext ctx(nullptr);
+    ComplianceEngine::CommonContext ctx(nullptr, "/tmp");
     auto result = ctx.GetFileContents("/non_existent_file");
     EXPECT_FALSE(result);
 }
 
 TEST_F(CommonContextTest, GetFileContents_ExistingFile)
 {
-    ComplianceEngine::CommonContext ctx(nullptr);
+    ComplianceEngine::CommonContext ctx(nullptr, "/tmp");
     // Create a dummy file with known content
     std::string filePath = "/tmp/test_common_context.txt";
     std::string expectedContent = "Hello from dummy file";
@@ -62,4 +65,16 @@ TEST_F(CommonContextTest, GetFileContents_ExistingFile)
     EXPECT_EQ(result.Value(), expectedContent);
 
     remove(filePath.c_str());
+}
+
+TEST_F(CommonContextTest, GuestConfigurationContext_StatePath)
+{
+    ComplianceEngine::GuestConfigurationContext ctx(nullptr);
+    EXPECT_EQ(ctx.GetStatePath(), "/var/lib/GuestConfig");
+}
+
+TEST_F(CommonContextTest, AssessorContext_StatePath)
+{
+    ComplianceEngine::AssessorContext ctx(nullptr);
+    EXPECT_EQ(ctx.GetStatePath(), "/tmp/compliance-engine");
 }

--- a/src/modules/complianceengine/tests/CommonContextTest.cpp
+++ b/src/modules/complianceengine/tests/CommonContextTest.cpp
@@ -72,9 +72,3 @@ TEST_F(CommonContextTest, GuestConfigurationContext_StatePath)
     ComplianceEngine::GuestConfigurationContext ctx(nullptr);
     EXPECT_EQ(ctx.GetStatePath(), "/var/lib/GuestConfig");
 }
-
-TEST_F(CommonContextTest, AssessorContext_StatePath)
-{
-    ComplianceEngine::AssessorContext ctx(nullptr);
-    EXPECT_EQ(ctx.GetStatePath(), "/tmp/compliance-engine");
-}

--- a/src/modules/complianceengine/tests/CommonContextTest.cpp
+++ b/src/modules/complianceengine/tests/CommonContextTest.cpp
@@ -3,7 +3,6 @@
 
 #include "CommonContext.h"
 
-#include "AssessorContext.h"
 #include "GuestConfigurationContext.h"
 
 #include <fstream>

--- a/src/modules/complianceengine/tests/MockContext.h
+++ b/src/modules/complianceengine/tests/MockContext.h
@@ -144,6 +144,11 @@ struct MockContext : public ComplianceEngine::ContextInterface
         return mTempRootDir;
     }
 
+    std::string GetStatePath() const override
+    {
+        return mTempdir;
+    }
+
 private:
     char mTempdir[PATH_MAX];
     std::string mTempRootDir;

--- a/src/modules/complianceengine/tests/procedures/PackageInstalledTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/PackageInstalledTest.cpp
@@ -76,16 +76,8 @@ protected:
 
     void SetUp() override
     {
-        char* tempDir = mkdtemp(dirTemplate);
-        ASSERT_NE(tempDir, nullptr);
-        dir = tempDir;
-        cacheFile = dir + "/packageCache";
+        cacheFile = mContext.GetStatePath() + "/ComplianceEnginePackageCache";
         mIndicators.Push("PackageInstalled");
-    }
-
-    void TearDown() override
-    {
-        rmdir(dir.c_str());
     }
 
     void CreateCacheFile(const std::string& packageManager, time_t timestamp, const std::vector<std::pair<std::string, std::string>>& packages)
@@ -109,7 +101,6 @@ TEST_F(PackageInstalledTest, DetectDpkgPackageManager)
 
     PackageInstalledParams params;
     params.packageName = "sample-package";
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
 

--- a/src/modules/complianceengine/tests/procedures/PackageInstalledTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/PackageInstalledTest.cpp
@@ -117,7 +117,6 @@ TEST_F(PackageInstalledTest, DetectRpmPackageManager)
 
     PackageInstalledParams params;
     params.packageName = "sample-package";
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
 
@@ -133,7 +132,6 @@ TEST_F(PackageInstalledTest, NoPackageManagerDetected)
 
     PackageInstalledParams params;
     params.packageName = "sample-package";
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
 
@@ -150,7 +148,6 @@ TEST_F(PackageInstalledTest, SpecifiedPackageManagerOverridesDetection)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
 
@@ -164,7 +161,6 @@ TEST_F(PackageInstalledTest, RpmPackageExists)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -177,7 +173,6 @@ TEST_F(PackageInstalledTest, RpmPackageDoesNotExist)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -190,7 +185,6 @@ TEST_F(PackageInstalledTest, DpkgPackageExists)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -203,7 +197,6 @@ TEST_F(PackageInstalledTest, DpkgPackageDoesNotExist)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -216,7 +209,6 @@ TEST_F(PackageInstalledTest, RpmCommandFails)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_FALSE(result.HasValue());
@@ -229,7 +221,6 @@ TEST_F(PackageInstalledTest, DpkgCommandFails)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_FALSE(result.HasValue());
@@ -245,7 +236,6 @@ TEST_F(PackageInstalledTest, UseCacheWhenAvailable)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -262,7 +252,6 @@ TEST_F(PackageInstalledTest, UseStaleCache)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -279,7 +268,6 @@ TEST_F(PackageInstalledTest, RefreshStaleCache)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -296,7 +284,6 @@ TEST_F(PackageInstalledTest, PackageManagerMismatch)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM; // Mismatch with cache
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -315,7 +302,6 @@ TEST_F(PackageInstalledTest, InvalidCacheFormat)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -336,7 +322,6 @@ TEST_F(PackageInstalledTest, CacheWithInvalidTimestamp)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -354,7 +339,6 @@ TEST_F(PackageInstalledTest, CacheTooStale)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -368,7 +352,6 @@ TEST_F(PackageInstalledTest, CachePathBroken)
     PackageInstalledParams params;
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", "/invalid/path/to/cache"); // Invalid path
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -384,7 +367,6 @@ TEST_F(PackageInstalledTest, MinVersionRequiredAndMet_Rpm)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "3.0.0-1"; // Required version is less than installed 3.1.4-5
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -399,7 +381,6 @@ TEST_F(PackageInstalledTest, MinVersionRequiredAndNotMet_Rpm)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "4.0.0-1"; // Required version is greater than installed 3.1.4-5
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -414,7 +395,6 @@ TEST_F(PackageInstalledTest, MinVersionRequiredExactMatch_Rpm)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "3.1.4-5"; // Exact match with installed version including release
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -429,7 +409,6 @@ TEST_F(PackageInstalledTest, MinVersionRequiredAndMet_Dpkg)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
     params.minPackageVersion = "3.0.0-1"; // Required version is less than installed 3.1.4-2
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -444,7 +423,6 @@ TEST_F(PackageInstalledTest, MinVersionRequiredAndNotMet_Dpkg)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
     params.minPackageVersion = "4.0.0-1"; // Required version is greater than installed 3.1.4-2
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -459,7 +437,6 @@ TEST_F(PackageInstalledTest, MinVersionRequiredExactMatch_Dpkg)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::DPKG;
     params.minPackageVersion = "3.1.4-2"; // Exact match with installed version
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -474,7 +451,6 @@ TEST_F(PackageInstalledTest, PackageNotInstalledWithMinVersion)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "1.0.0-1";
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -492,7 +468,6 @@ TEST_F(PackageInstalledTest, ComplexVersionComparison_Rpm)
     params.packageName = "complex-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "2.4.0-1"; // Should be satisfied by 2.4.1-rc3
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -509,7 +484,6 @@ TEST_F(PackageInstalledTest, ComplexVersionComparisonFails_Rpm)
     params.packageName = "complex-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "2.4.0-1"; // Should not be satisfied by 2.3.5-beta
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -527,7 +501,6 @@ TEST_F(PackageInstalledTest, VersionComparisonWithCache)
     params.packageName = "version-test";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "2.5.0-1"; // Should be satisfied by cached 2.5.1-2
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -545,7 +518,6 @@ TEST_F(PackageInstalledTest, VersionComparisonWithCacheFails)
     params.packageName = "version-test";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "2.5.0-1"; // Should not be satisfied by cached 2.4.9-1
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -560,7 +532,6 @@ TEST_F(PackageInstalledTest, EmptyMinVersionIsIgnored)
     params.packageName = "sample-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = ""; // Empty version should be ignored
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -577,7 +548,6 @@ TEST_F(PackageInstalledTest, NumericVersionComparison)
     params.packageName = "numeric2";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "1.9.0-1"; // Should be satisfied by 1.10.0-2
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -595,7 +565,6 @@ TEST_F(PackageInstalledTest, MixedAlphanumericVersionComparison)
     params.packageName = "mixed3";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "1.0b-1"; // Should be satisfied by 1.0.1-2
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -613,7 +582,6 @@ TEST_F(PackageInstalledTest, AlphaOnlyVersionComparison)
     params.packageName = "alpha";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "1.alpha.0-1";
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -631,7 +599,6 @@ TEST_F(PackageInstalledTest, LongerVersionComparison)
     params.packageName = "alpha";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "1.beta.3.7-1";
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -651,7 +618,6 @@ TEST_F(PackageInstalledTest, EpochVersionComparison_Rpm)
     params.packageName = "epoch-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "1:2.0.0-1"; // Should be satisfied by 2:1.0.0-1 (higher epoch)
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -670,7 +636,6 @@ TEST_F(PackageInstalledTest, EpochVersionComparisonFails_Rpm)
     params.packageName = "epoch-package";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "2:1.0.0-1"; // Should not be satisfied by 1:1.0.0-1 (lower epoch)
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());
@@ -688,7 +653,6 @@ TEST_F(PackageInstalledTest, MixedEpochAndNoEpochComparison_Rpm)
     params.packageName = "with-epoch";
     params.packageManager = PackageManagerType::RPM;
     params.minPackageVersion = "2.0.0-1"; // Should be satisfied by 1:1.0.0-1 (epoch 1 > implicit epoch 0)
-    mContext.SetSpecialFilePath("/var/lib/GuestConfig/ComplianceEnginePackageCache", cacheFile);
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
     ASSERT_TRUE(result.HasValue());


### PR DESCRIPTION
## Description

Drop `/var/lib/GuestConfig` static path that is directly tied to the GC module. Since we're adding the assessor local tool scanning capability which may work on a system without an installed GC modules, this path must be abstracted out of the source.

### New `GetStatePath()` interface
A new abstract method is added to dispatch specific values to implementing classes.

### New context classes
New classess are added: `GuestConfigurationContext` and `AssessorContext` to enclose different behavior in different types. They differ only in the state path values.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
