### PR TITLE
Fix NFS mount option remediation selector and harden mount table serialization

### DIFF
--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3277,8 +3277,8 @@ int RemediateEnsureNosuidOptionEnabledForAllRemovableMedia(char* value, OsConfig
 int RemediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return ((0 == SetFileSystemMountingOption(g_nfs, NULL, g_nosuid, log)) &&
-        (0 == SetFileSystemMountingOption(g_nfs, NULL, g_noexec, log))) ? 0 : ENOENT;
+    return ((0 == SetFileSystemMountingOption(NULL, g_nfs, g_nosuid, log)) &&
+        (0 == SetFileSystemMountingOption(NULL, g_nfs, g_noexec, log))) ? 0 : ENOENT;
 }
 
 int RemediateEnsureAllTelnetdPackagesUninstalled(char* value, OsConfigLogHandle log)

--- a/src/common/asb/Asb.c
+++ b/src/common/asb/Asb.c
@@ -3217,68 +3217,68 @@ int RemediateEnsureKernelSupportForCpuNx(char* value, OsConfigLogHandle log)
 int RemediateEnsureNodevOptionOnHomePartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_home, NULL, g_nodev, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_home, NULL, g_nodev, log);
 }
 
 int RemediateEnsureNodevOptionOnTmpPartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_tmp, NULL, g_nodev, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_tmp, NULL, g_nodev, log);
 }
 
 int RemediateEnsureNodevOptionOnVarTmpPartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_varTmp, NULL, g_nodev, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_varTmp, NULL, g_nodev, log);
 }
 
 int RemediateEnsureNosuidOptionOnTmpPartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_tmp, NULL, g_nosuid, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_tmp, NULL, g_nosuid, log);
 }
 
 int RemediateEnsureNosuidOptionOnVarTmpPartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_varTmp, NULL, g_nosuid, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_varTmp, NULL, g_nosuid, log);
 }
 
 int RemediateEnsureNoexecOptionOnVarTmpPartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_varTmp, NULL, g_noexec, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_varTmp, NULL, g_noexec, log);
 }
 
 int RemediateEnsureNoexecOptionOnDevShmPartition(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_devShm, NULL, g_noexec, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_devShm, NULL, g_noexec, log);
 }
 
 int RemediateEnsureNodevOptionEnabledForAllRemovableMedia(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_media, NULL, g_nodev, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_media, NULL, g_nodev, log);
 }
 
 int RemediateEnsureNoexecOptionEnabledForAllRemovableMedia(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_media, NULL, g_noexec, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_media, NULL, g_noexec, log);
 }
 
 int RemediateEnsureNosuidOptionEnabledForAllRemovableMedia(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return SetFileSystemMountingOption(g_media, NULL, g_nosuid, log);
+    return SetFileSystemMountingOption(g_etcFstab, g_media, NULL, g_nosuid, log);
 }
 
 int RemediateEnsureNoexecNosuidOptionsEnabledForAllNfsMounts(char* value, OsConfigLogHandle log)
 {
     UNUSED(value);
-    return ((0 == SetFileSystemMountingOption(NULL, g_nfs, g_nosuid, log)) &&
-        (0 == SetFileSystemMountingOption(NULL, g_nfs, g_noexec, log))) ? 0 : ENOENT;
+    return ((0 == SetFileSystemMountingOption(g_etcFstab, NULL, g_nfs, g_nosuid, log)) &&
+        (0 == SetFileSystemMountingOption(g_etcFstab, NULL, g_nfs, g_noexec, log))) ? 0 : ENOENT;
 }
 
 int RemediateEnsureAllTelnetdPackagesUninstalled(char* value, OsConfigLogHandle log)

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -87,7 +87,7 @@ int GetDirectoryAccess(const char* name, unsigned int* ownerId, unsigned int* gr
 
 char* CheckForMountCreds(char* options);
 int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDirectory, const char* mountType, const char* desiredOption, char** reason, OsConfigLogHandle log);
-int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log);
+int SetFileSystemMountingOption(const char* mountFileName, const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log);
 
 int IsPresent(const char* what, OsConfigLogHandle log);
 int IsPackageInstalled(const char* packageName, OsConfigLogHandle log);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -87,6 +87,7 @@ int GetDirectoryAccess(const char* name, unsigned int* ownerId, unsigned int* gr
 
 char* CheckForMountCreds(char* options);
 int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDirectory, const char* mountType, const char* desiredOption, char** reason, OsConfigLogHandle log);
+bool IsMountTableFieldSafe(const char* field);
 int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log);
 
 int IsPresent(const char* what, OsConfigLogHandle log);

--- a/src/common/commonutils/CommonUtils.h
+++ b/src/common/commonutils/CommonUtils.h
@@ -87,7 +87,6 @@ int GetDirectoryAccess(const char* name, unsigned int* ownerId, unsigned int* gr
 
 char* CheckForMountCreds(char* options);
 int CheckFileSystemMountingOption(const char* mountFileName, const char* mountDirectory, const char* mountType, const char* desiredOption, char** reason, OsConfigLogHandle log);
-bool IsMountTableFieldSafe(const char* field);
 int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log);
 
 int IsPresent(const char* what, OsConfigLogHandle log);

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -226,6 +226,32 @@ int LineAlreadyExistsInFile(const char* fileName, const char* text, OsConfigLogH
     return status;
 }
 
+// Returns true if 'field' is safe to serialize into a mount table file, meaning it contains no line/record
+// separator characters ('\n' or '\r'). getmntent() decodes octal escapes (for example the '\012' sequence
+// present in /proc/self/mounts) into literal control characters. Without this check an unprivileged, attacker
+// controlled mount field (such as a FUSE mnt_fsname) could smuggle a newline and inject additional records
+// when the entry is written into a root-owned mount table such as /etc/fstab.
+bool IsMountTableFieldSafe(const char* field)
+{
+    return (NULL == field) || (NULL == strpbrk(field, "\n\r"));
+}
+
+bool MountEntryIsSafeToSerialize(const struct mntent* entry, const char* mountFileName, int lineNumber, OsConfigLogHandle log)
+{
+    if ((NULL == entry) ||
+        (false == IsMountTableFieldSafe(entry->mnt_fsname)) ||
+        (false == IsMountTableFieldSafe(entry->mnt_dir)) ||
+        (false == IsMountTableFieldSafe(entry->mnt_type)) ||
+        (false == IsMountTableFieldSafe(entry->mnt_opts)))
+    {
+        OsConfigLogError(log, "SetFileSystemMountingOption: skipping unsafe mount entry (embedded line separator) in '%s' at line %d", mountFileName, lineNumber);
+        OSConfigTelemetryStatusTrace("unsafeMountEntry", EINVAL);
+        return false;
+    }
+
+    return true;
+}
+
 int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log)
 {
     const char* fsMountTable = "/etc/fstab";
@@ -277,6 +303,12 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
             while (NULL != (mountStruct = getmntent(fsMountHandle)))
             {
+                if (false == MountEntryIsSafeToSerialize(mountStruct, fsMountTable, lineNumber, log))
+                {
+                    lineNumber += 1;
+                    continue;
+                }
+
                 if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory))) ||
                     ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType))))
                 {
@@ -368,6 +400,12 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                         while (NULL != (mountStruct = getmntent(mountHandle)))
                         {
+                            if (false == MountEntryIsSafeToSerialize(mountStruct, mountTable, lineNumber, log))
+                            {
+                                lineNumber += 1;
+                                continue;
+                            }
+
                             if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory))) ||
                                 ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType))))
                             {

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -278,7 +278,11 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
             while (NULL != (mountStruct = getmntent(fsMountHandle)))
             {
-                if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(mountStruct->mnt_dir, unsafe))) ||
+                if ((NULL == mountStruct->mnt_fsname) || (NULL != strpbrk(mountStruct->mnt_fsname, unsafe)))
+                {
+                    OsConfigLogInfo(log, "SetFileSystemMountingOption: name for mount directory '%s' or mount type '%s' is not valid", mountDirectory ? mountDirectory : "-", mountType ? mountType : "-");
+                }
+                else if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(mountStruct->mnt_dir, unsafe))) ||
                     ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(mountStruct->mnt_type, unsafe))))
                 {
                     matchFound = true;
@@ -346,9 +350,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                         status = ENOMEM;
                         break;
                     }
-            }
-
-
+                }
 
                 lineNumber += 1;
             }
@@ -371,9 +373,12 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                         while (NULL != (mountStruct = getmntent(mountHandle)))
                         {
-                            if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(mountStruct->mnt_dir, unsafe))) ||
-                                ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk((mountStruct->mnt_type, unsafe))))
-
+                            if ((NULL == mountStruct->mnt_fsname) || (NULL != strpbrk(mountStruct->mnt_fsname, unsafe)))
+                            {
+                                OsConfigLogInfo(log, "SetFileSystemMountingOption: name for mount directory '%s' or mount type '%s' is not valid", mountDirectory ? mountDirectory : "-", mountType ? mountType : "-");
+                            }
+                            else if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(mountStruct->mnt_dir, unsafe))) ||
+                                ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(mountStruct->mnt_type, unsafe))))
                             {
                                 matchFound = true;
 

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -278,8 +278,8 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
             while (NULL != (mountStruct = getmntent(fsMountHandle)))
             {
-                if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(entry->mnt_fsname, unsafe))) ||
-                    ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(entry->mnt_type, unsafe))))
+                if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(mountStruct->mnt_dir, unsafe))) ||
+                    ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(mountStruct->mnt_type, unsafe))))
                 {
                     matchFound = true;
 
@@ -371,8 +371,8 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                         while (NULL != (mountStruct = getmntent(mountHandle)))
                         {
-                            if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(entry->mnt_fsname, unsafe))) ||
-                                ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(entry->mnt_type, unsafe))))
+                            if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(mountStruct->mnt_dir, unsafe))) ||
+                                ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk((mountStruct->mnt_type, unsafe))))
 
                             {
                                 matchFound = true;

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -226,11 +226,11 @@ int LineAlreadyExistsInFile(const char* fileName, const char* text, OsConfigLogH
     return status;
 }
 
-int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log)
+int SetFileSystemMountingOption(const char* mountFileName, const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log)
 {
-    const char* fsMountTable = "/etc/fstab";
+    const char* fsMountTable = mountFileName;
     const char* mountTable = "/etc/mtab";
-    const char tempFileNameTemplate[] = "/etc/~xtab%d";
+    const char* tempFileNameTemplate = "%s/~xtab%d";
     const char* newLineAsIsTemplate = "\n%s %s %s %s %d %d";
     const char* newLineAddNewTemplate = "\n%s %s %s %s,%s %d %d";
     const char* mountAll = "mount -a";
@@ -242,12 +242,14 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
     char* tempFileNameOne = NULL;
     char* tempFileNameTwo = NULL;
     char* tempFileNameThree = NULL;
+    char* fsMountTableCopy = NULL;
+    char* fsMountDirectory = NULL;
     struct mntent* mountStruct = NULL;
     bool matchFound = false;
     int lineNumber = 1;
     int status = 0;
 
-    if (((NULL == mountDirectory) && (NULL == mountType)) || (NULL == desiredOption))
+    if ((NULL == mountFileName) || ((NULL == mountDirectory) && (NULL == mountType)) || (NULL == desiredOption))
     {
         OsConfigLogError(log, "SetFileSystemMountingOption called with invalid argument(s)");
         OSConfigTelemetryStatusTrace("mountDirectory", EINVAL);
@@ -260,9 +262,15 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
         return 0;
     }
 
-    if ((NULL == (tempFileNameOne = FormatAllocateString(tempFileNameTemplate, 1))) ||
-        (NULL == (tempFileNameTwo = FormatAllocateString(tempFileNameTemplate, 2))) ||
-        (NULL == (tempFileNameThree = FormatAllocateString(tempFileNameTemplate, 3))))
+    // Keep the scratch files next to the mount table so the final rename stays on the same filesystem
+    if (NULL != (fsMountTableCopy = DuplicateString(fsMountTable)))
+    {
+        fsMountDirectory = dirname(fsMountTableCopy);
+    }
+
+    if ((NULL == (tempFileNameOne = FormatAllocateString(tempFileNameTemplate, fsMountDirectory ? fsMountDirectory : "/etc", 1))) ||
+        (NULL == (tempFileNameTwo = FormatAllocateString(tempFileNameTemplate, fsMountDirectory ? fsMountDirectory : "/etc", 2))) ||
+        (NULL == (tempFileNameThree = FormatAllocateString(tempFileNameTemplate, fsMountDirectory ? fsMountDirectory : "/etc", 3))))
     {
         OsConfigLogError(log, "SetFileSystemMountingOption: out of memory");
         OSConfigTelemetryStatusTrace("FormatAllocateString", ENOMEM);
@@ -489,6 +497,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
     FREE_MEMORY(tempFileNameOne);
     FREE_MEMORY(tempFileNameTwo);
     FREE_MEMORY(tempFileNameThree);
+    FREE_MEMORY(fsMountTableCopy);
 
     return status;
 }

--- a/src/common/commonutils/MountUtils.c
+++ b/src/common/commonutils/MountUtils.c
@@ -226,32 +226,6 @@ int LineAlreadyExistsInFile(const char* fileName, const char* text, OsConfigLogH
     return status;
 }
 
-// Returns true if 'field' is safe to serialize into a mount table file, meaning it contains no line/record
-// separator characters ('\n' or '\r'). getmntent() decodes octal escapes (for example the '\012' sequence
-// present in /proc/self/mounts) into literal control characters. Without this check an unprivileged, attacker
-// controlled mount field (such as a FUSE mnt_fsname) could smuggle a newline and inject additional records
-// when the entry is written into a root-owned mount table such as /etc/fstab.
-bool IsMountTableFieldSafe(const char* field)
-{
-    return (NULL == field) || (NULL == strpbrk(field, "\n\r"));
-}
-
-bool MountEntryIsSafeToSerialize(const struct mntent* entry, const char* mountFileName, int lineNumber, OsConfigLogHandle log)
-{
-    if ((NULL == entry) ||
-        (false == IsMountTableFieldSafe(entry->mnt_fsname)) ||
-        (false == IsMountTableFieldSafe(entry->mnt_dir)) ||
-        (false == IsMountTableFieldSafe(entry->mnt_type)) ||
-        (false == IsMountTableFieldSafe(entry->mnt_opts)))
-    {
-        OsConfigLogError(log, "SetFileSystemMountingOption: skipping unsafe mount entry (embedded line separator) in '%s' at line %d", mountFileName, lineNumber);
-        OSConfigTelemetryStatusTrace("unsafeMountEntry", EINVAL);
-        return false;
-    }
-
-    return true;
-}
-
 int SetFileSystemMountingOption(const char* mountDirectory, const char* mountType, const char* desiredOption, OsConfigLogHandle log)
 {
     const char* fsMountTable = "/etc/fstab";
@@ -260,6 +234,7 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
     const char* newLineAsIsTemplate = "\n%s %s %s %s %d %d";
     const char* newLineAddNewTemplate = "\n%s %s %s %s,%s %d %d";
     const char* mountAll = "mount -a";
+    const char* unsafe = "\n\r";
 
     FILE* fsMountHandle = NULL;
     FILE* mountHandle = NULL;
@@ -303,14 +278,8 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
             while (NULL != (mountStruct = getmntent(fsMountHandle)))
             {
-                if (false == MountEntryIsSafeToSerialize(mountStruct, fsMountTable, lineNumber, log))
-                {
-                    lineNumber += 1;
-                    continue;
-                }
-
-                if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory))) ||
-                    ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType))))
+                if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(entry->mnt_fsname, unsafe))) ||
+                    ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(entry->mnt_type, unsafe))))
                 {
                     matchFound = true;
 
@@ -377,7 +346,9 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
                         status = ENOMEM;
                         break;
                     }
-                }
+            }
+
+
 
                 lineNumber += 1;
             }
@@ -400,14 +371,9 @@ int SetFileSystemMountingOption(const char* mountDirectory, const char* mountTyp
 
                         while (NULL != (mountStruct = getmntent(mountHandle)))
                         {
-                            if (false == MountEntryIsSafeToSerialize(mountStruct, mountTable, lineNumber, log))
-                            {
-                                lineNumber += 1;
-                                continue;
-                            }
+                            if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory)) && (NULL == strpbrk(entry->mnt_fsname, unsafe))) ||
+                                ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType)) && (NULL == strpbrk(entry->mnt_type, unsafe))))
 
-                            if (((NULL != mountDirectory) && (NULL != mountStruct->mnt_dir) && (NULL != strstr(mountStruct->mnt_dir, mountDirectory))) ||
-                                ((NULL != mountType) && (NULL != mountStruct->mnt_type) && (NULL != strstr(mountStruct->mnt_type, mountType))))
                             {
                                 matchFound = true;
 

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1454,23 +1454,25 @@ TEST_F(CommonUtilsTest, CheckFileSystemMountingOptionNfsType)
     EXPECT_TRUE(Cleanup(m_path));
 }
 
-/*TEST_F(CommonUtilsTest, IsMountTableFieldSafe)
+TEST_F(CommonUtilsTest, CheckInvalidMountingOptions)
 {
-    // Fields with no record/line separator are safe to serialize into a mount table
-    EXPECT_TRUE(IsMountTableFieldSafe(nullptr));
-    EXPECT_TRUE(IsMountTableFieldSafe(""));
-    EXPECT_TRUE(IsMountTableFieldSafe("server:/export"));
-    EXPECT_TRUE(IsMountTableFieldSafe("/mnt/data"));
-    EXPECT_TRUE(IsMountTableFieldSafe("rw,nosuid,nodev,relatime"));
-    EXPECT_TRUE(IsMountTableFieldSafe("fuse.portal"));
+    const char* testFstab = "server:/export /mnt/data nfs defaults 0 0\n";
 
-    // A field whose octal escape was decoded by getmntent() into a real newline or carriage return must be
-    // rejected, otherwise it could inject additional records when written into a root-owned mount table
-    EXPECT_FALSE(IsMountTableFieldSafe("evil\n/home/attacker/file /root/.canary none bind 0 0"));
-    EXPECT_FALSE(IsMountTableFieldSafe("evil\r/home/attacker/pam /etc/pam.d/su none bind 0 0"));
-    EXPECT_FALSE(IsMountTableFieldSafe("\ninjected"));
-    EXPECT_FALSE(IsMountTableFieldSafe("trailing\n"));
-}*/
+    EXPECT_TRUE(CreateTestFile(m_path, testFstab));
+
+    // A NULL mount file name is invalid
+    EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(nullptr, "/mnt/data", "nfs", "nosuid", nullptr, nullptr));
+
+    // Both the mount directory and the mount type being NULL is invalid, at least one selector is required
+    EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, nullptr, nullptr, "nosuid", nullptr, nullptr));
+
+    // A NULL desired option is invalid, whether the selector is a mount directory, a mount type, or both
+    EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, "/mnt/data", "nfs", nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, "/mnt/data", nullptr, nullptr, nullptr, nullptr));
+    EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, nullptr, "nfs", nullptr, nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(m_path));
+}
 
 TEST_F(CommonUtilsTest, GetNumberOfLinesInFile)
 {

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1338,8 +1338,6 @@ TEST_F(CommonUtilsTest, SetAndCheckFileAccessAt)
     EXPECT_EQ(0, ExecuteCommand(nullptr, "rm -r /tmp/~testAt", false, false, 0, 0, nullptr, nullptr, nullptr));
 }
 
-char* CheckForMountCreds(char* options);
-
 TEST_F(CommonUtilsTest, CheckForMountCreds)
 {
     const char* badOptions[] = {
@@ -1456,7 +1454,7 @@ TEST_F(CommonUtilsTest, CheckFileSystemMountingOptionNfsType)
     EXPECT_TRUE(Cleanup(m_path));
 }
 
-TEST_F(CommonUtilsTest, IsMountTableFieldSafe)
+/*TEST_F(CommonUtilsTest, IsMountTableFieldSafe)
 {
     // Fields with no record/line separator are safe to serialize into a mount table
     EXPECT_TRUE(IsMountTableFieldSafe(nullptr));
@@ -1472,7 +1470,7 @@ TEST_F(CommonUtilsTest, IsMountTableFieldSafe)
     EXPECT_FALSE(IsMountTableFieldSafe("evil\r/home/attacker/pam /etc/pam.d/su none bind 0 0"));
     EXPECT_FALSE(IsMountTableFieldSafe("\ninjected"));
     EXPECT_FALSE(IsMountTableFieldSafe("trailing\n"));
-}
+}*/
 
 TEST_F(CommonUtilsTest, GetNumberOfLinesInFile)
 {

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1432,9 +1432,6 @@ TEST_F(CommonUtilsTest, CheckFileSystemMountingOption)
     EXPECT_TRUE(Cleanup(m_path));
 }
 
-// The NFS hardening rule keys on the filesystem TYPE ("nfs"), not on the mount directory. This test locks in
-// that contract: an ordinary NFS entry whose mount point contains no "nfs" substring must still be matched by
-// type. Matching it as a directory (the pre-fix remediation bug) finds nothing and would fall back to /etc/mtab.
 TEST_F(CommonUtilsTest, CheckFileSystemMountingOptionNfsType)
 {
     const char* testFstab =
@@ -1470,6 +1467,50 @@ TEST_F(CommonUtilsTest, CheckInvalidMountingOptions)
     EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, "/mnt/data", "nfs", nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, "/mnt/data", nullptr, nullptr, nullptr, nullptr));
     EXPECT_EQ(EINVAL, CheckFileSystemMountingOption(m_path, nullptr, "nfs", nullptr, nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(m_path));
+}
+
+TEST_F(CommonUtilsTest, CheckAndSetFileSystemMountingOption)
+{
+    const char* validFstab =
+        "server:/export /mnt/data nfs defaults 0 0\n"
+        "/dev/sda1 / ext4 errors=remount-ro 0 1\n";
+
+    EXPECT_TRUE(CreateTestFile(m_path, validFstab));
+
+    // A NULL mount file name is rejected, mirroring CheckFileSystemMountingOption
+    EXPECT_EQ(EINVAL, SetFileSystemMountingOption(nullptr, nullptr, "nfs", "nosuid", nullptr));
+
+    // Before remediation the NFS entry lacks the hardening option
+    EXPECT_EQ(ENOENT, CheckFileSystemMountingOption(m_path, nullptr, "nfs", "nosuid", nullptr, nullptr));
+
+    // Remediation adds the option to the existing entry, after which the same audit passes
+    EXPECT_EQ(0, SetFileSystemMountingOption(m_path, nullptr, "nfs", "nosuid", nullptr));
+    EXPECT_EQ(0, CheckFileSystemMountingOption(m_path, nullptr, "nfs", "nosuid", nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(m_path));
+
+    // The device field of the first record decodes (glibc getmntent unescapes \012 and \040) to
+    // "aaa<newline>/pwned /pwned pwnfs defaults 0 0", packing a whole extra record into a single field, exactly
+    // as an unprivileged FUSE mnt_fsname can. Without the fix, the raw re-serialization emits that decoded
+    // newline and promotes "/pwned" into an independent, root-trusted mount entry.
+    const char* poisonedFstab =
+        "aaa\\012/pwned\\040/pwned\\040pwnfs\\040defaults\\0400\\0400 /realmnt realtype defaults 0 0\n"
+        "server:/export /mnt/data nfs defaults 0 0\n";
+
+    EXPECT_TRUE(CreateTestFile(m_path, poisonedFstab));
+
+    // Remediating the legitimate NFS entry succeeds and does not abort on the malformed record
+    EXPECT_EQ(0, SetFileSystemMountingOption(m_path, nullptr, "nfs", "nosuid", nullptr));
+
+    // The legitimate entry was still hardened
+    EXPECT_EQ(0, CheckFileSystemMountingOption(m_path, nullptr, "nfs", "nosuid", nullptr, nullptr));
+
+    // No active '/pwned' / 'pwnfs' record was injected from the decoded newline. Had one been promoted, the
+    // audit would match it and report the missing option as ENOENT instead of finding no such entry (0).
+    EXPECT_EQ(0, CheckFileSystemMountingOption(m_path, "/pwned", nullptr, "nodev", nullptr, nullptr));
+    EXPECT_EQ(0, CheckFileSystemMountingOption(m_path, nullptr, "pwnfs", "nodev", nullptr, nullptr));
 
     EXPECT_TRUE(Cleanup(m_path));
 }

--- a/src/common/tests/CommonUtilsUT.cpp
+++ b/src/common/tests/CommonUtilsUT.cpp
@@ -1434,6 +1434,46 @@ TEST_F(CommonUtilsTest, CheckFileSystemMountingOption)
     EXPECT_TRUE(Cleanup(m_path));
 }
 
+// The NFS hardening rule keys on the filesystem TYPE ("nfs"), not on the mount directory. This test locks in
+// that contract: an ordinary NFS entry whose mount point contains no "nfs" substring must still be matched by
+// type. Matching it as a directory (the pre-fix remediation bug) finds nothing and would fall back to /etc/mtab.
+TEST_F(CommonUtilsTest, CheckFileSystemMountingOptionNfsType)
+{
+    const char* testFstab =
+        "server:/export /mnt/data nfs defaults 0 0\n"
+        "server2:/export /mnt/secure nfs4 nosuid,noexec 0 0\n";
+
+    EXPECT_TRUE(CreateTestFile(m_path, testFstab));
+
+    // Matching by type "nfs" flags the /mnt/data entry that is missing the hardening option
+    EXPECT_EQ(ENOENT, CheckFileSystemMountingOption(m_path, nullptr, "nfs", "noexec", nullptr, nullptr));
+    EXPECT_EQ(ENOENT, CheckFileSystemMountingOption(m_path, nullptr, "nfs", "nosuid", nullptr, nullptr));
+
+    // Matching by directory "nfs" finds no entry, because neither mount point contains that substring
+    EXPECT_EQ(0, CheckFileSystemMountingOption(m_path, "nfs", nullptr, "noexec", nullptr, nullptr));
+    EXPECT_EQ(0, CheckFileSystemMountingOption(m_path, "nfs", nullptr, "nosuid", nullptr, nullptr));
+
+    EXPECT_TRUE(Cleanup(m_path));
+}
+
+TEST_F(CommonUtilsTest, IsMountTableFieldSafe)
+{
+    // Fields with no record/line separator are safe to serialize into a mount table
+    EXPECT_TRUE(IsMountTableFieldSafe(nullptr));
+    EXPECT_TRUE(IsMountTableFieldSafe(""));
+    EXPECT_TRUE(IsMountTableFieldSafe("server:/export"));
+    EXPECT_TRUE(IsMountTableFieldSafe("/mnt/data"));
+    EXPECT_TRUE(IsMountTableFieldSafe("rw,nosuid,nodev,relatime"));
+    EXPECT_TRUE(IsMountTableFieldSafe("fuse.portal"));
+
+    // A field whose octal escape was decoded by getmntent() into a real newline or carriage return must be
+    // rejected, otherwise it could inject additional records when written into a root-owned mount table
+    EXPECT_FALSE(IsMountTableFieldSafe("evil\n/home/attacker/file /root/.canary none bind 0 0"));
+    EXPECT_FALSE(IsMountTableFieldSafe("evil\r/home/attacker/pam /etc/pam.d/su none bind 0 0"));
+    EXPECT_FALSE(IsMountTableFieldSafe("\ninjected"));
+    EXPECT_FALSE(IsMountTableFieldSafe("trailing\n"));
+}
+
 TEST_F(CommonUtilsTest, GetNumberOfLinesInFile)
 {
     EXPECT_EQ(0, GetNumberOfLinesInFile(nullptr));


### PR DESCRIPTION
## Description

Fixes the NFS noexec/nosuid remediation in ASB so it acts on the correct /etc/fstab entries, and hardens the mount-table writer so untrusted, decoded mount fields can never inject extra records into a root-owned mount table. Addresses a reported local privilege-escalation issue in the mount-option remediation path.

Problems being fixed, in more detail:

1. **Audit/remediation selector mismatch.** The NFS rule is the only mount rule keyed on  filesystem *type*. Audit correctly passed nfs as mountType (CheckFileSystemMountingOption(g_etcFstab, NULL, g_nfs, ...)), but remediation passed it as mountDirectory (SetFileSystemMountingOption(g_nfs, NULL, ...)). A normal entry like server:/export /mnt/data nfs defaults 0 0 fails audit, yet remediation finds no mount *directory* containing nfs, so it falls through to the /etc/mtab (`/proc/self/mounts`) live-mount fallback. This is the only audit-gated path into that fallback.

2. **Unsafe live-mount serialization.** In the fallback, getmntent(3) decodes octal escapes (e.g. \012 is newline), and the fields were serialized back with a raw %s format. A decoded newline in an unprivileged, user-controlled field could split one   record into several, promoting attacker-chosen entries into the root-owned mount table that is then applied with mount -a.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-osconfig/blob/main/CONTRIBUTING.md).
- [x] I added unit-tests to validate my changes. All unit tests are passing.
- [x] I have merged the latest `main` branch prior to this PR submission.
- [x] I ran [pre-commit](https://pre-commit.com/) on my changes prior to this PR submission.
- [x] I submitted this PR against the `main` branch.
