### PR TITLE
Add Lua logging interface

### DIFF
--- a/src/modules/complianceengine/src/lib/LuaEvaluator.cpp
+++ b/src/modules/complianceengine/src/lib/LuaEvaluator.cpp
@@ -247,8 +247,7 @@ void LuaEvaluator::SecureLuaEnvironment()
 {
     lua_newtable(L);
 
-    const std::vector<const char*> safeGlobals = {
-        "print", "type", "tostring", "tonumber", "pairs", "ipairs", "next", "pcall", "xpcall", "select", "math"};
+    const std::vector<const char*> safeGlobals = {"type", "tostring", "tonumber", "pairs", "ipairs", "next", "pcall", "xpcall", "select", "math"};
     const std::map<const char*, std::vector<const char*>> safeModuleFunctions = {
         {"string", {"byte", "char", "find", "format", "gsub", "len", "lower", "match", "gmatch", "rep", "reverse", "sub", "upper"}},
         {"table", {"concat", "insert", "remove", "sort"}}, {"io", {"lines"}}, {"os", {"time", "date", "clock", "difftime"}}};

--- a/src/modules/complianceengine/src/lib/LuaProcedures.cpp
+++ b/src/modules/complianceengine/src/lib/LuaProcedures.cpp
@@ -528,6 +528,75 @@ int LuaIndicatorsNonCompliant(lua_State* L)
 {
     return LuaIndicatorsAddIndicator(L, Status::NonCompliant);
 }
+
+int LuaLogImpl(lua_State* L, LoggingLevel level)
+{
+    // Fetch call context placed in registry by evaluator to access ContextInterface
+    lua_pushstring(L, "lua_call_context");
+    lua_gettable(L, LUA_REGISTRYINDEX);
+    void* cc = lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    if (!cc)
+    {
+        luaL_error(L, "internal error: missing call context");
+        return 0;
+    }
+    auto* view = reinterpret_cast<LuaCallContext*>(cc);
+
+    // Message parameter
+    constexpr int messageArgIndex = 1;
+    if (lua_isnoneornil(L, messageArgIndex))
+    {
+        luaL_error(L, "expected a message");
+        return 0;
+    }
+    if (!lua_isnone(L, messageArgIndex + 1))
+    {
+        luaL_error(L, "expected a single argument");
+        return 0;
+    }
+    if (!lua_isstring(L, messageArgIndex))
+    {
+        luaL_error(L, "expected a string argument");
+        return 0;
+    }
+    const char* message = lua_tostring(L, messageArgIndex);
+    if (!message)
+    {
+        luaL_error(L, "expected a message");
+        return 0;
+    }
+    if (!::strlen(message))
+    {
+        luaL_error(L, "message must not be empty");
+        return 0;
+    }
+
+    // The message is passed as the %s argument, never as the format string,
+    // preventing format-string injection from Lua-supplied content.
+    OsConfigLog(view->ctx.GetLogHandle(), level, "[Lua] %s", message);
+    return 0;
+}
+
+int LuaLogInfo(lua_State* L)
+{
+    return LuaLogImpl(L, LoggingLevelInformational);
+}
+
+int LuaLogWarning(lua_State* L)
+{
+    return LuaLogImpl(L, LoggingLevelWarning);
+}
+
+int LuaLogError(lua_State* L)
+{
+    return LuaLogImpl(L, LoggingLevelError);
+}
+
+int LuaLogDebug(lua_State* L)
+{
+    return LuaLogImpl(L, LoggingLevelDebug);
+}
 } // anonymous namespace
 
 void RegisterLuaProcedures(lua_State* L)
@@ -560,6 +629,29 @@ void RegisterLuaProcedures(lua_State* L)
 
     lua_pushcfunction(L, LuaSystemdCatConfig);
     lua_setfield(L, -2, "SystemdCatConfig");
+
+    // Get or create ce.log table
+    lua_getfield(L, -1, "log");
+    if (!lua_istable(L, -1))
+    {
+        lua_pop(L, 1);   // pop non-table
+        lua_newtable(L); // create log
+        lua_pushvalue(L, -1);
+        lua_setfield(L, -3, "log");
+
+        lua_pushcfunction(L, LuaLogInfo);
+        lua_setfield(L, -2, "info");
+
+        lua_pushcfunction(L, LuaLogWarning);
+        lua_setfield(L, -2, "warning");
+
+        lua_pushcfunction(L, LuaLogError);
+        lua_setfield(L, -2, "error");
+
+        lua_pushcfunction(L, LuaLogDebug);
+        lua_setfield(L, -2, "debug");
+    }
+    lua_pop(L, 1); // pop log table
 
     // Get or create ce.indicators table
     lua_getfield(L, -1, "indicators");

--- a/src/modules/complianceengine/src/lib/LuaProcedures.h
+++ b/src/modules/complianceengine/src/lib/LuaProcedures.h
@@ -49,10 +49,10 @@ struct LuaCallContext
 //   - Snapshot semantics: iterator holds shared_ptr<const FSCache>; unaffected by background refresh.
 //   - Arguments outside unsigned 32-bit range produce Lua error.
 //
-//   ce.log.info(message)    -- log at informational level via OsConfigLogInfo
-//   ce.log.warning(message) -- log at warning level via OsConfigLogWarning
-//   ce.log.error(message)   -- log at error level via OsConfigLogError
-//   ce.log.debug(message)   -- log at debug level via OsConfigLogDebug
+//   ce.log.info(message)    -- log at informational level
+//   ce.log.warning(message) -- log at warning level
+//   ce.log.error(message)   -- log at error level
+//   ce.log.debug(message)   -- log at debug level
 //     message: string (required, non-empty) text to emit; prefixed with "[Lua] " in the log output.
 // Behavior:
 //   - Routes to the OsConfigLog* macros using the log handle from the current call context.

--- a/src/modules/complianceengine/src/lib/LuaProcedures.h
+++ b/src/modules/complianceengine/src/lib/LuaProcedures.h
@@ -48,6 +48,16 @@ struct LuaCallContext
 // Notes:
 //   - Snapshot semantics: iterator holds shared_ptr<const FSCache>; unaffected by background refresh.
 //   - Arguments outside unsigned 32-bit range produce Lua error.
+//
+//   ce.log.info(message)    -- log at informational level via OsConfigLogInfo
+//   ce.log.warning(message) -- log at warning level via OsConfigLogWarning
+//   ce.log.error(message)   -- log at error level via OsConfigLogError
+//   ce.log.debug(message)   -- log at debug level via OsConfigLogDebug
+//     message: string (required, non-empty) text to emit; prefixed with "[Lua] " in the log output.
+// Behavior:
+//   - Routes to the OsConfigLog* macros using the log handle from the current call context.
+//   - The message string is always a %s argument, never the format string (prevents format-string injection).
+//   - Raises Lua error if message is missing, non-string, empty, or more than one argument is passed.
 void RegisterLuaProcedures(lua_State* L);
 
 } // namespace ComplianceEngine

--- a/src/modules/complianceengine/tests/LuaEvaluatorTest.cpp
+++ b/src/modules/complianceengine/tests/LuaEvaluatorTest.cpp
@@ -4,6 +4,7 @@
 #include "LuaEvaluator.h"
 
 #include "Indicators.h"
+#include "Logging.h"
 #include "MockContext.h"
 #include "Result.h"
 
@@ -596,6 +597,157 @@ TEST_F(LuaEvaluatorTest, Performance_MultipleEvaluations)
         ASSERT_TRUE(result.HasValue());
         EXPECT_EQ(result.Value(), Status::Compliant);
     }
+}
+
+// Test ce.log functions exist and can be called without error
+TEST_F(LuaEvaluatorTest, Log_Callable_AllLevels)
+{
+    LuaEvaluator evaluator;
+
+    const std::string script = R"(
+        ce.log.info("info message")
+        ce.log.warning("warning message")
+        ce.log.error("error message")
+        ce.log.debug("debug message")
+        return true
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+// Test that print is no longer available in the restricted Lua environment
+TEST_F(LuaEvaluatorTest, Security_PrintBlocked)
+{
+    LuaEvaluator evaluator;
+
+    const std::string script = "if print then return 'print available' else return true end";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+// Test that ce.log.info with no argument raises a Lua error
+TEST_F(LuaEvaluatorTest, Log_InvalidUsage_NoArgument)
+{
+    LuaEvaluator evaluator;
+
+    const std::string script = R"(
+        local ok, err = pcall(function() ce.log.info() end)
+        if ok then
+            return false, "expected error for missing argument"
+        end
+        return true, tostring(err)
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+// Test that ce.log.info with a non-string, non-coercible argument raises a Lua error
+TEST_F(LuaEvaluatorTest, Log_InvalidUsage_NonStringArgument)
+{
+    LuaEvaluator evaluator;
+
+    // Boolean false is not coercible to a string in Lua
+    const std::string script = R"(
+        local ok, err = pcall(function() ce.log.info(false) end)
+        if ok then
+            return false, "expected error for non-string argument"
+        end
+        return true, tostring(err)
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+// Test that ce.log.info with more than one argument raises a Lua error
+TEST_F(LuaEvaluatorTest, Log_InvalidUsage_ExtraArguments)
+{
+    LuaEvaluator evaluator;
+
+    const std::string script = R"(
+        local ok, err = pcall(function() ce.log.info("msg", "extra") end)
+        if ok then
+            return false, "expected error for extra argument"
+        end
+        return true, tostring(err)
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+// Test that ce.log.info with an empty string raises a Lua error
+TEST_F(LuaEvaluatorTest, Log_InvalidUsage_EmptyString)
+{
+    LuaEvaluator evaluator;
+
+    const std::string script = R"(
+        local ok, err = pcall(function() ce.log.info("") end)
+        if ok then
+            return false, "expected error for empty message"
+        end
+        return true, tostring(err)
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+}
+
+// E2E test: verify ce.log messages are written to the log file with the [Lua] prefix
+TEST_F(LuaEvaluatorTest, Log_E2E_WritesToLogFile)
+{
+    const std::string logPath = mContext.GetTempdirPath() + "/lua_test.log";
+    OsConfigLogHandle logHandle = OpenLog(logPath.c_str(), nullptr);
+    ASSERT_NE(nullptr, logHandle);
+
+    const LoggingLevel savedLevel = GetLoggingLevel();
+    const bool savedConsole = IsConsoleLoggingEnabled();
+    SetLoggingLevel(LoggingLevelDebug);
+    SetConsoleLoggingEnabled(false);
+
+    mContext.SetLogHandle(logHandle);
+
+    LuaEvaluator evaluator;
+    const std::string script = R"(
+        ce.log.info("info message")
+        ce.log.warning("warning message")
+        ce.log.error("error message")
+        ce.log.debug("debug message")
+        return true
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    CloseLog(&logHandle);
+    mContext.SetLogHandle(nullptr);
+    SetLoggingLevel(savedLevel);
+    SetConsoleLoggingEnabled(savedConsole);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+
+    std::ifstream logFile(logPath);
+    const std::string contents((std::istreambuf_iterator<char>(logFile)), std::istreambuf_iterator<char>());
+
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] info message"));
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] warning message"));
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] error message"));
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] debug message"));
 }
 
 // Test non-copyable nature of LuaEvaluator

--- a/src/modules/complianceengine/tests/LuaEvaluatorTest.cpp
+++ b/src/modules/complianceengine/tests/LuaEvaluatorTest.cpp
@@ -8,7 +8,9 @@
 #include "MockContext.h"
 #include "Result.h"
 
+#include <fstream>
 #include <gtest/gtest.h>
+#include <iterator>
 #include <memory>
 #include <string>
 

--- a/src/modules/complianceengine/tests/LuaEvaluatorTest.cpp
+++ b/src/modules/complianceengine/tests/LuaEvaluatorTest.cpp
@@ -752,6 +752,48 @@ TEST_F(LuaEvaluatorTest, Log_E2E_WritesToLogFile)
     EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] debug message"));
 }
 
+// Test that format specifiers in log messages are emitted verbatim and not interpreted
+TEST_F(LuaEvaluatorTest, Log_E2E_FormatSpecifiersPassedVerbatim)
+{
+    const std::string logPath = mContext.GetTempdirPath() + "/lua_fmt_test.log";
+    OsConfigLogHandle logHandle = OpenLog(logPath.c_str(), nullptr);
+    ASSERT_NE(nullptr, logHandle);
+
+    const LoggingLevel savedLevel = GetLoggingLevel();
+    const bool savedConsole = IsConsoleLoggingEnabled();
+    SetLoggingLevel(LoggingLevelDebug);
+    SetConsoleLoggingEnabled(false);
+
+    mContext.SetLogHandle(logHandle);
+
+    LuaEvaluator evaluator;
+    const std::string script = R"(
+        ce.log.info("%d")
+        ce.log.info("%s")
+        ce.log.info("%n")
+        ce.log.info("%%")
+        return true
+    )";
+
+    auto result = evaluator.Evaluate(script, mIndicators, mContext, Action::Audit);
+
+    CloseLog(&logHandle);
+    mContext.SetLogHandle(nullptr);
+    SetLoggingLevel(savedLevel);
+    SetConsoleLoggingEnabled(savedConsole);
+
+    ASSERT_TRUE(result.HasValue());
+    EXPECT_EQ(result.Value(), Status::Compliant);
+
+    std::ifstream logFile(logPath);
+    const std::string contents((std::istreambuf_iterator<char>(logFile)), std::istreambuf_iterator<char>());
+
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] %d"));
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] %s"));
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] %n"));
+    EXPECT_THAT(contents, ::testing::HasSubstr("[Lua] %%"));
+}
+
 // Test non-copyable nature of LuaEvaluator
 TEST_F(LuaEvaluatorTest, NonCopyable)
 {

--- a/src/modules/complianceengine/tests/MockContext.h
+++ b/src/modules/complianceengine/tests/MockContext.h
@@ -22,7 +22,12 @@ struct MockContext : public ComplianceEngine::ContextInterface
 
     OsConfigLogHandle GetLogHandle() const override
     {
-        return nullptr;
+        return mLogHandle;
+    }
+
+    void SetLogHandle(OsConfigLogHandle logHandle)
+    {
+        mLogHandle = logHandle;
     }
 
     MockContext()
@@ -155,4 +160,5 @@ private:
     std::vector<std::string> mTempfiles;
     std::map<std::string, std::string> mSpecialFilesMap;
     std::unique_ptr<ComplianceEngine::FilesystemScanner> mFsScannerp;
+    OsConfigLogHandle mLogHandle{nullptr};
 };


### PR DESCRIPTION
## Description

### Motivation

Lua compliance scripts had `print` available, which writes directly to stdout and can clobber output. This change removes `print` from the Lua sandbox and replaces it with `ce.log.*`, routing script messages through the existing `OsConfigLog*` infrastructure (respects log levels, file and console sinks).

### Changes

| File | Change |
|------|--------|
| `LuaProcedures.cpp` | Added `LuaLogImpl(lua_State*, LoggingLevel)` + four wrappers (`LuaLogInfo/Warning/Error/Debug`). Registered `ce.log` subtable with `info`, `warning`, `error`, `debug` in `RegisterLuaProcedures()`. |
| `LuaEvaluator.cpp` | Removed `"print"` from `safeGlobals` in `SecureLuaEnvironment()`. |
| `LuaProcedures.h` | Extended doc comment on `RegisterLuaProcedures` to document `ce.log.*`. |
| `MockContext.h` | `GetLogHandle()` now returns a settable `mLogHandle` member (default `nullptr`) instead of hardcoded `nullptr`. Added `SetLogHandle()`. |
| `LuaEvaluatorTest.cpp` | 8 new tests: callability of all four levels, `print` blocked, invalid-usage cases (no arg / non-string / extra args / empty string), and an e2e test that writes to a real log file and asserts `[Lua] <message>` substrings. |

### Usage

```lua
ce.log.info("Checking sshd configuration")
ce.log.warning("Deprecated option found")
ce.log.error("Required file missing")
ce.log.debug("Raw value: " .. tostring(value))
```

### Security

The argument validation in `LuaLogImpl` applies three checks in deliberate order:

1. **Presence** — `lua_isnoneornil` rejects both a missing argument and an explicit `nil`.
2. **Arity** — `!lua_isnone(L, 2)` rejects any second argument before the type check, so `ce.log.info(false, "extra")` gives *"expected a single argument"* rather than a misleading type error.
3. **Type** — `lua_isstring` accepts strings and numbers (Lua coerces numbers to strings) but rejects booleans, tables, userdata, and functions.

After all three checks pass, the message is used only as the `%s` argument to `OsConfigLog`:

```cpp
OsConfigLog(view->ctx.GetLogHandle(), level, "[Lua] %s", message);
```

The Lua-supplied string is never the format string — format-string injection is structurally impossible regardless of message content. This follows the same validation pattern as the existing `LuaIndicatorsAddIndicator`.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
