### PR TITLE
Relax MOF parser: Skip the OMI_ConfigurationDocument block

### DIFF
--- a/src/modules/complianceengine/src/assessor/Mof.cpp
+++ b/src/modules/complianceengine/src/assessor/Mof.cpp
@@ -41,6 +41,11 @@ constexpr size_t kMaxMofEntries = 100000;
 constexpr char kHeaderPrefix[] = "instance of OsConfigResource as $OsConfigResource";
 constexpr char kHeaderSuffix[] = "ref";
 
+// Header of the document metadata block the augmentation engine emits once per
+// MOF (Version, Author, GenerationDate, Name). It carries no resource data and
+// is skipped by the parser.
+constexpr char kConfigurationDocumentHeader[] = "instance of OMI_ConfigurationDocument";
+
 // The complete, fixed set of field keys the Compliance Augmentation Engine
 // emits for every resource. The parser is strict: it rejects any key not in
 // this set (unknown/extra fields) and requires every key in this set to be
@@ -361,7 +366,9 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
     };
 
     // Locate the next entry header, skipping blank lines between entries. A
-    // clean end of input here means there are no more entries.
+    // clean end of input here means there are no more entries. The document
+    // metadata block (OMI_ConfigurationDocument) carries no resource data and
+    // is skipped in its entirety.
     string header;
     while (true)
     {
@@ -375,10 +382,32 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
             return Optional<Resource>(); // Clean EOF — no more entries.
         }
         header = TrimWhiteSpaces(read.Value().Value());
-        if (!header.empty())
+        if (header.empty())
         {
-            break;
+            continue;
         }
+        if (header == kConfigurationDocumentHeader)
+        {
+            // Consume the block ('{' ... '};') and resume the header search.
+            while (true)
+            {
+                auto blockRead = readLine();
+                if (!blockRead.HasValue())
+                {
+                    return blockRead.Error();
+                }
+                if (!blockRead.Value().HasValue())
+                {
+                    return Error("Truncated MOF entry: missing closing '};'", EIO);
+                }
+                if (TrimWhiteSpaces(blockRead.Value().Value()) == "};")
+                {
+                    break;
+                }
+            }
+            continue;
+        }
+        break;
     }
     const size_t prefixLen = sizeof(kHeaderPrefix) - 1;
     const size_t suffixLen = sizeof(kHeaderSuffix) - 1;

--- a/src/modules/complianceengine/src/assessor/Mof.cpp
+++ b/src/modules/complianceengine/src/assessor/Mof.cpp
@@ -389,6 +389,19 @@ Result<Optional<Resource>> MofResourceRange::ParseNext()
         if (header == kConfigurationDocumentHeader)
         {
             // Consume the block ('{' ... '};') and resume the header search.
+            // The opening brace is required on its own line, exactly as for a
+            // normal resource entry; without this check a malformed block
+            // missing its '{' would swallow lines up to the next entry's '};'
+            // and silently drop that entry.
+            auto openRead = readLine();
+            if (!openRead.HasValue())
+            {
+                return openRead.Error();
+            }
+            if (!openRead.Value().HasValue() || TrimWhiteSpaces(openRead.Value().Value()) != "{")
+            {
+                return Error("Expected '{' after OMI_ConfigurationDocument header", EINVAL);
+            }
             while (true)
             {
                 auto blockRead = readLine();

--- a/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/configuration_document.mof
+++ b/src/modules/complianceengine/src/assessor/fuzzer/seed_corpus/configuration_document.mof
@@ -1,0 +1,25 @@
+instance of OMI_ConfigurationDocument
+{
+    Version = "3.0.0";                     CompatibleVersionAdditionalProperties = {"Omi_BaseResource:ConfigurationName"};
+    Author = "Microsoft";
+    GenerationDate = "07/10/2026 04:11:24 UTC";
+    Name = "ComplianceEngine";
+};
+instance of OsConfigResource as $OsConfigResource0ref
+{
+    ResourceID = "1.1.1 Rule A";
+    PayloadKey = "/cis/ubuntu/22.04/v2.0.0/1/1/1";
+    RuleId = "00000000-0000-0000-0000-000000000000";
+    ComponentName = "ComplianceEngine";
+    ProcedureObjectName = "procedureRuleA";
+    ProcedureObjectValue = "eyJhdWRpdCI6e319";
+    InitObjectName = "initRuleA";
+    ReportedObjectName = "auditRuleA";
+    ExpectedObjectValue = "PASS";
+    DesiredObjectName = "remediateRuleA";
+    DesiredObjectValue = "";
+    ModuleName = "GuestConfiguration";
+    ModuleVersion = "1.0.0";
+    ConfigurationName = "ComplianceEngine";
+    SourceInfo = "::4::5::OsConfigResource";
+};

--- a/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
@@ -221,6 +221,66 @@ TEST(MofParserTest, WhitespaceOnlyInputHasNoEntries)
     EXPECT_TRUE(range.begin() == range.end());
 }
 
+TEST(MofParserTest, ConfigurationDocumentBlockIsSkipped)
+{
+    // The augmentation engine emits an OMI_ConfigurationDocument metadata block
+    // that carries no resource data. It must be skipped, not rejected. The
+    // Version line intentionally packs a second field on the same line to match
+    // the exact shape our generator produces.
+    const std::string document =
+        "instance of OMI_ConfigurationDocument\n"
+        "{\n"
+        "    Version = \"3.0.0\";                     CompatibleVersionAdditionalProperties = {\"Omi_BaseResource:ConfigurationName\"};\n"
+        "    Author = \"Microsoft\";\n"
+        "    GenerationDate = \"07/10/2026 04:11:24 UTC\";\n"
+        "    Name = \"ComplianceEngine\";\n"
+        "};\n";
+
+    std::string text = Render(DefaultFields()) + document + Render(DefaultFields());
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    int count = 0;
+    for (const auto& entry : range)
+    {
+        ASSERT_TRUE(entry.HasValue()) << entry.Error().message;
+        ++count;
+    }
+    EXPECT_EQ(count, 2);
+}
+
+TEST(MofParserTest, ConfigurationDocumentOnlyInputHasNoEntries)
+{
+    const std::string text =
+        "instance of OMI_ConfigurationDocument\n"
+        "{\n"
+        "    Version = \"3.0.0\";\n"
+        "    Name = \"ComplianceEngine\";\n"
+        "};\n";
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    EXPECT_TRUE(range.begin() == range.end());
+}
+
+TEST(MofParserTest, TruncatedConfigurationDocumentBlockIsRejected)
+{
+    // A document block without its closing '};' is a truncated input error.
+    const std::string text =
+        "instance of OMI_ConfigurationDocument\n"
+        "{\n"
+        "    Version = \"3.0.0\";\n";
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    EXPECT_FALSE((*it).HasValue());
+}
+
 TEST(MofParserTest, IterationStopsAfterError)
 {
     // A malformed first entry must surface an error and halt iteration rather

--- a/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
+++ b/src/modules/complianceengine/src/assessor/tests/MofTest.cpp
@@ -281,6 +281,22 @@ TEST(MofParserTest, TruncatedConfigurationDocumentBlockIsRejected)
     EXPECT_FALSE((*it).HasValue());
 }
 
+TEST(MofParserTest, ConfigurationDocumentMissingBraceDoesNotSwallowNextEntry)
+{
+    // A document block missing its opening '{' must be rejected, not consumed up
+    // to the following real entry's '};'. Without requiring the brace, the skip
+    // loop would silently swallow the resource below and drop it.
+    const std::string text = std::string("instance of OMI_ConfigurationDocument\n") + Render(DefaultFields());
+    std::istringstream stream(text);
+    auto rangeResult = MofResourceRange::MakeFromStream(stream, nullptr);
+    ASSERT_TRUE(rangeResult.HasValue());
+    auto& range = rangeResult.Value();
+    auto it = range.begin();
+    ASSERT_TRUE(it != range.end());
+    ASSERT_FALSE((*it).HasValue());
+    EXPECT_EQ((*it).Error().message, "Expected '{' after OMI_ConfigurationDocument header");
+}
+
 TEST(MofParserTest, IterationStopsAfterError)
 {
     // A malformed first entry must surface an error and halt iteration rather


### PR DESCRIPTION
## Description

Fix a regression in MOF file parsing. We produce an `OMI_ConfigurationDocument` block in the MOF files and the hardened parsing fails on this. 

This PR relaxes the parser by skipping this entire block.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
