### PR TITLE
Fix invalid handling of comma-separated mach modes

### DIFF
--- a/src/modules/complianceengine/src/lib/procedures/SshdOption.cpp
+++ b/src/modules/complianceengine/src/lib/procedures/SshdOption.cpp
@@ -92,13 +92,30 @@ Result<std::vector<std::string>> GetAllMatches(ContextInterface& context)
                 lineStream >> type >> value;
                 std::transform(type.begin(), type.end(), type.begin(), ::tolower);
                 std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-                if ((type == "address") || (type == "localaddress"))
-                {
-                    value = value.substr(0, value.find_first_of('/'));
-                }
                 if ((type == "user") || (type == "group") || (type == "host") || (type == "port") || (type == "address") || (type == "localaddress"))
                 {
-                    allMatches.push_back(type + "=" + value);
+                    // The Match criteria value may be a comma-separated pattern list, e.g.
+                    // "Match User *@*,<uuid>" (as appended by the aadsshlogin installer). In
+                    // sshd_config a comma is an OR separator between patterns, but `sshd -T -C`
+                    // treats commas as separators between distinct connection-spec items. Feeding
+                    // the raw comma list into `-C user=...` makes sshd misparse the trailing
+                    // patterns as bogus spec keys and abort with "Invalid test mode specification".
+                    // Emit one match context per pattern so each Match block a pattern could
+                    // activate is simulated independently.
+                    std::istringstream valueStream(value);
+                    std::string pattern;
+                    while (std::getline(valueStream, pattern, ','))
+                    {
+                        if (pattern.empty())
+                        {
+                            continue;
+                        }
+                        if ((type == "address") || (type == "localaddress"))
+                        {
+                            pattern = pattern.substr(0, pattern.find_first_of('/'));
+                        }
+                        allMatches.push_back(type + "=" + pattern);
+                    }
                 }
             }
         }
@@ -235,17 +252,21 @@ static Result<Status> EvaluateDelimitedNumericLimits(const std::string& option, 
 // Helper that evaluates a single sshd option against the provided operation/value.
 // valueRegexes are only used (and must be valid) when op is regex, match, or not_match.
 static Result<Status> EvaluateSshdOption(const std::map<std::string, std::string>& sshdConfig, const std::string& option, const std::string& value,
-    const std::string& op, const std::vector<regex>& valueRegexes, IndicatorsTree& indicators)
+    const std::string& op, const std::vector<regex>& valueRegexes, const Optional<std::string>& matchContext, IndicatorsTree& indicators)
 {
+    // When evaluating a specific Match block (all_matches mode), qualify every message with the
+    // connection context (e.g. "user=*@*") so results from different Match contexts are
+    // distinguishable in the indicator tree.
+    const std::string ctx = matchContext.HasValue() ? " (Match context '" + matchContext.Value() + "')" : "";
     auto itOptions = sshdConfig.find(option);
     if (itOptions == sshdConfig.end())
     {
         // For not_match semantics, absence means the forbidden pattern is not present -> compliant
         if (op == "not_match")
         {
-            return indicators.Compliant("Option '" + option + "' not found.");
+            return indicators.Compliant("Option '" + option + "' not found." + ctx);
         }
-        return indicators.NonCompliant("Option '" + option + "' not found in SSH daemon configuration");
+        return indicators.NonCompliant("Option '" + option + "' not found in SSH daemon configuration" + ctx);
     }
 
     auto realValue = itOptions->second;
@@ -270,10 +291,10 @@ static Result<Status> EvaluateSshdOption(const std::map<std::string, std::string
         {
             if (regex_search(realValue, valueRegex))
             {
-                return indicators.Compliant("Option '" + option + "' has a compliant value '" + realValue + "'");
+                return indicators.Compliant("Option '" + option + "' has a compliant value '" + realValue + "'" + ctx);
             }
         }
-        return indicators.NonCompliant("Option '" + option + "' has value '" + realValue + "' which does not match required pattern '" + value + "'");
+        return indicators.NonCompliant("Option '" + option + "' has value '" + realValue + "' which does not match required pattern '" + value + "'" + ctx);
     }
     else if (op == "not_match")
     {
@@ -285,10 +306,10 @@ static Result<Status> EvaluateSshdOption(const std::map<std::string, std::string
         {
             if (regex_search(realValue, valueRegex))
             {
-                return indicators.NonCompliant("Option '" + option + "' has value '" + realValue + "' which matches forbidden pattern '" + value + "'");
+                return indicators.NonCompliant("Option '" + option + "' has value '" + realValue + "' which matches forbidden pattern '" + value + "'" + ctx);
             }
         }
-        return indicators.Compliant("Option '" + option + "' has a compliant value '" + realValue + "'");
+        return indicators.Compliant("Option '" + option + "' has a compliant value '" + realValue + "'" + ctx);
     }
     else if (op == "lt" || op == "le" || op == "gt" || op == "ge")
     {
@@ -297,7 +318,7 @@ static Result<Status> EvaluateSshdOption(const std::map<std::string, std::string
         if (!realIntRes.HasValue() || !wantedIntRes.HasValue())
         {
             return indicators.NonCompliant("Option '" + option + "' has non-numeric value '" + realValue + "' or comparison target '" + value +
-                                           "' (cannot apply numeric operation '" + op + "')");
+                                           "' (cannot apply numeric operation '" + op + "')" + ctx);
         }
         long long realInt = realIntRes.Value();
         long long wantedInt = wantedIntRes.Value();
@@ -328,9 +349,9 @@ static Result<Status> EvaluateSshdOption(const std::map<std::string, std::string
         if (pass)
         {
             return indicators.Compliant("Option '" + option + "' has a compliant numeric value '" + realValue + "' (" + expectation + " '" + value +
-                                        "')");
+                                        "')" + ctx);
         }
-        return indicators.NonCompliant("Option '" + option + "' has numeric value '" + realValue + "' which is not " + expectation + " '" + value + "'");
+        return indicators.NonCompliant("Option '" + option + "' has numeric value '" + realValue + "' which is not " + expectation + " '" + value + "'" + ctx);
     }
     else
     {
@@ -392,7 +413,7 @@ Result<Status> AuditSshdOption(const SshdOptionParams& params, IndicatorsTree& i
         }
     }
 
-    std::vector<std::string> matchModes;
+    std::vector<Optional<std::string>> matchModes;
     auto mode = params.mode.Value();
     if (mode == SshdOptionMode::AllMatches)
     {
@@ -405,11 +426,14 @@ Result<Status> AuditSshdOption(const SshdOptionParams& params, IndicatorsTree& i
         {
             return indicators.Compliant("No Match blocks in SSH daemon configuration, skipping Match evaluation");
         }
-        matchModes = allMatches.Value();
+        for (auto& match : allMatches.Value())
+        {
+            matchModes.emplace_back(std::move(match));
+        }
     }
     else
     {
-        matchModes.push_back(""); // regular
+        matchModes.emplace_back(); // regular (no Match context)
     }
 
     std::string extraConfig;
@@ -429,16 +453,21 @@ Result<Status> AuditSshdOption(const SshdOptionParams& params, IndicatorsTree& i
 
     for (auto const& matchMode : matchModes)
     {
-        auto sshdConfig = GetSshdOptions(context, extraConfig, matchMode);
+        auto sshdConfig = GetSshdOptions(context, extraConfig, matchMode.ValueOr(""));
         if (!sshdConfig.HasValue())
         {
-            return indicators.NonCompliant("Failed to get sshd options: " + sshdConfig.Error().message);
+            // A failure to *evaluate* the sshd configuration (e.g. sshd -T could not run, or a
+            // Match context could not be simulated) is an engine error, not evidence that the
+            // system is non-compliant. Reporting it as NonCompliant produces a false negative;
+            // propagate it as an Error so it is surfaced as "could not evaluate" and honored by
+            // the assessor's --continue-on-error handling.
+            return Error("Failed to get sshd options: " + sshdConfig.Error().message, sshdConfig.Error().code);
         }
         for (auto const& option : options)
         {
             OsConfigLogInfo(log, "Evaluating SSH daemon option '%s' in mode '%s' with op '%s' against value '%s'", option.c_str(),
-                matchMode.empty() ? "regular" : matchMode.c_str(), std::to_string(op).c_str(), params.value.c_str());
-            auto result = EvaluateSshdOption(sshdConfig.Value(), option, params.value, std::to_string(op), valueRegexes, indicators);
+                matchMode.HasValue() ? matchMode.Value().c_str() : "regular", std::to_string(op).c_str(), params.value.c_str());
+            auto result = EvaluateSshdOption(sshdConfig.Value(), option, params.value, std::to_string(op), valueRegexes, matchMode, indicators);
             if (!result.HasValue())
             {
                 return result.Error();

--- a/src/modules/complianceengine/tests/procedures/SshdOptionTest.cpp
+++ b/src/modules/complianceengine/tests/procedures/SshdOptionTest.cpp
@@ -82,11 +82,9 @@ TEST_F(EnsureSshdOptionTest, InitialCommandFails)
     params.value = "no";
 
     auto result = AuditSshdOption(params, mIndicators, mContext);
-    ASSERT_TRUE(result.HasValue());
-    ASSERT_EQ(result.Value(), Status::NonCompliant);
-    auto formatted = mFormatter.Format(mIndicators).Value();
-    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("[NonCompliant]") != std::string::npos);
-    ASSERT_TRUE(mFormatter.Format(mIndicators).Value().find("Failed to execute sshd") != std::string::npos);
+    // A failure to run sshd -T is an evaluation error, not a compliance verdict.
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_TRUE(result.Error().message.find("Failed to execute sshd") != std::string::npos);
 }
 
 TEST_F(EnsureSshdOptionTest, SimpleConfigOptionExists)
@@ -149,10 +147,9 @@ TEST_F(EnsureSshdOptionTest, CommandFailure)
     params.value = "no";
 
     auto result = AuditSshdOption(params, mIndicators, mContext);
-    ASSERT_TRUE(result.HasValue());
-    auto formatted = mFormatter.Format(mIndicators).Value();
-    ASSERT_TRUE(formatted.find("Failed to get sshd options:") != std::string::npos);
-    ASSERT_TRUE(formatted.find("Failed to execute sshd -T") != std::string::npos);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_TRUE(result.Error().message.find("Failed to get sshd options:") != std::string::npos);
+    ASSERT_TRUE(result.Error().message.find("Failed to execute sshd -T") != std::string::npos);
 }
 
 TEST_F(EnsureSshdOptionTest, WithMatchGroupConfig)
@@ -185,10 +182,9 @@ TEST_F(EnsureSshdOptionTest, HostnameCommandFailure)
     params.value = "no";
 
     auto result = AuditSshdOption(params, mIndicators, mContext);
-    ASSERT_TRUE(result.HasValue());
-    auto formatted = mFormatter.Format(mIndicators).Value();
-    ASSERT_TRUE(formatted.find("Failed to get sshd options:") != std::string::npos);
-    ASSERT_TRUE(formatted.find("Failed to execute hostname command") != std::string::npos);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_TRUE(result.Error().message.find("Failed to get sshd options:") != std::string::npos);
+    ASSERT_TRUE(result.Error().message.find("Failed to execute hostname command") != std::string::npos);
 }
 
 TEST_F(EnsureSshdOptionTest, HostAddressCommandFailure)
@@ -204,10 +200,9 @@ TEST_F(EnsureSshdOptionTest, HostAddressCommandFailure)
     params.value = "no";
 
     auto result = AuditSshdOption(params, mIndicators, mContext);
-    ASSERT_TRUE(result.HasValue());
-    auto formatted = mFormatter.Format(mIndicators).Value();
-    ASSERT_TRUE(formatted.find("Failed to get sshd options:") != std::string::npos);
-    ASSERT_TRUE(formatted.find("Failed to get host address") != std::string::npos);
+    ASSERT_FALSE(result.HasValue());
+    ASSERT_TRUE(result.Error().message.find("Failed to get sshd options:") != std::string::npos);
+    ASSERT_TRUE(result.Error().message.find("Failed to get host address") != std::string::npos);
 }
 
 TEST_F(EnsureSshdOptionTest, RegexMatches)
@@ -721,7 +716,54 @@ TEST_F(EnsureSshdOptionTest, Match_FileReadFailure_NoMatchesReturnsCompliant)
     ASSERT_EQ(result.Value(), Status::Compliant);
 }
 
-// ========================= Tests for readExtraConfigs parameter =========================
+// Reproduces the aadsshlogin failure: the installer appends
+//   Match User *@*,<uuid>    # Added by aadsshlogin installer
+// to sshd_config. The comma separates a *pattern list* for the Match User
+// criterion. When all_matches mode feeds that value verbatim into
+// `sshd -T -C user=<value>`, sshd treats the comma as the separator between
+// connection-spec `key=value` pairs, so the tail after the comma is parsed as
+// a bogus spec item and sshd aborts with
+//   "Invalid test mode specification <uuid>".
+// The connection spec must carry a single concrete user, so the pattern list
+// is split into one match context per pattern: `sshd -T -C user=*@*` and
+// `sshd -T -C user=<uuid>` are simulated independently.
+static const char sshdConfigWithAadMatchUser[] =
+    "Port 22\n"
+    "Match User *@*,\?\?\?\?\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?\?\?\?\?\?\?\?\?    # Added by aadsshlogin installer\n";
+
+static const char sshdMatchUserAadFirstPatternCommand[] = "sshd -T -C user=*@*";
+static const char sshdMatchUserAadSecondPatternCommand[] = "sshd -T -C user=\?\?\?\?\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?\?\?\?\?\?\?\?\?";
+static const char sshdMatchUserAadBrokenCommand[] = "sshd -T -C user=*@*,\?\?\?\?\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?\?\?\?\?\?\?\?\?";
+
+TEST_F(EnsureSshdOptionTest, Match_UserPatternListWithComma_SplitsIntoOneContextPerPattern)
+{
+    EXPECT_CALL(mContext, GetFileContents("/etc/ssh/sshd_config")).WillOnce(Return(Result<std::string>(sshdConfigWithAadMatchUser)));
+
+    // The forbidden call: passing the whole comma-separated pattern list to
+    // `sshd -T -C user=...` is what triggers "Invalid test mode specification".
+    EXPECT_CALL(mContext, ExecuteCommand(sshdMatchUserAadBrokenCommand)).Times(0);
+
+    // The correct behaviour: each pattern of the comma-separated list is simulated
+    // as its own connection spec.
+    EXPECT_CALL(mContext, ExecuteCommand(sshdMatchUserAadFirstPatternCommand)).WillOnce(Return(Result<std::string>("banner /etc/issue.net\n")));
+    EXPECT_CALL(mContext, ExecuteCommand(sshdMatchUserAadSecondPatternCommand)).WillOnce(Return(Result<std::string>("banner /etc/issue.net\n")));
+
+    SshdOptionParams params;
+    params.option = {{"banner"}};
+    params.value = "/etc/issue.net";
+    params.op = SshdOptionOperation::Match;
+    params.mode = SshdOptionMode::AllMatches;
+
+    auto result = AuditSshdOption(params, mIndicators, mContext);
+    ASSERT_TRUE(result.HasValue());
+    ASSERT_EQ(result.Value(), Status::Compliant);
+    auto formatted = mFormatter.Format(mIndicators).Value();
+    ASSERT_TRUE(formatted.find("All options are compliant") != std::string::npos);
+    // Each per-pattern result is qualified with its own Match context so the two
+    // otherwise-identical compliant messages are distinguishable.
+    ASSERT_TRUE(formatted.find("(Match context 'user=*@*')") != std::string::npos);
+    ASSERT_TRUE(formatted.find("(Match context 'user=\?\?\?\?\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?-\?\?\?\?\?\?\?\?\?\?\?\?')") != std::string::npos);
+}
 TEST_F(EnsureSshdOptionTest, ReadExtraConfigs_AppendsExtraOptionsToSshdCommand)
 {
     using ::testing::InSequence;


### PR DESCRIPTION
## Description

Fix improper handling of comma-separated mach modes.

### Root cause

```
Match User *@*,<guid>
```
Contents of the pattern were passed directly to the `sshd` command:  `sshd -T -C user=*@*,<guid>`. The semantics is that the patterns are comma-separated and consittute an alternative of matches. The `sshd` command though, expects only a single parameter: either `*@*` or `<guid>`.

### The fix

Now the code splits the pattern by the comma character and tries `sshd -T -C user=<param>` command for each parsed parameter. Compliance is determined by combining all the patterns to not leave room for missed settings. For example, if we checked only the first pattern, we could miss settings for the users that have GUID as username in this case.

### Additional changes

As now for each parameter we check the same setting, I added the parameter context to the indicators to distinguish them. In the original IcM scenario we could have 2 indicators with the same message.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
