### PR TITLE
MOF parser hardening

### DIFF
--- a/src/modules/complianceengine/src/assessor/CMakeLists.txt
+++ b/src/modules/complianceengine/src/assessor/CMakeLists.txt
@@ -55,3 +55,7 @@ install(TARGETS ${target_name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if (BUILD_TESTS)
     add_subdirectory(tests)
 endif()
+
+if (BUILD_FUZZER)
+    add_subdirectory(fuzzer)
+endif()

--- a/src/modules/complianceengine/src/assessor/JsonFormatter.cpp
+++ b/src/modules/complianceengine/src/assessor/JsonFormatter.cpp
@@ -1,3 +1,4 @@
+#include <Engine.h>
 #include <JsonFormatter.hpp>
 #include <parson.h>
 #include <sstream>

--- a/src/modules/complianceengine/src/assessor/Main.cpp
+++ b/src/modules/complianceengine/src/assessor/Main.cpp
@@ -11,8 +11,11 @@
 // are treated as operator-supplied (trusted to be benign in intent, but not
 // to be free of bugs or accidental hostile content).
 //
-//  - The input MOF parser is intentionally loose. Add fuzz coverage when
-//    extending it.
+//  - The input MOF parser is strict and streaming (see MofResourceRange): it
+//    validates the fixed field set the augmentation engine emits, rejects
+//    unknown fields, and bounds line length, total size, and entry count. It
+//    owns the input file and encapsulates the integrity checks below. A fuzzer
+//    target exercises it; extend the corpus when changing the format.
 //
 //  - Input file integrity (when --input is used; stdin bypasses all checks):
 //
@@ -35,17 +38,17 @@
 //       they cannot block the read or stream unbounded data), root-owned, and
 //       not group/world-writable.
 //
-//    4. The file is read into memory immediately after opening and the fd is
-//       closed. The fd keeps the inode reachable across the read even if the
-//       directory entry is concurrently renamed or unlinked. The total bytes
-//       read are capped (kMaxInputBytes) to bound memory use.
+//    4. The verified fd is wrapped in a stream and read incrementally (never
+//       slurped whole). The fd keeps the inode reachable across the read even
+//       if the directory entry is concurrently renamed or unlinked. The total
+//       bytes read, per-line length, and entry count are all bounded inside the
+//       streaming parser to keep memory use bounded.
 //
 //  - stdin (--input not supplied): all file integrity checks are bypassed.
 //    Streaming inputs (pipes, process substitution) must use stdin. The bytes
-//    consumed are still capped (kMaxInputBytes), and per-entry line length and
-//    total entry count are bounded by the MOF parser / scan loop.
-//    Callers in automated pipelines should always use --input with a
-//    root-owned, non-world-writable file.
+//    consumed, per-line length, and total entry count are still bounded inside
+//    the streaming MOF parser. Callers in automated pipelines should always use
+//    --input with a root-owned, non-world-writable file.
 //
 //  - umask is tightened to at least S_IRWXG|S_IRWXO (preserving any stricter
 //    inherited mask). The log file when --log-file is supplied is the primary
@@ -77,22 +80,22 @@
 //    engine spawns. Sanitizing the environment is the engine's
 //    responsibility, not the assessor's.
 
+#include "CliOptions.hpp"
+#include "CompactListFormatter.hpp"
+#include "DebugFormatter.hpp"
+#include "InputSecurity.hpp"
+#include "JsonFormatter.hpp"
+#include "Mof.hpp"
+#include "NestedListFormatter.hpp"
+
 #include <AssessorContext.h>
-#include <CliOptions.hpp>
-#include <CompactListFormatter.hpp>
-#include <DebugFormatter.hpp>
 #include <Engine.h>
-#include <InputSecurity.hpp>
-#include <JsonFormatter.hpp>
 #include <Logging.h>
-#include <Mof.hpp>
-#include <NestedListFormatter.hpp>
 #include <Optional.h>
 #include <cerrno>
 #include <cstring>
 #include <iostream>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -109,33 +112,17 @@ using ComplianceEngine::Result;
 using ComplianceEngine::Status;
 using ComplianceEngine::Assessor::Command;
 using ComplianceEngine::Assessor::Format;
-using ComplianceEngine::Assessor::OpenVerifiedInput;
 using ComplianceEngine::Assessor::Options;
 using ComplianceEngine::Assessor::ParseCommandLine;
 using ComplianceEngine::Assessor::PrintHelp;
-using ComplianceEngine::Assessor::RefusePathTraversal;
 using ComplianceEngine::Assessor::RefuseUnsafeLogFile;
-using ComplianceEngine::Assessor::RefuseWritableParentDir;
 using ComplianceEngine::BenchmarkFormatters::BenchmarkFormatter;
 using ComplianceEngine::BenchmarkFormatters::CompactListFormatter;
 using ComplianceEngine::BenchmarkFormatters::DebugFormatter;
 using ComplianceEngine::BenchmarkFormatters::JsonFormatter;
 using ComplianceEngine::BenchmarkFormatters::NestedListFormatter;
-using ComplianceEngine::MOF::Resource;
-using std::istream;
+using ComplianceEngine::MOF::MofResourceRange;
 using std::string;
-
-// Upper bound on the total bytes accepted from either --input or stdin. A
-// real benchmark MOF is far smaller; the cap prevents a malformed or hostile
-// input (or a pipe that never ends) from exhausting memory while we run as
-// root. NOTE: when MOF parsing is reworked to stream both file and stdin
-// inputs, this byte-accounting moves into the streaming parser.
-static constexpr size_t kMaxInputBytes = static_cast<size_t>(8) * 1024 * 1024;
-
-// Upper bound on the number of MOF entries processed from a single input. A
-// real benchmark has a few hundred rules; a vastly larger count indicates a
-// malformed or hostile input.
-static constexpr size_t kMaxMofEntries = 100000;
 
 int main(int argc, char* argv[])
 {
@@ -246,105 +233,31 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    std::istringstream fileStream;
-    if (!options.input.empty())
+    // Open the input as a strictly-validated, streaming MOF range. For --input
+    // the range encapsulates the full input-hardening posture (path-traversal
+    // rejection, root-owned non-writable parent directory, O_NOFOLLOW open, and
+    // regular-file/ownership/mode checks) and owns the file; for stdin it
+    // streams without those on-disk checks. Size, line, and entry caps are
+    // enforced inside the range.
+    auto rangeResult = options.input.empty() ? MofResourceRange::Make(std::cin, logHandle.get()) : MofResourceRange::Make(options.input, logHandle.get());
+    if (!rangeResult.HasValue())
     {
-        if (RefusePathTraversal(options.input, logHandle.get()))
-        {
-            return 1;
-        }
-        if (RefuseWritableParentDir(options.input, logHandle.get()))
-        {
-            return 1;
-        }
-        const auto inputFdResult = OpenVerifiedInput(options.input, logHandle.get());
-        if (!inputFdResult.HasValue())
-        {
-            return 1;
-        }
-        const int inputFd = inputFdResult.Value();
-        std::string content;
-        char buf[4096];
-        ssize_t n = 0;
-        bool tooLarge = false;
-        while (true)
-        {
-            n = ::read(inputFd, buf, sizeof(buf));
-            if (n > 0)
-            {
-                if (content.size() + static_cast<size_t>(n) > kMaxInputBytes)
-                {
-                    tooLarge = true;
-                    break;
-                }
-                content.append(buf, static_cast<size_t>(n));
-            }
-            else if (n == 0)
-            {
-                break; // EOF
-            }
-            else if (errno != EINTR)
-            {
-                break; // real error
-            }
-            // EINTR: signal interrupted the syscall; retry
-        }
-        const int savedErrno = errno;
-        ::close(inputFd);
-        if (tooLarge)
-        {
-            OsConfigLogError(logHandle.get(), "Refusing to read input file '%s': exceeds maximum size of %zu bytes.", options.input.c_str(), kMaxInputBytes);
-            return 1;
-        }
-        if (n < 0)
-        {
-            OsConfigLogError(logHandle.get(), "Failed to read input file '%s': %s", options.input.c_str(), std::strerror(savedErrno));
-            return 1;
-        }
-        fileStream.str(content);
+        OsConfigLogError(logHandle.get(), "Failed to open MOF input: %s", rangeResult.Error().message.c_str());
+        return 1;
     }
+    auto& mofRange = rangeResult.Value();
 
-    istream& inputStream = options.input.empty() ? std::cin : fileStream;
-    string line;
     auto status = Status::Compliant;
     bool hasError = false;
-    // Total bytes consumed from the input stream (outer scan loop + all lines
-    // read inside Resource::ParseSingleEntry). The --input path is already
-    // bounded by kMaxInputBytes above; this shared counter applies the same
-    // ceiling to the stdin path without buffering all of stdin (per the
-    // planned MOF streaming rework). Per-entry line-length and entry-count
-    // limits are also enforced inside Resource::ParseSingleEntry.
-    size_t bytesConsumed = 0;
-    size_t entryCount = 0;
-    while (std::getline(inputStream, line))
+    for (const auto& entryResult : mofRange)
     {
-        // Include one byte for the newline that std::getline() discards.
-        bytesConsumed += line.size() + 1;
-        if (bytesConsumed > kMaxInputBytes)
+        if (!entryResult.HasValue())
         {
-            OsConfigLogError(logHandle.get(), "Refusing to process input: exceeds maximum size of %zu bytes.", kMaxInputBytes);
+            OsConfigLogError(logHandle.get(), "Failed to parse MOF entry: %s", entryResult.Error().message.c_str());
             return 1;
         }
 
-        if (line.find("instance of OsConfigResource as") == std::string::npos)
-        {
-            continue;
-        }
-
-        if (++entryCount > kMaxMofEntries)
-        {
-            OsConfigLogError(logHandle.get(), "Refusing to process input: exceeds maximum of %zu MOF entries.", kMaxMofEntries);
-            return 1;
-        }
-
-        auto mofParsingResult = Resource::ParseSingleEntry(inputStream, bytesConsumed, kMaxInputBytes);
-        if (!mofParsingResult.HasValue())
-        {
-            OsConfigLogError(logHandle.get(), "Failed to parse MOF entry: %s", mofParsingResult.Error().message.c_str());
-            return 1;
-        }
-
-        auto mofEntry = std::move(mofParsingResult.Value());
+        const auto& mofEntry = entryResult.Value();
         if (options.section.HasValue())
         {
             if (mofEntry.benchmarkInfo.section.find(options.section.Value()) != 0)
@@ -423,19 +336,13 @@ int main(int argc, char* argv[])
             }
 
             case Command::Remediate: {
-                if (!mofEntry.payload.HasValue())
-                {
-                    OsConfigLogError(logHandle.get(), "Cannot remediate '%s': missing DesiredObjectValue.", mofEntry.resourceID.c_str());
-                    status = Status::NonCompliant;
-                    if (!options.continueOnError)
-                    {
-                        return 1;
-                    }
-                    hasError = true;
-                    continue;
-                }
+                // The augmentation engine emits an empty DesiredObjectValue for
+                // every rule (modelled here as an absent payload); fall back to
+                // an empty JSON object so remediation can still run, mirroring
+                // the audit-init path above.
+                const string remediatePayload = mofEntry.payload.HasValue() ? mofEntry.payload.Value() : string("{}");
                 auto ruleName = string("remediate") + mofEntry.ruleName;
-                auto result = engine.MmiSet(ruleName.c_str(), mofEntry.payload.Value());
+                auto result = engine.MmiSet(ruleName.c_str(), remediatePayload);
                 if (!result.HasValue())
                 {
                     OsConfigLogError(logHandle.get(), "Failed to remediate: %s", result.Error().message.c_str());

--- a/src/modules/complianceengine/src/assessor/Mof.cpp
+++ b/src/modules/complianceengine/src/assessor/Mof.cpp
@@ -1,13 +1,23 @@
-#include <Mof.hpp>
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "Mof.hpp"
+
+#include "InputSecurity.hpp"
+
+#include <StringTools.h>
 #include <algorithm>
-#include <array>
+#include <cerrno>
+#include <ext/stdio_filebuf.h>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
 
 namespace ComplianceEngine
 {
 namespace MOF
 {
-using std::array;
-using std::istream;
 using std::map;
 using std::string;
 
@@ -15,27 +25,64 @@ namespace
 {
 // Upper bound on a single MOF line. MOF values (notably the base64-encoded
 // ProcedureObjectValue) can be long, but a multi-megabyte line indicates a
-// malformed or hostile input rather than a real benchmark entry. Bounding the
-// line length keeps a single getline() from exhausting memory while we run as
-// root.
+// malformed or hostile input rather than a real benchmark entry. The line read
+// stops as soon as this many bytes have accumulated, so a newline-free input
+// cannot exhaust memory while we run as root.
 constexpr size_t kMaxLineLength = static_cast<size_t>(4) * 1024 * 1024;
 
-string GetValue(const std::string& line)
+// Upper bound on the total number of input bytes consumed across all entries.
+constexpr size_t kMaxInputBytes = static_cast<size_t>(8) * 1024 * 1024;
+
+// Upper bound on the number of MOF entries processed from a single input.
+constexpr size_t kMaxMofEntries = 100000;
+
+// Header that introduces each resource block, e.g.
+// "instance of OsConfigResource as $OsConfigResource0ref".
+constexpr char kHeaderPrefix[] = "instance of OsConfigResource as $OsConfigResource";
+constexpr char kHeaderSuffix[] = "ref";
+
+// The complete, fixed set of field keys the Compliance Augmentation Engine
+// emits for every resource. The parser is strict: it rejects any key not in
+// this set (unknown/extra fields) and requires every key in this set to be
+// present (missing fields). This is the single source of truth for both checks.
+const std::set<string>& KnownMofKeys()
 {
-    const auto start = line.find('"');
-    if (start == std::string::npos)
+    static const std::set<string> keys = {"ResourceID", "PayloadKey", "RuleId", "ComponentName", "ProcedureObjectName", "ProcedureObjectValue",
+        "InitObjectName", "ReportedObjectName", "ExpectedObjectValue", "DesiredObjectName", "DesiredObjectValue", "ModuleName", "ModuleVersion",
+        "ConfigurationName", "SourceInfo"};
+    return keys;
+}
+
+// Returns the suffix of `value` after `prefix`, or an empty Optional when
+// `value` does not start with `prefix`.
+Optional<string> StripPrefix(const string& value, const string& prefix)
+{
+    if (value.size() < prefix.size() || value.compare(0, prefix.size(), prefix) != 0)
     {
-        return std::string();
+        return Optional<string>();
     }
-    // Walk from the opening quote, honouring \" and \\ escape sequences so
-    // that MOF string values like "{\"key\":\"val\"}" are returned
-    // unescaped as {"key":"val"} instead of being truncated at the first
-    // inner quote.
-    std::string result;
-    size_t pos = start + 1;
+    return value.substr(prefix.size());
+}
+
+// Extracts the double-quoted value beginning at or after `from`, honouring \"
+// and \\ escape sequences so that MOF string values like "{\"key\":\"val\"}"
+// are returned unescaped as {"key":"val"}. Requires both an opening and a
+// closing quote; a missing quote is a parse error.
+Result<string> ParseQuoted(const string& line, size_t from)
+{
+    const auto open = line.find('"', from);
+    if (open == string::npos)
+    {
+        return Error("MOF field value is not quoted: '" + line + "'", EINVAL);
+    }
+
+    string result;
+    size_t pos = open + 1;
+    bool closed = false;
     while (pos < line.size())
     {
-        if (line[pos] == '\\' && pos + 1 < line.size())
+        const char c = line[pos];
+        if (c == '\\' && pos + 1 < line.size())
         {
             const char next = line[pos + 1];
             if (next == '"' || next == '\\')
@@ -45,166 +92,427 @@ string GetValue(const std::string& line)
                 continue;
             }
         }
-        else if (line[pos] == '"')
+        if (c == '"')
         {
+            closed = true;
             break;
         }
-        result += line[pos];
+        result += c;
         ++pos;
     }
+
+    if (!closed)
+    {
+        return Error("MOF field value is missing a closing quote: '" + line + "'", EINVAL);
+    }
+
+    const string tail = TrimWhiteSpaces(line.substr(pos + 1));
+    if (tail != ";")
+    {
+        return Error("MOF field line must end with ';': '" + line + "'", EINVAL);
+    }
     return result;
-};
-} // anonymous namespace
-
-Result<SemVer> SemVer::Parse(const std::string& version)
-{
-    if (version.find("v") != 0)
-    {
-        return Error("Invalid version format: must start with 'v' prefix");
-    }
-
-    const auto pos1 = version.find('.', 1);
-    if (pos1 == std::string::npos)
-    {
-        return Error("Invalid version format: missing minor version");
-    }
-
-    const auto pos2 = version.find('.', pos1 + 1);
-    if (pos2 == std::string::npos)
-    {
-        return Error("Invalid version format: missing patch version");
-    }
-
-    try
-    {
-        const auto major = std::stoi(version.substr(1, pos1));
-        const auto minor = std::stoi(version.substr(pos1 + 1, pos2 - pos1 - 1));
-        const auto patch = std::stoi(version.substr(pos2 + 1));
-
-        return SemVer{major, minor, patch};
-    }
-    catch (std::exception& e)
-    {
-        return Error(string("Invalid version format: ") + e.what());
-    }
 }
 
-Result<Resource> Resource::ParseSingleEntry(std::istream& stream, size_t& bytesConsumed, size_t maxBytes)
+// Parses a single `Key = "value";` field line into its key and unescaped value.
+Result<std::pair<string, string>> ParseFieldLine(const string& line)
 {
-    string line;
-    Optional<std::string> resourceID;
-    Optional<CISBenchmarkInfo> benchmarkInfo;
-    Optional<std::string> procedure;
-    bool hasInitAudit = false;
-    Optional<std::string> ruleName;
-    Optional<std::string> payload;
-    while (std::getline(stream, line))
+    const auto eq = line.find('=');
+    if (eq == string::npos)
     {
-        bytesConsumed += line.size() + 1;
-        if (bytesConsumed > maxBytes)
-        {
-            return Error("MOF input exceeds maximum size");
-        }
+        return Error("MOF field line is missing '=': '" + line + "'", EINVAL);
+    }
 
-        if (line.size() > kMaxLineLength)
-        {
-            return Error("MOF line exceeds maximum length");
-        }
+    const string key = TrimWhiteSpaces(line.substr(0, eq));
+    if (key.empty())
+    {
+        return Error("MOF field line has an empty key: '" + line + "'", EINVAL);
+    }
 
-        if (line.find("ResourceID") != string::npos)
-        {
-            resourceID = GetValue(line);
-            continue;
-        }
+    auto value = ParseQuoted(line, eq + 1);
+    if (!value.HasValue())
+    {
+        return value.Error();
+    }
+    return std::make_pair(key, std::move(value.Value()));
+}
 
-        if (line.find("PayloadKey") != string::npos)
+// Validates a fully-collected field map and assembles the Resource. Enforces
+// the constant fields, the required-field set, and rule-name consistency across
+// the four object-name fields. The base64 ProcedureObjectValue is stored as-is;
+// decoding and JSON validation are the ComplianceEngine's responsibility, which
+// keeps the parser/engine boundary explicit.
+Result<Resource> BuildResource(const map<string, string>& fields)
+{
+    for (const auto& key : KnownMofKeys())
+    {
+        if (fields.find(key) == fields.end())
         {
-            auto result = CISBenchmarkInfo::Parse(GetValue(line));
-            if (!result.HasValue())
-            {
-                return Error("Failed to parse PayloadKey: " + result.Error().message);
-            }
-            benchmarkInfo = std::move(result.Value());
-            continue;
+            return Error("MOF entry is missing required field: '" + key + "'", EINVAL);
         }
+    }
 
-        if (line.find("ProcedureObjectValue") != std::string::npos)
-        {
-            procedure = GetValue(line);
-            continue;
-        }
+    if (fields.at("ComponentName") != "ComplianceEngine")
+    {
+        return Error("MOF entry has unexpected ComponentName: '" + fields.at("ComponentName") + "'", EINVAL);
+    }
+    if (fields.at("ConfigurationName") != "ComplianceEngine")
+    {
+        return Error("MOF entry has unexpected ConfigurationName: '" + fields.at("ConfigurationName") + "'", EINVAL);
+    }
+    if (fields.at("ExpectedObjectValue") != "PASS")
+    {
+        return Error("MOF entry has unexpected ExpectedObjectValue: '" + fields.at("ExpectedObjectValue") + "'", EINVAL);
+    }
 
-        if (line.find("InitObjectName") != std::string::npos)
-        {
-            auto value = GetValue(line);
-            if (value.find("init") != 0)
-            {
-                return Error("Invalid init object name");
-            }
-            hasInitAudit = true;
-            continue;
-        }
+    const auto procedureName = StripPrefix(fields.at("ProcedureObjectName"), "procedure");
+    if (!procedureName.HasValue())
+    {
+        return Error("ProcedureObjectName must start with 'procedure': '" + fields.at("ProcedureObjectName") + "'", EINVAL);
+    }
+    const auto initName = StripPrefix(fields.at("InitObjectName"), "init");
+    if (!initName.HasValue())
+    {
+        return Error("InitObjectName must start with 'init': '" + fields.at("InitObjectName") + "'", EINVAL);
+    }
+    const auto auditName = StripPrefix(fields.at("ReportedObjectName"), "audit");
+    if (!auditName.HasValue())
+    {
+        return Error("ReportedObjectName must start with 'audit': '" + fields.at("ReportedObjectName") + "'", EINVAL);
+    }
+    const auto remediateName = StripPrefix(fields.at("DesiredObjectName"), "remediate");
+    if (!remediateName.HasValue())
+    {
+        return Error("DesiredObjectName must start with 'remediate': '" + fields.at("DesiredObjectName") + "'", EINVAL);
+    }
 
-        if (line.find("ReportedObjectName") != std::string::npos)
-        {
-            auto value = GetValue(line);
-            if (value.find("audit") != 0)
-            {
-                return Error("Invalid reported object name");
-            }
-            ruleName = value.substr(strlen("audit"));
-            continue;
-        }
+    const string& ruleName = procedureName.Value();
+    if (ruleName.empty())
+    {
+        return Error("MOF entry has an empty rule name", EINVAL);
+    }
+    if (initName.Value() != ruleName || auditName.Value() != ruleName || remediateName.Value() != ruleName)
+    {
+        return Error("MOF entry object names disagree on the rule name '" + ruleName + "'", EINVAL);
+    }
 
-        if (line.find("DesiredObjectValue") != std::string::npos)
-        {
-            payload = GetValue(line);
-            continue;
-        }
+    if (fields.at("ResourceID").empty())
+    {
+        return Error("MOF entry has an empty ResourceID", EINVAL);
+    }
+    if (fields.at("ProcedureObjectValue").empty())
+    {
+        return Error("MOF entry has an empty ProcedureObjectValue", EINVAL);
+    }
 
-        if (line.find("};") != std::string::npos)
-        {
-            // End of MOF entry, validate and return
-            break;
-        }
+    auto benchmarkInfo = CISBenchmarkInfo::Parse(fields.at("PayloadKey"));
+    if (!benchmarkInfo.HasValue())
+    {
+        return Error("Failed to parse PayloadKey: " + benchmarkInfo.Error().message, benchmarkInfo.Error().code);
     }
 
     Resource resource;
-    if (!resourceID.HasValue())
-    {
-        return Error("Failed to parse MOF file: ResourceID is missing");
-    }
-    resource.resourceID = std::move(resourceID.Value());
-
-    if (!benchmarkInfo.HasValue())
-    {
-        return Error("Failed to parse MOF file: PayloadKey is missing");
-    }
+    resource.resourceID = fields.at("ResourceID");
     resource.benchmarkInfo = std::move(benchmarkInfo.Value());
-    auto& section = resource.benchmarkInfo.section;
-    std::transform(section.begin(), section.end(), section.begin(), [](char c) {
-        if (c == '/')
-        {
-            return '.';
-        }
-        return c;
-    });
+    // The section in the payload key is '/'-separated (e.g. "1/1/1/1"); the rest
+    // of the assessor expects dotted notation (e.g. "1.1.1.1").
+    std::replace(resource.benchmarkInfo.section.begin(), resource.benchmarkInfo.section.end(), '/', '.');
+    resource.procedure = fields.at("ProcedureObjectValue");
+    resource.ruleName = ruleName;
+    resource.hasInitAudit = true; // InitObjectName is required and validated above.
 
-    if (!ruleName.HasValue())
+    // An empty DesiredObjectValue (emitted for every rule today) is modelled as
+    // an absent payload; a non-empty value is carried through.
+    const string& desired = fields.at("DesiredObjectValue");
+    if (!desired.empty())
     {
-        return Error("Failed to parse MOF file: ReportedObjectName is missing");
+        resource.payload = desired;
     }
-    resource.ruleName = std::move(ruleName.Value());
-
-    if (!procedure.HasValue())
-    {
-        return Error("Failed to parse MOF file: ProcedureObjectValue is missing");
-    }
-    resource.procedure = std::move(procedure.Value());
-    resource.payload = std::move(payload);
-    resource.hasInitAudit = hasInitAudit;
 
     return resource;
+}
+} // anonymous namespace
+
+MofResourceRange::MofResourceRange(std::istream& stream, OsConfigLogHandle logHandle) noexcept
+    : mStream(&stream),
+      mLog(logHandle),
+      mOwnedBuf(),
+      mOwnedStream()
+
+{
+}
+
+MofResourceRange::MofResourceRange(MofResourceRange&& other) noexcept
+    : mStream(other.mStream),
+      mLog(other.mLog),
+      mOwnedBuf(std::move(other.mOwnedBuf)),
+      mOwnedStream(std::move(other.mOwnedStream)),
+      mBytesConsumed(other.mBytesConsumed),
+      mEntryCount(other.mEntryCount)
+{
+    other.mStream = nullptr;
+}
+
+Result<MofResourceRange> MofResourceRange::Make(const string& path, OsConfigLogHandle logHandle)
+{
+    // Encapsulate the full input-hardening posture so callers never open the
+    // file themselves: reject path traversal, require a root-owned non-writable
+    // parent directory, and open with O_NOFOLLOW plus regular-file/ownership/
+    // mode checks on the resulting fd.
+    if (Assessor::RefusePathTraversal(path, logHandle))
+    {
+        return Error("Refusing to open MOF input with an unsafe path: '" + path + "'", EACCES);
+    }
+    if (Assessor::RefuseWritableParentDir(path, logHandle))
+    {
+        return Error("Refusing to open MOF input in a writable parent directory: '" + path + "'", EACCES);
+    }
+    auto fdResult = Assessor::OpenVerifiedInput(path, logHandle);
+    if (!fdResult.HasValue())
+    {
+        return fdResult.Error();
+    }
+
+    // Bridge the verified fd into a std::istream for streaming. stdio_filebuf
+    // takes ownership of the fd and closes it when destroyed.
+    std::unique_ptr<__gnu_cxx::stdio_filebuf<char>> buffer(new __gnu_cxx::stdio_filebuf<char>(fdResult.Value(), std::ios_base::in));
+    std::unique_ptr<std::istream> stream(new std::istream(buffer.get()));
+
+    MofResourceRange range(*stream, logHandle);
+    range.mOwnedBuf = std::move(buffer);
+    range.mOwnedStream = std::move(stream);
+    range.mStream = range.mOwnedStream.get();
+    return range;
+}
+
+Result<MofResourceRange> MofResourceRange::MakeFromStream(std::istream& stream, OsConfigLogHandle logHandle)
+{
+    return MofResourceRange(stream, logHandle);
+}
+
+Result<MofResourceRange> MofResourceRange::Make(std::istream& stream, OsConfigLogHandle logHandle)
+{
+    return MofResourceRange(stream, logHandle);
+}
+
+MofResourceIterator MofResourceRange::begin() // NOLINT(*-identifier-naming)
+{
+    return MofResourceIterator(*this);
+}
+
+MofResourceIterator MofResourceRange::end() // NOLINT(*-identifier-naming)
+{
+    return MofResourceIterator();
+}
+
+Result<Optional<Resource>> MofResourceRange::ParseNext()
+{
+    // Reads a single line from the stream.  Returns:
+    //   Error              — a resource cap was exceeded (line too long, total bytes too large)
+    //   Optional<string>() — clean end of input (EOF with nothing buffered)
+    //   Optional<string>(line) — one complete line (newline consumed but not included)
+    //
+    // A non-empty partial line at EOF (no trailing newline) is returned as an
+    // error: the augmentation engine always terminates every block with '};'
+    // followed by a newline, so a line without a terminator means the input was
+    // truncated.
+    const auto readLine = [this]() -> Result<Optional<string>> {
+        string line;
+        std::istream& stream = *mStream;
+        while (true)
+        {
+            const std::istream::int_type ch = stream.get();
+            if (ch == std::istream::traits_type::eof())
+            {
+                if (line.empty())
+                {
+                    return Optional<string>(); // Clean EOF.
+                }
+                return Error("Truncated MOF input: last line has no newline terminator", EIO);
+            }
+            if (ch == '\n')
+            {
+                // Count the line terminator alongside the content.
+                if (++mBytesConsumed > kMaxInputBytes)
+                {
+                    return Error("MOF input exceeds the maximum size of " + std::to_string(kMaxInputBytes) + " bytes", E2BIG);
+                }
+                return Optional<string>(std::move(line));
+            }
+            if (line.size() >= kMaxLineLength)
+            {
+                return Error("MOF line exceeds the maximum length of " + std::to_string(kMaxLineLength) + " bytes", E2BIG);
+            }
+            line.push_back(static_cast<char>(ch));
+            if (++mBytesConsumed > kMaxInputBytes)
+            {
+                return Error("MOF input exceeds the maximum size of " + std::to_string(kMaxInputBytes) + " bytes", E2BIG);
+            }
+        }
+    };
+
+    // Locate the next entry header, skipping blank lines between entries. A
+    // clean end of input here means there are no more entries.
+    Optional<string> headerLine;
+    while (true)
+    {
+        auto read = readLine();
+        if (!read.HasValue())
+        {
+            return read.Error();
+        }
+        if (!read.Value().HasValue())
+        {
+            return Optional<Resource>(); // Clean EOF — no more entries.
+        }
+        if (!TrimWhiteSpaces(read.Value().Value()).empty())
+        {
+            headerLine = std::move(read.Value());
+            break;
+        }
+    }
+
+    const string header = TrimWhiteSpaces(headerLine.Value());
+    const size_t prefixLen = sizeof(kHeaderPrefix) - 1;
+    const size_t suffixLen = sizeof(kHeaderSuffix) - 1;
+    if (header.size() < prefixLen + suffixLen || header.compare(0, prefixLen, kHeaderPrefix) != 0 ||
+        header.compare(header.size() - suffixLen, suffixLen, kHeaderSuffix) != 0)
+    {
+        return Error("Malformed MOF entry header: '" + header + "'", EINVAL);
+    }
+
+    if (++mEntryCount > kMaxMofEntries)
+    {
+        return Error("MOF input exceeds the maximum of " + std::to_string(kMaxMofEntries) + " entries", E2BIG);
+    }
+
+    // The header must be followed by an opening brace on its own line.
+    {
+        auto read = readLine();
+        if (!read.HasValue())
+        {
+            return read.Error();
+        }
+        if (!read.Value().HasValue() || TrimWhiteSpaces(read.Value().Value()) != "{")
+        {
+            return Error("Expected '{' after MOF entry header", EINVAL);
+        }
+    }
+
+    // Collect the field lines up to the closing '};', rejecting unknown and
+    // duplicate keys.
+    map<string, string> fields;
+    bool closed = false;
+    while (true)
+    {
+        auto read = readLine();
+        if (!read.HasValue())
+        {
+            return read.Error();
+        }
+        if (!read.Value().HasValue())
+        {
+            break; // EOF before '};'
+        }
+
+        const string trimmed = TrimWhiteSpaces(read.Value().Value());
+        if (trimmed.empty())
+        {
+            continue;
+        }
+        if (trimmed == "};")
+        {
+            closed = true;
+            break;
+        }
+
+        auto field = ParseFieldLine(trimmed);
+        if (!field.HasValue())
+        {
+            return field.Error();
+        }
+        if (KnownMofKeys().find(field.Value().first) == KnownMofKeys().end())
+        {
+            return Error("Unknown MOF field key: '" + field.Value().first + "'", EINVAL);
+        }
+        if (!fields.emplace(field.Value().first, std::move(field.Value().second)).second)
+        {
+            return Error("Duplicate MOF field key: '" + field.Value().first + "'", EINVAL);
+        }
+    }
+
+    if (!closed)
+    {
+        return Error("Truncated MOF entry: missing closing '};'", EIO);
+    }
+
+    auto resource = BuildResource(fields);
+    if (!resource.HasValue())
+    {
+        return resource.Error();
+    }
+    return Optional<Resource>(std::move(resource.Value()));
+}
+
+MofResourceIterator::MofResourceIterator(MofResourceRange& range)
+    : mRange(&range)
+{
+    Advance();
+}
+
+void MofResourceIterator::Advance()
+{
+    auto result = mRange->ParseNext();
+    if (!result.HasValue())
+    {
+        // Surface the parse error once; the next increment terminates iteration
+        // because a desynchronized stream cannot be resumed reliably.
+        mCurrent = Result<Resource>(result.Error());
+        mErrored = true;
+        return;
+    }
+
+    Optional<Resource>& entry = result.Value();
+    if (!entry.HasValue())
+    {
+        mRange = nullptr; // Clean end of input.
+        return;
+    }
+    mCurrent = Result<Resource>(std::move(entry.Value()));
+}
+
+MofResourceIterator& MofResourceIterator::operator++()
+{
+    if (mErrored)
+    {
+        mRange = nullptr;
+        return *this;
+    }
+    if (mRange != nullptr)
+    {
+        Advance();
+    }
+    return *this;
+}
+
+MofResourceIterator::reference MofResourceIterator::operator*() const
+{
+    return mCurrent;
+}
+
+MofResourceIterator::pointer MofResourceIterator::operator->() const
+{
+    return &mCurrent;
+}
+
+bool MofResourceIterator::operator==(const MofResourceIterator& other) const
+{
+    return mRange == other.mRange;
+}
+
+bool MofResourceIterator::operator!=(const MofResourceIterator& other) const
+{
+    return mRange != other.mRange;
 }
 } // namespace MOF
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/src/assessor/Mof.cpp
+++ b/src/modules/complianceengine/src/assessor/Mof.cpp
@@ -362,7 +362,7 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
 
     // Locate the next entry header, skipping blank lines between entries. A
     // clean end of input here means there are no more entries.
-    Optional<string> headerLine;
+    string header;
     while (true)
     {
         auto read = readLine();
@@ -374,14 +374,12 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
         {
             return Optional<Resource>(); // Clean EOF — no more entries.
         }
-        if (!TrimWhiteSpaces(read.Value().Value()).empty())
+        header = TrimWhiteSpaces(read.Value().Value());
+        if (!header.empty())
         {
-            headerLine = std::move(read.Value());
             break;
         }
     }
-
-    const string header = TrimWhiteSpaces(headerLine.Value());
     const size_t prefixLen = sizeof(kHeaderPrefix) - 1;
     const size_t suffixLen = sizeof(kHeaderSuffix) - 1;
     if (header.size() < prefixLen + suffixLen || header.compare(0, prefixLen, kHeaderPrefix) != 0 ||

--- a/src/modules/complianceengine/src/assessor/Mof.cpp
+++ b/src/modules/complianceengine/src/assessor/Mof.cpp
@@ -324,6 +324,10 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
             const std::istream::int_type ch = stream.get();
             if (ch == std::istream::traits_type::eof())
             {
+                if (stream.bad())
+                {
+                    return Error("I/O error reading MOF input", EIO);
+                }
                 if (line.empty())
                 {
                     return Optional<string>(); // Clean EOF.
@@ -332,6 +336,11 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
             }
             if (ch == '\n')
             {
+                // Strip a trailing '\r' to handle CRLF line endings.
+                if (!line.empty() && line.back() == '\r')
+                {
+                    line.pop_back();
+                }
                 // Count the line terminator alongside the content.
                 if (++mBytesConsumed > kMaxInputBytes)
                 {

--- a/src/modules/complianceengine/src/assessor/Mof.hpp
+++ b/src/modules/complianceengine/src/assessor/Mof.hpp
@@ -1,36 +1,153 @@
-#ifndef COMPLIANCE_ENGINE_ASSESOR_MOF_HPP
-#define COMPLIANCE_ENGINE_ASSESOR_MOF_HPP
+#ifndef COMPLIANCE_ENGINE_ASSESSOR_MOF_HPP
+#define COMPLIANCE_ENGINE_ASSESSOR_MOF_HPP
 
 #include <BenchmarkInfo.h>
-#include <Engine.h>
+#include <Logging.h>
 #include <Optional.h>
 #include <Result.h>
+#include <istream>
+#include <memory>
+#include <streambuf>
 #include <string>
 
 namespace ComplianceEngine
 {
 namespace MOF
 {
-struct SemVer
-{
-    int major;
-    int minor;
-    int patch;
-
-    static Result<SemVer> Parse(const std::string& version);
-};
-
+// A single parsed MOF resource entry.
+//
+// Only the fields actually consumed by the assessor's main loop and output
+// formatters are stored. The parser validates every field the augmentation
+// engine emits (see MofResourceRange), but deliberately discards the ones the
+// assessor does not use (RuleId, the constant ComponentName/ExpectedObjectValue/
+// ConfigurationName/ModuleName fields, ModuleVersion, SourceInfo, etc.).
 struct Resource
 {
+    // ResourceID, e.g. "1.1.1.1 Ensure cramfs kernel module is not available".
     std::string resourceID;
-    CISBenchmarkInfo benchmarkInfo;
-    std::string procedure;
-    Optional<std::string> payload;
-    std::string ruleName;
-    bool hasInitAudit = false;
 
-    static Result<Resource> ParseSingleEntry(std::istream& stream, size_t& bytesConsumed, size_t maxBytes);
+    // Benchmark info parsed from the PayloadKey. Only `.section` is consumed
+    // (section filtering in the main loop and the JSON formatter), but the whole
+    // struct is retained so the formatters need no changes.
+    CISBenchmarkInfo benchmarkInfo;
+
+    // Base64-encoded rule payload (ProcedureObjectValue). The parser does NOT
+    // decode or validate this blob; base64/JSON parsing is owned by the
+    // ComplianceEngine (Engine/Procedure), which keeps the parser/engine
+    // boundary clear. See MofResourceRange for the validation the parser does do.
+    std::string procedure;
+
+    // DesiredObjectValue. The augmentation engine emits an empty string for
+    // every rule today; an empty value is modelled as an absent payload.
+    Optional<std::string> payload;
+
+    // The rule name shared by the ProcedureObjectName ("procedure<Name>"),
+    // InitObjectName ("init<Name>"), ReportedObjectName ("audit<Name>") and
+    // DesiredObjectName ("remediate<Name>") fields. The parser enforces that all
+    // four agree before storing the common suffix here.
+    std::string ruleName;
+
+    // True when the entry carries an InitObjectName (the engine always emits one).
+    bool hasInitAudit = false;
+};
+
+class MofResourceRange;
+
+// Input iterator over the MOF resource entries in a stream.
+//
+// Dereferencing yields a `const Result<Resource>&`: a per-entry parse error is
+// delivered in-band as an Error value so the caller can check each entry and
+// bail out, rather than being thrown. Once an entry fails to parse (or end of
+// input is reached) the iterator becomes equal to end(); a desynchronized
+// stream cannot be resumed reliably, so iteration stops.
+class MofResourceIterator
+{
+public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = Result<Resource>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const Result<Resource>*;
+    using reference = const Result<Resource>&;
+
+    reference operator*() const;
+    pointer operator->() const;
+    MofResourceIterator& operator++();
+    bool operator==(const MofResourceIterator& other) const;
+    bool operator!=(const MofResourceIterator& other) const;
+
+private:
+    friend class MofResourceRange;
+    explicit MofResourceIterator(MofResourceRange& range);
+    MofResourceIterator() = default; // end iterator
+
+    void Advance();
+
+    MofResourceRange* mRange = nullptr; // nullptr == end
+    bool mErrored = false;
+    Result<Resource> mCurrent = ComplianceEngine::Error("uninitialized MOF iterator");
+};
+
+// Owns the input stream (RAII) and streams strictly-validated MOF resource
+// entries from it. Construct via the Make* factories, which encapsulate the
+// input-hardening safeguards so callers never open the input file themselves.
+//
+// Strictness: the parser targets the exact, regular format emitted by the
+// Compliance Augmentation Engine. It requires every expected field to be
+// present, rejects unknown field keys, validates the constant fields
+// (ComponentName/ExpectedObjectValue/ConfigurationName) and enforces that the
+// four object-name fields share a single rule name. The base64 ProcedureObject
+// payload is passed through untouched; decoding/JSON validation is the
+// ComplianceEngine's responsibility.
+class MofResourceRange
+{
+public:
+    // Opens a regular file on disk, applying the full input-hardening posture
+    // (path-traversal rejection, root-owned non-writable parent directory,
+    // O_NOFOLLOW open, regular-file/ownership/mode fstat checks) before the
+    // first byte is read. The verified fd is owned and closed on destruction.
+    static Result<MofResourceRange> Make(const std::string& path, OsConfigLogHandle logHandle);
+
+    // Streams from stdin (or any externally-owned istream representing stdin).
+    // The stream is not owned. stdin has no on-disk identity, so the file-based
+    // safeguards do not apply, but the size/line/entry caps still bound resource
+    // usage.
+    static Result<MofResourceRange> Make(std::istream& stream, OsConfigLogHandle logHandle);
+
+    // Streams from an externally-owned istream. Intended for unit tests and the
+    // fuzzer; applies the same strict parsing and caps as the other factories.
+    static Result<MofResourceRange> MakeFromStream(std::istream& stream, OsConfigLogHandle logHandle);
+
+    MofResourceRange(MofResourceRange&& other) noexcept;
+    MofResourceRange& operator=(MofResourceRange&&) = delete;
+    MofResourceRange(const MofResourceRange&) = delete;
+    MofResourceRange& operator=(const MofResourceRange&) = delete;
+    ~MofResourceRange() = default;
+
+    MofResourceIterator begin(); // NOLINT(*-identifier-naming)
+    MofResourceIterator end();   // NOLINT(*-identifier-naming)
+
+private:
+    friend class MofResourceIterator;
+    MofResourceRange(std::istream& stream, OsConfigLogHandle logHandle) noexcept;
+
+    // Parses the next entry from the stream, enforcing the size/line/entry caps.
+    // Returns:
+    //   - a Resource             -> a parsed entry,
+    //   - an empty Optional      -> clean end of input (no more entries),
+    //   - an Error               -> malformed input or a cap was exceeded.
+    Result<Optional<Resource>> ParseNext();
+
+    std::istream* mStream;
+    OsConfigLogHandle mLog;
+    // For file inputs the range owns the streambuf that bridges the verified fd
+    // into an istream (and the istream itself). For stdin/test inputs these are
+    // null and mStream references the caller's stream. Declared before
+    // mOwnedStream so the istream is destroyed before the streambuf it uses.
+    std::unique_ptr<std::streambuf> mOwnedBuf;
+    std::unique_ptr<std::istream> mOwnedStream;
+    size_t mBytesConsumed = 0;
+    size_t mEntryCount = 0;
 };
 } // namespace MOF
 } // namespace ComplianceEngine
-#endif // COMPLIANCE_ENGINE_ASSESOR_MOF_HPP
+#endif // COMPLIANCE_ENGINE_ASSESSOR_MOF_HPP

--- a/src/modules/complianceengine/src/assessor/fuzzer/CMakeLists.txt
+++ b/src/modules/complianceengine/src/assessor/fuzzer/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# MOF parser fuzzer. Built only when -DBUILD_FUZZER=ON, which also requires
+# clang and enables -fsanitize=fuzzer-no-link,address,undefined globally
+# (see src/CMakeLists.txt). Run manually:
+#
+#   ./mof-parser-fuzzer -max_total_time=60 seed_corpus/
+
+add_executable(mof-parser-fuzzer target.cpp)
+
+# The shared library is built with -fsanitize=fuzzer-no-link (no main); add
+# -fsanitize=fuzzer here to pull in libFuzzer's entry point and link it.
+target_compile_options(mof-parser-fuzzer PRIVATE -fsanitize=fuzzer)
+target_link_options(mof-parser-fuzzer PRIVATE -fsanitize=fuzzer)
+
+target_link_libraries(mof-parser-fuzzer PRIVATE
+    compliance-engine-assessor-lib
+)

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/.gitignore
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/.gitignore
@@ -1,0 +1,6 @@
+# Only the hand-authored *.mof seed inputs are tracked. Fuzzer-generated corpus
+# entries land here when seed_corpus is passed directly as the corpus directory,
+# but they are not source files; ignore them.
+*
+!.gitignore
+!*.mof

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/audit_minimal.mof
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/audit_minimal.mof
@@ -1,0 +1,18 @@
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "1.1.1 Sample Rule";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/1";
+    RuleId = "00000000-0000-0000-0000-000000000000";
+    ComponentName = "ComplianceEngine";
+    ProcedureObjectName = "procedureSample";
+    ProcedureObjectValue = "eyJhdWRpdCI6e319";
+    InitObjectName = "initSample";
+    ReportedObjectName = "auditSample";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateSample";
+    DesiredObjectValue = "";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "ComplianceEngine";
+    SourceInfo = "::4::5::OsConfigResource";
+};

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/init_audit.mof
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/init_audit.mof
@@ -1,0 +1,18 @@
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "2.1.1 Sample With Init";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/2/1/1";
+    RuleId = "00000000-0000-0000-0000-000000000000";
+    ComponentName = "ComplianceEngine";
+    ProcedureObjectName = "procedureInit";
+    ProcedureObjectValue = "eyJhdWRpdCI6e319";
+    InitObjectName = "initInit";
+    ReportedObjectName = "auditInit";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateInit";
+    DesiredObjectValue = "{\"mask\":\"0600\"}";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "ComplianceEngine";
+    SourceInfo = "::4::5::OsConfigResource";
+};

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/remediate_minimal.mof
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/remediate_minimal.mof
@@ -1,0 +1,18 @@
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "1.1.1 Sample Rule";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/1";
+    RuleId = "00000000-0000-0000-0000-000000000000";
+    ComponentName = "ComplianceEngine";
+    ProcedureObjectName = "procedureSample";
+    ProcedureObjectValue = "eyJhdWRpdCI6e319";
+    InitObjectName = "initSample";
+    ReportedObjectName = "auditSample";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateSample";
+    DesiredObjectValue = "{}";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "ComplianceEngine";
+    SourceInfo = "::4::5::OsConfigResource";
+};

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/truncated.mof
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/truncated.mof
@@ -1,0 +1,4 @@
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "Truncated";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/two_entries.mof
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/two_entries.mof
@@ -1,0 +1,36 @@
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "1.1.1 Rule A";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/1";
+    RuleId = "00000000-0000-0000-0000-000000000000";
+    ComponentName = "ComplianceEngine";
+    ProcedureObjectName = "procedureRuleA";
+    ProcedureObjectValue = "eyJhdWRpdCI6e319";
+    InitObjectName = "initRuleA";
+    ReportedObjectName = "auditRuleA";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateRuleA";
+    DesiredObjectValue = "";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "ComplianceEngine";
+    SourceInfo = "::4::5::OsConfigResource";
+};
+instance of OsConfigResource as $OsConfigResource1ref
+{
+    ResourceID = "1.1.2 Rule B";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/2";
+    RuleId = "00000000-0000-0000-0000-000000000001";
+    ComponentName = "ComplianceEngine";
+    ProcedureObjectName = "procedureRuleB";
+    ProcedureObjectValue = "eyJhdWRpdCI6e319";
+    InitObjectName = "initRuleB";
+    ReportedObjectName = "auditRuleB";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateRuleB";
+    DesiredObjectValue = "";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "ComplianceEngine";
+    SourceInfo = "::4::5::OsConfigResource";
+};

--- a/src/modules/complianceengine/src/assessor/fuzzer/target.cpp
+++ b/src/modules/complianceengine/src/assessor/fuzzer/target.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+//
+// libFuzzer target for the MOF parser used by the compliance-engine-assessor.
+//
+// Scope: parser only (MofResourceRange / MofResourceIterator). The engine and
+// procedure evaluation are intentionally out of scope — the goal is to ensure
+// the parser is crash-free and bounded against adversarial input.
+//
+// Run:
+//   ./mof-parser-fuzzer -max_total_time=60 seed_corpus/
+
+#include "Mof.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+using ComplianceEngine::MOF::MofResourceRange;
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
+{
+    if (size == 0)
+    {
+        return 0; // not interesting
+    }
+
+    try
+    {
+        std::string input(reinterpret_cast<const char*>(data), size);
+        std::istringstream stream(input);
+
+        auto rangeResult = MofResourceRange::Make(stream, nullptr);
+        if (!rangeResult.HasValue())
+        {
+            return 0; // rejected at open; not a crash
+        }
+
+        // Drain the iterator, discarding results. We only care that the parser
+        // is crash-free and that every error is surfaced as a Result<> rather
+        // than an exception or undefined behaviour.
+        for (const auto& entry : rangeResult.Value())
+        {
+            (void)entry;
+        }
+    }
+    catch (...)
+    {
+        // The parser must never throw. Surface any exception as a crash so
+        // libFuzzer records the reproducer.
+        __builtin_trap();
+    }
+    return 0;
+}

--- a/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
@@ -494,6 +494,53 @@ TEST(MofParserTest, TruncatedNoNewlineAtEofIsRejected)
     EXPECT_EQ(result.Error().code, EIO);
 }
 
+TEST(MofParserTest, IoErrorOnReadIsReportedWithEio)
+{
+    // When the underlying streambuf throws during get(), istream sets badbit
+    // and returns EOF. The parser must detect stream.bad() and return an I/O
+    // error rather than misreporting the state as a clean EOF or truncation.
+    struct ErrorBuf : std::streambuf
+    {
+        int_type underflow() override
+        {
+            throw std::ios_base::failure("simulated I/O error");
+        }
+    } buf;
+    std::istream stream(&buf);
+    // Suppress exceptions so that istream catches the throw and sets badbit.
+    stream.exceptions(std::ios_base::goodbit);
+    auto rangeResult = MofResourceRange::Make(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    ASSERT_FALSE((*it).HasValue());
+    EXPECT_EQ((*it).Error().code, EIO);
+    EXPECT_NE((*it).Error().message.find("I/O error"), std::string::npos);
+}
+
+TEST(MofParserTest, CrlfLineEndingsAreAccepted)
+{
+    // MOF files may carry Windows-style CRLF line endings. The parser must
+    // strip the trailing '\r' so that field keys, values, and block delimiters
+    // are recognised correctly.
+    std::string text = Render(DefaultFields());
+    // Replace every \n with \r\n.
+    std::string crlf;
+    crlf.reserve(text.size() + std::count(text.begin(), text.end(), '\n'));
+    for (char c : text)
+    {
+        if (c == '\n')
+        {
+            crlf += '\r';
+        }
+        crlf += c;
+    }
+    auto result = ParseFirst(crlf);
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    EXPECT_EQ(result.Value().ruleName, "MyRule");
+}
+
 // ---------------------------------------------------------------------------
 // Make(istream&) overload and operator->
 // ---------------------------------------------------------------------------

--- a/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
@@ -1,62 +1,630 @@
-// Smoke tests for the MOF parser library. Verifies the lib links and that
-// ParseSingleEntry accepts a well-formed MOF body. The MOF stream iterator
-// (ParseAll), bounded-line reader, and adversarial-input tests land in the
-// MOF parser-rework PR along with their own tests.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-#include <Mof.hpp>
-#include <cstddef>
+// Unit tests for the strict, streaming MOF parser (MofResourceRange /
+// MofResourceIterator). The parser validates the fixed field set the
+// augmentation engine emits, rejects unknown/duplicate fields, enforces field
+// constants and rule-name consistency, and bounds line length, total size, and
+// entry count. These tests focus on the happy path and a broad set of
+// adversarial / malformed inputs.
+
+#include "Mof.hpp"
+
+#include <algorithm>
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <sstream>
 #include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
 
+using ComplianceEngine::Error;
+using ComplianceEngine::Result;
+using ComplianceEngine::MOF::MofResourceRange;
 using ComplianceEngine::MOF::Resource;
 
 namespace
 {
-constexpr const char* kValidBody = R"(    ResourceID = "Some Rule";
-    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/1";
-    ProcedureObjectName = "procedureMyRule";
-    ProcedureObjectValue = "base64data==";
-    InitObjectName = "initMyRule";
-    ReportedObjectName = "auditMyRule";
-    DesiredObjectValue = "mask=0600";
-};
-)";
-} // namespace
+using Fields = std::vector<std::pair<std::string, std::string>>;
 
-TEST(MofSmokeTest, ParseSingleEntryHappyPath)
+constexpr const char* kHeader = "instance of OsConfigResource as $OsConfigResource0ref";
+
+// A complete, valid field set matching what the augmentation engine emits.
+Fields DefaultFields()
 {
-    std::istringstream s(kValidBody);
-    size_t bytesConsumed = 0;
-    auto result = Resource::ParseSingleEntry(s, bytesConsumed, SIZE_MAX);
-    ASSERT_TRUE(result.HasValue()) << result.Error().message;
-    EXPECT_EQ(result.Value().resourceID, "Some Rule");
-    EXPECT_EQ(result.Value().ruleName, "MyRule");
-    EXPECT_EQ(result.Value().procedure, "base64data==");
-    EXPECT_TRUE(result.Value().hasInitAudit);
-    ASSERT_TRUE(result.Value().payload.HasValue());
-    EXPECT_EQ(result.Value().payload.Value(), "mask=0600");
-    EXPECT_EQ(result.Value().benchmarkInfo.section, "1.1.1");
+    return {
+        {"ResourceID", "1.1.1 Some Rule"},
+        {"PayloadKey", "/cis/ubuntu/22.04/v2.0.0/1/1/1"},
+        {"RuleId", "00000000-0000-0000-0000-000000000000"},
+        {"ComponentName", "ComplianceEngine"},
+        {"ProcedureObjectName", "procedureMyRule"},
+        {"ProcedureObjectValue", "base64data=="},
+        {"InitObjectName", "initMyRule"},
+        {"ReportedObjectName", "auditMyRule"},
+        {"ExpectedObjectValue", "PASS"},
+        {"DesiredObjectName", "remediateMyRule"},
+        {"DesiredObjectValue", ""},
+        {"ModuleName", "GuestConfiguration"},
+        {"ModuleVersion", "1.0.0"},
+        {"ConfigurationName", "ComplianceEngine"},
+        {"SourceInfo", "::4::5::OsConfigResource"},
+    };
 }
 
-TEST(MofSmokeTest, JsonEscapedDesiredObjectValue)
+void SetField(Fields& fields, const std::string& key, const std::string& value)
 {
-    // Production MOFs use JSON for DesiredObjectValue with MOF-escaped inner
-    // quotes. Verifies pr1's GetValue escape handling is preserved through
-    // the library extraction.
-    const std::string body =
-        "    ResourceID = \"Some Rule\";\n"
-        "    PayloadKey = \"/cis/rhel/8/v4.0.0/1/2/3\";\n"
-        "    ProcedureObjectName = \"procedureMyRule\";\n"
-        "    ProcedureObjectValue = \"base64data==\";\n"
-        "    InitObjectName = \"initMyRule\";\n"
-        "    ReportedObjectName = \"auditMyRule\";\n"
-        "    DesiredObjectValue = \"{\\\"mountPoint\\\":\\\"/tmp\\\"}\";\n"
-        "};\n";
-    std::istringstream s(body);
-    size_t bytesConsumed = 0;
-    auto result = Resource::ParseSingleEntry(s, bytesConsumed, SIZE_MAX);
+    for (auto& f : fields)
+    {
+        if (f.first == key)
+        {
+            f.second = value;
+            return;
+        }
+    }
+    fields.emplace_back(key, value);
+}
+
+void EraseField(Fields& fields, const std::string& key)
+{
+    fields.erase(std::remove_if(fields.begin(), fields.end(), [&](const std::pair<std::string, std::string>& f) { return f.first == key; }), fields.end());
+}
+
+std::string RenderBlock(const std::string& header, const Fields& fields, bool withClose = true)
+{
+    std::string out = header + "\n{\n";
+    for (const auto& f : fields)
+    {
+        out += "    " + f.first + " = \"" + f.second + "\";\n";
+    }
+    if (withClose)
+    {
+        out += "};\n";
+    }
+    return out;
+}
+
+std::string Render(const Fields& fields)
+{
+    return RenderBlock(kHeader, fields);
+}
+
+// Raw single entry with a custom body (between the braces). Used for syntactic
+// tests that cannot be expressed via the field renderer.
+std::string Wrap(const std::string& body)
+{
+    return std::string(kHeader) + "\n{\n" + body + "};\n";
+}
+
+// Parse the supplied text and return the first entry's Result. Returns an Error
+// if the input contains no entries.
+Result<Resource> ParseFirst(const std::string& text)
+{
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    if (!rangeResult.HasValue())
+    {
+        return rangeResult.Error();
+    }
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    if (it == range.end())
+    {
+        return Error("no entries parsed");
+    }
+    return *it;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+TEST(MofParserTest, ParsesValidEntry)
+{
+    auto result = ParseFirst(Render(DefaultFields()));
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    const auto& res = result.Value();
+    EXPECT_EQ(res.resourceID, "1.1.1 Some Rule");
+    EXPECT_EQ(res.ruleName, "MyRule");
+    EXPECT_EQ(res.procedure, "base64data==");
+    EXPECT_TRUE(res.hasInitAudit);
+    EXPECT_EQ(res.benchmarkInfo.section, "1.1.1");
+}
+
+TEST(MofParserTest, EmptyDesiredObjectValueYieldsAbsentPayload)
+{
+    auto result = ParseFirst(Render(DefaultFields()));
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    EXPECT_FALSE(result.Value().payload.HasValue());
+}
+
+TEST(MofParserTest, NonEmptyDesiredObjectValueYieldsPayload)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "DesiredObjectValue", "mask=0600");
+    auto result = ParseFirst(Render(fields));
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    ASSERT_TRUE(result.Value().payload.HasValue());
+    EXPECT_EQ(result.Value().payload.Value(), "mask=0600");
+}
+
+TEST(MofParserTest, JsonEscapedDesiredObjectValue)
+{
+    // Production MOFs embed JSON in DesiredObjectValue with MOF-escaped inner
+    // quotes; verify they round-trip to unescaped JSON.
+    auto fields = DefaultFields();
+    SetField(fields, "DesiredObjectValue", "{\\\"mountPoint\\\":\\\"/tmp\\\"}");
+    auto result = ParseFirst(Render(fields));
     ASSERT_TRUE(result.HasValue()) << result.Error().message;
     ASSERT_TRUE(result.Value().payload.HasValue());
     EXPECT_EQ(result.Value().payload.Value(), "{\"mountPoint\":\"/tmp\"}");
+}
+
+TEST(MofParserTest, SectionSlashesBecomeDots)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "PayloadKey", "/cis/rhel/8/v4.0.0/5/4/2/1");
+    auto result = ParseFirst(Render(fields));
+    ASSERT_TRUE(result.HasValue()) << result.Error().message;
+    EXPECT_EQ(result.Value().benchmarkInfo.section, "5.4.2.1");
+}
+
+TEST(MofParserTest, MultipleEntriesAreStreamed)
+{
+    std::string text = Render(DefaultFields()) + Render(DefaultFields());
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    int count = 0;
+    for (const auto& entry : range)
+    {
+        ASSERT_TRUE(entry.HasValue()) << entry.Error().message;
+        ++count;
+    }
+    EXPECT_EQ(count, 2);
+}
+
+TEST(MofParserTest, BlankLinesBetweenEntriesAreSkipped)
+{
+    std::string text = "\n\n" + Render(DefaultFields()) + "\n\n\n" + Render(DefaultFields()) + "\n";
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    int count = 0;
+    for (const auto& entry : range)
+    {
+        ASSERT_TRUE(entry.HasValue()) << entry.Error().message;
+        ++count;
+    }
+    EXPECT_EQ(count, 2);
+}
+
+TEST(MofParserTest, EmptyInputHasNoEntries)
+{
+    std::istringstream stream("");
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    EXPECT_TRUE(range.begin() == range.end());
+}
+
+TEST(MofParserTest, WhitespaceOnlyInputHasNoEntries)
+{
+    std::istringstream stream("\n   \n\t\n");
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    EXPECT_TRUE(range.begin() == range.end());
+}
+
+TEST(MofParserTest, IterationStopsAfterError)
+{
+    // A malformed first entry must surface an error and halt iteration rather
+    // than silently skipping to the next entry.
+    auto fields = DefaultFields();
+    EraseField(fields, "ResourceID");
+    std::string text = Render(fields) + Render(DefaultFields());
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    EXPECT_FALSE((*it).HasValue());
+    ++it;
+    EXPECT_TRUE(it == range.end());
+}
+
+// ---------------------------------------------------------------------------
+// Missing / unknown / duplicate fields
+// ---------------------------------------------------------------------------
+
+TEST(MofParserTest, MissingRequiredFieldIsRejected)
+{
+    auto fields = DefaultFields();
+    EraseField(fields, "ProcedureObjectValue");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, UnknownFieldKeyIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "BogusField", "x");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, DuplicateFieldKeyIsRejected)
+{
+    auto fields = DefaultFields();
+    fields.emplace_back("ResourceID", "duplicate");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+// ---------------------------------------------------------------------------
+// Field constant / consistency validation
+// ---------------------------------------------------------------------------
+
+TEST(MofParserTest, WrongComponentNameIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ComponentName", "SomethingElse");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, WrongConfigurationNameIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ConfigurationName", "SomethingElse");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, WrongExpectedObjectValueIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ExpectedObjectValue", "FAIL");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, ProcedureObjectNameWrongPrefixIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ProcedureObjectName", "fooMyRule");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, InitObjectNameWrongPrefixIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "InitObjectName", "fooMyRule");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, ReportedObjectNameWrongPrefixIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ReportedObjectName", "fooMyRule");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, DesiredObjectNameWrongPrefixIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "DesiredObjectName", "fooMyRule");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, RuleNameMismatchIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ReportedObjectName", "auditOtherRule");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, EmptyRuleNameIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ProcedureObjectName", "procedure");
+    SetField(fields, "InitObjectName", "init");
+    SetField(fields, "ReportedObjectName", "audit");
+    SetField(fields, "DesiredObjectName", "remediate");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, EmptyResourceIdIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ResourceID", "");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, EmptyProcedureObjectValueIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "ProcedureObjectValue", "");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, InvalidPayloadKeyIsRejected)
+{
+    auto fields = DefaultFields();
+    SetField(fields, "PayloadKey", "garbage");
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+// ---------------------------------------------------------------------------
+// Structural / syntactic errors
+// ---------------------------------------------------------------------------
+
+TEST(MofParserTest, MalformedHeaderIsRejected)
+{
+    EXPECT_FALSE(ParseFirst("not a header\n{\n};\n").HasValue());
+}
+
+TEST(MofParserTest, HeaderMissingSuffixIsRejected)
+{
+    std::string text = "instance of OsConfigResource as $OsConfigResource0\n{\n};\n";
+    EXPECT_FALSE(ParseFirst(text).HasValue());
+}
+
+TEST(MofParserTest, MissingOpeningBraceIsRejected)
+{
+    std::string text = std::string(kHeader) + "\n    ResourceID = \"x\";\n";
+    EXPECT_FALSE(ParseFirst(text).HasValue());
+}
+
+TEST(MofParserTest, MissingClosingBraceIsRejected)
+{
+    std::string text = RenderBlock(kHeader, DefaultFields(), /*withClose=*/false);
+    EXPECT_FALSE(ParseFirst(text).HasValue());
+}
+
+TEST(MofParserTest, TruncatedMidEntryIsRejected)
+{
+    std::string text = std::string(kHeader) + "\n{\n    ResourceID = \"x\";\n";
+    EXPECT_FALSE(ParseFirst(text).HasValue());
+}
+
+TEST(MofParserTest, FieldLineMissingEqualsIsRejected)
+{
+    EXPECT_FALSE(ParseFirst(Wrap("    GarbageLineWithoutEquals\n")).HasValue());
+}
+
+TEST(MofParserTest, FieldValueMissingQuotesIsRejected)
+{
+    EXPECT_FALSE(ParseFirst(Wrap("    ResourceID = novalue;\n")).HasValue());
+}
+
+TEST(MofParserTest, FieldValueMissingClosingQuoteIsRejected)
+{
+    EXPECT_FALSE(ParseFirst(Wrap("    ResourceID = \"unterminated;\n")).HasValue());
+}
+
+// ---------------------------------------------------------------------------
+// Resource limits
+// ---------------------------------------------------------------------------
+
+TEST(MofParserTest, OverlongLineIsRejected)
+{
+    // A single line beyond the parser's per-line cap (4 MiB) must be refused
+    // rather than buffered without bound.
+    auto fields = DefaultFields();
+    SetField(fields, "ProcedureObjectValue", std::string(4 * 1024 * 1024 + 16, 'A'));
+    EXPECT_FALSE(ParseFirst(Render(fields)).HasValue());
+}
+
+TEST(MofParserTest, ByteCapPreemptsUnreachableEntryCountCap)
+{
+    // With the strict 15-field format, 100 001 valid entries cannot fit under
+    // the 8 MiB input cap. The byte cap is the tighter security boundary and
+    // must stop the stream before unbounded parsing can reach the entry cap.
+    std::string entry = Render(DefaultFields());
+    std::string text;
+    constexpr size_t kMaxInputBytesForTest = static_cast<size_t>(8) * 1024 * 1024;
+    const size_t entriesNeededToExceedByteCap = (kMaxInputBytesForTest / entry.size()) + 2;
+    text.reserve(entry.size() * entriesNeededToExceedByteCap);
+    for (size_t i = 0; i < entriesNeededToExceedByteCap; ++i)
+    {
+        text += entry;
+    }
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    bool sawError = false;
+    int count = 0;
+    for (const auto& entry : range)
+    {
+        if (!entry.HasValue())
+        {
+            sawError = true;
+            EXPECT_EQ(entry.Error().code, E2BIG);
+            break;
+        }
+        ++count;
+    }
+    EXPECT_TRUE(sawError) << "expected an E2BIG error after the byte cap, but saw " << count << " valid entries";
+    EXPECT_LT(static_cast<size_t>(count), entriesNeededToExceedByteCap);
+}
+
+TEST(MofParserTest, BlankLineInsideFieldSectionIsSkipped)
+{
+    // A blank line between field lines inside a valid block must be silently
+    // skipped, not treated as an error.
+    std::string body = "\n    ResourceID = \"1.1 rule\";\n\n    PayloadKey = \"/cis/ubuntu/22.04/v2.0.0/1/1\";\n";
+    // Build a full valid entry manually so the blank-line path in the field
+    // collection loop is exercised, then wrap the rest using DefaultFields().
+    auto fields = DefaultFields();
+    // Render manually inserting a blank line in the middle of the fields.
+    std::string text = std::string(kHeader) + "\n{\n";
+    bool firstHalf = true;
+    int emitted = 0;
+    for (const auto& f : fields)
+    {
+        text += "    " + f.first + " = \"" + f.second + "\";\n";
+        ++emitted;
+        if (firstHalf && emitted == 7)
+        {
+            text += "\n"; // inject blank line halfway through
+            firstHalf = false;
+        }
+    }
+    text += "};\n";
+    auto result = ParseFirst(text);
+    EXPECT_TRUE(result.HasValue()) << result.Error().message;
+}
+
+TEST(MofParserTest, FieldLineEmptyKeyIsRejected)
+{
+    // A line that starts with '=' has an empty key, which must be rejected.
+    EXPECT_FALSE(ParseFirst(Wrap("    = \"value\";\n")).HasValue());
+}
+
+TEST(MofParserTest, TruncatedNoNewlineAtEofIsRejected)
+{
+    // The line terminator is missing from the very last byte of input (no \n
+    // at the end). This is distinct from the EOF-before-}; path: here the
+    // stream ends inside a line that has no \n, triggering EIO.
+    std::string text = std::string(kHeader) + "\n{\n    ResourceID = \"x\";"; // no trailing \n
+    auto result = ParseFirst(text);
+    EXPECT_FALSE(result.HasValue());
+    EXPECT_EQ(result.Error().code, EIO);
+}
+
+// ---------------------------------------------------------------------------
+// Make(istream&) overload and operator->
+// ---------------------------------------------------------------------------
+
+TEST(MofParserTest, MakeFromIstreamOverloadParsesValidEntry)
+{
+    // Make(istream&, log) is a distinct code path from MakeFromStream; verify
+    // it produces the same result on a well-formed single entry.
+    std::istringstream stream(Render(DefaultFields()));
+    auto rangeResult = MofResourceRange::Make(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    ASSERT_TRUE((*it).HasValue()) << (*it).Error().message;
+    EXPECT_EQ((*it).Value().ruleName, "MyRule");
+}
+
+TEST(MofParserTest, ArrowOperatorDereferencesCurrentEntry)
+{
+    // operator-> must return a pointer to the current Result<Resource>.
+    std::istringstream stream(Render(DefaultFields()));
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    ASSERT_TRUE(it->HasValue()) << it->Error().message;
+    EXPECT_EQ(it->Value().ruleName, "MyRule");
+}
+
+// ---------------------------------------------------------------------------
+// Make(path) — file-based factory
+// ---------------------------------------------------------------------------
+
+namespace
+{
+struct TempMofFile
+{
+    std::string directory;
+    std::string path;
+};
+
+TempMofFile WriteTempMofInSafeParent(const std::string& content)
+{
+    TempMofFile result;
+    char dirTmpl[] = "/tmp/moftest_safe_XXXXXX";
+    char* dir = ::mkdtemp(dirTmpl);
+    if (dir == nullptr)
+    {
+        return result;
+    }
+    result.directory = dir;
+    // Make the immediate parent acceptable to InputSecurity. This still leaves
+    // /tmp itself writable, but RefuseWritableParentDir intentionally validates
+    // the immediate parent that can rename-swap the file entry.
+    ::chmod(result.directory.c_str(), 0700);
+
+    result.path = result.directory + "/test.mof";
+    int fd = ::open(result.path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+    if (fd < 0)
+    {
+        ::rmdir(result.directory.c_str());
+        return TempMofFile();
+    }
+    const ssize_t written = ::write(fd, content.data(), content.size());
+    ::close(fd);
+    if (written != static_cast<ssize_t>(content.size()))
+    {
+        ::unlink(result.path.c_str());
+        ::rmdir(result.directory.c_str());
+        return TempMofFile();
+    }
+    return result;
+}
+} // namespace
+
+TEST(MofParserTest, MakeFromPathParsesValidEntry)
+{
+    if (::geteuid() != 0)
+    {
+        GTEST_SKIP() << "Make(path) requires a root-owned file in a root-owned non-writable parent";
+    }
+    TempMofFile file = WriteTempMofInSafeParent(Render(DefaultFields()));
+    if (file.path.empty())
+    {
+        GTEST_SKIP() << "could not create temporary file";
+    }
+    auto rangeResult = MofResourceRange::Make(file.path, nullptr);
+    ::unlink(file.path.c_str());
+    ::rmdir(file.directory.c_str());
+    ASSERT_TRUE(rangeResult.HasValue()) << rangeResult.Error().message;
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    ASSERT_TRUE((*it).HasValue()) << (*it).Error().message;
+    EXPECT_EQ((*it).Value().ruleName, "MyRule");
+}
+
+TEST(MofParserTest, MakeFromPathRejectsPathTraversal)
+{
+    auto result = MofResourceRange::Make("/tmp/../etc/passwd", nullptr);
+    ASSERT_FALSE(result.HasValue());
+    EXPECT_EQ(result.Error().code, EACCES);
+}
+
+TEST(MofParserTest, MakeFromPathRejectsWritableParentDir)
+{
+    // Create a world-writable subdirectory under /tmp, then a file inside it.
+    // InputSecurity must refuse the file because its parent is writable.
+    char dirTmpl[] = "/tmp/moftest_dir_XXXXXX";
+    char* dir = ::mkdtemp(dirTmpl);
+    if (dir == nullptr)
+    {
+        GTEST_SKIP() << "could not create temporary directory";
+    }
+    ::chmod(dir, 0777); // world-writable — triggers the refusal
+
+    std::string path = std::string(dir) + "/test.mof";
+    const int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+    if (fd >= 0)
+    {
+        const std::string content = Render(DefaultFields());
+        ::write(fd, content.data(), content.size());
+        ::close(fd);
+    }
+
+    auto result = MofResourceRange::Make(path, nullptr);
+    ::unlink(path.c_str());
+    ::rmdir(dir);
+
+    ASSERT_FALSE(result.HasValue());
+    EXPECT_EQ(result.Error().code, EACCES);
 }

--- a/src/modules/complianceengine/src/lib/payload.schema.json
+++ b/src/modules/complianceengine/src/lib/payload.schema.json
@@ -204,9 +204,6 @@
           "$ref": "procedures/MtaLocalOnly.schema.json#/definitions/audit"
         },
         {
-          "$ref": "procedures/NetworkInterface.schema.json#/definitions/audit"
-        },
-        {
           "$ref": "procedures/NetworkInterfaceFlag.schema.json#/definitions/audit"
         },
         {
@@ -341,9 +338,6 @@
         },
         {
           "$ref": "procedures/MtaLocalOnly.schema.json#/definitions/remediation"
-        },
-        {
-          "$ref": "procedures/NetworkInterface.schema.json#/definitions/remediation"
         },
         {
           "$ref": "procedures/NetworkInterfaceFlag.schema.json#/definitions/remediation"


### PR DESCRIPTION
## Description

This PR hardens `compliance-engine-assessor` MOF parsing by replacing the previous loose parser with a strict, streaming `MofResourceRange` / `MofResourceIterator` parser.

The new parser targets the exact 15-field `OsConfigResource` shape emitted by the Compliance Augmentation Engine, keeps input processing bounded, and encapsulates file-input hardening behind `MofResourceRange::Make()`.

### Changes

- Added streaming `MofResourceRange` / `MofResourceIterator` parser.
- Updated `Main.cpp` to use a range-based `for` loop over parsed MOF entries.
- Kept parser failures in-band via `Result<Resource>`.
- Enforced strict MOF validation:
  - required 15-field resource shape
  - no unknown or duplicate fields
  - validated constant fields (`ComponentName`, `ConfigurationName`, `ExpectedObjectValue`)
  - consistent rule name across `procedure*`, `init*`, `audit*`, and `remediate*` object names
- Added input limits:
  - 8 MiB total input
  - 4 MiB max line length
  - 100,000 max entries
- Moved file-input hardening into `MofResourceRange::Make(path, log)`:
  - path traversal rejection
  - writable-parent rejection
  - `O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC`
  - `fstat` validation
  - regular-file, root-owner, and permission checks
- Treated empty `DesiredObjectValue` as absent payload and retained `{}` fallback for audit/remediation setup.
- Added MOF parser unit tests and expanded malformed-input coverage.
- Added optional libFuzzer target and seed corpus for parser crash testing.
- Fixed older compiler compatibility by removing an invalid explicit `noexcept` from the end-iterator constructor.

### Validation

- `compliance-engine-assessor-tests` pass locally.
- `Mof.cpp` coverage:
  - line coverage: `93.5%`
  - function coverage: `100.0%`
- Fuzzer target builds with `-DBUILD_FUZZER=ON` and seed corpus smoke test runs without crashes.

### Security Notes

The parser now rejects malformed, oversized, unexpected, or structurally unfamiliar MOF input. File-backed input is validated before streaming, while stdin remains supported with the same parser size and structure limits.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [ ] I submitted this PR against the `dev` branch.
