### PR TITLE
Harden SSH configuration input against command/config injection

### DIFF
--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -274,6 +274,66 @@ static int IsSshConfigIncludeSupported(OsConfigLogHandle log)
     return result;
 }
 
+// Validates that an SSH configuration value destined for interpolation into a shell command (or
+// written to and later read back from the SSH Server configuration) contains only characters that
+// legitimate values use: user, group, user@host and wildcard patterns, and comma-separated MAC and
+// cipher algorithm lists. This is a defense-in-depth guard: the values themselves are not validated
+// (they are passed to the SSH Server as-is, which validates them), but they must not be allowed to
+// break out of the command OSConfig builds around them and inject arbitrary commands, nor to break
+// the SSH Server configuration parsing.
+static bool IsValueSafe(const char* value, const char* additionalAllowedCharacters, OsConfigLogHandle log)
+{
+    // First layer: reject known-dangerous byte sequences outright, independently of the character
+    // allowlist below, so that they are caught (and clearly named in the log) even if the allowlist
+    // is ever relaxed. These can be used to inject an additional command or to break configuration
+    // parsing (command substitution, command chaining, redirection, quoting/escaping, comments,
+    // extra configuration lines via new lines, or relative path traversal).
+    const char* forbiddenSequences[] = {
+        "\n", "\r", "\t", "$", "`", "$(", "${", ";", "|", "&", "<", ">", "\\", "\"", "'", "#", ".."
+    };
+    size_t forbiddenSequencesSize = ARRAY_SIZE(forbiddenSequences);
+    size_t i = 0;
+    char c = 0;
+    bool result = false;
+
+    if ((NULL == value) || (0 == value[0]))
+    {
+        return result;
+    }
+
+    result = true;
+
+    for (i = 0; i < forbiddenSequencesSize; i++)
+    {
+        if (NULL != strstr(value, forbiddenSequences[i]))
+        {
+            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden sequence '%s'", value, forbiddenSequences[i]);
+            result = false;
+        }
+    }
+
+    if (true == result)
+    {
+        // Second layer: allow only the characters that legitimate SSH configuration values need
+        // (user, group, user@host and wildcard patterns and the space that separates a list of
+        // them), plus any extra characters the caller explicitly permits for this particular check.
+        for (i = 0; 0 != (c = value[i]); i++)
+        {
+            if (isalnum(c) || (' ' == c) || ('_' == c) || ('-' == c) || ('.' == c) || ('*' == c) ||
+                ('?' == c) || ('!' == c) || ('@' == c) || (':' == c) || ('/' == c) ||
+                ((NULL != additionalAllowedCharacters) && (NULL != strchr(additionalAllowedCharacters, c))))
+            {
+                continue;
+            }
+
+            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden character '%c'", value, c);
+            result = false;
+        }
+    }
+
+    return result;
+}
+
 static int CheckOnlyApprovedMacAlgorithmsAreUsed(const char* macs, char** reason, OsConfigLogHandle log)
 {
     char* sshMacs = NULL;
@@ -767,66 +827,6 @@ int CheckSshProtocol(char** reason, OsConfigLogHandle log)
     OsConfigLogInfo(log, "CheckSshProtocol returning %d", status);
 
     return status;
-}
-
-// Validates that an SSH configuration value destined for interpolation into a shell command (or
-// written to and later read back from the SSH Server configuration) contains only characters that
-// legitimate values use: user, group, user@host and wildcard patterns, and comma-separated MAC and
-// cipher algorithm lists. This is a defense-in-depth guard: the values themselves are not validated
-// (they are passed to the SSH Server as-is, which validates them), but they must not be allowed to
-// break out of the command OSConfig builds around them and inject arbitrary commands, nor to break
-// the SSH Server configuration parsing.
-static bool IsValueSafe(const char* value, const char* additionalAllowedCharacters, OsConfigLogHandle log)
-{
-    // First layer: reject known-dangerous byte sequences outright, independently of the character
-    // allowlist below, so that they are caught (and clearly named in the log) even if the allowlist
-    // is ever relaxed. These can be used to inject an additional command or to break configuration
-    // parsing (command substitution, command chaining, redirection, quoting/escaping, comments,
-    // extra configuration lines via new lines, or relative path traversal).
-    const char* forbiddenSequences[] = {
-        "\n", "\r", "\t", "$", "`", "$(", "${", ";", "|", "&", "<", ">", "\\", "\"", "'", "#", ".."
-    };
-    size_t forbiddenSequencesSize = ARRAY_SIZE(forbiddenSequences);
-    size_t i = 0;
-    char c = 0;
-    bool result = false;
-
-    if ((NULL == value) || (0 == value[0]))
-    {
-        return result;
-    }
-
-    result = true;
-
-    for (i = 0; i < forbiddenSequencesSize; i++)
-    {
-        if (NULL != strstr(value, forbiddenSequences[i]))
-        {
-            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden sequence '%s'", value, forbiddenSequences[i]);
-            result = false;
-        }
-    }
-
-    if (true == result)
-    {
-        // Second layer: allow only the characters that legitimate SSH configuration values need
-        // (user, group, user@host and wildcard patterns and the space that separates a list of
-        // them), plus any extra characters the caller explicitly permits for this particular check.
-        for (i = 0; 0 != (c = value[i]); i++)
-        {
-            if (isalnum(c) || (' ' == c) || ('_' == c) || ('-' == c) || ('.' == c) || ('*' == c) ||
-                ('?' == c) || ('!' == c) || ('@' == c) || (':' == c) || ('/' == c) ||
-                ((NULL != additionalAllowedCharacters) && (NULL != strchr(additionalAllowedCharacters, c))))
-            {
-                continue;
-            }
-
-            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden character '%c'", value, c);
-            result = false;
-        }
-    }
-
-    return result;
 }
 
 static int CheckAllowDenyUsersGroups(const char* lowercase, const char* expectedValue, char** reason, OsConfigLogHandle log)

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -309,6 +309,7 @@ static bool IsValueSafe(const char* value, const char* additionalAllowedCharacte
         {
             OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden sequence '%s'", value, forbiddenSequences[i]);
             result = false;
+            break;
         }
     }
 
@@ -328,6 +329,7 @@ static bool IsValueSafe(const char* value, const char* additionalAllowedCharacte
 
             OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden character '%c'", value, c);
             result = false;
+            break;
         }
     }
 

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -293,6 +293,12 @@ static int CheckOnlyApprovedMacAlgorithmsAreUsed(const char* macs, char** reason
     {
         return status;
     }
+    else if (false == IsValueSafe(macs, ",", log))
+    {
+        OsConfigCaptureReason(reason, "'%s' contains characters or sequences that are not allowed and cannot be safely evaluated", macs);
+        OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: '%s' contains characters or sequences that are not allowed and cannot be safely evaluated", macs);
+        return EINVAL;
+    }
     else if (NULL == (sshMacs = DuplicateStringToLowercase(g_sshMacs)))
     {
         OsConfigLogError(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: failed to duplicate string to lowercase");
@@ -368,6 +374,12 @@ static int CheckAppropriateCiphersForSsh(const char* ciphers, char** reason, OsC
     else if (0 != IsSshServerActive(log))
     {
         return status;
+    }
+    else if (false == IsValueSafe(ciphers, ",", log))
+    {
+        OsConfigCaptureReason(reason, "'%s' contains characters or sequences that are not allowed and cannot be safely evaluated", ciphers);
+        OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh: '%s' contains characters or sequences that are not allowed and cannot be safely evaluated", ciphers);
+        return EINVAL;
     }
     else if (NULL == (sshCiphers = DuplicateStringToLowercase(g_sshCiphers)))
     {
@@ -757,6 +769,66 @@ int CheckSshProtocol(char** reason, OsConfigLogHandle log)
     return status;
 }
 
+// Validates that an SSH configuration value destined for interpolation into a shell command (or
+// written to and later read back from the SSH Server configuration) contains only characters that
+// legitimate values use: user, group, user@host and wildcard patterns, and comma-separated MAC and
+// cipher algorithm lists. This is a defense-in-depth guard: the values themselves are not validated
+// (they are passed to the SSH Server as-is, which validates them), but they must not be allowed to
+// break out of the command OSConfig builds around them and inject arbitrary commands, nor to break
+// the SSH Server configuration parsing.
+static bool IsValueSafe(const char* value, const char* additionalAllowedCharacters, OsConfigLogHandle log)
+{
+    // First layer: reject known-dangerous byte sequences outright, independently of the character
+    // allowlist below, so that they are caught (and clearly named in the log) even if the allowlist
+    // is ever relaxed. These can be used to inject an additional command or to break configuration
+    // parsing (command substitution, command chaining, redirection, quoting/escaping, comments,
+    // extra configuration lines via new lines, or relative path traversal).
+    const char* forbiddenSequences[] = {
+        "\n", "\r", "\t", "$", "`", "$(", "${", ";", "|", "&", "<", ">", "\\", "\"", "'", "#", ".."
+    };
+    size_t forbiddenSequencesSize = ARRAY_SIZE(forbiddenSequences);
+    size_t i = 0;
+    char c = 0;
+    bool result = false;
+
+    if ((NULL == value) || (0 == value[0]))
+    {
+        return result;
+    }
+
+    result = true;
+
+    for (i = 0; i < forbiddenSequencesSize; i++)
+    {
+        if (NULL != strstr(value, forbiddenSequences[i]))
+        {
+            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden sequence '%s'", value, forbiddenSequences[i]);
+            result = false;
+        }
+    }
+
+    if (true == result)
+    {
+        // Second layer: allow only the characters that legitimate SSH configuration values need
+        // (user, group, user@host and wildcard patterns and the space that separates a list of
+        // them), plus any extra characters the caller explicitly permits for this particular check.
+        for (i = 0; 0 != (c = value[i]); i++)
+        {
+            if (isalnum(c) || (' ' == c) || ('_' == c) || ('-' == c) || ('.' == c) || ('*' == c) ||
+                ('?' == c) || ('!' == c) || ('@' == c) || (':' == c) || ('/' == c) ||
+                ((NULL != additionalAllowedCharacters) && (NULL != strchr(additionalAllowedCharacters, c))))
+            {
+                continue;
+            }
+
+            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden character '%c'", value, c);
+            result = false;
+        }
+    }
+
+    return result;
+}
+
 static int CheckAllowDenyUsersGroups(const char* lowercase, const char* expectedValue, char** reason, OsConfigLogHandle log)
 {
     const char* commandTemplate = "%s -T | grep \"%s %s\"";
@@ -776,6 +848,12 @@ static int CheckAllowDenyUsersGroups(const char* lowercase, const char* expected
     else if (0 != IsSshServerActive(log))
     {
         return status;
+    }
+    else if (false == IsValueSafe(expectedValue, NULL, log))
+    {
+        OsConfigCaptureReason(reason, "'%s' contains characters or sequences that are not allowed and cannot be safely evaluated", lowercase);
+        OsConfigLogInfo(log, "CheckAllowDenyUsersGroups: '%s' contains characters or sequences that are not allowed and cannot be safely evaluated", lowercase);
+        return EINVAL;
     }
     else if (NULL == strchr(expectedValue, ' '))
     {
@@ -1478,6 +1556,18 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, OsConfigL
             status = SetFileAccess(g_sshServerConfiguration, 0, 0, strtol(g_desiredPermissionsOnEtcSshSshdConfig ?
                 g_desiredPermissionsOnEtcSshSshdConfig : g_sshDefaultSshSshdConfigAccess, NULL, 8), log);
         }
+    }
+    else if ((0 == strcmp(name, g_remediateEnsureAllowUsersIsConfiguredObject)) ||
+        (0 == strcmp(name, g_remediateEnsureDenyUsersIsConfiguredObject)) ||
+        (0 == strcmp(name, g_remediateEnsureAllowGroupsIsConfiguredObject)) ||
+        (0 == strcmp(name, g_remediateEnsureDenyGroupsConfiguredObject)))
+    {
+        status = IsValueSafe(value, NULL, log) ? InitializeSshAuditCheck(name, value, log) : EINVAL;
+    }
+    else if ((0 == strcmp(name, g_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject)) ||
+        (0 == strcmp(name, g_remediateEnsureAppropriateCiphersForSshObject)))
+    {
+        status = IsValueSafe(value, ",", log) ? InitializeSshAuditCheck(name, value, log) : EINVAL;
     }
     else if ((0 == strcmp(name, g_remediateEnsureSshPortIsConfiguredObject)) ||
         (0 == strcmp(name, g_remediateEnsureSshBestPracticeProtocolObject)) ||

--- a/src/common/commonutils/SshUtils.c
+++ b/src/common/commonutils/SshUtils.c
@@ -281,17 +281,8 @@ static int IsSshConfigIncludeSupported(OsConfigLogHandle log)
 // (they are passed to the SSH Server as-is, which validates them), but they must not be allowed to
 // break out of the command OSConfig builds around them and inject arbitrary commands, nor to break
 // the SSH Server configuration parsing.
-static bool IsValueSafe(const char* value, const char* additionalAllowedCharacters, OsConfigLogHandle log)
+static bool IsValueSafe(const char* value, char additionalAllowedCharacter, OsConfigLogHandle log)
 {
-    // First layer: reject known-dangerous byte sequences outright, independently of the character
-    // allowlist below, so that they are caught (and clearly named in the log) even if the allowlist
-    // is ever relaxed. These can be used to inject an additional command or to break configuration
-    // parsing (command substitution, command chaining, redirection, quoting/escaping, comments,
-    // extra configuration lines via new lines, or relative path traversal).
-    const char* forbiddenSequences[] = {
-        "\n", "\r", "\t", "$", "`", "$(", "${", ";", "|", "&", "<", ">", "\\", "\"", "'", "#", ".."
-    };
-    size_t forbiddenSequencesSize = ARRAY_SIZE(forbiddenSequences);
     size_t i = 0;
     char c = 0;
     bool result = false;
@@ -303,34 +294,24 @@ static bool IsValueSafe(const char* value, const char* additionalAllowedCharacte
 
     result = true;
 
-    for (i = 0; i < forbiddenSequencesSize; i++)
+    for (i = 0; 0 != (c = value[i]); i++)
     {
-        if (NULL != strstr(value, forbiddenSequences[i]))
+        if (('.' == c) && ('.' == value[i + 1]))
         {
-            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden sequence '%s'", value, forbiddenSequences[i]);
+            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden sequence '..'", value);
             result = false;
             break;
         }
-    }
 
-    if (true == result)
-    {
-        // Second layer: allow only the characters that legitimate SSH configuration values need
-        // (user, group, user@host and wildcard patterns and the space that separates a list of
-        // them), plus any extra characters the caller explicitly permits for this particular check.
-        for (i = 0; 0 != (c = value[i]); i++)
+        if (isalnum(c) || (' ' == c) || ('_' == c) || ('-' == c) || ('.' == c) || ('*' == c) ||
+            ('?' == c) || ('!' == c) || ('@' == c) || (':' == c) || ('/' == c) || (additionalAllowedCharacter == c))
         {
-            if (isalnum(c) || (' ' == c) || ('_' == c) || ('-' == c) || ('.' == c) || ('*' == c) ||
-                ('?' == c) || ('!' == c) || ('@' == c) || (':' == c) || ('/' == c) ||
-                ((NULL != additionalAllowedCharacters) && (NULL != strchr(additionalAllowedCharacters, c))))
-            {
-                continue;
-            }
-
-            OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden character '%c'", value, c);
-            result = false;
-            break;
+            continue;
         }
+
+        OsConfigLogInfo(log, "IsValueSafe: '%s' contains forbidden character '%c'", value, c);
+        result = false;
+        break;
     }
 
     return result;
@@ -355,7 +336,7 @@ static int CheckOnlyApprovedMacAlgorithmsAreUsed(const char* macs, char** reason
     {
         return status;
     }
-    else if (false == IsValueSafe(macs, ",", log))
+    else if (false == IsValueSafe(macs, ',', log))
     {
         OsConfigCaptureReason(reason, "'%s' contains characters or sequences that are not allowed and cannot be safely evaluated", macs);
         OsConfigLogInfo(log, "CheckOnlyApprovedMacAlgorithmsAreUsed: '%s' contains characters or sequences that are not allowed and cannot be safely evaluated", macs);
@@ -437,7 +418,7 @@ static int CheckAppropriateCiphersForSsh(const char* ciphers, char** reason, OsC
     {
         return status;
     }
-    else if (false == IsValueSafe(ciphers, ",", log))
+    else if (false == IsValueSafe(ciphers, ',', log))
     {
         OsConfigCaptureReason(reason, "'%s' contains characters or sequences that are not allowed and cannot be safely evaluated", ciphers);
         OsConfigLogInfo(log, "CheckAppropriateCiphersForSsh: '%s' contains characters or sequences that are not allowed and cannot be safely evaluated", ciphers);
@@ -851,7 +832,7 @@ static int CheckAllowDenyUsersGroups(const char* lowercase, const char* expected
     {
         return status;
     }
-    else if (false == IsValueSafe(expectedValue, NULL, log))
+    else if (false == IsValueSafe(expectedValue, 0, log))
     {
         OsConfigCaptureReason(reason, "'%s' contains characters or sequences that are not allowed and cannot be safely evaluated", lowercase);
         OsConfigLogInfo(log, "CheckAllowDenyUsersGroups: '%s' contains characters or sequences that are not allowed and cannot be safely evaluated", lowercase);
@@ -1564,12 +1545,12 @@ int ProcessSshAuditCheck(const char* name, char* value, char** reason, OsConfigL
         (0 == strcmp(name, g_remediateEnsureAllowGroupsIsConfiguredObject)) ||
         (0 == strcmp(name, g_remediateEnsureDenyGroupsConfiguredObject)))
     {
-        status = IsValueSafe(value, NULL, log) ? InitializeSshAuditCheck(name, value, log) : EINVAL;
+        status = IsValueSafe(value, 0, log) ? InitializeSshAuditCheck(name, value, log) : EINVAL;
     }
     else if ((0 == strcmp(name, g_remediateEnsureOnlyApprovedMacAlgorithmsAreUsedObject)) ||
         (0 == strcmp(name, g_remediateEnsureAppropriateCiphersForSshObject)))
     {
-        status = IsValueSafe(value, ",", log) ? InitializeSshAuditCheck(name, value, log) : EINVAL;
+        status = IsValueSafe(value, ',', log) ? InitializeSshAuditCheck(name, value, log) : EINVAL;
     }
     else if ((0 == strcmp(name, g_remediateEnsureSshPortIsConfiguredObject)) ||
         (0 == strcmp(name, g_remediateEnsureSshBestPracticeProtocolObject)) ||

--- a/src/modules/test/recipes/SecurityBaselineTests.json
+++ b/src/modules/test/recipes/SecurityBaselineTests.json
@@ -252,6 +252,13 @@
     "ObjectType": "Desired",
     "ComponentName": "SecurityBaseline",
     "ObjectName": "remediateEnsureAllowUsersIsConfigured",
+    "Payload": "x\";id>/tmp/osconfig-marker;# z",
+    "ExpectedResult": 22
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureAllowUsersIsConfigured",
     "Payload": "*@*"
   },
   {
@@ -367,6 +374,13 @@
     "ComponentName": "SecurityBaseline",
     "ObjectName": "initEnsureOnlyApprovedMacAlgorithmsAreUsed",
     "Payload": "hmac-sha2-256,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-512-etm@openssh.com"
+  },
+  {
+    "ObjectType": "Desired",
+    "ComponentName": "SecurityBaseline",
+    "ObjectName": "remediateEnsureOnlyApprovedMacAlgorithmsAreUsed",
+    "Payload": "hmac-sha2-256\";id>/tmp/osconfig-marker;# z",
+    "ExpectedResult": 22
   },
   {
     "ObjectType": "Desired",


### PR DESCRIPTION
## Description

Adds defense-in-depth input validation in SshUtils.c for the SSH and ASB policies to detect and:
- Reject dangerous byte sequences (command substitution, chaining, redirection,  quoting/escaping, comments, new lines, relative path traversal, etc.).
- Allow characters covering what legitimate values need (user, group, `user@host` and wildcard patterns, plus comma-separated MAC/cipher lists.

The check is applied at the points where these values are consumed:
- **Audit sinks:** `CheckAllowDenyUsersGroups`, `CheckOnlyApprovedMacAlgorithmsAreUsed`,   `CheckAppropriateCiphersForSsh`where a failing value produces a captured reason and `EINVAL`  instead of being evaluated.
- **Remediation (Set) path:** the `AllowUsers`/`DenyUsers`/`AllowGroups`/`DenyGroups` and  `Macs`/`Ciphers` remediations reject unsafe values with `EINVAL` before applying them.

These values arrive as configuration parameters and are otherwise passed to the SSH Server as-is (the SSH Server remains the authority on their validity). This change ensures such a value cannot break out of the command OSConfig builds around it or corrupt SSH Server configuration parsing. It does not change how valid values are handled.

Legitimate MAC and cipher lists (comma-separated) and standard user/group/`user@host` ildcard patterns remain accepted.

Rejections are logged (the offending character/sequence is named), we do not have silent failures.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `dev` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `dev` branch.
