### PR TITLE
Do not treat missing package manager as hard error

### DIFF
--- a/src/modules/complianceengine/src/lib/procedures/PackageInstalled.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/PackageInstalled.cpp
@@ -485,6 +485,13 @@ Result<Status> AuditPackageInstalled(const PackageInstalledParams& params, Indic
         auto result = DetectPackageManager(context);
         if (!result.HasValue())
         {
+            OsConfigLogInfo(log, "Failed to detect package manager: %s", result.Error().message.c_str());
+            if (result.Error().code == ENOENT)
+            {
+                // Failed to detect package manager, return the NotApplicable indicator instead of an error, since this is a valid state for some systems.
+                return indicators.NotApplicable(result.Error().message);
+            }
+
             return result.Error();
         }
 

--- a/src/modules/complianceengine/tests/procedures/PackageInstalledTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/PackageInstalledTest.cpp
@@ -135,8 +135,8 @@ TEST_F(PackageInstalledTest, NoPackageManagerDetected)
 
     auto result = AuditPackageInstalled(params, mIndicators, mContext);
 
-    ASSERT_FALSE(result.HasValue());
-    ASSERT_EQ(result.Error().message, "No package manager found");
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::NotApplicable);
 }
 
 TEST_F(PackageInstalledTest, SpecifiedPackageManagerOverridesDetection)


### PR DESCRIPTION
## Description

On ACL, benchmarks still use the `PackageInstalled` procedure. While this should not be part of the benchmark itself I believe in general we should avoid hard failure and reply with `NotApplicable` state in case no package manager is available on a system.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
