### PR TITLE
Telemetry: Fail initialization if cache file cannot be opened

### DIFF
--- a/src/adapters/mc/CMakeLists.txt
+++ b/src/adapters/mc/CMakeLists.txt
@@ -21,6 +21,10 @@ if (BUILD_TELEMETRY)
             -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
         )
     endif()
+    # Pre-compute binary dir so it can be declared as BUILD_BYPRODUCTS (required for
+    # Ninja to know that libtelemetrylib.a and libmat.a are produced by this target).
+    set(_telemetry_binary_dir ${CMAKE_CURRENT_BINARY_DIR}/telemetry-external-prefix/src/telemetry-external-build)
+
     ExternalProject_Add(
         telemetry-external
         INSTALL_COMMAND ""  # No install target on telemetry target
@@ -37,6 +41,9 @@ if (BUILD_TELEMETRY)
             -DBUILD_TESTS=${BUILD_TESTS}
             -DGTEST_OUTPUT_DIR=${GTEST_OUTPUT_DIR}
             -DONEDS_CPP_SDK_VERSION=${ONEDS_CPP_SDK_VERSION}
+        BUILD_BYPRODUCTS
+            ${_telemetry_binary_dir}/lib/libtelemetrylib.a
+            ${_telemetry_binary_dir}/1ds_install/lib/libmat.a
     )
     ExternalProject_Get_Property(telemetry-external BINARY_DIR)
 

--- a/src/common/telemetry/bin/main.cpp
+++ b/src/common/telemetry/bin/main.cpp
@@ -46,7 +46,8 @@ int main(int argc, char* argv[])
         OsConfigLogInfo(g_log, "%s", init_message.c_str());
 
         OsConfigLogInfo(g_log, "Telemetry initializing...");
-        Telemetry::TelemetryManager telemetryManager(args.verbose, args.teardown_time, g_log);
+        std::string cacheFilePath(Telemetry::TelemetryManager::TELEMETRY_CACHE_FILE_NAME);
+        Telemetry::TelemetryManager telemetryManager(cacheFilePath, args.verbose, args.teardown_time, g_log);
 
         (void)(telemetryManager.ProcessJsonFile(args.filepath));
         OsConfigLogInfo(g_log, "Processed telemetry JSON file: %s", args.filepath.c_str());

--- a/src/common/telemetry/bin/tests/TelemetryBinTests.cpp
+++ b/src/common/telemetry/bin/tests/TelemetryBinTests.cpp
@@ -22,6 +22,7 @@ class TelemetryBinTest : public ::testing::Test
 {
 protected:
     std::string m_testDir;
+    std::string m_telemetryCache;
 
     void SetUp() override
     {
@@ -29,6 +30,8 @@ protected:
         char tmpDir[] = "/tmp/telemetry_test_XXXXXX";
         ASSERT_NE(nullptr, mkdtemp(tmpDir));
         m_testDir = std::string(tmpDir);
+
+        m_telemetryCache = m_testDir + "/telemetry_cache_db";
     }
 
     void TearDown() override
@@ -290,14 +293,13 @@ TEST_F(TelemetryBinTest, FileAndPositionalArgumentCannotBothBeUsed)
 TEST_F(TelemetryBinTest, ProcessesValidSingleLineJson)
 {
     std::string jsonFile = CreateTestJsonFile(R"({"EventName":"TestEvent","TestKey":"TestValue"})");
-
     try
     {
-        Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds{1});
+        Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds{1});
         EXPECT_FALSE(telemetryManager.ProcessJsonFile(jsonFile));
     }
     catch (const std::exception& e)
     {
-        GTEST_SKIP() << "TelemetryManager creation failed: " << e.what();
+        EXPECT_TRUE(false);
     }
 }

--- a/src/common/telemetry/lib/CMakeLists.txt
+++ b/src/common/telemetry/lib/CMakeLists.txt
@@ -47,6 +47,8 @@ ExternalProject_Add(
         # Install to vcpkg's installed directory instead of system paths
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/1ds_install
     INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
+    BUILD_BYPRODUCTS
+        ${CMAKE_BINARY_DIR}/1ds_install/lib/libmat.a
 )
 
 # Get the install directory for 1DS SDK

--- a/src/common/telemetry/lib/Telemetry.cpp
+++ b/src/common/telemetry/lib/Telemetry.cpp
@@ -51,7 +51,7 @@ TelemetryManager::TelemetryManager(std::string cacheFilePath,bool enableDebug, s
     m_logConfig[CFG_BOOL_ENABLE_DB_DROP_IF_FULL] = true;
 
     status_t status = STATUS_SUCCESS;
-    m_logManager.reset(LogManagerProvider::CreateLogManager(m_logConfig, status));
+    m_logManager = LogManagerProvider::CreateLogManager(m_logConfig, status);
     if ((STATUS_SUCCESS != status) || !m_logManager)
     {
         OsConfigLogError(m_log, "Telemetry initialization failed. status=%d", status);
@@ -72,12 +72,20 @@ TelemetryManager::~TelemetryManager() noexcept
 {
     try
     {
-        m_logManager->FlushAndTeardown();
+        if (nullptr != m_logManager)
+        {
+            m_logManager->FlushAndTeardown();
+        }
     }
     catch(...)
     {
         OsConfigLogError(m_log, "Exception during telemetry shutdown");
     }
+
+    LogManagerProvider::DestroyLogManager(TELEMETRY_NAME);
+
+    m_logger = nullptr;
+    m_logManager = nullptr;
     OsConfigLogInfo(m_log, "Telemetry shutdown complete.");
 }
 

--- a/src/common/telemetry/lib/Telemetry.cpp
+++ b/src/common/telemetry/lib/Telemetry.cpp
@@ -21,18 +21,31 @@ using namespace MAT;
 namespace Telemetry
 {
 
-TelemetryManager::TelemetryManager(bool enableDebug, std::chrono::seconds teardownTime, OsConfigLogHandle logHandle)
+TelemetryManager::TelemetryManager(std::string cacheFilePath,bool enableDebug, std::chrono::seconds teardownTime, OsConfigLogHandle logHandle)
     : m_log(logHandle)
     , m_logManager(nullptr)
     , m_logger(nullptr)
 {
+    {
+        FILE* testWrite = fopen(cacheFilePath.c_str(), "a");
+        if (testWrite)
+        {
+            fclose(testWrite);
+        }
+        else
+        {
+            OsConfigLogError(m_log, "Telemetry sdk cache path '%s' not writable, aborting", cacheFilePath.c_str() );
+            throw std::runtime_error("Telemetry sdk cache path not writable, aborting");
+        }
+    }
+
     m_logConfig["name"] = TELEMETRY_NAME;
     m_logConfig["version"] = TELEMETRY_VERSION;
     m_logConfig["config"]["host"] = "*";
     m_logConfig[CFG_BOOL_ENABLE_TRACE] = enableDebug;
     m_logConfig[CFG_INT_TRACE_LEVEL_MIN] = 0;
     m_logConfig[CFG_INT_MAX_TEARDOWN_TIME] = teardownTime.count();
-    m_logConfig[CFG_STR_CACHE_FILE_PATH] = TELEMETRY_CACHE_FILE_NAME;
+    m_logConfig[CFG_STR_CACHE_FILE_PATH] = cacheFilePath;
     m_logConfig[CFG_INT_CACHE_FILE_SIZE] = TELEMETRY_CACHE_FILE_SIZE;
     m_logConfig[CFG_INT_RAM_QUEUE_SIZE] = TELEMETRY_RAM_QUEUE_SIZE;
     m_logConfig[CFG_BOOL_ENABLE_DB_DROP_IF_FULL] = true;

--- a/src/common/telemetry/lib/Telemetry.hpp
+++ b/src/common/telemetry/lib/Telemetry.hpp
@@ -29,7 +29,8 @@ public:
     static constexpr const int TELEMETRY_CACHE_FILE_SIZE = 10 * 1024 * 1024;
     static constexpr const int TELEMETRY_RAM_QUEUE_SIZE = 2 * 1024 * 1024;
 
-    explicit TelemetryManager(bool enableDebug = false, std::chrono::seconds teardownTime = CONFIG_DEFAULT_TEARDOWN_TIME, OsConfigLogHandle logHandle = nullptr);
+    explicit TelemetryManager(std::string cacheFilePath, bool enableDebug = false, std::chrono::seconds teardownTime = CONFIG_DEFAULT_TEARDOWN_TIME,
+        OsConfigLogHandle logHandle = nullptr);
 
     ~TelemetryManager() noexcept;
 

--- a/src/common/telemetry/lib/Telemetry.hpp
+++ b/src/common/telemetry/lib/Telemetry.hpp
@@ -10,7 +10,6 @@
 #include <LogManager.hpp>
 #include <Logging.h>
 #include <chrono>
-#include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -46,7 +45,7 @@ public:
 private:
     OsConfigLogHandle m_log;
     MAT::ILogConfiguration m_logConfig;
-    std::unique_ptr<MAT::ILogManager> m_logManager;
+    MAT::ILogManager* m_logManager;
     MAT::ILogger* m_logger;
 
     void EventWrite(Microsoft::Applications::Events::EventProperties event);

--- a/src/common/telemetry/lib/tests/TelemetryTests.cpp
+++ b/src/common/telemetry/lib/tests/TelemetryTests.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstdlib>
+
 #include <chrono>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -13,6 +15,7 @@ class TelemetryTest : public ::testing::Test
 protected:
     std::string m_testDir;
     std::string m_testJsonFile;
+    std::string m_telemetryCache;
 
     void SetUp() override
     {
@@ -21,7 +24,15 @@ protected:
         ASSERT_NE(nullptr, mkdtemp(tmpDir));
         m_testDir = std::string(tmpDir);
         m_testJsonFile = m_testDir + "/test_telemetry.json";
-    }
+
+        std::string telemetryCache = m_testDir + "/telemetry_cache_db.XXXXXX";
+        std::vector<char> buffer(telemetryCache.begin(), telemetryCache.end());
+        buffer.push_back('\0');
+
+        int fd = ::mkstemp(buffer.data());
+        EXPECT_TRUE(0 < fd);
+        m_telemetryCache.assign(buffer.data(), buffer.size());
+        }
 
     void TearDown() override
     {
@@ -50,7 +61,7 @@ protected:
 // Test processing a non-existent file
 TEST_F(TelemetryTest, ProcessNonExistentFile)
 {
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile("/non/existent/file.json"));
 }
 
@@ -58,7 +69,7 @@ TEST_F(TelemetryTest, ProcessNonExistentFile)
 TEST_F(TelemetryTest, ProcessEmptyFile)
 {
     ASSERT_TRUE(CreateTestJsonFile(""));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_TRUE(telemetryManager.ProcessJsonFile(m_testJsonFile)); // Empty file should be processed successfully
 }
 
@@ -68,7 +79,7 @@ TEST_F(TelemetryTest, ProcessValidJsonFile)
     // Create a test file with a valid event
     std::string validJson = R"({"EventName": "TestEvent", "TestParam": "value"})";
     ASSERT_TRUE(CreateTestJsonFile(validJson));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -76,7 +87,7 @@ TEST_F(TelemetryTest, ProcessValidJsonFile)
 TEST_F(TelemetryTest, ProcessInvalidJsonFile)
 {
     ASSERT_TRUE(CreateTestJsonFile("invalid json content"));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -87,7 +98,7 @@ TEST_F(TelemetryTest, ProcessMixedJsonFile)
 invalid json line
 {"EventName": "AnotherEvent", "Param": "value2"})";
     ASSERT_TRUE(CreateTestJsonFile(mixedContent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -98,7 +109,7 @@ TEST_F(TelemetryTest, ProcessMultipleValidJsonLines)
 {"EventName": "Event2", "Param2": "value2"}
 {"EventName": "Event3", "Param3": "value3"})";
     ASSERT_TRUE(CreateTestJsonFile(multipleLines));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -107,7 +118,7 @@ TEST_F(TelemetryTest, ProcessRuleCompleteEvent)
 {
     std::string realEvent = R"({"EventName":"RuleComplete","Timestamp":"2025-10-17 22:52:56+0000","ComponentName":"SecurityBaseline","ObjectName":"auditEnsureAuditdInstalled","ObjectResult":"0","Microseconds":"29","DistroName":"CentOS","CorrelationId":"","Version":"1.0.5.20251017-g03b36b7d"})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_TRUE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -115,7 +126,7 @@ TEST_F(TelemetryTest, ProcessRuleCompleteMissingComponentNameEvent)
 {
     std::string realEvent = R"({"EventName":"RuleComplete","Timestamp":"2025-10-17 22:52:56+0000","ComponentName":"SecurityBaseline","ObjectResult":"0","Microseconds":"29","DistroName":"CentOS","CorrelationId":"","Version":"1.0.5.20251017-g03b36b7d"})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -123,7 +134,7 @@ TEST_F(TelemetryTest, ProcessBaselineRunEvent)
 {
     std::string realEvent = R"({"EventName":"BaselineRun","Timestamp":"2025-10-17 22:52:56+0000","BaselineName":"Azure Security Baseline for Linux","Mode":"audit-only","DurationSeconds":"8.87","DistroName":"CentOS","CorrelationId":"","Version":"1.0.5.20251017-g03b36b7d"})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_TRUE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -131,7 +142,7 @@ TEST_F(TelemetryTest, ProcessBaselineRunMissingTimestampEvent)
 {
     std::string realEvent = R"({"EventName":"BaselineRun","BaselineName":"Azure Security Baseline for Linux","Mode":"audit-only","DurationSeconds":"8.87","DistroName":"CentOS","CorrelationId":"","Version":"1.0.5.20251017-g03b36b7d"})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -139,7 +150,7 @@ TEST_F(TelemetryTest, ProcessStatusTraceEvent)
 {
     std::string realEvent = R"({"EventName":"StatusTrace","Timestamp":"2025-10-17 22:52:56+0000","FileName":"/workspaces/azure-osconfig/src/common/asb/Asb.c","LineNumber":"1109","FunctionName":"AsbShutdown","RuleCodename":"auditEnsureSmbWithSambaIsDisabled","CallingFunctionName":"TestingStatusTrace","ResultCode":"0","ResultString":"OK","ScenarioName":"TestingScenario","Microseconds":"101807","DistroName":"CentOS","CorrelationId":"","Version":"1.0.5.20251017-g03b36b7d"})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_TRUE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -147,7 +158,7 @@ TEST_F(TelemetryTest, ProcessStatusTraceMissingScenarioNameEvent)
 {
     std::string realEvent = R"({"EventName":"StatusTrace","Timestamp":"2025-10-17 22:52:56+0000","FileName":"/workspaces/azure-osconfig/src/common/asb/Asb.c","LineNumber":"1109","FunctionName":"AsbShutdown","RuleCodename":"auditEnsureSmbWithSambaIsDisabled","CallingFunctionName":"TestingStatusTrace","ResultCode":"0","Microseconds":"101807","DistroName":"CentOS","CorrelationId":"","Version":"1.0.5.20251017-g03b36b7d"})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -155,7 +166,7 @@ TEST_F(TelemetryTest, ProcessCommandExecutedEvent)
 {
     std::string realEvent = R"({"EventName":"CommandExecuted","DistroName":"CentOS","Version":"1.3.0-preview123","CorrelationId":"{00000000-0000-0000-0000-000000000000}","CorrelationGroup":"TestGroup","Timestamp":"2025-10-17 22:52:56+0000","IsTestMode":true,"Subcommand":"get resource","Duration":1234.5678,"Success":true,"ErrorKind":"Resource","ErrorResourceName":"Test Resource","ErrorResourceType":"Microsoft.OSConfig/Test","ErrorLocation":"utils/test.rs:123","ErrorCode":1})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_TRUE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }
 
@@ -163,6 +174,6 @@ TEST_F(TelemetryTest, ProcessCommandExecutedMissingSubcommandEvent)
 {
     std::string realEvent = R"({"EventName":"CommandExecuted","DistroName":"CentOS","Version":"1.3.0-preview123","CorrelationId":"{00000000-0000-0000-0000-000000000000}","CorrelationGroup":"TestGroup","Timestamp":"2025-10-17 22:52:56+0000","IsTestMode":true,"Duration":1234.5678,"Success":true,"ErrorKind":"Resource","ErrorResourceName":"Test Resource","ErrorResourceType":"Microsoft.OSConfig/Test","ErrorLocation":"utils/test.rs:123","ErrorCode":1})";
     ASSERT_TRUE(CreateTestJsonFile(realEvent));
-    Telemetry::TelemetryManager telemetryManager(false, std::chrono::seconds(1));
+    Telemetry::TelemetryManager telemetryManager(m_telemetryCache, false, std::chrono::seconds(1));
     EXPECT_FALSE(telemetryManager.ProcessJsonFile(m_testJsonFile));
 }

--- a/src/tests/fuzzer/CMakeLists.txt
+++ b/src/tests/fuzzer/CMakeLists.txt
@@ -21,3 +21,7 @@ target_link_libraries(osconfig-fuzzer PRIVATE
     parsonlib
     $<$<BOOL:${BUILD_TELEMETRY}>:telemetry-interface>
 )
+
+if(BUILD_TELEMETRY)
+    add_dependencies(osconfig-fuzzer telemetry-external)
+endif()

--- a/src/tests/fuzzer/target.cpp
+++ b/src/tests/fuzzer/target.cpp
@@ -52,6 +52,7 @@ struct Context
     MMI_HANDLE handle;
     std::string tempdir;
 #ifdef BUILD_TELEMETRY
+    std::string telemetryCache;
     std::unique_ptr<Telemetry::TelemetryManager> telemetryManager;
 #endif
 
@@ -72,12 +73,16 @@ struct Context
             throw std::runtime_error("failed to initialized SecurityBaseline library");
         }
 #ifdef BUILD_TELEMETRY
-        telemetryManager.reset(new Telemetry::TelemetryManager(false, std::chrono::seconds{1}));
+        telemetryCache = tempdir + "/telemetry_cache_db";
+        telemetryManager.reset(new Telemetry::TelemetryManager(telemetryCache, false, std::chrono::seconds{1}));
 #endif
     }
 
     ~Context() noexcept
     {
+#ifdef BUILD_TELEMETRY
+        ::remove(telemetryCache.c_str());
+#endif
         ::remove(tempdir.c_str());
         SecurityBaselineMmiClose(handle);
         SecurityBaselineShutdown();


### PR DESCRIPTION
If the cache file cannot be opened, fail initialization early. Otherwise telemetry events are not persisted and never reach the Aria backend.

## Description

*Describe your changes in as much detail as possible. Provide a link/reference to the issue solved with this request if any.*

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
